### PR TITLE
Default the log level to error if the status code is error, and vice versa

### DIFF
--- a/logfire/_internal/exporters/processor_wrapper.py
+++ b/logfire/_internal/exporters/processor_wrapper.py
@@ -6,11 +6,14 @@ from opentelemetry import context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.semconv.trace import SpanAttributes
+from opentelemetry.trace import Status, StatusCode
 
 from ..constants import (
+    ATTRIBUTES_LOG_LEVEL_NUM_KEY,
     ATTRIBUTES_MESSAGE_KEY,
     ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
     ATTRIBUTES_SPAN_TYPE_KEY,
+    LEVEL_NUMBERS,
     PENDING_SPAN_NAME_SUFFIX,
     log_level_attributes,
 )
@@ -45,6 +48,7 @@ class SpanProcessorWrapper(SpanProcessor):
         span_dict = span_to_dict(span)
         _tweak_asgi_send_receive_spans(span_dict)
         _tweak_http_spans(span_dict)
+        _set_error_level_and_status(span_dict)
         self.scrubber.scrub_span(span_dict)
         span = ReadableSpan(**span_dict)
         self.processor.on_end(span)
@@ -54,6 +58,21 @@ class SpanProcessorWrapper(SpanProcessor):
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return self.processor.force_flush(timeout_millis)  # pragma: no cover
+
+
+def _set_error_level_and_status(span: ReadableSpanDict) -> None:
+    """Default the log level to error if the status code is error, and vice versa.
+
+    This makes querying for `level` and `otel_status_code` interchangeable ways to find errors.
+    """
+    status = span['status']
+    attributes = span['attributes']
+    if status.status_code == StatusCode.ERROR and ATTRIBUTES_LOG_LEVEL_NUM_KEY not in attributes:
+        span['attributes'] = {**attributes, **log_level_attributes('error')}
+    elif status.is_unset:
+        level = attributes.get(ATTRIBUTES_LOG_LEVEL_NUM_KEY)
+        if isinstance(level, int) and level >= LEVEL_NUMBERS['error']:
+            span['status'] = Status(status_code=StatusCode.ERROR, description=status.description)
 
 
 def _set_log_level_on_asgi_send_receive_spans(span: Span) -> None:

--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -75,6 +75,7 @@ def test_error_route(client: Client, exporter: TestExporter):
                     'http.route': 'django_test_app/bad/',
                     'http.status_code': 400,
                     'http.target': '/django_test_app/bad/',
+                    'logfire.level_num': 17,
                 },
                 'events': [
                     {

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -756,6 +756,7 @@ def test_fastapi_unhandled_exception(client: TestClient, exporter: TestExporter)
                     'net.peer.ip': 'testclient',
                     'net.peer.port': 50000,
                     'http.route': '/exception',
+                    'logfire.level_num': 17,
                 },
                 'events': [
                     {

--- a/tests/otel_integrations/test_starlette.py
+++ b/tests/otel_integrations/test_starlette.py
@@ -177,6 +177,7 @@ def test_scrubbing(client: TestClient, exporter: TestExporter) -> None:
                     'net.peer.port': 50000,
                     'http.route': '/secret/{path_param}',
                     'http.request.header.testauthorization': ("[Redacted due to 'auth']",),
+                    'logfire.level_num': 17,
                 },
                 'events': [
                     {


### PR DESCRIPTION
- If `otel_status_code` is `ERROR` and the log level is unset, then the log level is set to error. This way a query for `level >= level_num('error')` will generally find all kinds of errors.
- Similarly, if the log level is >= error and `otel_status_code` is `UNSET`, then `otel_status_code` is set to `ERROR`. This means that `otel_status_code = 'ERROR'` will find all errors in the same way. I think I've seen some users querying `otel_status_code` so this will make that easy and discoverable, whereas querying `level` is not super user-friendly.