### PR TITLE
Allow sending to custom OTEL_EXPORTER_OTLP_ENDPOINT without logfire auth

### DIFF
--- a/logfire/_internal/config_params.py
+++ b/logfire/_internal/config_params.py
@@ -7,7 +7,7 @@ from functools import cached_property, lru_cache
 from pathlib import Path
 from typing import Any, Callable, Literal, Set, TypeVar
 
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_SERVICE_NAME
+from opentelemetry.sdk.environment_variables import OTEL_SERVICE_NAME
 from typing_extensions import get_args, get_origin
 
 from logfire.exceptions import LogfireConfigError
@@ -61,7 +61,7 @@ _send_to_logfire_default = _DefaultCallback(lambda: 'PYTEST_CURRENT_TEST' not in
 """When running under pytest, don't send spans to Logfire by default."""
 
 # fmt: off
-BASE_URL = ConfigParam(env_vars=['LOGFIRE_BASE_URL', OTEL_EXPORTER_OTLP_ENDPOINT], allow_file_config=True, default=LOGFIRE_BASE_URL)
+BASE_URL = ConfigParam(env_vars=['LOGFIRE_BASE_URL'], allow_file_config=True, default=LOGFIRE_BASE_URL)
 """Use to set the base URL of the Logfire backend."""
 SEND_TO_LOGFIRE = ConfigParam(env_vars=['LOGFIRE_SEND_TO_LOGFIRE'], allow_file_config=True, default=_send_to_logfire_default, tp=bool)
 """Whether to send spans to Logfire."""


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/298. Still thinking through some details, could use feedback. Here's how this currently works:

1. If you want to export over HTTP, you need `send_to_logfire=True` (the default) even if you're sending to something that isn't logfire. If you want to simultaneously export to both logfire and something custom, you can't just use the env vars, you have to manually set up the exporters and processors. Nothing below applies when `send_to_logfire=False`.
2. If you want to send both traces and metrics somewhere custom, set the env var `OTEL_EXPORTER_OTLP_ENDPOINT`. Traces will then be sent to `{OTEL_EXPORTER_OTLP_ENDPOINT}/v1/traces`, similar for metrics.
3. Otherwise you can set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` and/or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` if you need to be more specific.
4. If `OTEL_EXPORTER_OTLP_ENDPOINT` and/or `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` is set, we assume that you are sending traces to something that isn't logfire, and set up basic exporters with minimal configuration. If neither is set, we assume that you're sending to a logfire instance hosted at `base_url`, and refine the exporters with extra logic. Similar for metrics.
5. Unless you're sending both traces and metrics to somewhere that isn't logfire, we require authentication. So for example if you only set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, we assume that you're still going to send metrics to logfire and expect to find a token somewhere. We don't wait until you start creating metrics data.

Problems:

1. The name `send_to_logfire` is misleading
2. `base_url` is now only for a logfire URL. For users this means it's only relevant when self-hosting logfire, which isn't possible yet. If we want to reuse it for general OTLP endpoints we need a way to indicate whether or not `base_url` represents a logfire URL. We could maybe do this by sending a special request to the backend, but I feel iffy about this.
3. OTEL endpoints can only be configured via env vars, not `logfire.configure()` or `pyproject.toml`. Adding them as regular config options could be a fair amount of API bloat.
4. This is quite a bit of logic that's hard to document in a way that's both clear and concise.