### PR TITLE
Remove extra deps that were only for tests now skipped in 3.8

### DIFF
--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -201,7 +201,7 @@ class _ProxyTracer(Tracer):
 
     # This means that `with start_as_current_span(...):`
     # is roughly equivalent to `with use_span(start_span(...)):`
-    start_as_current_span = SDKTracer.start_as_current_span  # type: ignore
+    start_as_current_span = SDKTracer.start_as_current_span
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,6 @@ dev-dependencies = [
     "celery>=5.4.0",
     "testcontainers",
     "mysql-connector-python~=8.0",
-    # Python 3.8 requires an older version of testcontainers, which in turn needs these for a mysql container
-    "pymysql; python_version < '3.9'",
-    "cryptography; python_version < '3.9'",
 ]
 
 [tool.rye.scripts]

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -9,33 +9,34 @@
 #   generate-hashes: false
 
 -e file:.
-aiohttp==3.9.5
+aiohappyeyeballs==2.3.4
+    # via aiohttp
+aiohttp==3.10.1
 aiosignal==1.3.1
     # via aiohttp
 amqp==5.2.0
     # via kombu
 annotated-types==0.7.0
     # via pydantic
-anthropic==0.31.2
+anthropic==0.32.0
 anyio==4.3.0
     # via anthropic
     # via httpx
     # via openai
     # via starlette
-    # via watchfiles
 asgiref==3.8.1
     # via django
     # via opentelemetry-instrumentation-asgi
 asttokens==2.4.1
     # via inline-snapshot
 asyncpg==0.29.0
-attrs==23.2.0
+attrs==24.1.0
     # via aiohttp
 babel==2.15.0
     # via mkdocs-material
 billiard==4.2.0
     # via celery
-black==24.4.2
+black==24.8.0
     # via inline-snapshot
 blinker==1.8.2
     # via flask
@@ -58,8 +59,6 @@ click==8.1.7
     # via inline-snapshot
     # via mkdocs
     # via mkdocstrings
-    # via typer
-    # via uvicorn
 click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1
@@ -70,7 +69,7 @@ cloudpickle==3.0.0
 colorama==0.4.6
     # via griffe
     # via mkdocs-material
-coverage==7.6.0
+coverage==7.6.1
 deprecated==1.2.14
     # via opentelemetry-api
     # via opentelemetry-exporter-otlp-proto-http
@@ -83,19 +82,14 @@ distro==1.9.0
     # via openai
 django==5.0.7
 dnspython==2.6.1
-    # via email-validator
     # via pymongo
 docker==7.1.0
     # via testcontainers
-email-validator==2.2.0
-    # via fastapi
 eval-type-backport==0.2.0
 executing==2.0.1
     # via inline-snapshot
     # via logfire
-fastapi==0.111.1
-fastapi-cli==0.0.4
-    # via fastapi
+fastapi==0.112.0
 filelock==3.15.4
     # via huggingface-hub
     # via virtualenv
@@ -113,22 +107,17 @@ griffe==0.48.0
     # via mkdocstrings-python
 h11==0.14.0
     # via httpcore
-    # via uvicorn
 httpcore==1.0.5
     # via httpx
-httptools==0.6.1
-    # via uvicorn
 httpx==0.27.0
     # via anthropic
-    # via fastapi
     # via openai
-huggingface-hub==0.24.2
+huggingface-hub==0.24.5
     # via tokenizers
 identify==2.6.0
     # via pre-commit
 idna==3.7
     # via anyio
-    # via email-validator
     # via httpx
     # via requests
     # via yarl
@@ -141,7 +130,6 @@ inline-snapshot==0.12.0
 itsdangerous==2.2.0
     # via flask
 jinja2==3.1.4
-    # via fastapi
     # via flask
     # via mkdocs
     # via mkdocs-material
@@ -179,16 +167,16 @@ mkdocs-autorefs==1.0.1
 mkdocs-get-deps==0.2.0
     # via mkdocs
 mkdocs-glightbox==0.4.0
-mkdocs-material==9.5.30
+mkdocs-material==9.5.31
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-mkdocstrings==0.25.1
+mkdocstrings==0.25.2
     # via mkdocstrings-python
