### PR TITLE
Do not require project name on `logfire projects use` command

### DIFF
--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -270,7 +270,6 @@ def parse_auth(args: argparse.Namespace) -> None:
 
     console.print()
     console.print(f'Your Logfire credentials are stored in [bold]{DEFAULT_FILE}[/]')
-    # TODO(Marcelo): Add a message to inform which commands can be used.
 
 
 def parse_list_projects(args: argparse.Namespace) -> None:
@@ -323,9 +322,10 @@ def parse_use_project(args: argparse.Namespace) -> None:
     """Use an existing project."""
     data_dir = Path(args.data_dir)
     logfire_url = args.logfire_url
-    project_name = args.project_name
+    project_name = args.project
     organization = args.org
     console = Console(file=sys.stderr)
+
     projects = LogfireCredentials.get_user_projects(session=args._session, logfire_api_url=logfire_url)
     project_info = LogfireCredentials.use_existing_project(
         session=args._session,
@@ -438,7 +438,7 @@ def _main(args: list[str] | None = None) -> None:
     cmd_projects_new.set_defaults(func=parse_create_new_project)
 
     cmd_projects_use = projects_subparsers.add_parser('use', help='use a project')
-    cmd_projects_use.add_argument('project_name', help='project name')
+    cmd_projects_use.add_argument('--project', help='project name')
     cmd_projects_use.add_argument('--org', help='project organization')
     cmd_projects_use.add_argument('--data-dir', default='.logfire')
     cmd_projects_use.set_defaults(func=parse_use_project)

--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -322,7 +322,7 @@ def parse_use_project(args: argparse.Namespace) -> None:
     """Use an existing project."""
     data_dir = Path(args.data_dir)
     logfire_url = args.logfire_url
-    project_name = args.project
+    project_name = args.project_name
     organization = args.org
     console = Console(file=sys.stderr)
 
@@ -438,7 +438,7 @@ def _main(args: list[str] | None = None) -> None:
     cmd_projects_new.set_defaults(func=parse_create_new_project)
 
     cmd_projects_use = projects_subparsers.add_parser('use', help='use a project')
-    cmd_projects_use.add_argument('--project', help='project name')
+    cmd_projects_use.add_argument('project_name', nargs='?', help='project name')
     cmd_projects_use.add_argument('--org', help='project organization')
     cmd_projects_use.add_argument('--data-dir', default='.logfire')
     cmd_projects_use.set_defaults(func=parse_use_project)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -913,7 +913,7 @@ To create a write token, refer to https://docs.pydantic.dev/logfire/guides/advan
             project_name: Name of project that has to be used.
 
         Returns:
-            The configured project informations.
+            The configured project information.
 
         Raises:
             LogfireConfigError: If there was an error configuring the project.
@@ -1142,10 +1142,7 @@ To create a write token, refer to https://docs.pydantic.dev/logfire/guides/advan
 
         projects = cls.get_user_projects(session=session, logfire_api_url=logfire_api_url)
         if projects:
-            use_existing_projects = Confirm.ask(
-                'Do you want to use one of your existing projects? ',
-                default=True,
-            )
+            use_existing_projects = Confirm.ask('Do you want to use one of your existing projects? ', default=True)
             if use_existing_projects:  # pragma: no branch
                 credentials = cls.use_existing_project(
                     session=session, logfire_api_url=logfire_api_url, projects=projects

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,7 +809,7 @@ def test_projects_use(tmp_dir_cwd: Path, default_credentials: Path) -> None:
             [create_project_response],
         )
 
-        main(['projects', 'use', '--project', 'myproject'])
+        main(['projects', 'use', 'myproject'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -904,7 +904,7 @@ def test_projects_use_multiple(tmp_dir_cwd: Path, default_credentials: Path) -> 
             [create_project_response],
         )
 
-        main(['projects', 'use', '--project', 'myproject'])
+        main(['projects', 'use', 'myproject'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -962,7 +962,7 @@ def test_projects_use_multiple_with_org(tmp_dir_cwd: Path, default_credentials: 
             [create_project_response],
         )
 
-        main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
+        main(['projects', 'use', 'myproject', '--org', 'fake_org'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -1000,7 +1000,7 @@ def test_projects_use_wrong_project(tmp_dir_cwd: Path, default_credentials: Path
             [create_project_response],
         )
 
-        main(['projects', 'use', '--project', 'wrong-project', '--org', 'fake_org'])
+        main(['projects', 'use', 'wrong-project', '--org', 'fake_org'])
 
         assert prompt_mock.mock_calls == [
             call(
@@ -1040,7 +1040,7 @@ def test_projects_use_wrong_project_give_up(tmp_dir_cwd: Path, default_credentia
             json=[{'organization_name': 'fake_org', 'project_name': 'myproject'}],
         )
 
-        main(['projects', 'use', '--project', 'wrong-project', '--org', 'fake_org'])
+        main(['projects', 'use', 'wrong-project', '--org', 'fake_org'])
 
         assert prompt_mock.mock_calls == [
             call(
@@ -1071,7 +1071,7 @@ def test_projects_use_without_projects(tmp_dir_cwd: Path, capsys: pytest.Capture
             json=[],
         )
 
-        main(['projects', 'use', '--project', 'myproject'])
+        main(['projects', 'use', 'myproject'])
 
         assert (
             re.sub(r'\s+', ' ', capsys.readouterr().err).strip()
@@ -1104,7 +1104,7 @@ def test_projects_use_error(tmp_dir_cwd: Path, default_credentials: Path) -> Non
         )
 
         with pytest.raises(LogfireConfigError, match='Invalid credentials, when initializing project:'):
-            main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
+            main(['projects', 'use', 'myproject', '--org', 'fake_org'])
 
 
 def test_projects_use_write_token_error(tmp_dir_cwd: Path, default_credentials: Path) -> None:
@@ -1126,7 +1126,7 @@ def test_projects_use_write_token_error(tmp_dir_cwd: Path, default_credentials: 
         )
 
         with pytest.raises(LogfireConfigError, match='Error creating project write token.'):
-            main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
+            main(['projects', 'use', 'myproject', '--org', 'fake_org'])
 
 
 def test_info(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -809,7 +809,7 @@ def test_projects_use(tmp_dir_cwd: Path, default_credentials: Path) -> None:
             [create_project_response],
         )
 
-        main(['projects', 'use', 'myproject'])
+        main(['projects', 'use', '--project', 'myproject'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -904,7 +904,7 @@ def test_projects_use_multiple(tmp_dir_cwd: Path, default_credentials: Path) -> 
             [create_project_response],
         )
 
-        main(['projects', 'use', 'myproject'])
+        main(['projects', 'use', '--project', 'myproject'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -962,7 +962,7 @@ def test_projects_use_multiple_with_org(tmp_dir_cwd: Path, default_credentials: 
             [create_project_response],
         )
 
-        main(['projects', 'use', 'myproject', '--org', 'fake_org'])
+        main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
 
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]
         assert console_calls == [
@@ -1000,7 +1000,7 @@ def test_projects_use_wrong_project(tmp_dir_cwd: Path, default_credentials: Path
             [create_project_response],
         )
 
-        main(['projects', 'use', 'wrong-project', '--org', 'fake_org'])
+        main(['projects', 'use', '--project', 'wrong-project', '--org', 'fake_org'])
 
         assert prompt_mock.mock_calls == [
             call(
@@ -1040,7 +1040,7 @@ def test_projects_use_wrong_project_give_up(tmp_dir_cwd: Path, default_credentia
             json=[{'organization_name': 'fake_org', 'project_name': 'myproject'}],
         )
 
-        main(['projects', 'use', 'wrong-project', '--org', 'fake_org'])
+        main(['projects', 'use', '--project', 'wrong-project', '--org', 'fake_org'])
 
         assert prompt_mock.mock_calls == [
             call(
@@ -1071,7 +1071,7 @@ def test_projects_use_without_projects(tmp_dir_cwd: Path, capsys: pytest.Capture
             json=[],
         )
 
-        main(['projects', 'use', 'myproject'])
+        main(['projects', 'use', '--project', 'myproject'])
 
         assert (
             re.sub(r'\s+', ' ', capsys.readouterr().err).strip()
@@ -1104,7 +1104,7 @@ def test_projects_use_error(tmp_dir_cwd: Path, default_credentials: Path) -> Non
         )
 
         with pytest.raises(LogfireConfigError, match='Invalid credentials, when initializing project:'):
-            main(['projects', 'use', 'myproject', '--org', 'fake_org'])
+            main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
 
 
 def test_projects_use_write_token_error(tmp_dir_cwd: Path, default_credentials: Path) -> None:
@@ -1126,7 +1126,7 @@ def test_projects_use_write_token_error(tmp_dir_cwd: Path, default_credentials: 
         )
 
         with pytest.raises(LogfireConfigError, match='Error creating project write token.'):
-            main(['projects', 'use', 'myproject', '--org', 'fake_org'])
+            main(['projects', 'use', '--project', 'myproject', '--org', 'fake_org'])
 
 
 def test_info(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
- Closes https://github.com/pydantic/logfire/issues/175