### PR TITLE
Add `logfire.instrument_django()`

### DIFF
--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -1,6 +1,8 @@
 # Django
 
-The [OpenTelemetry Instrumentation Django][opentelemetry-django] package can be used to instrument [Django][django].
+The [`logfire.instrument_django()`][logfire.Logfire.instrument_django] function can be used to instrument the [Django][django] web framework with **Logfire**.
+
+See the documentation for the [OpenTelemetry Instrumentation Django][opentelemetry-django] package for more details.
 
 ## Installation
 
@@ -10,22 +12,17 @@ Install `logfire` with the `django` extra:
 
 ## Usage
 
-You need to add the [`DjangoInstrumentor`][django-instrumentor] to your code before your application is started.
-
 In the `settings.py` file, add the following lines:
 
 ```py
 import logfire
-from opentelemetry.instrumentation.django import DjangoInstrumentor
 
 # ...All the other settings...
 
 # Add the following lines at the end of the file
 logfire.configure()
-DjangoInstrumentor().instrument()
+logfire.instrument_django()
 ```
-
-You can read more about the Django OpenTelemetry package [here][opentelemetry-django].
 
 ## Capturing request and response headers
 <!-- note that this section is duplicated for different frameworks but with slightly different links -->

--- a/docs/integrations/django.md
+++ b/docs/integrations/django.md
@@ -1,8 +1,6 @@
 # Django
 
-The [`logfire.instrument_django()`][logfire.Logfire.instrument_django] function can be used to instrument the [Django][django] web framework with **Logfire**.
-
-See the documentation for the [OpenTelemetry Instrumentation Django][opentelemetry-django] package for more details.
+The [`logfire.instrument_django()`][logfire.Logfire.instrument_django] method can be used to instrument the [Django][django] web framework with **Logfire**.
 
 ## Installation
 
@@ -23,6 +21,10 @@ import logfire
 logfire.configure()
 logfire.instrument_django()
 ```
+
+[`logfire.instrument_django()`][logfire.Logfire.instrument_django] uses the
+**OpenTelemetry Django Instrumentation** package,
+which you can find more information about [here][opentelemetry-django].
 
 ## Capturing request and response headers
 <!-- note that this section is duplicated for different frameworks but with slightly different links -->

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -6,7 +6,12 @@ from typing import Any
 
 from ._internal.auto_trace import AutoTraceModule
 from ._internal.auto_trace.rewrite_ast import no_auto_trace
-from ._internal.config import METRICS_PREFERRED_TEMPORALITY, ConsoleOptions, PydanticPlugin, configure
+from ._internal.config import (
+    METRICS_PREFERRED_TEMPORALITY,
+    ConsoleOptions,
+    PydanticPlugin,
+    configure,
+)
 from ._internal.constants import LevelName
 from ._internal.exporters.file import load_file as load_spans_from_file
 from ._internal.main import Logfire, LogfireSpan
@@ -24,6 +29,7 @@ instrument_openai = DEFAULT_LOGFIRE_INSTANCE.instrument_openai
 instrument_anthropic = DEFAULT_LOGFIRE_INSTANCE.instrument_anthropic
 instrument_asyncpg = DEFAULT_LOGFIRE_INSTANCE.instrument_asyncpg
 instrument_psycopg = DEFAULT_LOGFIRE_INSTANCE.instrument_psycopg
+instrument_django = DEFAULT_LOGFIRE_INSTANCE.instrument_django
 shutdown = DEFAULT_LOGFIRE_INSTANCE.shutdown
 with_tags = DEFAULT_LOGFIRE_INSTANCE.with_tags
 # with_trace_sample_rate = DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate

--- a/logfire/_internal/integrations/django.py
+++ b/logfire/_internal/integrations/django.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+
+def instrument_django(**kwargs: Any):
+    """Instrument the `django` module so that spans are automatically created for each web request.
+
+    See the `Logfire.instrument_django` method for details.
+    """
+    DjangoInstrumentor().instrument(**kwargs)  # type: ignore[reportUnknownMemberType]

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -989,35 +989,36 @@ class Logfire:
         is_sql_commentor_enabled: bool | None = None,
         request_hook: Callable[[Span, HttpRequest], None] | None = None,
         response_hook: Callable[[Span, HttpRequest, HttpResponse], None] | None = None,
-        excluded_urls: list[str] | None = None,
+        excluded_urls: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Instrument `django` so that spans are automatically created for each web request.
 
-        Uses the OpenTelemetry instrumentation library for
-        [`django`](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html)
+        Uses the
+        [OpenTelemetry Django Instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/django/django.html)
+        library.
 
         Args:
-            is_sql_commentor_enabled: You can optionally configure django instrumentation to enable
-                sqlcommenter which enriches the query with contextual information.
+            is_sql_commentor_enabled: Adds comments to SQL queries performed by Django,
+                so that database logs have additional context.
+
+                This does NOT create spans/logs for the queries themselves.
+                For that you need to instrument the database driver, e.g. with `logfire.instrument_psycopg()`.
+
+                To configure the SQL Commentor, see the OpenTelemetry documentation for the
+                values that need to be added to `settings.py`.
 
             request_hook: A function called right after a span is created for a request.
-
-            ```py
-            def request_hook(span, request):
-                pass
-            ```
+                The function should accept two arguments: the span and the Django `Request` object.
 
             response_hook: A function called right before a span is finished for the response.
+                The function should accept three arguments:
+                the span, the Django `Request` object, and the Django `Response` object.
 
-            ```py
-            def response_hook(span, request, response):
-                pass
-            ```
-            excluded_urls: To exclude certain URLs from tracking, set the parameter
-                a list of comma delimited regexes that match the URLs to be excluded.
+            excluded_urls: A string containing a comma-delimited list of regexes used to exclude URLs from tracking.
 
-            **kwargs: Additional keyword arguments to pass to the OpenTelemetry `instrument` methods.
+            **kwargs: Additional keyword arguments to pass to the OpenTelemetry `instrument` method,
+                for future compatibility.
 
         """
         from .integrations.django import instrument_django

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -878,11 +878,7 @@ class Logfire:
                 Use of this context manager is optional.
         """
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
-        from .integrations.llm_providers.openai import (
-            get_endpoint_config,
-            is_async_client,
-            on_response,
-        )
+        from .integrations.llm_providers.openai import get_endpoint_config, is_async_client, on_response
 
         return instrument_llm_provider(
             self,
@@ -939,11 +935,7 @@ class Logfire:
             A context manager that will revert the instrumentation when exited.
                 Use of this context manager is optional.
         """
-        from .integrations.llm_providers.anthropic import (
-            get_endpoint_config,
-            is_async_client,
-            on_response,
-        )
+        from .integrations.llm_providers.anthropic import get_endpoint_config, is_async_client, on_response
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
 
         return instrument_llm_provider(

--- a/tests/otel_integrations/django_test_project/django_test_site/settings.py
+++ b/tests/otel_integrations/django_test_project/django_test_site/settings.py
@@ -13,7 +13,7 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 from typing import Any
 
-from opentelemetry.instrumentation.django import DjangoInstrumentor
+import logfire
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -128,4 +128,4 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 LOGGING_CONFIG = None
 
 
-DjangoInstrumentor().instrument()  # type: ignore
+logfire.instrument_django()


### PR DESCRIPTION
Hi All,

I attended the Pydantic development sprint at PyCon US, and I worked with Alex to add a Django-specific wrapper (logfire.instrument_django) to replace the client-direct call to the OpenTelemetry API.  Note, I did not complete the django.md update.

Thanks,
Roger Hurwitz