### PR TITLE
Stop collecting package versions

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -53,12 +53,10 @@ from logfire.exceptions import LogfireConfigError
 from logfire.version import VERSION
 
 from .auth import DEFAULT_FILE, DefaultFile, is_logged_in
-from .collect_system_info import collect_package_info
 from .config_params import ParamManager, PydanticPluginRecordValues
 from .constants import (
     DEFAULT_FALLBACK_FILE_NAME,
     OTLP_MAX_BODY_SIZE,
-    RESOURCE_ATTRIBUTES_PACKAGE_VERSIONS,
     LevelName,
 )
 from .exporters.console import (
@@ -583,8 +581,10 @@ class LogfireConfig(_LogfireConfigData):
         with suppress_instrumentation():
             otel_resource_attributes: dict[str, Any] = {
                 ResourceAttributes.SERVICE_NAME: self.service_name,
-                RESOURCE_ATTRIBUTES_PACKAGE_VERSIONS: json.dumps(collect_package_info(), separators=(',', ':')),
                 ResourceAttributes.PROCESS_PID: os.getpid(),
+                # Having this giant blob of data associated with every span/metric causes various problems so it's
+                # disabled for now, but we may want to re-enable something like it in the future
+                # RESOURCE_ATTRIBUTES_PACKAGE_VERSIONS: json.dumps(collect_package_info(), separators=(',', ':')),
             }
             if self.service_version:
                 otel_resource_attributes[ResourceAttributes.SERVICE_VERSION] = self.service_version

--- a/tests/test_collect_package_resources.py
+++ b/tests/test_collect_package_resources.py
@@ -1,21 +1,8 @@
-import json
-
 from dirty_equals import IsPartialDict
 
-from logfire import VERSION, info
-from logfire.testing import TestExporter
+from logfire import VERSION
+from logfire._internal.collect_system_info import collect_package_info
 
 
-def test_collect_resources(exporter: TestExporter) -> None:
-    info('test')
-
-    resources = [
-        span['resource']
-        for span in exporter.exported_spans_as_dict(include_resources=True, include_package_versions=True)
-    ]
-
-    assert len(resources) == 1
-    resource = resources[0]
-    data = json.loads(resource['attributes']['logfire.package_versions'])
-
-    assert data == IsPartialDict({'logfire': VERSION})
+def test_collect_package_info() -> None:
+    assert collect_package_info() == IsPartialDict({'logfire': VERSION})


### PR DESCRIPTION
A user report in https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1724080095886999 revealed that the big `logfire.package_versions` resource attribute caused errors like the following when exporting metrics to Mimir (Prometheus):

```
Failed to export batch code: 400, reason:�received a series whose label value length exceeds the limit, label: 'logfire_package_versions', value: '{"Babel":"2.15.0","Deprecated":"1.2.14","Django":"5.1","Flask":"3.0.3","Jinja2":"3.1.4","Markdown":"3.6","MarkupSafe":"2.1.5","PyYAML":"6.0.2","Pygments":"2.18.0","SQLAlchemy":"2.0.32","Werkzeug":"3.0' (truncated) series: 'target_info{instance="362467f7ff7c489eba331bc7d4833c79", job="unknown_service", logfire_package_versions="{\"Babel\":\"2.15.0\",\"Deprecated\":\"1.2.14\",\"Django\":\"5.1\",\"Flask\":\"3.0.3\",\"Jinja' (err-mimir-label-value-too-long). To adjust the related per-tenant limit, configure -validation.max-length-label-value, or contact your service administrator.
```

Package versions have caused various problems, this was the final straw. Hopefully we can revive this feature in some smarter form in the future, but for now it seems best to just drop it entirely.

Internal discussion: https://pydantic.slack.com/archives/C05AF4A4WRM/p1724084380802899