### PR TITLE
`suppress_instrumentation` when retrying exports

### DIFF
--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -161,7 +161,8 @@ class DiskRetryer:
                     # and then come back up then retry requests will be spread out over a time of MAX_DELAY.
                     time.sleep(delay * (1 + random.random()))
                     try:
-                        response = self.session.post(**kwargs, data=data)
+                        with logfire.suppress_instrumentation():
+                            response = self.session.post(**kwargs, data=data)
                         raise_for_retryable_status(response)
                     except requests.exceptions.RequestException:
                         # Failed, increase delay exponentially up to MAX_DELAY.


### PR DESCRIPTION
So that instrumenting `requests` doesn't create spans like `POST /v1/traces`.

Tested manually by running the following script with and without these changes and without WiFi:

```python
import time

import logfire

logfire.configure()

logfire.instrument_requests()

logfire.info('hi')
logfire.force_flush()
time.sleep(100)
```