### PR TITLE
Fix recursive logging from OTEL's `BatchSpanProcessor`

### DIFF
--- a/logfire/_internal/exporters/processor_wrapper.py
+++ b/logfire/_internal/exporters/processor_wrapper.py
@@ -8,6 +8,8 @@ from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from opentelemetry.semconv.trace import SpanAttributes
 from opentelemetry.trace import Status, StatusCode
 
+import logfire
+
 from ..constants import (
     ATTRIBUTES_LOG_LEVEL_NUM_KEY,
     ATTRIBUTES_MESSAGE_KEY,
@@ -41,7 +43,8 @@ class MainSpanProcessorWrapper(WrapperSpanProcessor):
         if is_instrumentation_suppressed():
             return
         _set_log_level_on_asgi_send_receive_spans(span)
-        super().on_start(span, parent_context)
+        with logfire.suppress_instrumentation():
+            super().on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan) -> None:
         if is_instrumentation_suppressed():
@@ -52,7 +55,8 @@ class MainSpanProcessorWrapper(WrapperSpanProcessor):
         _set_error_level_and_status(span_dict)
         self.scrubber.scrub_span(span_dict)
         span = ReadableSpan(**span_dict)
-        super().on_end(span)
+        with logfire.suppress_instrumentation():
+            super().on_end(span)
 
 
 def _set_error_level_and_status(span: ReadableSpanDict) -> None:

--- a/logfire/_internal/exporters/wrapper.py
+++ b/logfire/_internal/exporters/wrapper.py
@@ -8,6 +8,8 @@ from opentelemetry.sdk.metrics.view import Aggregation
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
+import logfire
+
 
 class WrapperSpanExporter(SpanExporter):
     """A base class for SpanExporters that wrap another exporter."""
@@ -60,7 +62,9 @@ class WrapperSpanProcessor(SpanProcessor):
         self.processor.on_end(span)
 
     def shutdown(self) -> None:
-        self.processor.shutdown()
+        with logfire.suppress_instrumentation():
+            self.processor.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return self.processor.force_flush(timeout_millis)  # pragma: no cover
+        with logfire.suppress_instrumentation():
+            return self.processor.force_flush(timeout_millis)

--- a/tests/test_stdlib_logging.py
+++ b/tests/test_stdlib_logging.py
@@ -275,7 +275,8 @@ def test_logging_from_opentelemetry(exporter: TestExporter) -> None:
         logging.error('test')  # sanity check
 
         # This causes OTEL to log a warning.
-        # Unlike the test above, there's no risk of recursion since the exporter doesn't raise errors.
+        # Unlike the test_recursive_logging* tests above,
+        # there's no risk of recursion since the exporter doesn't raise errors.
         # So the log appears in the exported spans below.
         Status(description=4)  # type: ignore
 


### PR DESCRIPTION
Fixes a problem reported in https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1720181277066769

Script to reproduce a similar problem before this PR:

```python
import atexit
import logging
from logging import basicConfig

import logfire

atexit.register(lambda *_: logging.error('!!!!'))

logfire.configure(console=False)

basicConfig(handlers=[logfire.LogfireLoggingHandler()])

for _ in range(10000):
    logfire.info('hi')
```

The logging in a loop fills up the queue which leads to this hellish traceback being logged:

