### PR TITLE
Allow passing OTEL kwargs through instrument_fastapi

### DIFF
--- a/logfire/_internal/integrations/fastapi.py
+++ b/logfire/_internal/integrations/fastapi.py
@@ -44,6 +44,7 @@ def instrument_fastapi(
     | None = None,
     use_opentelemetry_instrumentation: bool = True,
     excluded_urls: str | Iterable[str] | None = None,
+    **opentelemetry_kwargs: Any,
 ) -> ContextManager[None]:
     """Instrument a FastAPI app so that spans and logs are automatically created for each request.
 
@@ -55,7 +56,7 @@ def instrument_fastapi(
         excluded_urls = ','.join(excluded_urls)
 
     if use_opentelemetry_instrumentation:  # pragma: no branch
-        FastAPIInstrumentor.instrument_app(app, excluded_urls=excluded_urls)  # type: ignore
+        FastAPIInstrumentor.instrument_app(app, excluded_urls=excluded_urls, **opentelemetry_kwargs)  # type: ignore
 
     registry = patch_fastapi()
     if app in registry:  # pragma: no cover

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -856,6 +856,7 @@ class Logfire:
             request_attributes_mapper=request_attributes_mapper,
             excluded_urls=excluded_urls,
             use_opentelemetry_instrumentation=use_opentelemetry_instrumentation,
+            **opentelemetry_kwargs,
         )
 
     def instrument_openai(

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -809,6 +809,7 @@ class Logfire:
         | None = None,
         use_opentelemetry_instrumentation: bool = True,
         excluded_urls: str | Iterable[str] | None = None,
+        **opentelemetry_kwargs: Any,
     ) -> ContextManager[None]:
         """Instrument a FastAPI app so that spans and logs are automatically created for each request.
 
@@ -838,6 +839,7 @@ class Logfire:
                 will also instrument the app.
 
                 See [OpenTelemetry FastAPI Instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/fastapi/fastapi.html).
+            opentelemetry_kwargs: Additional keyword arguments to pass to the OpenTelemetry FastAPI instrumentation.
 
         Returns:
             A context manager that will revert the instrumentation when exited.


### PR DESCRIPTION
Similar to https://github.com/pydantic/logfire/issues/193: `instrument_fastapi` exists but it didn't accept all the arguments of OTEL and encouraged using OTEL directly if those arguments were needed. This changes that, along with some other small doc updates.