### PR TITLE
Make pip install command printed by 'logfire inspect' easy to copy

### DIFF
--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -222,7 +222,7 @@ def parse_inspect(args: argparse.Namespace) -> None:
         )
         install_command = f'pip install {otel_packages_to_install}'
         console.print('\n[bold green]To install these packages, run:[/bold green]\n')
-        console.print(f'[bold]$[/bold] [cyan]{install_command}[/cyan]', justify='center')
+        console.print(f'[cyan]{install_command}[/cyan]', soft_wrap=True)
         console.print('\n[bold blue]For further information, visit[/bold blue]', end=' ')
         console.print(f'[link={INTEGRATIONS_DOCS_URL}]{INTEGRATIONS_DOCS_URL}[/link]')
 


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/126

For example, instead of printing:

```
To install these packages, run:

$ pip install opentelemetry-instrumentation-sqlite3 opentelemetry-instrumentation-jinja2
       opentelemetry-instrumentation-urllib opentelemetry-instrumentation-urllib3    
```

it now prints:

```
To install these packages, run:

pip install opentelemetry-instrumentation-urllib opentelemetry-instrumentation-sqlite3 opentelemetry-instrumentation-jinja2 opentelemetry-instrumentation-urllib3
```

i.e. the whole command is on one line, and there's no `$`. Now triple-clicking that line (at least in my terminals) selects the whole line for easy copy-pasting.