### PR TITLE
Hide `docker run` details on docs

### DIFF
--- a/docs/integrations/asyncpg.md
+++ b/docs/integrations/asyncpg.md
@@ -18,21 +18,20 @@ demonstrate how to use **Logfire** with asyncpg.
 First, we need to initialize a PostgreSQL database. This can be easily done using Docker with the following command:
 
 ```bash
-docker run --name postgres \
-    -e POSTGRES_USER=user \
-    -e POSTGRES_PASSWORD=secret \
-    -e POSTGRES_DB=database \
-    -p 5432:5432 -d postgres
+docker run --name postgres \  # (1)!
+    -e POSTGRES_USER=user \  # (2)!
+    -e POSTGRES_PASSWORD=secret \  # (3)!
+    -e POSTGRES_DB=database \  # (4)!
+    -p 5432:5432 \  # (5)!
+    -d postgres  # (6)!
 ```
 
-This command accomplishes the following:
-
-- `--name postgres`: This defines the name of the Docker container.
-- `-e POSTGRES_USER=user`: This sets a user for the PostgreSQL server.
-- `-e POSTGRES_PASSWORD=secret`: This sets a password for the PostgreSQL server.
-- `-e POSTGRES_DB=database`: This creates a new database named "database", the same as the one used in your Python script.
-- `-p 5432:5432`: This makes the PostgreSQL instance available on your local machine under port 5432.
-- `-d postgres`: This denotes the Docker image to be used, in this case, "postgres".
+1. `--name postgres`: This defines the name of the Docker container.
+2. `-e POSTGRES_USER=user`: This sets a user for the PostgreSQL server.
+3. `-e POSTGRES_PASSWORD=secret`: This sets a password for the PostgreSQL server.
+4. `-e POSTGRES_DB=database`: This creates a new database named "database", the same as the one used in your Python script.
+5. `-p 5432:5432`: This makes the PostgreSQL instance available on your local machine under port 5432.
+6. `-d postgres`: This denotes the Docker image to be used, in this case, "postgres", and starts the container in detached mode.
 
 ### Run the Python script
 

--- a/docs/integrations/mysql.md
+++ b/docs/integrations/mysql.md
@@ -18,23 +18,22 @@ demonstrate how to use **Logfire** with MySQL.
 First, we need to initialize a MySQL database. This can be easily done using Docker with the following command:
 
 ```bash
-docker run --name mysql \
-    -e MYSQL_ROOT_PASSWORD=secret \
-    -e MYSQL_DATABASE=database \
-    -e MYSQL_USER=user \
-    -e MYSQL_PASSWORD=secret \
-    -p 3306:3306 -d mysql
+docker run --name mysql \  # (1)!
+    -e MYSQL_ROOT_PASSWORD=secret \  # (2)!
+    -e MYSQL_DATABASE=database \  # (3)!
+    -e MYSQL_USER=user \  # (4)!
+    -e MYSQL_PASSWORD=secret \  # (5)!
+    -p 3306:3306 \  # (6)!
+    -d mysql  # (7)!
 ```
 
-This command accomplishes the following:
-
-- `--name mysql`: gives the container a name of "mysql".
-- `-e MYSQL_ROOT_PASSWORD=secret` sets the root password to "secret".
-- `-e MYSQL_DATABASE=database` creates a new database named "database".
-- `-e MYSQL_USER=user` creates a new user named "user".
-- `-e MYSQL_PASSWORD=secret` sets the password for the new user to "secret".
-- `-p 3306:3306` maps port 3306 inside Docker as port 3306 on the host machine.
-- `-d mysql` runs the container in the background and prints the container ID. The image is "mysql".
+1. `--name mysql`: This defines the name of the Docker container.
+2. `-e MYSQL_ROOT_PASSWORD=secret`: This sets a password for the MySQL root user.
+3. `-e MYSQL_DATABASE=database`: This creates a new database named "database", the same as the one used in your Python script.
+4. `-e MYSQL_USER=user`: This sets a user for the MySQL server.
+5. `-e MYSQL_PASSWORD=secret`: This sets a password for the MySQL server.
+6. `-p 3306:3306`: This makes the MySQL instance available on your local machine under port 3306.
+7. `-d mysql`: This denotes the Docker image to be used, in this case, "mysql", and starts the container in detached mode.
 
 ### Run the Python script
 

--- a/docs/integrations/psycopg.md
+++ b/docs/integrations/psycopg.md
@@ -24,21 +24,20 @@ demonstrate how to use **Logfire** with Psycopg.
 First, we need to initialize a PostgreSQL database. This can be easily done using Docker with the following command:
 
 ```bash
-docker run --name postgres \
-    -e POSTGRES_USER=user \
-    -e POSTGRES_PASSWORD=secret \
-    -e POSTGRES_DB=database \
-    -p 5432:5432 -d postgres
+docker run --name postgres \  # (1)!
+    -e POSTGRES_USER=user \  # (2)!
+    -e POSTGRES_PASSWORD=secret \  # (3)!
+    -e POSTGRES_DB=database \  # (4)!
+    -p 5432:5432 \  # (5)!
+    -d postgres  # (6)!
 ```
 
-This command accomplishes the following:
-
-- `--name postgres`: This defines the name of the Docker container.
-- `-e POSTGRES_USER=user`: This sets a user for the PostgreSQL server.
-- `-e POSTGRES_PASSWORD=secret`: This sets a password for the PostgreSQL server.
-- `-e POSTGRES_DB=database`: This creates a new database named "database", the same as the one used in your Python script.
-- `-p 5432:5432`: This makes the PostgreSQL instance available on your local machine under port 5432.
-- `-d postgres`: This denotes the Docker image to be used, in this case, "postgres".
+1. `--name postgres`: This defines the name of the Docker container.
+2. `-e POSTGRES_USER=user`: This sets a user for the PostgreSQL server.
+3. `-e POSTGRES_PASSWORD=secret`: This sets a password for the PostgreSQL server.
+4. `-e POSTGRES_DB=database`: This creates a new database named "database", the same as the one used in your Python script.
+5. `-p 5432:5432`: This makes the PostgreSQL instance available on your local machine under port 5432.
+6. `-d postgres`: This denotes the Docker image to be used, in this case, "postgres", and starts the container in detached mode.
 
 ### Run the Python script
 


### PR DESCRIPTION
We should focus on Logfire, not on the docker here. I want to minimize not needed content on the page.