### PR TITLE
Raise error if use `logfire clean` on home directory

### DIFF
--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -77,7 +77,6 @@ def parse_whoami(args: argparse.Namespace) -> None:
 
 def parse_clean(args: argparse.Namespace) -> None:
     """Remove the contents of the Logfire data directory."""
-    # Check if running directory is HOME_LOGFIRE.
     if Path.cwd() == Path.home():
         sys.stderr.write('The clean command cannot be run in the home directory. ')
         sys.stderr.write('Please run the command from a different directory.\n')

--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -77,6 +77,12 @@ def parse_whoami(args: argparse.Namespace) -> None:
 
 def parse_clean(args: argparse.Namespace) -> None:
     """Remove the contents of the Logfire data directory."""
+    # Check if running directory is HOME_LOGFIRE.
+    if Path.cwd() == Path.home():
+        sys.stderr.write('The clean command cannot be run in the home directory. ')
+        sys.stderr.write('Please run the command from a different directory.\n')
+        sys.exit(1)
+
     if args.logs and LOGFIRE_LOG_FILE.exists():
         LOGFIRE_LOG_FILE.unlink()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -141,6 +141,23 @@ def test_clean(
     assert capsys.readouterr().err == output
 
 
+def test_clean_home_dir(
+    tmp_dir_cwd: Path,
+    logfire_credentials: LogfireCredentials,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, 'stdin', io.StringIO('y'))
+    monkeypatch.setattr(Path, 'home', lambda: tmp_dir_cwd)
+    logfire_credentials.write_creds_file(tmp_dir_cwd)
+    with pytest.raises(SystemExit) as exc:
+        main(['clean'])
+    assert capsys.readouterr().err == (
+        'The clean command cannot be run in the home directory. Please run the command from a different directory.\n'
+    )
+    assert exc.value.code == 1
+
+
 def test_clean_default_dir_does_not_exist(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc:
         main(shlex.split('clean --data-dir potato'))


### PR DESCRIPTION
https://linear.app/pydantic/issue/PYD-875/logfire-clean-documentation-is-wrong