### PR TITLE
Add verbosity to logfire-api release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,8 @@ jobs:
 
       - name: Publish logfire to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
 
       - name: Build logfire-api
         run: rye build
@@ -158,3 +160,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: logfire-api/dist
+          verbose: true


### PR DESCRIPTION
@alexmojaki I'll recreate the tag with this commit, and run the pipeline. I don't want to release multiple versions all the time...