### PR TITLE
Log async stack in `log_slow_async_callbacks`

### DIFF
--- a/logfire/_internal/async_.py
+++ b/logfire/_internal/async_.py
@@ -96,9 +96,11 @@ def _callback_attributes(callback: Any) -> _CallbackAttributes:
         if function_name := stack_info.get('code.function'):  # pragma: no branch
             result['name'] += f' ({function_name})'
 
+        # Walk through the coroutines being awaited to create an 'async stacktrace'
         stack = [stack_info]
         while isinstance(coro := coro.cr_await, CoroutineType):
             stack_info = stack_info_from_coroutine(coro)  # type: ignore
+            # Ignore frames from the stdlib asyncio
             if not stack_info.get('code.filepath', '').startswith(ASYNCIO_PATH):
                 stack.append(stack_info)
         result['stack'] = stack

--- a/tests/test_slow_async_callbacks.py
+++ b/tests/test_slow_async_callbacks.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio.events import Handle
 
 import pytest
-from dirty_equals import IsInt
+from dirty_equals import IsInt, IsJson
 from inline_snapshot import snapshot
 
 import logfire
@@ -65,7 +65,16 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'code.lineno': 28,
                     'duration': 2.0,
                     'name': 'task foo 1 (foo)',
-                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
+                    'stack': IsJson(
+                        [
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'foo',
+                                'code.lineno': 28,
+                            }
+                        ]
+                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
                     'logfire.tags': ('slow-async',),
                 },
             },
@@ -85,7 +94,21 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'code.lineno': 15,
                     'duration': 2.0,
                     'name': 'task bar 1 (bar)',
-                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
+                    'stack': IsJson(
+                        [
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'bar',
+                                'code.lineno': 15,
+                            },
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'foo',
+                                'code.lineno': 28,
+                            },
+                        ]
+                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
                     'logfire.tags': ('slow-async',),
                 },
             },
@@ -105,7 +128,16 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'code.lineno': 18,
                     'duration': 3.0,
                     'name': 'task bar 1 (bar)',
-                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
+                    'stack': IsJson(
+                        [
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'bar',
+                                'code.lineno': 18,
+                            }
+                        ]
+                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
                     'logfire.tags': ('slow-async',),
                 },
             },
@@ -125,7 +157,16 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'code.lineno': 28,
                     'duration': 2.0,
                     'name': 'task foo 2 (foo)',
-                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
+                    'stack': IsJson(
+                        [
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'foo',
+                                'code.lineno': 28,
+                            }
+                        ]
+                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
                     'logfire.tags': ('slow-async',),
                 },
             },
@@ -145,7 +186,16 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'code.lineno': 14,
                     'duration': 4.0,
                     'name': 'task bar 1 (bar)',
-                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
+                    'stack': IsJson(
+                        [
+                            {
+                                'code.filepath': 'tests/import_used_for_tests/slow_async_callbacks_example.py',
+                                'code.function': 'bar',
+                                'code.lineno': 14,
+                            }
+                        ]
+                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
                     'logfire.tags': ('slow-async',),
                 },
             },


### PR DESCRIPTION
First part of https://linear.app/pydantic/issue/PYD-588/more-information-when-logging-slow-async-callbacks

Should help with https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1719393315909219?thread_ts=1719218705.208939&cid=C06EDRBSAH3