### PR TITLE
Handle and test other OpenAI/Anthropic  client methods

### DIFF
--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -13,7 +13,6 @@ if TYPE_CHECKING:
 
     from ...main import LogfireSpan
 
-
 __all__ = (
     'get_endpoint_config',
     'on_response',
@@ -25,8 +24,9 @@ def get_endpoint_config(options: FinalRequestOptions) -> EndpointConfig:
     """Returns the endpoint config for Anthropic depending on the url."""
     url = options.url
     json_data = options.json_data
-    if not isinstance(json_data, dict):
-        raise ValueError('Expected `options.json_data` to be a dictionary')
+    if not isinstance(json_data, dict):  # pragma: no cover
+        # Ensure that `{request_data[model]!r}` doesn't raise an error, just a warning about `model` missing.
+        json_data = {}
 
     if url == '/v1/messages':
         return EndpointConfig(
@@ -35,7 +35,11 @@ def get_endpoint_config(options: FinalRequestOptions) -> EndpointConfig:
             content_from_stream=content_from_messages,
         )
     else:
-        raise ValueError(f'Unknown Anthropic API endpoint: `{url}`')
+        return EndpointConfig(
+            message_template='Anthropic API call to {url!r}',
+            span_data={'request_data': json_data, 'url': url},
+            content_from_stream=None,
+        )
 
 
 def content_from_messages(chunk: anthropic.types.MessageStreamEvent) -> str | None:

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -76,14 +76,7 @@ def instrument_llm_provider(
         if is_instrumentation_suppressed():
             return None, None, kwargs
 
-        options = kwargs['options']
-        try:
-            message_template, span_data, content_from_stream = get_endpoint_config_fn(options)
-        except ValueError as exc:
-            logfire_llm.warn(
-                'Unable to instrument {suffix} API call: {error}', suffix=scope_suffix, error=str(exc), kwargs=kwargs
-            )
-            return None, None, kwargs
+        message_template, span_data, content_from_stream = get_endpoint_config_fn(kwargs['options'])
 
         span_data['async'] = is_async
 

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -20,7 +20,7 @@ def instrument_llm_provider(
     client: Any,
     suppress_otel: bool,
     scope_suffix: str,
-    get_endpoint_config_fn: Callable[[Any], EndpointConfig | None],
+    get_endpoint_config_fn: Callable[[Any], EndpointConfig],
     on_response_fn: Callable[[Any, LogfireSpan], Any],
     is_async_client_fn: Callable[[type[Any]], bool],
 ) -> ContextManager[None]:
@@ -77,10 +77,6 @@ def instrument_llm_provider(
             return None, None, kwargs
 
         options = kwargs['options']
-        if options is None:
-            # This happens for not-yet-supported APIs, including beta.threads
-            return None, None, kwargs
-
         try:
             message_template, span_data, content_from_stream = get_endpoint_config_fn(options)
         except ValueError as exc:

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -20,7 +20,7 @@ def instrument_llm_provider(
     client: Any,
     suppress_otel: bool,
     scope_suffix: str,
-    get_endpoint_config_fn: Callable[[Any], EndpointConfig],
+    get_endpoint_config_fn: Callable[[Any], EndpointConfig | None],
     on_response_fn: Callable[[Any, LogfireSpan], Any],
     is_async_client_fn: Callable[[type[Any]], bool],
 ) -> ContextManager[None]:
@@ -77,6 +77,10 @@ def instrument_llm_provider(
             return None, None, kwargs
 
         options = kwargs['options']
+        if options is None:
+            # This happens for not-yet-supported APIs, including beta.threads
+            return None, None, kwargs
+
         try:
             message_template, span_data, content_from_stream = get_endpoint_config_fn(options)
         except ValueError as exc:

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -30,7 +30,7 @@ def get_endpoint_config(options: FinalRequestOptions) -> EndpointConfig:
     url = options.url
 
     json_data = options.json_data
-    if not isinstance(json_data, dict):
+    if not isinstance(json_data, dict):  # pragma: no cover
         # Ensure that `{request_data[model]!r}` doesn't raise an error, just a warning about `model` missing.
         json_data = {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ dev-dependencies = [
     "aiohttp",
     "redis",
     "pymongo",
-    "starlette",
     "fastapi",
     "Flask",
     "django",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -168,7 +168,7 @@ mkdocstrings-python==1.10.5
 multidict==6.0.5
     # via aiohttp
     # via yarl
-mypy==1.10.1
+mypy==1.11.0
 mypy-extensions==1.0.0
     # via black
     # via mypy
@@ -177,7 +177,7 @@ nodeenv==1.9.1
     # via pyright
 numpy==2.0.0
     # via pandas
-openai==1.35.14
+openai==1.36.0
 opentelemetry-api==1.25.0
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-instrumentation
@@ -324,7 +324,7 @@ pymdown-extensions==10.8.1
     # via mkdocstrings
 pymongo==4.8.0
 pyright==1.1.372
-pytest==8.2.2
+pytest==8.3.1
     # via pytest-django
     # via pytest-pretty
 pytest-django==4.8.0
@@ -363,8 +363,8 @@ rich==13.7.1
     # via logfire
     # via pytest-pretty
     # via typer
-ruff==0.5.2
-setuptools==71.0.1
+ruff==0.5.3
+setuptools==71.0.4
     # via opentelemetry-instrumentation
 shellingham==1.5.4
     # via typer
@@ -412,7 +412,7 @@ tzdata==2024.1
     # via pandas
 urllib3==2.2.2
     # via requests
-uvicorn==0.30.1
+uvicorn==0.30.3
     # via fastapi
 uvloop==0.19.0
     # via uvicorn

--- a/requirements.lock
+++ b/requirements.lock
@@ -57,7 +57,7 @@ requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 rich==13.7.1
     # via logfire
-setuptools==71.0.1
+setuptools==71.0.4
     # via opentelemetry-instrumentation
 typing-extensions==4.12.2
     # via logfire


### PR DESCRIPTION
Building on https://github.com/pydantic/logfire/pull/309

User request: https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1720726405203889

Basically when an OpenAI/Anthropic client request is made to a URL that we don't specifically handle, make a generic span with the URL (which should still be somewhat useful) instead of a noisy warning log.