### PR TITLE
Allow instrumenting OpenAI/Anthropic client classes or modules

### DIFF
--- a/docs/integrations/anthropic.md
+++ b/docs/integrations/anthropic.md
@@ -21,7 +21,7 @@ response = client.messages.create(
 print(response.content[0].text)
 ```
 
-1. In general, `logfire.instrument_anthropic()` should be all you need.
+1. If you don't have access to the client instance, you can pass a class (e.g. `logfire.instrument_anthropic(anthropic.Anthropic)`), or just pass no arguments (i.e. `logfire.instrument_anthropic()`) to instrument both the `anthropic.Anthropic` and `anthropic.AsyncAnthropic` classes.
 
 _For more information, see the [`instrument_anthropic()` API reference][logfire.Logfire.instrument_anthropic]._
 

--- a/docs/integrations/openai.md
+++ b/docs/integrations/openai.md
@@ -22,7 +22,7 @@ response = client.chat.completions.create(
 print(response.choices[0].message)
 ```
 
-1. In general, `logfire.instrument_openai()` should be all you need.
+1. If you don't have access to the client instance, you can pass a class (e.g. `logfire.instrument_openai(openai.Client)`), or just pass no arguments (i.e. `logfire.instrument_openai()`) to instrument both the `openai.Client` and `openai.AsyncClient` classes.
 
 _For more information, see the [`instrument_openai()` API reference][logfire.Logfire.instrument_openai]._
 

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -72,5 +72,5 @@ def is_async_client(client: type[anthropic.Anthropic] | type[anthropic.AsyncAnth
     """Returns whether or not the `client` class is async."""
     if issubclass(client, anthropic.Anthropic):
         return False
-    assert isinstance(client, anthropic.AsyncAnthropic), f'Expected Anthropic or AsyncAnthropic type, got: {client}'
+    assert issubclass(client, anthropic.AsyncAnthropic), f'Expected Anthropic or AsyncAnthropic type, got: {client}'
     return True

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -68,9 +68,9 @@ def on_response(response: ResponseT, span: LogfireSpan) -> ResponseT:
     return response
 
 
-def is_async_client(client: anthropic.Anthropic | anthropic.AsyncAnthropic):
-    """Returns whether or not `client` is async."""
-    if isinstance(client, anthropic.Anthropic):
+def is_async_client(client: type[anthropic.Anthropic] | type[anthropic.AsyncAnthropic]):
+    """Returns whether or not the `client` class is async."""
+    if issubclass(client, anthropic.Anthropic):
         return False
-    assert isinstance(client, anthropic.AsyncAnthropic), f'Unexpected Anthropic or AsyncAnthropic type, got: {client}'
+    assert isinstance(client, anthropic.AsyncAnthropic), f'Expected Anthropic or AsyncAnthropic type, got: {client}'
     return True

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -27,9 +27,9 @@ def instrument_llm_provider(
 ) -> ContextManager[None]:
     """Instruments the provided `client` (or clients) with `logfire`.
 
-    `client` can be:
-    - a single client instance, e.g. an instance of `openai.OpenAI`.
-    - a class of a client
+    The `client` argument can be:
+    - a single client instance, e.g. an instance of `openai.OpenAI`,
+    - a class of a client, or
     - an iterable of clients/classes.
 
     Returns:

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -37,7 +37,7 @@ def instrument_llm_provider(
                 on_response_fn,
                 is_async_client_fn,
             )
-            for c in cast(Iterable[Any], client)
+            for c in cast('Iterable[Any]', client)
         ]
 
         @contextmanager

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -22,15 +22,23 @@ def instrument_llm_provider(
     scope_suffix: str,
     get_endpoint_config_fn: Callable[[Any], EndpointConfig],
     on_response_fn: Callable[[Any, LogfireSpan], Any],
-    is_async_client_fn: Callable[[Any], bool],
+    is_async_client_fn: Callable[[type[Any]], bool],
 ) -> ContextManager[None]:
     """Instruments the provided `client` with `logfire`."""
+    if getattr(client, '_is_instrumented_by_logfire', False):
+
+        @contextmanager
+        def dummy_context():
+            yield
+
+        return dummy_context()
+
     logfire_llm = logfire.with_settings(custom_scope_suffix=scope_suffix.lower(), tags=['LLM'])
 
     client._is_instrumented_by_logfire = True
     client._original_request_method = original_request_method = client._request
 
-    is_async = is_async_client_fn(client)
+    is_async = is_async_client_fn(client if isinstance(client, type) else type(client))
 
     def _instrumentation_setup(**kwargs: Any) -> Any:
         if context.get_value('suppress_instrumentation'):
@@ -76,30 +84,30 @@ def instrument_llm_provider(
 
         return message_template, span_data, kwargs
 
-    def instrumented_llm_request_sync(**kwargs: Any) -> Any:
+    def instrumented_llm_request_sync(*args: Any, **kwargs: Any) -> Any:
         message_template, span_data, kwargs = _instrumentation_setup(**kwargs)
         if message_template is None:
-            return original_request_method(**kwargs)
+            return original_request_method(*args, **kwargs)
         stream = kwargs['stream']
         with logfire_llm.span(message_template, **span_data) as span:
             with maybe_suppress_instrumentation(suppress_otel):
                 if stream:
-                    return original_request_method(**kwargs)
+                    return original_request_method(*args, **kwargs)
                 else:
-                    response = on_response_fn(original_request_method(**kwargs), span)
+                    response = on_response_fn(original_request_method(*args, **kwargs), span)
                     return response
 
-    async def instrumented_llm_request_async(**kwargs: Any) -> Any:
+    async def instrumented_llm_request_async(*args: Any, **kwargs: Any) -> Any:
         message_template, span_data, kwargs = _instrumentation_setup(**kwargs)
         if message_template is None:
-            return await original_request_method(**kwargs)
+            return await original_request_method(*args, **kwargs)
         stream = kwargs['stream']
         with logfire_llm.span(message_template, **span_data) as span:
             with maybe_suppress_instrumentation(suppress_otel):
                 if stream:
-                    return await original_request_method(**kwargs)
+                    return await original_request_method(*args, **kwargs)
                 else:
-                    response = on_response_fn(await original_request_method(**kwargs), span)
+                    response = on_response_fn(await original_request_method(*args, **kwargs), span)
                     return response
 
     if is_async:
@@ -118,7 +126,7 @@ def instrument_llm_provider(
         try:
             yield
         finally:
-            client._request = client._original_request_method
+            client._request = client._original_request_method  # type: ignore
             del client._original_request_method
             client._is_instrumented_by_logfire = False
 

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -99,9 +99,9 @@ def on_response(response: ResponseT, span: LogfireSpan) -> ResponseT:
     return response
 
 
-def is_async_client(client: openai.OpenAI | openai.AsyncOpenAI):
-    """Returns whether or not `client` is async."""
-    if isinstance(client, openai.OpenAI):
+def is_async_client(client: type[openai.OpenAI] | type[openai.AsyncOpenAI]):
+    """Returns whether or not the `client` class is async."""
+    if issubclass(client, openai.OpenAI):
         return False
-    assert isinstance(client, openai.AsyncOpenAI), f'Unexpected OpenAI or AsyncOpenAI type, got: {client}'
+    assert issubclass(client, openai.AsyncOpenAI), f'Expected OpenAI or AsyncOpenAI type, got: {client}'
     return True

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -822,7 +822,10 @@ class Logfire:
         )
 
     def instrument_openai(
-        self, openai_client: openai.OpenAI | openai.AsyncOpenAI, *, suppress_other_instrumentation: bool = True
+        self,
+        openai_client: openai.OpenAI | openai.AsyncOpenAI | type[openai.OpenAI] | type[openai.AsyncOpenAI],
+        *,
+        suppress_other_instrumentation: bool = True,
     ) -> ContextManager[None]:
         """Instrument an OpenAI client so that spans are automatically created for each request.
 
@@ -879,7 +882,10 @@ class Logfire:
 
     def instrument_anthropic(
         self,
-        anthropic_client: anthropic.Anthropic | anthropic.AsyncAnthropic,
+        anthropic_client: anthropic.Anthropic
+        | anthropic.AsyncAnthropic
+        | type[anthropic.Anthropic]
+        | type[anthropic.AsyncAnthropic],
         *,
         suppress_other_instrumentation: bool = True,
     ) -> ContextManager[None]:

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -862,7 +862,14 @@ class Logfire:
         ```
 
         Args:
-            openai_client: The OpenAI client to instrument, either `openai.OpenAI` or `openai.AsyncOpenAI`.
+            openai_client: The OpenAI client or class to instrument:
+
+                - `None` (the default) to instrument both the `openai.OpenAI` and `openai.AsyncOpenAI` classes.
+                - The `openai.OpenAI` class or a subclass
+                - The `openai.AsyncOpenAI` class or a subclass
+                - An instance of `openai.OpenAI`
+                - An instance of `openai.AsyncOpenAI`
+
             suppress_other_instrumentation: If True, suppress any other OTEL instrumentation that may be otherwise
                 enabled. In reality, this means the HTTPX instrumentation, which could otherwise be called since
                 OpenAI uses HTTPX to make HTTP requests.
@@ -926,7 +933,15 @@ class Logfire:
         ```
 
         Args:
-            anthropic_client: The Anthropic client to instrument, either `anthropic.Anthropic` or `anthropic.AsyncAnthropic`.
+            anthropic_client: The Anthropic client or class to instrument:
+
+                - `None` (the default) to instrument both the
+                    `anthropic.Anthropic` and `anthropic.AsyncAnthropic` classes.
+                - The `anthropic.Anthropic` class or a subclass
+                - The `anthropic.AsyncAnthropic` class or a subclass
+                - An instance of `anthropic.Anthropic`
+                - An instance of `anthropic.AsyncAnthropic`
+
             suppress_other_instrumentation: If True, suppress any other OTEL instrumentation that may be otherwise
                 enabled. In reality, this means the HTTPX instrumentation, which could otherwise be called since
                 OpenAI uses HTTPX to make HTTP requests.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -823,7 +823,11 @@ class Logfire:
 
     def instrument_openai(
         self,
-        openai_client: openai.OpenAI | openai.AsyncOpenAI | type[openai.OpenAI] | type[openai.AsyncOpenAI],
+        openai_client: openai.OpenAI
+        | openai.AsyncOpenAI
+        | type[openai.OpenAI]
+        | type[openai.AsyncOpenAI]
+        | None = None,
         *,
         suppress_other_instrumentation: bool = True,
     ) -> ContextManager[None]:
@@ -867,12 +871,14 @@ class Logfire:
             A context manager that will revert the instrumentation when exited.
                 Use of this context manager is optional.
         """
+        import openai
+
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
         from .integrations.llm_providers.openai import get_endpoint_config, is_async_client, on_response
 
         return instrument_llm_provider(
             self,
-            openai_client,
+            openai_client or (openai.OpenAI, openai.AsyncOpenAI),
             suppress_other_instrumentation,
             'OpenAI',
             get_endpoint_config,
@@ -885,7 +891,8 @@ class Logfire:
         anthropic_client: anthropic.Anthropic
         | anthropic.AsyncAnthropic
         | type[anthropic.Anthropic]
-        | type[anthropic.AsyncAnthropic],
+        | type[anthropic.AsyncAnthropic]
+        | None = None,
         *,
         suppress_other_instrumentation: bool = True,
     ) -> ContextManager[None]:
@@ -928,12 +935,14 @@ class Logfire:
             A context manager that will revert the instrumentation when exited.
                 Use of this context manager is optional.
         """
+        import anthropic
+
         from .integrations.llm_providers.anthropic import get_endpoint_config, is_async_client, on_response
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
 
         return instrument_llm_provider(
             self,
-            anthropic_client,
+            anthropic_client or (anthropic.Anthropic, anthropic.AsyncAnthropic),
             suppress_other_instrumentation,
             'Anthropic',
             get_endpoint_config,

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -136,6 +136,7 @@ async def instrumented_async_client() -> AsyncIterator[anthropic.AsyncAnthropic]
         # use a hardcoded API key to make sure one in the environment is never used
         anthropic_client = anthropic.AsyncAnthropic(api_key='foobar', http_client=httpx_client)
 
+        # Test instrumenting EVERYTHING
         with logfire.instrument_anthropic():
             yield anthropic_client
 

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -136,7 +136,7 @@ async def instrumented_async_client() -> AsyncIterator[anthropic.AsyncAnthropic]
         # use a hardcoded API key to make sure one in the environment is never used
         anthropic_client = anthropic.AsyncAnthropic(api_key='foobar', http_client=httpx_client)
 
-        with logfire.instrument_anthropic(anthropic_client):
+        with logfire.instrument_anthropic(anthropic.AsyncAnthropic):
             yield anthropic_client
 
 

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -136,7 +136,7 @@ async def instrumented_async_client() -> AsyncIterator[anthropic.AsyncAnthropic]
         # use a hardcoded API key to make sure one in the environment is never used
         anthropic_client = anthropic.AsyncAnthropic(api_key='foobar', http_client=httpx_client)
 
-        with logfire.instrument_anthropic(anthropic.AsyncAnthropic):
+        with logfire.instrument_anthropic():
             yield anthropic_client
 
 

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -199,9 +199,15 @@ def instrumented_client() -> Iterator[openai.Client]:
         # use a hardcoded API key to make sure one in the environment is never used
         openai_client = openai.Client(api_key='foobar', http_client=httpx_client)
 
+        # Test instrumenting a class
         with logfire.instrument_openai(openai.Client):
+            # Test repeatedly instrumenting something already instrumented (should do nothing)
             with logfire.instrument_openai(openai.Client):
-                yield openai_client
+                pass
+            with logfire.instrument_openai(openai_client):
+                pass
+
+            yield openai_client
 
 
 @pytest.fixture

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -199,8 +199,9 @@ def instrumented_client() -> Iterator[openai.Client]:
         # use a hardcoded API key to make sure one in the environment is never used
         openai_client = openai.Client(api_key='foobar', http_client=httpx_client)
 
-        with logfire.instrument_openai(openai_client):
-            yield openai_client
+        with logfire.instrument_openai(openai.Client):
+            with logfire.instrument_openai(openai.Client):
+                yield openai_client
 
 
 @pytest.fixture


### PR DESCRIPTION
For a user who wanted to just `logfire.instrument_openai()` without passing a client, since they want to instrument langchain which doesn't expose/accept an openai client object: https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1715977569378699