### PR TITLE
Handle message formatting errors

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -75,7 +75,7 @@ from .exporters.remove_pending import RemovePendingSpansExporter
 from .exporters.tail_sampling import TailSamplingOptions, TailSamplingProcessor
 from .integrations.executors import instrument_executors
 from .metrics import ProxyMeterProvider, configure_metrics
-from .scrubbing import BaseScrubber, NoopScrubber, Scrubber, ScrubbingOptions, ScrubCallback
+from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions, ScrubCallback
 from .stack_info import get_user_frame_and_stacklevel
 from .tracer import PendingSpanProcessor, ProxyTracerProvider
 from .utils import UnexpectedResponse, ensure_data_dir_exists, get_version, read_toml_file, suppress_instrumentation
@@ -402,7 +402,7 @@ class _LogfireConfigData:
             scrubbing = ScrubbingOptions()
         self.scrubbing: ScrubbingOptions | Literal[False] = scrubbing
         self.scrubber: BaseScrubber = (
-            Scrubber(scrubbing.extra_patterns, scrubbing.callback) if scrubbing else NoopScrubber()
+            Scrubber(scrubbing.extra_patterns, scrubbing.callback) if scrubbing else NOOP_SCRUBBER
         )
 
         if isinstance(console, dict):

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -275,15 +275,17 @@ class ChunksFormatter(Formatter):
                 except IndexError:
                     raise KnownFormattingError('Numeric field names are not allowed.')
                 except KeyError as exc1:
-                    missing = str(exc1)
-                    if missing == repr(field_name):
+                    if str(exc1) == repr(field_name):
                         raise KnownFormattingError(f'The field {{{field_name}}} is not defined.') from exc1
 
                     try:
-                        # fall back to getting a key with the dots in the name
+                        # field_name is something like 'a.b' or 'a[b]'
+                        # Evaluating that expression failed, so now just try getting the whole thing from kwargs.
+                        # In particular, OTEL attributes with dots in their names are normal and handled here.
                         obj = kwargs[field_name]
                     except KeyError as exc2:
