### PR TITLE
Uninstrument SQLAlchemy after test to not mess with other tests

### DIFF
--- a/tests/otel_integrations/test_sqlalchemy.py
+++ b/tests/otel_integrations/test_sqlalchemy.py
@@ -188,3 +188,5 @@ def test_sqlalchemy_instrumentation(exporter: TestExporter):
             },
         },
     ]
+
+    SQLAlchemyInstrumentor().uninstrument()

--- a/tests/test_json_args.py
+++ b/tests/test_json_args.py
@@ -856,50 +856,11 @@ def test_log_sqlalchemy_class(exporter: TestExporter) -> None:
     assert exporter.exported_spans_as_dict() == snapshot(
         [
             {
-                'name': 'connect',
+                'name': 'test message {var=}',
                 'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
                 'parent': None,
                 'start_time': 1000000000,
-                'end_time': 2000000000,
-                'attributes': {
-                    'logfire.span_type': 'span',
-                    'logfire.msg': 'connect',
-                    'db.name': ':memory:',
-                    'db.system': 'sqlite',
-                },
-            },
-            {
-                'name': 'connect',
-                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
-                'parent': None,
-                'start_time': 3000000000,
-                'end_time': 4000000000,
-                'attributes': {
-                    'logfire.span_type': 'span',
-                    'logfire.msg': 'connect',
-                    'db.name': ':memory:',
-                    'db.system': 'sqlite',
-                },
-            },
-            {
-                'name': 'connect',
-                'context': {'trace_id': 3, 'span_id': 5, 'is_remote': False},
-                'parent': None,
-                'start_time': 5000000000,
-                'end_time': 6000000000,
-                'attributes': {
-                    'logfire.span_type': 'span',
-                    'logfire.msg': 'connect',
-                    'db.name': ':memory:',
-                    'db.system': 'sqlite',
-                },
-            },
-            {
-                'name': 'test message {var=}',
-                'context': {'trace_id': 4, 'span_id': 7, 'is_remote': False},
-                'parent': None,
-                'start_time': 7000000000,
-                'end_time': 7000000000,
+                'end_time': 1000000000,
                 'attributes': {
                     'logfire.span_type': 'log',
                     'logfire.level_num': 9,
@@ -911,7 +872,7 @@ def test_log_sqlalchemy_class(exporter: TestExporter) -> None:
                     'var': '{"id":1,"name":"test name"}',
                     'logfire.json_schema': '{"type":"object","properties":{"var":{"type":"object","title":"Model","x-python-datatype":"sqlalchemy"}}}',
                 },
-            },
+            }
         ]
     )
 


### PR DESCRIPTION
`tests/otel_integrations/test_sqlalchemy.py` instruments SQLAlchemy, which causes spans to show up in `tests/test_json_args.py` that don't show when that test is run in isolation.