-mkdocstrings-python==1.10.5
+mkdocstrings-python==1.10.7
 multidict==6.0.5
     # via aiohttp
     # via yarl
-mypy==1.11.0
+mypy==1.11.1
 mypy-extensions==1.0.0
     # via black
     # via mypy
@@ -198,7 +186,7 @@ nodeenv==1.9.1
     # via pyright
 numpy==2.0.1
     # via pandas
-openai==1.37.0
+openai==1.38.0
 opentelemetry-api==1.26.0
     # via opentelemetry-exporter-otlp-proto-http
     # via opentelemetry-instrumentation
@@ -327,7 +315,7 @@ platformdirs==4.2.2
     # via virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.7.1
+pre-commit==3.8.0
 prompt-toolkit==3.0.47
     # via click-repl
 protobuf==4.25.4
@@ -350,12 +338,12 @@ pydantic-core==2.20.1
 pygments==2.18.0
     # via mkdocs-material
     # via rich
-pymdown-extensions==10.8.1
+pymdown-extensions==10.9
     # via mkdocs-material
     # via mkdocstrings
 pymongo==4.8.0
-pyright==1.1.373
-pytest==8.3.1
+pyright==1.1.374
+pytest==8.3.2
     # via pytest-django
     # via pytest-pretty
 pytest-django==4.8.0
@@ -364,10 +352,6 @@ python-dateutil==2.9.0.post0
     # via celery
     # via ghp-import
     # via pandas
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
 pytz==2024.1
     # via dirty-equals
     # via pandas
@@ -378,10 +362,9 @@ pyyaml==6.0.1
     # via pre-commit
     # via pymdown-extensions
     # via pyyaml-env-tag
-    # via uvicorn
 pyyaml-env-tag==0.1
     # via mkdocs
-redis==5.0.7
+redis==5.0.8
 regex==2024.7.24
     # via mkdocs-material
 requests==2.32.3
@@ -395,12 +378,9 @@ rich==13.7.1
     # via inline-snapshot
     # via logfire
     # via pytest-pretty
-    # via typer
-ruff==0.5.4
-setuptools==71.1.0
+ruff==0.5.6
+setuptools==72.1.0
     # via opentelemetry-instrumentation
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via asttokens
     # via python-dateutil
@@ -422,11 +402,9 @@ tokenizers==0.19.1
     # via anthropic
 toml==0.10.2
     # via inline-snapshot
-tqdm==4.66.4
+tqdm==4.66.5
     # via huggingface-hub
     # via openai
-typer==0.12.3
-    # via fastapi-cli
 types-toml==0.10.8.20240310
     # via inline-snapshot
 typing-extensions==4.12.2
@@ -443,7 +421,6 @@ typing-extensions==4.12.2
     # via pydantic-core
     # via sqlalchemy
     # via testcontainers
-    # via typer
 tzdata==2024.1
     # via celery
     # via pandas
@@ -451,10 +428,6 @@ urllib3==2.2.2
     # via docker
     # via requests
     # via testcontainers
-uvicorn==0.30.3
-    # via fastapi
-uvloop==0.19.0
-    # via uvicorn
 vine==5.1.0
     # via amqp
     # via celery
@@ -463,12 +436,8 @@ virtualenv==20.26.3
     # via pre-commit
 watchdog==4.0.1
     # via mkdocs
-watchfiles==0.22.0
-    # via uvicorn
 wcwidth==0.2.13
     # via prompt-toolkit
-websockets==12.0
-    # via uvicorn
 werkzeug==3.0.3
     # via flask
 wrapt==1.16.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -58,7 +58,7 @@ requests==2.32.3
     # via opentelemetry-exporter-otlp-proto-http
 rich==13.7.1
     # via logfire
-setuptools==71.1.0
+setuptools==72.1.0
     # via opentelemetry-instrumentation
 typing-extensions==4.12.2
     # via logfire


### PR DESCRIPTION
Since we skip test_mysql in Python 3.8, we don't need these extra dependencies that were only for the combination of `testcontainers`, mysql, and 3.8.

Also updated the requirements locks while I'm at it.