### PR TITLE
Don't configure automatically

### DIFF
--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -795,6 +795,9 @@ class Logfire:
         """
         install_auto_tracing(self, modules, check_imported_modules=check_imported_modules, min_duration=min_duration)
 
+    def _warn_if_not_initialized_for_instrumentation(self):
+        self.config.warn_if_not_initialized('Instrumentation will have no effect')
+
     def instrument_fastapi(
         self,
         app: FastAPI,
@@ -850,6 +853,7 @@ class Logfire:
         """
         from .integrations.fastapi import instrument_fastapi
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_fastapi(
             self,
             app,
@@ -922,6 +926,7 @@ class Logfire:
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
         from .integrations.llm_providers.openai import get_endpoint_config, is_async_client, on_response
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_llm_provider(
             self,
             openai_client or (openai.OpenAI, openai.AsyncOpenAI),
@@ -995,6 +1000,7 @@ class Logfire:
         from .integrations.llm_providers.anthropic import get_endpoint_config, is_async_client, on_response
         from .integrations.llm_providers.llm_provider import instrument_llm_provider
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_llm_provider(
             self,
             anthropic_client or (anthropic.Anthropic, anthropic.AsyncAnthropic),
@@ -1009,6 +1015,7 @@ class Logfire:
         """Instrument the `asyncpg` module so that spans are automatically created for each query."""
         from .integrations.asyncpg import instrument_asyncpg
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_asyncpg()
 
     def instrument_httpx(self, **kwargs: Any):
@@ -1020,6 +1027,7 @@ class Logfire:
         """
         from .integrations.httpx import instrument_httpx
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_httpx(**kwargs)
 
     def instrument_django(
@@ -1061,6 +1069,7 @@ class Logfire:
         """
         from .integrations.django import instrument_django
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_django(
             is_sql_commentor_enabled=is_sql_commentor_enabled,
             request_hook=request_hook,
@@ -1079,6 +1088,7 @@ class Logfire:
         """
         from .integrations.requests import instrument_requests
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_requests(excluded_urls=excluded_urls, **kwargs)
 
     def instrument_psycopg(self, conn_or_module: Any = None, **kwargs: Any):
@@ -1102,6 +1112,7 @@ class Logfire:
         """
         from .integrations.psycopg import instrument_psycopg
 
+        self._warn_if_not_initialized_for_instrumentation()
         return instrument_psycopg(conn_or_module, **kwargs)
 
     def metric_counter(self, name: str, *, unit: str = '', description: str = '') -> Counter:

--- a/tests/otel_integrations/django_test_project/django_test_site/settings.py
+++ b/tests/otel_integrations/django_test_project/django_test_site/settings.py
@@ -13,8 +13,6 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 from pathlib import Path
 from typing import Any
 
-import logfire
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -126,6 +124,3 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGGING_CONFIG = None
-
-
-logfire.instrument_django()

--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -2,10 +2,12 @@ from django.http import HttpResponse
 from django.test import Client
 from inline_snapshot import snapshot
 
+import logfire
 from logfire.testing import TestExporter
 
 
 def test_good_route(client: Client, exporter: TestExporter):
+    logfire.instrument_django()
     response: HttpResponse = client.get(  # type: ignore
         '/django_test_app/123/?very_long_query_param_name=very+long+query+param+value&foo=1'
     )
@@ -41,6 +43,7 @@ def test_good_route(client: Client, exporter: TestExporter):
 
 
 def test_error_route(client: Client, exporter: TestExporter):
+    logfire.instrument_django()
     response: HttpResponse = client.get('/django_test_app/bad/?foo=1')  # type: ignore
     assert response.status_code == 400
 
@@ -84,6 +87,7 @@ def test_error_route(client: Client, exporter: TestExporter):
 
 
 def test_no_matching_route(client: Client, exporter: TestExporter):
+    logfire.instrument_django()
     response: HttpResponse = client.get('/django_test_app/nowhere/?foo=1')  # type: ignore
     assert response.status_code == 404
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -906,7 +906,7 @@ def test_logfire_with_its_own_config(exporter: TestExporter) -> None:
     assert warnings[0].lineno == inspect.currentframe().f_lineno - 9  # type: ignore
 
     with pytest.warns(LogfireNotConfiguredWarning) as warnings:
-        logfire.instrument_httpx()
+        logfire.instrument_django()
 
     assert str(warnings[0].message) == (
         'Instrumentation will have no effect until `logfire.configure()` has been '

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -903,6 +903,17 @@ def test_logfire_with_its_own_config(exporter: TestExporter) -> None:
         'No logs or spans will be created until `logfire.configure()` has been called. '
         'Set the environment variable LOGFIRE_IGNORE_NO_CONFIG=1 to suppress this warning.'
     )
+    assert warnings[0].lineno == inspect.currentframe().f_lineno - 9  # type: ignore
+
+    with pytest.warns(LogfireNotConfiguredWarning) as warnings:
+        logfire.instrument_httpx()
+
+    assert str(warnings[0].message) == (
+        'Instrumentation will have no effect until `logfire.configure()` has been '
+        'called. Set the environment variable LOGFIRE_IGNORE_NO_CONFIG=1 to suppress '
+        'this warning.'
+    )
+    assert warnings[0].lineno == inspect.currentframe().f_lineno - 7  # type: ignore
 
     assert exporter.exported_spans_as_dict(_include_pending_spans=True) == snapshot([])
     assert exporter1.exported_spans_as_dict(_include_pending_spans=True) == snapshot([])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from typing import Any, cast
 
 import pytest
@@ -320,27 +319,6 @@ def test_create_metric_up_down_counter_callback(metrics_reader: InMemoryMetricRe
             }
         ]
     )
-
-
-def test_metrics_without_configure():
-    # Ensure that methods like logfire.metric_counter() can be called without calling logfire.configure().
-    # language=python
-    code = """
-import logfire
-
-config = logfire.DEFAULT_LOGFIRE_INSTANCE._config
-
-def initialize():
-    # Just check that initialize() is called without actually starting metric exporters etc.
-    config._initialized = True
-
-config.initialize = initialize
-
-assert not config._initialized
-logfire.metric_counter('foo')
-assert config._initialized
-    """
-    subprocess.check_call(['python', '-c', code])
 
 
 def get_collected_metrics(metrics_reader: InMemoryMetricReader) -> list[dict[str, Any]]:


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/194

Step 2 there isn't done but I realize now that it's not really a blocker, and there's strong demand for this change.

The implementation here is simple but not ideal. In particular `logfire.span` etc will still do a lot of processing which will slow things down and maybe even raise errors, it's just that the actual OTEL span will be a no-op. But making `logfire.span` a proper no-op is nontrivial since it still needs to return a context manager with methods, and that work overlaps with https://github.com/pydantic/logfire/pull/146. Optimizing this can be done later, and the same strategy can also be applied to checking if the span/log will be sampled out or if instrumentation is currently suppressed.

`logfire.instrument_<module>` will also apply instrumentation including patching, but (1) that's necessary to allow calling `configure` later and having it all just work and (2) that's how OTEL works anyway.