### PR TITLE
Avoid importing gitpython

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1226,22 +1226,11 @@ def _get_creds_file(creds_dir: Path) -> Path:
     return creds_dir / CREDENTIALS_FILENAME
 
 
-try:
-    import git
+def get_git_revision_hash() -> str:
+    """Get the current git commit hash."""
+    import subprocess
 
-    def get_git_revision_hash() -> str:
-        repo = git.Repo(search_parent_directories=True)
-        return repo.head.object.hexsha
-
-except ImportError:  # pragma: no cover
-    # gitpython is not installed
-    # fall back to using the git command line
-
-    def get_git_revision_hash() -> str:
-        """Get the current git commit hash."""
-        import subprocess
-
-        return subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.STDOUT).decode('ascii').strip()
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD'], stderr=subprocess.STDOUT).decode('ascii').strip()
 
 
 def sanitize_project_name(name: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ dev-dependencies = [
     "opentelemetry-instrumentation-psycopg2",
     "opentelemetry-instrumentation-redis",
     "opentelemetry-instrumentation-pymongo",
-    "gitpython",
     "eval-type-backport",
     "requests-mock",
     "inline-snapshot",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -89,9 +89,6 @@ fsspec==2024.6.0
     # via huggingface-hub
 ghp-import==2.1.0
     # via mkdocs
-gitdb==4.0.11
-    # via gitpython
-gitpython==3.1.43
 googleapis-common-protos==1.63.1
     # via opentelemetry-exporter-otlp-proto-http
 griffe==0.45.2
@@ -373,8 +370,6 @@ shellingham==1.5.4
 six==1.16.0
     # via asttokens
     # via python-dateutil
-smmap==5.0.1
-    # via gitdb
 sniffio==1.3.1
     # via anthropic
     # via anyio


### PR DESCRIPTION
https://pydantic.slack.com/archives/C05AF4A4WRM/p1718135501452089

`import git` is quite slow so this could improve startup time a bit in some cases. Even if somehow gitpython does this job better than using subprocess, this won't matter when `.git` isn't present, which it shouldn't be in production environments.