```pytb
Internal error in Logfire
Traceback (most recent call last):
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 236, in handle_internal_errors
    yield
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 654, in log
    span = tracer.start_span(
           ^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/tracer.py", line 188, in start_span
    span = self.tracer.start_span(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 1165, in start_span
    span.start(start_time=start_time, parent_context=context)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 922, in start
    self._span_processor.on_start(self, parent_context=parent_context)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 164, in on_start
    sp.on_start(span, parent_context=parent_context)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/processor_wrapper.py", line 41, in on_start
    if is_instrumentation_suppressed():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 212, in is_instrumentation_suppressed
    return any(context.get_value(key) for key in SUPPRESS_INSTRUMENTATION_CONTEXT_KEYS)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 212, in <genexpr>
    return any(context.get_value(key) for key in SUPPRESS_INSTRUMENTATION_CONTEXT_KEYS)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/context/__init__.py", line 96, in get_value
    return context.get(key) if context is not None else get_current().get(key)
                                                        ^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/context/__init__.py", line 130, in get_current
    return _RUNTIME_CONTEXT.get_current()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 236, in handle_internal_errors
    yield
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 670, in log
    span.end(start_time)
  File "/Users/alex/work/logfire/logfire/_internal/tracer.py", line 103, in end
    self.span.end(end_time or self.ns_timestamp_generator())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 934, in end
    self._span_processor.on_end(self._readable_span())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 168, in on_end
    sp.on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/processor_wrapper.py", line 55, in on_end
    super().on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/wrapper.py", line 60, in on_end
    self.processor.on_end(span)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 228, in on_end
    logger.warning("Queue is full, likely spans will be dropped.")
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1551, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 70, in emit
    logfire.log(
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 591, in log
    with handle_internal_errors():
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 238, in handle_internal_errors
    log_internal_error()
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 230, in log_internal_error
    logger.exception('Internal error in Logfire')
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1574, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1682, in _log
    record = self.makeRecord(self.name, level, fn, lno, msg, args,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1651, in makeRecord
    rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 332, in __init__
    self.filename = os.path.basename(pathname)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 172, in basename
RecursionError: maximum recursion depth exceeded

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 236, in handle_internal_errors
    yield
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 670, in log
    span.end(start_time)
  File "/Users/alex/work/logfire/logfire/_internal/tracer.py", line 103, in end
    self.span.end(end_time or self.ns_timestamp_generator())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 934, in end
    self._span_processor.on_end(self._readable_span())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 168, in on_end
    sp.on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/processor_wrapper.py", line 55, in on_end
    super().on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/wrapper.py", line 60, in on_end
    self.processor.on_end(span)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 228, in on_end
    logger.warning("Queue is full, likely spans will be dropped.")
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1551, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 70, in emit
    logfire.log(
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 591, in log
    with handle_internal_errors():
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 238, in handle_internal_errors
    log_internal_error()
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 230, in log_internal_error
    logger.exception('Internal error in Logfire')
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1574, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 65, in emit
    self.fallback.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 711, in format
    record.exc_text = self.formatException(record.exc_info)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 661, in formatException
    traceback.print_exception(ei[0], ei[1], tb, None, sio)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/traceback.py", line 124, in print_exception
    te = TracebackException(type(value), value, tb, limit=limit, compact=True)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/traceback.py", line 733, in __init__
    self.stack = StackSummary._extract_from_extended_frame_gen(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/traceback.py", line 438, in _extract_from_extended_frame_gen
    f.line
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/traceback.py", line 323, in line
    self._line = linecache.getline(self.filename, self.lineno)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/linecache.py", line 30, in getline
    lines = getlines(filename, module_globals)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/linecache.py", line 46, in getlines
    return updatecache(filename, module_globals)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/linecache.py", line 136, in updatecache
    with tokenize.open(fullname) as fp:
         ^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```

and the attempt to log something when shutting down logs:

```pytb
Internal error in Logfire
Traceback (most recent call last):
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 236, in handle_internal_errors
    yield
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 670, in log
    span.end(start_time)
  File "/Users/alex/work/logfire/logfire/_internal/tracer.py", line 103, in end
    self.span.end(end_time or self.ns_timestamp_generator())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 934, in end
    self._span_processor.on_end(self._readable_span())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 168, in on_end
    sp.on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/processor_wrapper.py", line 55, in on_end
    super().on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/wrapper.py", line 60, in on_end
    self.processor.on_end(span)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 219, in on_end
    logger.warning("Already shutdown, dropping span.")
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1551, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 64, in emit
    if is_instrumentation_suppressed():
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 212, in is_instrumentation_suppressed
    return any(context.get_value(key) for key in SUPPRESS_INSTRUMENTATION_CONTEXT_KEYS)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 212, in <genexpr>
    return any(context.get_value(key) for key in SUPPRESS_INSTRUMENTATION_CONTEXT_KEYS)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/context/__init__.py", line 96, in get_value
    return context.get(key) if context is not None else get_current().get(key)
                                                        ^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/context/__init__.py", line 130, in get_current
    return _RUNTIME_CONTEXT.get_current()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 236, in handle_internal_errors
    yield
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 670, in log
    span.end(start_time)
  File "/Users/alex/work/logfire/logfire/_internal/tracer.py", line 103, in end
    self.span.end(end_time or self.ns_timestamp_generator())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 934, in end
    self._span_processor.on_end(self._readable_span())
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/__init__.py", line 168, in on_end
    sp.on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/processor_wrapper.py", line 55, in on_end
    super().on_end(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/wrapper.py", line 60, in on_end
    self.processor.on_end(span)
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 219, in on_end
    logger.warning("Already shutdown, dropping span.")
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1551, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 70, in emit
    logfire.log(
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 591, in log
    with handle_internal_errors():
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 238, in handle_internal_errors
    log_internal_error()
  File "/Users/alex/work/logfire/logfire/_internal/utils.py", line 230, in log_internal_error
    logger.exception('Internal error in Logfire')
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1574, in exception
    self.error(msg, *args, exc_info=exc_info, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1568, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/work/logfire/logfire/integrations/logging.py", line 65, in emit
    self.fallback.handle(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1028, in handle
    self.emit(record)
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 1160, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 999, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 706, in format
    s = self.formatMessage(record)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 675, in formatMessage
    return self._style.format(record)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/.rye/py/cpython@3.12.3/lib/python3.12/logging/__init__.py", line 464, in format
    return self._format(record)
           ^^^^^^^^^^^^^^^^^^^^
RecursionError: maximum recursion depth exceeded
```

Both of these are fixed here with one `with logfire.suppress_instrumentation():` in `MainSpanProcessorWrapper.on_end`. Similar lines are added elsewhere for extra caution.

Also refactored some tests similar to the one I added.