### PR TITLE
Pin griffe to fix import errors with mkdocstrings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       # see https://github.com/pydantic/logfire/pull/12
       - run: pip install uv
       - run: uv pip install --system -r requirements.lock -r requirements-dev.lock
-      - run: uv pip install --system -U mkdocs-material mkdocstrings-python
+      - run: uv pip install --system -U mkdocs-material mkdocstrings-python griffe==0.48.0
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
       - run: |

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,5 @@ cf-pages-build:
 	python3 -V
 	python3 -m pip install uv
 	python3 -m uv pip install --system -r requirements.lock -r requirements-dev.lock
-	python3 -m uv pip install --system --extra-index-url $(PPPR_URL) -U mkdocs-material mkdocstrings-python
+	python3 -m uv pip install --system --extra-index-url $(PPPR_URL) -U mkdocs-material mkdocstrings-python griffe==0.48.0
 	python3 -m mkdocs build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ dev-dependencies = [
     "celery>=5.4.0",
     "testcontainers",
     "mysql-connector-python~=8.0",
+    "griffe==0.48.0",
 ]
 
 [tool.rye.scripts]


### PR DESCRIPTION
`griffe` has been updated and its modules restructured. We need to update our private `mkdocstrings` wheel to use this. In the meantime, pinning griffe ensures that docs can build in CI.