### PR TITLE
[PYD-617] Remove default for modules parameter of `install_auto_tracing`

### DIFF
--- a/logfire/_internal/auto_trace/__init__.py
+++ b/logfire/_internal/auto_trace/__init__.py
@@ -23,10 +23,10 @@ def install_auto_tracing(
 
     See `Logfire.install_auto_tracing` for more information.
     """
-    if isinstance(modules, Sequence):  # pragma: no branch
+    if isinstance(modules, Sequence):
         modules = modules_func_from_sequence(modules)
 
-    if not callable(modules):  # pragma: no cover
+    if not callable(modules):
         raise TypeError('modules must be a list of strings or a callable')
 
     if check_imported_modules not in ('error', 'warn', 'ignore'):

--- a/logfire/_internal/auto_trace/__init__.py
+++ b/logfire/_internal/auto_trace/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import inspect
 import sys
 import warnings
 from typing import TYPE_CHECKING, Callable, Literal, Sequence
@@ -15,7 +14,7 @@ if TYPE_CHECKING:
 
 def install_auto_tracing(
     logfire: Logfire,
-    modules: Sequence[str] | Callable[[AutoTraceModule], bool] | None = None,
+    modules: Sequence[str] | Callable[[AutoTraceModule], bool],
     *,
     check_imported_modules: Literal['error', 'warn', 'ignore'] = 'error',
     min_duration: float = 0,
@@ -24,13 +23,7 @@ def install_auto_tracing(
 
     See `Logfire.install_auto_tracing` for more information.
     """
-    if modules is None:
-        frame = inspect.stack()[2]
-        module = inspect.getmodule(frame[0])
-        if module is None:  # pragma: no cover
-            raise KeyError('module not found')
-        modules = modules_func_from_sequence([module.__name__.split('.')[0]])
-    elif isinstance(modules, Sequence):  # pragma: no branch
+    if isinstance(modules, Sequence):  # pragma: no branch
         modules = modules_func_from_sequence(modules)
 
     if not callable(modules):  # pragma: no cover

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -774,7 +774,7 @@ class Logfire:
 
     def install_auto_tracing(
         self,
-        modules: Sequence[str] | Callable[[AutoTraceModule], bool] | None = None,
+        modules: Sequence[str] | Callable[[AutoTraceModule], bool],
         *,
         check_imported_modules: Literal['error', 'warn', 'ignore'] = 'error',
         min_duration: float = 0,
@@ -797,9 +797,6 @@ class Logfire:
         Args:
             modules: List of module names to trace, or a function which returns True for modules that should be traced.
                 If a list is provided, any submodules within a given module will also be traced.
-
-                Defaults to the root of the calling module, so e.g. calling this inside the module `foo.bar`
-                will trace all functions in `foo`, `foo.bar`, `foo.spam`, etc.
             check_imported_modules: If this is `'error'` (the default), then an exception will be raised if any of the
                 modules in `sys.modules` (i.e. modules that have already been imported) match the modules to trace.
                 Set to `'warn'` to issue a warning instead, or `'ignore'` to skip the check.

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -38,6 +38,9 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
 
     from tests.auto_trace_samples import foo
 
+    # Check ignoring imported modules
+    install_auto_tracing('tests.auto_trace_samples', check_imported_modules='ignore')
+
     loader = foo.__loader__
     assert isinstance(loader, LogfireLoader)
     # The exact plain loader here isn't that essential.

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -495,3 +495,8 @@ def test_min_duration(exporter: TestExporter):
             },
         ]
     )
+
+
+def test_wrong_type_modules():
+    with pytest.raises(TypeError, match='modules must be a list of strings or a callable'):
+        install_auto_tracing(123)  # type: ignore

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -163,41 +163,21 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
     )
 
 
-def test_default_modules() -> None:
+def test_check_already_imported() -> None:
     # Check that nothing gets imported during this test,
     # because we don't want anything to get auto-traced here.
     imported_modules = set(sys.modules.items())
 
-    # Test the default module filter argument of install_auto_tracing.
-    # Since we're in `tests.test_auto_trace`, it should match anything in the `tests` package.
-    # Since this has obviously already been imported, it requires `check_imported_modules='ignore'`.
-    with pytest.raises(AutoTraceModuleAlreadyImportedException, match=r"The module 'tests' matches modules to trace"):
-        install_auto_tracing()
+    with pytest.raises(AutoTraceModuleAlreadyImportedException, match=r"The module 'tests.*' matches modules to trace"):
+        install_auto_tracing(['tests'])
 
-    with pytest.raises(AutoTraceModuleAlreadyImportedWarning, match=r"The module 'tests' matches modules to trace"):
-        install_auto_tracing(check_imported_modules='warn')
+    with pytest.warns(AutoTraceModuleAlreadyImportedWarning, match=r"The module 'tests.*' matches modules to trace"):
+        install_auto_tracing(['tests'], check_imported_modules='warn')
 
     with pytest.raises(ValueError):
-        install_auto_tracing(check_imported_modules='other')  # type: ignore
+        install_auto_tracing(['tests'], check_imported_modules='other')  # type: ignore
 
-    # This should match anything in the `tests` package, so remove the finder at the end of the test.
-    meta_path = sys.meta_path.copy()
-    install_auto_tracing(check_imported_modules='ignore')
-    assert sys.meta_path[1:] == meta_path
-    finder = sys.meta_path[0]
-
-    try:
-        assert isinstance(finder, LogfireFinder)
-        assert finder.modules_filter(AutoTraceModule('tests', '<filename>'))
-        assert finder.modules_filter(AutoTraceModule('tests.foo', '<filename>'))
-        assert finder.modules_filter(AutoTraceModule('tests.bar.baz', '<filename>'))
-        assert not finder.modules_filter(AutoTraceModule('test', '<filename>'))
-        assert not finder.modules_filter(AutoTraceModule('tests_foo', '<filename>'))
-        assert not finder.modules_filter(AutoTraceModule('foo.bar.baz', '<filename>'))
-    finally:
-        assert sys.meta_path.pop(0) == finder
-        assert sys.meta_path == meta_path
-        assert set(sys.modules.items()) == imported_modules
+    assert set(sys.modules.items()) == imported_modules
 
 
 # language=Python


### PR DESCRIPTION
Currently by default:

- Modules under the root of the current module are traced if no modules are specified
- An error is raised if modules to be traced have already been imported

This means that providing no arguments will always raise an error about wanting to trace the current module which has obviously already been imported. Either `modules` or `check_imported_modules` must be specified. This is a bit weird.

This PR makes things less weird by requiring the user to specify `modules`. This seems like a case where explicit really is better than implicit.