### PR TITLE
Increase minumum typing-extensions version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "opentelemetry-instrumentation >= 0.41b0",
     "rich >= 13.4.2",
     "protobuf >= 4.23.4",
-    "typing-extensions >= 4.0.0",
+    "typing-extensions >= 4.1.0",
     "tomli >= 2.0.1; python_version < '3.11'",
 ]
 


### PR DESCRIPTION
Solves https://github.com/pydantic/logfire/issues/96#issuecomment-2095456237

Added in 4.1.0: https://typing-extensions.readthedocs.io/en/latest/#typing_extensions.assert_never