### PR TITLE
Retry connection errors

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -673,6 +673,7 @@ class LogfireConfig(_LogfireConfigData):
                                 endpoint=self.metrics_endpoint,
                                 headers=headers,
                                 preferred_temporality=METRICS_PREFERRED_TEMPORALITY,
+                                session=session,
                             )
                         )
                     ]

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -53,7 +53,8 @@ class OTLPExporterHttpSession(Session):
                     continue
                 raise
             return response
-        raise RuntimeError('Unreachable code')
+
+        raise RuntimeError('Unreachable code')  # for pyright
 
     def _check_body_size(self, size: int) -> None:
         if size > self.max_body_size:

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -43,7 +43,7 @@ class OTLPExporterHttpSession(Session):
                 request.body = gen()  # type: ignore
 
         max_attempts = 7
-        for attempt in range(max_attempts):
+        for attempt in range(max_attempts):  # pragma: no branch
             try:
                 response = super().send(request, **kwargs)
             except requests.exceptions.RequestException:
@@ -54,7 +54,7 @@ class OTLPExporterHttpSession(Session):
                 raise
             return response
 
-        raise RuntimeError('Unreachable code')  # for pyright
+        raise RuntimeError('Unreachable code')  # for pyright  # pragma: no cover
 
     def _check_body_size(self, size: int) -> None:
         if size > self.max_body_size:

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import contextlib
+import time
+from random import random
 from typing import Any, Iterable, Sequence, cast
 
+import requests.exceptions
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
 from requests import Session
@@ -38,7 +41,19 @@ class OTLPExporterHttpSession(Session):
                         yield chunk
 
                 request.body = gen()  # type: ignore
-        return super().send(request, **kwargs)
+
+        max_attempts = 7
+        for attempt in range(max_attempts):
+            try:
+                response = super().send(request, **kwargs)
+            except requests.exceptions.RequestException:
+                if attempt < max_attempts - 1:
+                    # Exponential backoff with jitter
+                    time.sleep(2**attempt + random())
+                    continue
+                raise
+            return response
+        raise RuntimeError('Unreachable code')
 
     def _check_body_size(self, size: int) -> None:
         if size > self.max_body_size:


### PR DESCRIPTION
After some investigation, I've found that neither OTEL nor `requests` does any retrying by default when there's a connection or timeout error while making a request.

OTEL does retry on certain status codes in a way that looks sensible so I'm leaving that case as is, although it's not the kind of problem we usually see.

It's possible to configure retries with `requests` but OTEL doesn't do so and it didn't seem easier than just coding the retries myself.