### PR TITLE
Fix docs saying you don't need logfire.configure when using env vars

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -16,7 +16,8 @@ You can use the following environment variables to configure **Logfire**:
 
 {{ env_var_table }}
 
-When using environment variables, you don't need to call [`logfire.configure()`][logfire.configure].
+When using environment variables, you still need to call [`logfire.configure()`][logfire.configure],
+but you can leave out the arguments.
 
 ## Using a configuration file (`pyproject.toml`)
 


### PR DESCRIPTION
For https://github.com/pydantic/logfire/issues/194