### PR TITLE
Ensure `logfire.testing` doesn't depend on pydantic and eval_type_backport

### DIFF
--- a/logfire/testing.py
+++ b/logfire/testing.py
@@ -19,7 +19,6 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, Sp
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.semconv.resource import ResourceAttributes
 from opentelemetry.semconv.trace import SpanAttributes
-from pydantic import BaseModel
 
 import logfire
 
@@ -163,52 +162,6 @@ class TestExporter(SpanExporter):
             if _include_pending_spans is True
             or (span.get('attributes', {}).get(ATTRIBUTES_SPAN_TYPE_KEY, 'span') != 'pending_span')
         ]
-
-    def exported_spans_as_models(
-        self,
-        fixed_line_number: int | None = 123,
-        strip_filepaths: bool = True,
-        include_resources: bool = False,
-        include_package_versions: bool = False,
-        _include_pending_spans: bool = False,
-        _strip_function_qualname: bool = True,
-    ) -> list[ReadableSpanModel]:
-        """Same as exported_spans_as_dict but converts the dicts to pydantic models.
-
-        This allows using the result in exporters that expect `ReadableSpan`s, not dicts.
-        """
-        return [
-            ReadableSpanModel(**span)
-            for span in self.exported_spans_as_dict(
-                fixed_line_number=fixed_line_number,
-                strip_filepaths=strip_filepaths,
-                include_resources=include_resources,
-                include_package_versions=include_package_versions,
-                _include_pending_spans=_include_pending_spans,
-                _strip_function_qualname=_strip_function_qualname,
-            )
-        ]
-
-
-class SpanContextModel(BaseModel):
-    """A pydantic model similar to an opentelemetry SpanContext."""
-
-    trace_id: int
-    span_id: int
-    is_remote: bool
-
-
-class ReadableSpanModel(BaseModel):
-    """A pydantic model similar to an opentelemetry ReadableSpan."""
-
-    name: str
-    context: SpanContextModel
-    parent: SpanContextModel | None
-    start_time: int
-    end_time: int
-    attributes: dict[str, Any] | None
-    events: list[dict[str, Any]] | None = None
-    resource: dict[str, Any] | None = None
 
 
 @dataclass(repr=True)

--- a/tests/test_console_exporter.py
+++ b/tests/test_console_exporter.py
@@ -14,7 +14,8 @@ from logfire._internal.exporters.console import (
     ShowParentsConsoleSpanExporter,
     SimpleConsoleSpanExporter,
 )
-from logfire.testing import ReadableSpanModel, SpanContextModel, TestExporter
+from logfire.testing import TestExporter
+from tests.utils import ReadableSpanModel, SpanContextModel, exported_spans_as_models
 
 tracer = trace.get_tracer('test')
 
@@ -355,7 +356,7 @@ def test_show_parents_console_exporter_interleaved() -> None:
 def test_verbose_attributes(exporter: TestExporter) -> None:
     d = {'a': 1, 'b': 2}
     logfire.info('Hello {name}!', name='world', d=d)
-    spans = exporter.exported_spans_as_models()
+    spans = exported_spans_as_models(exporter)
     # insert_assert(spans)
     assert spans == [
         ReadableSpanModel(
@@ -422,7 +423,7 @@ def test_verbose_attributes(exporter: TestExporter) -> None:
 
 def test_tags(exporter: TestExporter):
     logfire.with_tags('tag1', 'tag2').info('Hello')
-    spans = exporter.exported_spans_as_models()
+    spans = exported_spans_as_models(exporter)
     # insert_assert(spans)
     assert spans == [
         ReadableSpanModel(
@@ -465,7 +466,7 @@ def test_levels(exporter: TestExporter):
     logfire.error('error message')
     logfire.fatal('fatal message')
 
-    spans = exporter.exported_spans_as_models()
+    spans = exported_spans_as_models(exporter)
     # insert_assert(spans)
     assert spans == [
         ReadableSpanModel(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from logfire.testing import TestExporter
+
+
+def exported_spans_as_models(
+    exporter: TestExporter,
+    fixed_line_number: int | None = 123,
+    strip_filepaths: bool = True,
+    include_resources: bool = False,
+    include_package_versions: bool = False,
+    _include_pending_spans: bool = False,
+    _strip_function_qualname: bool = True,
+) -> list[ReadableSpanModel]:
+    """Same as exported_spans_as_dict but converts the dicts to pydantic models.
+
+    This allows using the result in exporters that expect `ReadableSpan`s, not dicts.
+    """
+    return [
+        ReadableSpanModel(**span)
+        for span in exporter.exported_spans_as_dict(
+            fixed_line_number=fixed_line_number,
+            strip_filepaths=strip_filepaths,
+            include_resources=include_resources,
+            include_package_versions=include_package_versions,
+            _include_pending_spans=_include_pending_spans,
+            _strip_function_qualname=_strip_function_qualname,
+        )
+    ]
+
+
+class SpanContextModel(BaseModel):
+    """A pydantic model similar to an opentelemetry SpanContext."""
+
+    trace_id: int
+    span_id: int
+    is_remote: bool
+
+
+class ReadableSpanModel(BaseModel):
+    """A pydantic model similar to an opentelemetry ReadableSpan."""
+
+    name: str
+    context: SpanContextModel
+    parent: SpanContextModel | None
+    start_time: int
+    end_time: int
+    attributes: dict[str, Any] | None
+    events: list[dict[str, Any]] | None = None
+    resource: dict[str, Any] | None = None


### PR DESCRIPTION
Fixes https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1714427146768789

I shouldn't have put this stuff in `logfire.testing` in the first place.