### PR TITLE
Fix JSON encoding/schema of pydantic v1 models

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -153,7 +153,12 @@ def _pydantic_model_encoder(o: Any, seen: set[int]) -> JsonValue:
     import pydantic
 
     assert isinstance(o, pydantic.BaseModel)
-    return to_json_value(o.model_dump(), seen)
+    try:
+        dump = o.model_dump()
+    except AttributeError:  # pragma: no cover
+        # pydantic v1
+        dump = o.dict()  # type: ignore
+    return to_json_value(dump, seen)
 
 
 def _get_sqlalchemy_data(o: Any, seen: set[int]) -> JsonValue:

--- a/logfire/_internal/json_schema.py
+++ b/logfire/_internal/json_schema.py
@@ -268,7 +268,14 @@ def _pydantic_model_schema(obj: Any, seen: set[int]) -> JsonDict:
     import pydantic
 
     assert isinstance(obj, pydantic.BaseModel)
-    return _custom_object_schema(obj, 'PydanticModel', [*obj.model_fields, *(obj.model_extra or {})], seen)
+    try:
+        fields = obj.model_fields
+        extra = obj.model_extra or {}
+    except AttributeError:  # pragma: no cover
+        # pydantic v1
+        fields = obj.__fields__  # type: ignore
+        extra = {}
+    return _custom_object_schema(obj, 'PydanticModel', [*fields, *extra], seen)
 
 
 def _pandas_schema(obj: Any, _seen: set[int]) -> JsonDict:


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/147

Tested manually by install pydantic v1 and running:

```python
import pydantic


class Foo(pydantic.BaseModel):
    bar: int
    baz: str


import logfire

logfire.configure(console=logfire.ConsoleOptions(verbose=True))

logfire.info('hi', foo=Foo(bar=1, baz='a'))
```

Automatic testing will require actually installing pydantic v1 in CI which is challenging. The tests fail to start in various ways with v1 installed. Using `pydantic.v1` with v2 installed doesn't reproduce the original problem.