### PR TITLE
Log more info about internal errors

### DIFF
--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+import traceback
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Sequence, Tuple, TypedDict, TypeVar, Union
@@ -227,7 +228,11 @@ def suppress_instrumentation():
 
 def log_internal_error():
     with suppress_instrumentation():  # prevent infinite recursion from the logging integration
-        logger.exception('Internal error in Logfire')
+        full_stack = traceback.extract_stack()
+        limit = 10  # this should generally be enough frames to see where the problematic call came from
+        parent_frames = full_stack[-limit:-1]
+        formatted_frames = '\n'.join(traceback.format_list(parent_frames))
+        logger.exception(f'Internal error in Logfire. Frames above traceback: {formatted_frames}')
 
 
 @contextmanager

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -2535,7 +2535,9 @@ def test_internal_exception_span(caplog: pytest.LogCaptureFixture, exporter: Tes
     with logfire.span('foo', _tags=123) as span:  # type: ignore
         # _tags=123 causes an exception (tags should be an iterable)
         assert len(caplog.records) == 1
-        assert caplog.records[0].message == 'Internal error in Logfire'
+        assert caplog.records[0].message.startswith('Internal error in Logfire')
+        # Ensure we log a reference to the line that resulted in the internal error
+        assert "logfire.span('foo', _tags=123)" in caplog.records[0].message
 
         assert isinstance(span, NoopSpan)
 
@@ -2559,7 +2561,9 @@ def test_internal_exception_log(caplog: pytest.LogCaptureFixture, exporter: Test
 
     # _tags=123 causes an exception (tags should be an iterable)
     assert len(caplog.records) == 1
-    assert caplog.records[0].message == 'Internal error in Logfire'
+    assert caplog.records[0].message.startswith('Internal error in Logfire')
+    # Ensure we log a reference to the line that resulted in the internal error
+    assert "logfire.info('foo', _tags=123)" in caplog.records[0].message
 
     assert exporter.exported_spans_as_dict(_include_pending_spans=True) == []
 


### PR DESCRIPTION
In https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1721433723530879 you can see an internal error where we don't produce enough information to determine what line of user code produced the issue. (We only get stack frames underneath the `try: except:` so can't see what user code led to the error.)  I think it would be better if we log a bit more frames up the stack when an internal error is produced to give us a better handle on debugging.

In particular, in this case, it seems to be an issue with magic formattting — seeing the source code could be very insightful.