### PR TITLE
Add missing `service_version` field to `_LogfireConfigData` so that it gets copied into subprocesses

### DIFF
--- a/logfire-api/logfire_api/_internal/config.pyi
+++ b/logfire-api/logfire_api/_internal/config.pyi
@@ -124,6 +124,7 @@ class _LogfireConfigData:
     token: str | None
     project_name: str | None
     service_name: str
+    service_version: str | None
     trace_sample_rate: float
     console: ConsoleOptions | Literal[False] | None
     show_summary: bool

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -319,6 +319,9 @@ class _LogfireConfigData:
     service_name: str
     """The name of this service"""
 
+    service_version: str | None
+    """The version of this service"""
+
     trace_sample_rate: float
     """The sampling ratio for spans"""
 
@@ -329,7 +332,7 @@ class _LogfireConfigData:
     """Whether to show the summary when starting a new project"""
 
     data_dir: Path
-    """The directory to store Logfire config in"""
+    """The directory to store Logfire data in"""
 
     id_generator: IdGenerator
     """The ID generator to use"""


### PR DESCRIPTION
This caused a failure here: https://github.com/pydantic/platform/actions/runs/10559855499/job/29252233102?pr=4053