### PR TITLE
Close spans when process shuts down before the exporter shuts down and drops them

### DIFF
--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1118,6 +1118,7 @@ class FastLogfireSpan:
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None:
+        atexit.unregister(self._atexit)
         context_api.detach(self._token)
         _exit_span(self._span, exc_value)
         self._span.end()
@@ -1142,6 +1143,7 @@ class LogfireSpan(ReadableSpan):
         self._token: None | object = None
         self._span: None | trace_api.Span = None
         self.end_on_exit = True
+        self._atexit: Callable[[], None] | None = None
 
     if not TYPE_CHECKING:  # pragma: no branch
 
@@ -1166,6 +1168,9 @@ class LogfireSpan(ReadableSpan):
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None:
         if self._token is None:  # pragma: no cover
             return
+
+        if self._atexit:
+            atexit.unregister(self._atexit)
 
         context_api.detach(self._token)
         self._token = None

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1169,7 +1169,7 @@ class LogfireSpan(ReadableSpan):
         if self._token is None:  # pragma: no cover
             return
 
-        if self._atexit:
+        if self._atexit:  # pragma: no branch
             atexit.unregister(self._atexit)
 
         context_api.detach(self._token)


### PR DESCRIPTION
Without this PR, this script:

```python
import logfire

def stream():
    with logfire.span('span'):
        yield 1
        yield 2

s = stream()
next(s)
```

logs an error: "Already shutdown, dropping span."

This PR registers exiting the span context managers with `atexit`. This happens after the tracer provider is initialized, where OTEL registers its own shutdown (and thus the shutdown of the span processors and exporters) with atexit. Since atexit runs the callbacks in reverse order of registration, that means the spans will be closed by atexit before the exporters shut down.