-                        raise KnownFormattingError(f'The fields {str(exc1)} and {str(exc2)} are not defined.') from exc2
+                        # e.g. neither 'a' nor 'a.b' is defined
+                        raise KnownFormattingError(f'The fields {exc1} and {exc2} are not defined.') from exc2
                 except Exception as exc:
                     raise KnownFormattingError(f'Error getting field {{{field_name}}}: {exc}') from exc
 

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -461,7 +461,7 @@ class KnownFormattingError(Exception):
     """
 
 
-class FormattingFailedWarning(Warning):
+class FormattingFailedWarning(UserWarning):
     pass
 
 

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -297,8 +297,7 @@ class ChunksFormatter(Formatter):
                     except KeyError:
                         obj = '{' + field_name + '}'
                         field = exc.args[0]
-                        _frame, stacklevel = get_user_frame_and_stacklevel()
-                        warnings.warn(f"The field '{field}' is not defined.", stacklevel=stacklevel)
+                        warn_formatting(f'The field {{{field}}} is not defined.')
 
                 # do any conversion on the resulting object
                 if conversion is not None:
@@ -454,3 +453,20 @@ def warn_inspect_arguments(msg: str, stacklevel: int):
     ) + msg
     warnings.warn(msg, InspectArgumentsFailedWarning, stacklevel=stacklevel)
     logfire.log('warn', msg)
+
+
+class FormattingFailedWarning(Warning):
+    pass
+
+
+def warn_formatting(msg: str):
+    _frame, stacklevel = get_user_frame_and_stacklevel()
+    warnings.warn(
+        'Failed to format the message. Ensure you are either '
+        '(1) passing an f-string directly, with inspect_arguments enabled and working, or '
+        '(2) passing a str.format-style template, not a preformatted string. '
+        'See https://docs.pydantic.dev/logfire/guides/onboarding_checklist/add_manual_tracing/#messages-and-span-names. '
+        f'The problem was: {msg}',
+        stacklevel=stacklevel,
+        category=FormattingFailedWarning,
+    )

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -17,7 +17,7 @@ import logfire
 from logfire._internal.stack_info import get_user_frame_and_stacklevel
 
 from .constants import ATTRIBUTES_SCRUBBED_KEY, MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT
-from .scrubbing import BaseScrubber, ScrubbedNote
+from .scrubbing import NOOP_SCRUBBER, BaseScrubber, ScrubbedNote
 from .utils import log_internal_error, truncate_string
 
 
@@ -304,7 +304,7 @@ class ChunksFormatter(Formatter):
                 # expand the format spec, if needed
                 # TODO use _vformat_chunks and increment recursion depth
                 # TODO test errors in nested format specs
-                format_spec = logfire_format(format_spec or '', kwargs, scrubber)
+                format_spec = logfire_format(format_spec or '', kwargs, NOOP_SCRUBBER)
 
                 if obj is None:
                     value = self.NONE_REPR

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -271,15 +271,12 @@ class ChunksFormatter(Formatter):
                 try:
                     obj, _arg_used = self.get_field(field_name, args, kwargs)
                 except IndexError:
+                    raise KnownFormattingError('Formatting numbered fields with positional arguments is not allowed.')
+                except KeyError as exc1:
                     if field_name == '':
                         raise KnownFormattingError(
                             'Empty curly brackets `{}` are not allowed. A field name is required.'
                         )
-                    else:
-                        raise KnownFormattingError(
-                            'Formatting numbered fields with positional arguments is not allowed.'
-                        )
-                except KeyError as exc1:
                     missing = str(exc1)
                     if missing == repr(field_name):
                         raise KnownFormattingError(f'The field {{{field_name}}} is not defined.') from exc1
@@ -289,6 +286,8 @@ class ChunksFormatter(Formatter):
                         obj = kwargs[field_name]
                     except KeyError as exc2:
                         raise KnownFormattingError(f'The fields {str(exc1)} and {str(exc2)} are not defined.') from exc2
+                except Exception as exc:
+                    raise KnownFormattingError(f'Error getting field {{{field_name}}}: {exc}') from exc
 
                 # do any conversion on the resulting object
                 if conversion is not None:

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -363,7 +363,11 @@ def logfire_format_with_magic(
     except KnownFormattingError as e:
         warn_formatting(str(e) or str(e.__cause__))
     except Exception:
+        # This is an unexpected error that likely indicates a bug in our logic.
+        # Handle it here so that the span/log still gets created, just without a nice message.
         log_internal_error()
+
+    # Formatting failed, so just use the original format string as the message.
     return format_string, {}, format_string
 
 
@@ -450,7 +454,11 @@ def warn_inspect_arguments(msg: str, stacklevel: int):
 
 
 class KnownFormattingError(Exception):
-    pass
+    """An error raised when there's something wrong with a format string or the field values.
+
+    In other words this should correspond to errors that would be raised when using `str.format`,
+    and generally indicate a user error, most likely that they weren't trying to pass a template string at all.
+    """
 
 
 class FormattingFailedWarning(Warning):

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -302,9 +302,11 @@ class ChunksFormatter(Formatter):
                     obj = self.convert_field(obj, conversion)
 
                 # expand the format spec, if needed
-                # TODO use _vformat_chunks and increment recursion depth
                 # TODO test errors in nested format specs
-                format_spec = logfire_format(format_spec or '', kwargs, NOOP_SCRUBBER)
+                format_spec_chunks, _ = self._vformat_chunks(
+                    format_spec or '', kwargs, scrubber=NOOP_SCRUBBER, recursion_depth=recursion_depth - 1
+                )
+                format_spec = ''.join(chunk['v'] for chunk in format_spec_chunks)
 
                 if obj is None:
                     value = self.NONE_REPR

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -257,6 +257,8 @@ class ChunksFormatter(Formatter):
             if field_name is not None:
                 # this is some markup, find the object and do
                 #  the formatting
+                if field_name == '':
+                    raise KnownFormattingError('Empty curly brackets `{}` are not allowed. A field name is required.')
 
                 # ADDED BY US:
                 if field_name.endswith('='):
@@ -273,10 +275,6 @@ class ChunksFormatter(Formatter):
                 except IndexError:
                     raise KnownFormattingError('Numeric field names are not allowed.')
                 except KeyError as exc1:
-                    if field_name == '':
-                        raise KnownFormattingError(
-                            'Empty curly brackets `{}` are not allowed. A field name is required.'
-                        )
                     missing = str(exc1)
                     if missing == repr(field_name):
                         raise KnownFormattingError(f'The field {{{field_name}}} is not defined.') from exc1

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -292,7 +292,10 @@ class ChunksFormatter(Formatter):
 
                 # do any conversion on the resulting object
                 if conversion is not None:
-                    obj = self.convert_field(obj, conversion)
+                    try:
+                        obj = self.convert_field(obj, conversion)
+                    except Exception as exc:
+                        raise KnownFormattingError(f'Error converting field {{{field_name}}}: {exc}') from exc
 
                 # expand the format spec, if needed
                 # TODO test errors in nested format specs

--- a/logfire/_internal/formatter.py
+++ b/logfire/_internal/formatter.py
@@ -271,7 +271,7 @@ class ChunksFormatter(Formatter):
                 try:
                     obj, _arg_used = self.get_field(field_name, args, kwargs)
                 except IndexError:
-                    raise KnownFormattingError('Formatting numbered fields with positional arguments is not allowed.')
+                    raise KnownFormattingError('Numeric field names are not allowed.')
                 except KeyError as exc1:
                     if field_name == '':
                         raise KnownFormattingError(
@@ -297,7 +297,6 @@ class ChunksFormatter(Formatter):
                         raise KnownFormattingError(f'Error converting field {{{field_name}}}: {exc}') from exc
 
                 # expand the format spec, if needed
-                # TODO test errors in nested format specs
                 format_spec_chunks, _ = self._vformat_chunks(
                     format_spec or '', kwargs, scrubber=NOOP_SCRUBBER, recursion_depth=recursion_depth - 1
                 )

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -141,6 +141,9 @@ class NoopScrubber(BaseScrubber):
         return value, []
 
 
+NOOP_SCRUBBER = NoopScrubber()
+
+
 class Scrubber(BaseScrubber):
     """Redacts potentially sensitive data."""
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -129,11 +129,22 @@ def test_missing_field():
 
 
 def test_missing_field_with_dot():
+    assert logfire_format('{a.b}', {'a.b': 123}, NOOP_SCRUBBER) == '123'
+
+    def a():
+        pass
+
+    a.b = 456  # type: ignore
+    assert logfire_format('{a.b}', {'a': a, 'a.b': 123}, NOOP_SCRUBBER) == '456'
+
     with warns_failed("The fields 'a' and 'a.b' are not defined."):
         logfire_format('{a.b}', {'b': 1}, NOOP_SCRUBBER)
 
 
 def test_missing_field_with_brackets():
+    assert logfire_format('{a[b]}', {'a[b]': 123}, NOOP_SCRUBBER) == '123'
+    assert logfire_format('{a[b]}', {'a': {'b': 456}, 'b': 1}, NOOP_SCRUBBER) == '456'
+
     with warns_failed("The fields 'a' and 'a[b]' are not defined."):
         logfire_format('{a[b]}', {'b': 1}, NOOP_SCRUBBER)
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -151,3 +151,8 @@ def test_empty_braces():
 def test_empty_braces_in_brackets():
     with warns_failed('Error getting field {a[]}: Empty attribute in format string'):
         logfire_format('{a[]}', {'a': {}}, NOOP_SCRUBBER)
+
+
+def test_numbered_fields():
+    with warns_failed('Numeric field names are not allowed.'):
+        logfire_format('{1}', {'1': 'a'}, NOOP_SCRUBBER)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -6,7 +6,7 @@ import pytest
 from inline_snapshot import snapshot
 
 from logfire._internal.formatter import FormattingFailedWarning, chunks_formatter, logfire_format
-from logfire._internal.scrubbing import NOOP_SCRUBBER, JsonPath, ScrubbedNote, Scrubber
+from logfire._internal.scrubbing import NOOP_SCRUBBER, JsonPath, Scrubber
 
 
 def chunks(format_string: str, kwargs: Mapping[str, Any]):
@@ -159,7 +159,7 @@ def test_numbered_fields():
 
 
 class BadScrubber(Scrubber):
-    def scrub_value(self, path: JsonPath, value: Any) -> tuple[Any, list[ScrubbedNote]]:
+    def scrub_value(self, path: JsonPath, value: Any):
         raise ValueError('bad scrubber')
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -156,6 +156,8 @@ def test_empty_braces_in_brackets():
 def test_numbered_fields():
     with warns_failed('Numeric field names are not allowed.'):
         logfire_format('{1}', {'1': 'a'}, NOOP_SCRUBBER)
+    with warns_failed('Numeric field names are not allowed.'):
+        logfire_format('{2.3}', {'2': 'a'}, NOOP_SCRUBBER)
 
 
 class BadScrubber(Scrubber):

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -8,7 +8,7 @@ from logfire._internal.scrubbing import Scrubber
 
 
 def chunks(format_string: str, kwargs: Mapping[str, Any]):
-    result, _extra_attrs, _span_name = chunks_formatter.chunks(format_string, kwargs, scrubber=Scrubber([]))
+    result, _extra_attrs, _span_name = chunks_formatter.chunks(format_string, dict(kwargs), scrubber=Scrubber([]))
     return result
 
 

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -141,3 +141,13 @@ def test_missing_field_with_brackets():
 def test_missing_key_in_brackets():
     with warns_failed("The fields 'b' and 'a[b]' are not defined."):
         logfire_format('{a[b]}', {'a': {}, 'b': 1}, NOOP_SCRUBBER)
+
+
+def test_empty_braces():
+    with warns_failed('Empty curly brackets `{}` are not allowed. A field name is required.'):
+        logfire_format('{}', {}, NOOP_SCRUBBER)
+
+
+def test_empty_braces_in_brackets():
+    with warns_failed('Error getting field {a[]}: Empty attribute in format string'):
+        logfire_format('{a[]}', {'a': {}}, NOOP_SCRUBBER)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,5 +1,6 @@
 import contextlib
 from collections import ChainMap
+from types import SimpleNamespace
 from typing import Any, Mapping
 
 import pytest
@@ -130,12 +131,7 @@ def test_missing_field():
 
 def test_missing_field_with_dot():
     assert logfire_format('{a.b}', {'a.b': 123}, NOOP_SCRUBBER) == '123'
-
-    def a():
-        pass
-
-    a.b = 456  # type: ignore
-    assert logfire_format('{a.b}', {'a': a, 'a.b': 123}, NOOP_SCRUBBER) == '456'
+    assert logfire_format('{a.b}', {'a': SimpleNamespace(b=456), 'a.b': 123}, NOOP_SCRUBBER) == '456'
 
     with warns_failed("The fields 'a' and 'a.b' are not defined."):
         logfire_format('{a.b}', {'b': 1}, NOOP_SCRUBBER)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,10 +1,12 @@
+import contextlib
 from collections import ChainMap
 from typing import Any, Mapping
 
+import pytest
 from inline_snapshot import snapshot
 
-from logfire._internal.formatter import chunks_formatter, logfire_format
-from logfire._internal.scrubbing import Scrubber
+from logfire._internal.formatter import FormattingFailedWarning, chunks_formatter, logfire_format
+from logfire._internal.scrubbing import NOOP_SCRUBBER, Scrubber
 
 
 def chunks(format_string: str, kwargs: Mapping[str, Any]):
@@ -81,3 +83,61 @@ def test_truncate():
         ' 3'
     )
     assert len(message) == snapshot(261)
+
+
+@contextlib.contextmanager
+def warns_failed(msg: str):
+    with pytest.warns(FormattingFailedWarning) as record:
+        yield
+    [warning] = record
+    assert str(warning.message).endswith(f'The problem was: {msg}')
+
+
+class BadRepr:
+    def __repr__(self):
+        raise ValueError('bad repr')
+
+
+def test_conversion_error():
+    with warns_failed('Error converting field {a}: bad repr'):
+        logfire_format('{a!r}', {'a': BadRepr()}, NOOP_SCRUBBER)
+
+
+def test_formatting_error():
+    with warns_failed('Error formatting field {a}: bad repr'):
+        logfire_format('{a}', {'a': BadRepr()}, NOOP_SCRUBBER)
+
+
+def test_formatting_error_with_spec():
+    with warns_failed("Error formatting field {a}: Unknown format code 'c' for object of type 'str'"):
+        logfire_format('{a:c}', {'a': 'b'}, NOOP_SCRUBBER)
+
+
+def test_format_spec_error():
+    with warns_failed("Error formatting field {b}: Unknown format code 'c' for object of type 'str'"):
+        logfire_format('{a:{b:c}}', {'a': '1', 'b': '2'}, NOOP_SCRUBBER)
+
+
+def test_recursion_error():
+    with warns_failed('Max format spec recursion exceeded'):
+        logfire_format('{a:{a:{a:{a:5}}}}', {'a': 1}, NOOP_SCRUBBER)
+
+
+def test_missing_field():
+    with warns_failed('The field {a} is not defined.'):
+        logfire_format('{a}', {}, NOOP_SCRUBBER)
+
+
+def test_missing_field_with_dot():
+    with warns_failed("The fields 'a' and 'a.b' are not defined."):
+        logfire_format('{a.b}', {'b': 1}, NOOP_SCRUBBER)
+
+
+def test_missing_field_with_brackets():
+    with warns_failed("The fields 'a' and 'a[b]' are not defined."):
+        logfire_format('{a[b]}', {'b': 1}, NOOP_SCRUBBER)
+
+
+def test_missing_key_in_brackets():
+    with warns_failed("The fields 'b' and 'a[b]' are not defined."):
+        logfire_format('{a[b]}', {'a': {}, 'b': 1}, NOOP_SCRUBBER)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -31,7 +31,7 @@ from logfire._internal.constants import (
     LEVEL_NUMBERS,
     NULL_ARGS_KEY,
 )
-from logfire._internal.formatter import InspectArgumentsFailedWarning
+from logfire._internal.formatter import FormattingFailedWarning, InspectArgumentsFailedWarning
 from logfire._internal.main import NoopSpan
 from logfire._internal.utils import is_instrumentation_suppressed
 from logfire.integrations.logging import LogfireLoggingHandler
@@ -40,7 +40,7 @@ from logfire.testing import IncrementalIdGenerator, TestExporter, TimeGenerator
 
 @pytest.mark.parametrize('method', ['trace', 'info', 'debug', 'warn', 'error', 'fatal'])
 def test_log_methods_without_kwargs(method: str):
-    with pytest.warns(UserWarning, match="The field 'foo' is not defined.") as warnings:
+    with pytest.warns(FormattingFailedWarning, match='The field {foo} is not defined.') as warnings:
         getattr(logfire, method)('{foo}', bar=2)
 
     warning = warnings.pop()
@@ -77,7 +77,7 @@ def test_instrument_with_no_args(exporter: TestExporter) -> None:
 
 
 def test_instrument_without_kwargs():
-    with pytest.warns(UserWarning, match="The field 'foo' is not defined.") as warnings:
+    with pytest.warns(FormattingFailedWarning, match='The field {foo} is not defined.') as warnings:
 
         @logfire.instrument('{foo}')
         def home() -> None: ...
@@ -89,7 +89,7 @@ def test_instrument_without_kwargs():
 
 
 def test_span_without_kwargs() -> None:
-    with pytest.warns(UserWarning, match="The field 'foo' is not defined.") as warnings:
+    with pytest.warns(FormattingFailedWarning, match='The field {foo} is not defined.') as warnings:
         with logfire.span('test {foo}'):
             pass  # pragma: no cover
 
@@ -1192,7 +1192,7 @@ def test_complex_attribute_added_after_span_started(exporter: TestExporter) -> N
 
 
 def test_format_attribute_added_after_pending_span_sent(exporter: TestExporter) -> None:
-    with pytest.warns(UserWarning, match=r'missing') as warnings:
+    with pytest.warns(FormattingFailedWarning, match=r'missing') as warnings:
         span = logfire.span('{present} {missing}', present='here')
 
     assert len(warnings) == 1

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -40,11 +40,19 @@ from logfire.testing import IncrementalIdGenerator, TestExporter, TimeGenerator
 
 @pytest.mark.parametrize('method', ['trace', 'info', 'debug', 'warn', 'error', 'fatal'])
 def test_log_methods_without_kwargs(method: str):
-    with pytest.warns(FormattingFailedWarning, match='The field {foo} is not defined.') as warnings:
+    with pytest.warns(FormattingFailedWarning) as warnings:
         getattr(logfire, method)('{foo}', bar=2)
 
-    warning = warnings.pop()
+    [warning] = warnings
     assert warning.filename.endswith('test_logfire.py')
+    assert str(warning.message) == snapshot("""\
+
+    Ensure you are either:
+      (1) passing an f-string directly, with inspect_arguments enabled and working, or
+      (2) passing a literal `str.format`-style template, not a preformatted string.
+    See https://docs.pydantic.dev/logfire/guides/onboarding_checklist/add_manual_tracing/#messages-and-span-names.
+    The problem was: The field {foo} is not defined.\
+""")
 
 
 def test_instrument_with_no_args(exporter: TestExporter) -> None:
@@ -1217,7 +1225,7 @@ def test_format_attribute_added_after_pending_span_sent(exporter: TestExporter) 
                     'code.function': 'test_format_attribute_added_after_pending_span_sent',
                     'present': 'here',
                     'logfire.msg_template': '{present} {missing}',
-                    'logfire.msg': 'here {missing}',
+                    'logfire.msg': '{present} {missing}',
                     'logfire.json_schema': '{"type":"object","properties":{"present":{}}}',
                     'logfire.span_type': 'pending_span',
                     'logfire.pending_parent_id': '0000000000000000',
@@ -1235,7 +1243,7 @@ def test_format_attribute_added_after_pending_span_sent(exporter: TestExporter) 
                     'code.function': 'test_format_attribute_added_after_pending_span_sent',
                     'present': 'here',
                     'logfire.msg_template': '{present} {missing}',
-                    'logfire.msg': 'here {missing}',
+                    'logfire.msg': '{present} {missing}',
                     'logfire.json_schema': '{"type":"object","properties":{"present":{},"missing":{}}}',
                     'logfire.span_type': 'span',
                     'missing': 'value',


### PR DESCRIPTION
Addresses https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1721433723530879

There were several places where we explicitly or implicitly raised errors which could lead to similar complaints from users. Many of these errors could be caused in the same way: by passing a preformatted string which gets unintentionally interpreted as a formatting template. I've converted all these known cases to warnings.

Previously we would warn about missing fields but continue trying to format the string. This had the small benefit of formatting other fields that weren't present, so the user gets something partially formatted. This helped in the specific case where they know what they're doing but made a typo. Keeping this behaviour would mean that something like `logfire.info("log {'1': {'2': {'3': {'4': 5}}}}")`would produce three warnings about missing fields `'1'`, `'2'`, and `'3'`, and a fourth warning about recursion depth, all from the same line. So instead I chose to just fail quickly when a field is missing. This just means that the message is just the format string, but the user can still find any correct fields in the attributes, so it's not a big loss. Also the better way to prevent these kinds of typos is to use an f-string, and the warning points to that page in the docs.