### PR TITLE
Uprev to version 0.35.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "0.34.0"
+version = "0.35.0"
 description = "The best Python observability tool! 🪵🔥"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },


### PR DESCRIPTION
So that the three new `instrument_*` methods now mentioned in the docs are actually available for use.