### PR TITLE
Ignore current directory on a `logfire.configure()` from the tests

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -963,7 +963,7 @@ def test_initialize_project_not_confirming_organization(tmp_path: Path) -> None:
         )
 
         with pytest.raises(SystemExit):
-            logfire.configure()
+            logfire.configure(data_dir=tmp_path)
 
         assert confirm_mock.mock_calls == [
             call('Do you want to use one of your existing projects? ', default=True),


### PR DESCRIPTION
This test fails when you have a `.logfire` on the root directory.

I'm just changing the data dir.