### PR TITLE
Fix query params not being in message

### DIFF
--- a/logfire/_internal/exporters/processor_wrapper.py
+++ b/logfire/_internal/exporters/processor_wrapper.py
@@ -174,30 +174,35 @@ def _tweak_http_spans(span: ReadableSpanDict):
             new_name += PENDING_SPAN_NAME_SUFFIX
         span['name'] = new_name
 
-    if messages and (message := messages[-1]) != name:
-        # Add query params to the message if:
-        # 1. The message currently ends with the target
-        # 2. We have a URL to parse query params from
-        # 3. Some query params exist
-        # 4. The target doesn't already end with the query string
-        #       (it's supposed to according to the spec, but the OTEL libraries don't include it)
-        if (
-            url and target and isinstance(url, str) and isinstance(target, str) and message.endswith(target)
-        ):  # pragma: no branch
-            query_string = urlparse(url).query
-            query_params = parse_qs(query_string)
-            if query_params and not target.endswith(query_string):
-                pairs = [(k, v) for k, vs in query_params.items() for v in vs]
-                # Put shorter query params first so that they'll be visible in the UI even if the whole message isn't.
-                pairs.sort(key=lambda pair: (len(pair[0]) + len(pair[1]), pair))
-                # Limit keys and values to 20 chars each.
-                truncated_pairs = [[truncate_string(s, max_length=20, middle='…') for s in pair] for pair in pairs]
-                # Show
-                #   /path?foo=1&bar=2%203
-                # as:
-                #   /path ? foo='1' & bar='2 3'
-                # to make things nice and readable.
-                # Note that we show decoded values, e.g. %20 -> ' '.
-                message += ' ? ' + ' & '.join(f'{k}={v!r}' for k, v in truncated_pairs)
+    if not messages:
+        return
 
+    message = messages[-1]
+
+    # Add query params to the message if:
+    # 1. The message currently ends with the target
+    # 2. We have a URL to parse query params from
+    # 3. Some query params exist
+    # 4. The target doesn't already end with the query string
+    #       (it's supposed to according to the spec, but the OTEL libraries don't include it)
+    if (
+        url and target and isinstance(url, str) and isinstance(target, str) and message.endswith(target)
+    ):  # pragma: no branch
+        query_string = urlparse(url).query
+        query_params = parse_qs(query_string)
+        if query_params and not target.endswith(query_string):
+            pairs = [(k, v) for k, vs in query_params.items() for v in vs]
+            # Put shorter query params first so that they'll be visible in the UI even if the whole message isn't.
+            pairs.sort(key=lambda pair: (len(pair[0]) + len(pair[1]), pair))
+            # Limit keys and values to 20 chars each.
+            truncated_pairs = [[truncate_string(s, max_length=20, middle='…') for s in pair] for pair in pairs]
+            # Show
+            #   /path?foo=1&bar=2%203
+            # as:
+            #   /path ? foo='1' & bar='2 3'
+            # to make things nice and readable.
+            # Note that we show decoded values, e.g. %20 -> ' '.
+            message += ' ? ' + ' & '.join(f'{k}={v!r}' for k, v in truncated_pairs)
+
+    if message != name:
         span['attributes'] = {**attributes, ATTRIBUTES_MESSAGE_KEY: message}

--- a/logfire/_internal/exporters/processor_wrapper.py
+++ b/logfire/_internal/exporters/processor_wrapper.py
@@ -174,7 +174,7 @@ def _tweak_http_spans(span: ReadableSpanDict):
             new_name += PENDING_SPAN_NAME_SUFFIX
         span['name'] = new_name
 
-    if not messages:
+    if not messages:  # pragma: no cover
         return
 
     message = messages[-1]

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -670,7 +670,7 @@ def test_fastapi_arguments(client: TestClient, exporter: TestExporter) -> None:
                 'end_time': 8000000000,
                 'attributes': {
                     'logfire.span_type': 'span',
-                    'logfire.msg': 'GET /other',
+                    'logfire.msg': "GET /other ? bar='bar_val' & foo='foo_val'",
                     'http.scheme': 'http',
                     'http.host': 'testserver',
                     'net.host.port': 80,
@@ -786,7 +786,7 @@ def test_get_fastapi_arguments(client: TestClient, exporter: TestExporter) -> No
                 'end_time': 10000000000,
                 'attributes': {
                     'logfire.span_type': 'span',
-                    'logfire.msg': 'GET /other',
+                    'logfire.msg': "GET /other ? bar='1' & foo='foo_val'",
                     'http.scheme': 'http',
                     'http.host': 'testserver',
                     'net.host.port': 80,


### PR DESCRIPTION
Fixes a small bug noticed in https://github.com/pydantic/logfire/pull/259#issuecomment-2180710771 (thanks @sneakyPad!) which happened when `http.route` and `http.target` were equal. The check for `message != name` is only for optimization and shouldn't have prevented the message from having the query params.