### PR TITLE
Reraise internal errors in tests

### DIFF
--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -226,6 +227,16 @@ def suppress_instrumentation():
 
 
 def log_internal_error():
+    try:
+        # Unless we're specifically testing this function, we should reraise the exception
+        # in tests for easier debugging.
+        current_test = os.environ.get('PYTEST_CURRENT_TEST', '')
+        reraise = bool(current_test and 'test_internal_exception' not in current_test)
+    except Exception:
+        reraise = False
+    if reraise:
+        raise
+
     with suppress_instrumentation():  # prevent infinite recursion from the logging integration
         logger.exception('Internal error in Logfire')
 


### PR DESCRIPTION
Often when running tests I get mysterious failures about missing logs, take a while to realize that an exception got swallowed, and have to manually temporarily tweak the internal error handling while I debug. This should make life easier.