### PR TITLE
Fix backfill command

### DIFF
--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -128,7 +128,9 @@ def parse_backfill(args: argparse.Namespace) -> None:  # pragma: no cover
                     progress.update(task, completed=f.tell())
 
             url = urljoin(config.base_url, '/v1/backfill/traces')
-            response = requests.post(url, data=reader(), headers={'Content-Length': str(total)})
+            response = requests.post(
+                url, data=reader(), headers={'Authorization': token, 'User-Agent': f'logfire/{VERSION}'}
+            )
             if response.status_code != 200:
                 try:
                     data = response.json()


### PR DESCRIPTION
`logfire backfill` would just print a 400 from cloudflare which was apparently unhappy about the `Content-Length` header (I don't know why). It was also missing `Authorization`.

We should test and maybe refactor this, I just wanted to make sure the command is working.