### PR TITLE
Use `logfire[extra]` instead of `logfire -E extra` on Poetry instructions

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -126,7 +126,7 @@ def install_logfire(markdown: str, page: Page) -> str:
 
 === "Poetry"
     ```bash
-    poetry add logfire {extras_arg}
+    poetry add {package}
     ```
 """
     if not extras:


### PR DESCRIPTION
- Closes https://github.com/pydantic/logfire/issues/165