### PR TITLE
Improve error raised when opentelemetry.instrumentation.django is not installed

### DIFF
--- a/logfire/_internal/integrations/django.py
+++ b/logfire/_internal/integrations/django.py
@@ -1,6 +1,13 @@
 from typing import Any
 
-from opentelemetry.instrumentation.django import DjangoInstrumentor
+try:
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
+except ModuleNotFoundError:
+    raise RuntimeError(
+        'The `logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.\n'
+        'You can install this with:\n'
+        "    pip install 'logfire[django]'"
+    )
 
 
 def instrument_django(**kwargs: Any):

--- a/logfire/_internal/integrations/django.py
+++ b/logfire/_internal/integrations/django.py
@@ -4,7 +4,7 @@ try:
     from opentelemetry.instrumentation.django import DjangoInstrumentor
 except ModuleNotFoundError:
     raise RuntimeError(
-        'The `logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.\n'
+        'logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.\n'
         'You can install this with:\n'
         "    pip install 'logfire[django]'"
     )

--- a/logfire/_internal/integrations/django.py
+++ b/logfire/_internal/integrations/django.py
@@ -4,7 +4,7 @@ try:
     from opentelemetry.instrumentation.django import DjangoInstrumentor
 except ModuleNotFoundError:
     raise RuntimeError(
-        'logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.\n'
+        '`logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.\n'
         'You can install this with:\n'
         "    pip install 'logfire[django]'"
     )

--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -129,7 +129,7 @@ def test_missing_opentelemetry_dependency() -> None:
         with pytest.raises(RuntimeError) as exc_info:
             importlib.reload(logfire._internal.integrations.django)
         assert str(exc_info.value) == snapshot("""\
-The `logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.
+`logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.
 You can install this with:
     pip install 'logfire[django]'\
 """)

--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -1,8 +1,15 @@
+import importlib
+from unittest import mock
+
+import pytest
 from django.http import HttpResponse
 from django.test import Client
 from inline_snapshot import snapshot
 
 import logfire
+import logfire._internal
+import logfire._internal.integrations
+import logfire._internal.integrations.django
 from logfire.testing import TestExporter
 
 
@@ -115,3 +122,14 @@ def test_no_matching_route(client: Client, exporter: TestExporter):
             }
         ]
     )
+
+
+def test_missing_opentelemetry_dependency() -> None:
+    with mock.patch.dict('sys.modules', {'opentelemetry.instrumentation.django': None}):
+        with pytest.raises(RuntimeError) as exc_info:
+            importlib.reload(logfire._internal.integrations.django)
+        assert str(exc_info.value) == snapshot("""\
+The `logfire.instrument_django()` requires the `opentelemetry-instrumentation-django` package.
+You can install this with:
+    pip install 'logfire[django]'\
+""")


### PR DESCRIPTION
I was looking through the logfire integrations with frameworks and libraries and found that a `ModuleNotFoundError` was not being raised in the django integration so I have added it here.