### PR TITLE
Use OTEL scopes better, especially instead of tags

### DIFF
--- a/logfire/_internal/async_.py
+++ b/logfire/_internal/async_.py
@@ -26,7 +26,7 @@ def log_slow_callbacks(logfire: Logfire, slow_duration: float) -> ContextManager
     Inspired by https://gitlab.com/quantlane/libs/aiodebug.
     """
     original_run = asyncio.events.Handle._run
-    logfire = logfire.with_tags('slow-async')
+    logfire = logfire.with_settings(custom_scope_suffix='asyncio')
     timer = logfire.config.ns_timestamp_generator
     slow_duration *= ONE_SECOND_IN_NANOSECONDS
 

--- a/logfire/_internal/auto_trace/__init__.py
+++ b/logfire/_internal/auto_trace/__init__.py
@@ -56,6 +56,7 @@ def install_auto_tracing(
                     )
 
     min_duration = int(min_duration * ONE_SECOND_IN_NANOSECONDS)
+    logfire = logfire.with_settings(custom_scope_suffix='auto_tracing')
     finder = LogfireFinder(logfire, modules, min_duration)
     sys.meta_path.insert(0, finder)
 

--- a/logfire/_internal/auto_trace/rewrite_ast.py
+++ b/logfire/_internal/auto_trace/rewrite_ast.py
@@ -53,7 +53,7 @@ def rewrite_ast(
     min_duration: int,
 ) -> ast.AST:
     tree = ast.parse(source)
-    logfire_args = LogfireArgs(logfire_instance._tags + ('auto-trace',), logfire_instance._sample_rate)  # type: ignore
+    logfire_args = LogfireArgs(logfire_instance._tags, logfire_instance._sample_rate)  # type: ignore
     transformer = AutoTraceTransformer(
         logfire_args, logfire_name, filename, module_name, logfire_instance, context_factories, min_duration
     )

--- a/logfire/_internal/integrations/fastapi.py
+++ b/logfire/_internal/integrations/fastapi.py
@@ -158,7 +158,7 @@ class FastAPIInstrumentation:
         ],
         excluded_urls: str | None,
     ):
-        self.logfire_instance = logfire_instance.with_tags('fastapi')
+        self.logfire_instance = logfire_instance.with_settings(custom_scope_suffix='fastapi')
         self.request_attributes_mapper = request_attributes_mapper
 
         # These lines, as well as the `excluded_urls_list.url_disabled` call below, are copied from OTEL.

--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pydantic_core import CoreConfig, CoreSchema
 
 
-METER = GLOBAL_CONFIG._meter_provider.get_meter('pydantic-plugin-meter')  # type: ignore
+METER = GLOBAL_CONFIG._meter_provider.get_meter('logfire.pydantic')  # type: ignore
 validation_counter = METER.create_counter('pydantic.validations')
 
 

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -187,6 +187,8 @@ def test_path_param(client: TestClient, exporter: TestExporter) -> None:
     assert response.status_code == 200
     assert response.json() == {'param': 'param_val'}
 
+    assert exporter.exported_spans[1].instrumentation_scope.name == 'logfire.fastapi'  # type: ignore
+
     span_dicts = exporter.exported_spans_as_dict(_include_pending_spans=True)
 
     # Highlights of the below mega-assert:

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -242,7 +242,6 @@ def test_path_param(client: TestClient, exporter: TestExporter) -> None:
                     'logfire.msg': 'FastAPI arguments',
                     'logfire.span_type': 'pending_span',
                     'logfire.pending_parent_id': '0000000000000001',
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -255,7 +254,6 @@ def test_path_param(client: TestClient, exporter: TestExporter) -> None:
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
                     'logfire.span_type': 'span',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                 },
             },
@@ -274,7 +272,6 @@ def test_path_param(client: TestClient, exporter: TestExporter) -> None:
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.span_type': 'pending_span',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.msg': 'GET /with_path_param/{param} (with_path_param)',
                     'logfire.level_num': 5,
                     'logfire.pending_parent_id': '0000000000000001',
@@ -295,7 +292,6 @@ def test_path_param(client: TestClient, exporter: TestExporter) -> None:
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.span_type': 'span',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.msg': 'GET /with_path_param/{param} (with_path_param)',
                     'logfire.level_num': 5,
                 },
@@ -461,7 +457,6 @@ def test_fastapi_instrumentation(client: TestClient, exporter: TestExporter) -> 
                     'logfire.msg': 'FastAPI arguments',
                     'logfire.span_type': 'pending_span',
                     'logfire.pending_parent_id': '0000000000000003',
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -472,7 +467,6 @@ def test_fastapi_instrumentation(client: TestClient, exporter: TestExporter) -> 
                 'end_time': 4000000000,
                 'attributes': {
                     'logfire.span_type': 'span',
-                    'logfire.tags': ('fastapi',),
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
                     'logfire.level_num': 5,
@@ -494,7 +488,6 @@ def test_fastapi_instrumentation(client: TestClient, exporter: TestExporter) -> 
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
                     'logfire.span_type': 'pending_span',
                     'logfire.msg': 'GET / (homepage)',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.pending_parent_id': '0000000000000003',
                 },
@@ -530,7 +523,6 @@ def test_fastapi_instrumentation(client: TestClient, exporter: TestExporter) -> 
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.span_type': 'span',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.msg': 'GET / (homepage)',
                     'logfire.level_num': 5,
                 },
@@ -684,7 +676,6 @@ def test_fastapi_arguments(client: TestClient, exporter: TestExporter) -> None:
                             },
                         }
                     ),
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -791,7 +782,6 @@ def test_get_fastapi_arguments(client: TestClient, exporter: TestExporter) -> No
                             },
                         }
                     ),
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -809,7 +799,6 @@ def test_get_fastapi_arguments(client: TestClient, exporter: TestExporter) -> No
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /other (other_route)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },
@@ -918,7 +907,6 @@ def test_first_lvl_subapp_fastapi_arguments(client: TestClient, exporter: TestEx
                             },
                         }
                     ),
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -936,7 +924,6 @@ def test_first_lvl_subapp_fastapi_arguments(client: TestClient, exporter: TestEx
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /other (other_route)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },
@@ -1045,7 +1032,6 @@ def test_second_lvl_subapp_fastapi_arguments(client: TestClient, exporter: TestE
                             },
                         }
                     ),
-                    'logfire.tags': ('fastapi',),
                 },
             },
             {
@@ -1063,7 +1049,6 @@ def test_second_lvl_subapp_fastapi_arguments(client: TestClient, exporter: TestE
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /other (other_route)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },
@@ -1149,7 +1134,6 @@ def test_fastapi_unhandled_exception(client: TestClient, exporter: TestExporter)
                 'attributes': {
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'logfire.level_num': 5,
                 },
@@ -1169,7 +1153,6 @@ def test_fastapi_unhandled_exception(client: TestClient, exporter: TestExporter)
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /exception (exception)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'logfire.level_num': 17,
                 },
@@ -1251,7 +1234,6 @@ def test_fastapi_handled_exception(client: TestClient, exporter: TestExporter) -
                 'attributes': {
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'logfire.level_num': 5,
                 },
@@ -1271,7 +1253,6 @@ def test_fastapi_handled_exception(client: TestClient, exporter: TestExporter) -
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /validation_error (validation_error)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'logfire.level_num': 17,
                 },
@@ -1390,7 +1371,6 @@ def test_scrubbing(client: TestClient, exporter: TestExporter) -> None:
                     'fastapi.route.name': 'secret',
                     'logfire.null_args': ('fastapi.route.operation_id',),
                     'logfire.json_schema': '{"type":"object","properties":{"values":{"type":"object"},"errors":{"type":"array"},"custom_attr":{},"http.method":{},"http.route":{},"fastapi.route.name":{},"fastapi.route.operation_id":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.scrubbed': IsJson(
                         [
                             {'path': ['attributes', 'values', 'path_param'], 'matched_substring': 'auth'},
@@ -1415,7 +1395,6 @@ def test_scrubbing(client: TestClient, exporter: TestExporter) -> None:
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'GET /secret/{path_param} (get_secret)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },
@@ -1541,7 +1520,6 @@ def test_request_hooks_without_send_receiev_spans(exporter: TestExporter):
                 'attributes': {
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'values': '{}',
                     'errors': '[]',
@@ -1583,7 +1561,6 @@ def test_request_hooks_without_send_receiev_spans(exporter: TestExporter):
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'POST /echo_body (echo_body)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },
@@ -1686,7 +1663,6 @@ def test_request_hooks_with_send_receive_spans(exporter: TestExporter):
                 'attributes': {
                     'logfire.msg_template': 'FastAPI arguments',
                     'logfire.msg': 'FastAPI arguments',
-                    'logfire.tags': ('fastapi',),
                     'logfire.span_type': 'span',
                     'values': '{}',
                     'errors': '[]',
@@ -1741,7 +1717,6 @@ def test_request_hooks_with_send_receive_spans(exporter: TestExporter):
                     'logfire.msg_template': '{method} {http.route} ({code.function})',
                     'logfire.msg': 'POST /echo_body (echo_body)',
                     'logfire.json_schema': '{"type":"object","properties":{"method":{},"http.route":{}}}',
-                    'logfire.tags': ('fastapi',),
                     'logfire.level_num': 5,
                     'logfire.span_type': 'span',
                 },

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -50,6 +50,8 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
     with pytest.raises(IndexError):  # foo.bar intentionally raises an error to test that it's recorded below
         asyncio.run(foo.bar())
 
+    assert exporter.exported_spans[0].instrumentation_scope.name == 'logfire.auto_tracing'  # type: ignore
+
     assert exporter.exported_spans_as_dict(_include_pending_spans=True) == snapshot(
         [
             {

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, ContextManager
 import pytest
 from inline_snapshot import snapshot
 
+import logfire
 from logfire import DEFAULT_LOGFIRE_INSTANCE, AutoTraceModule, install_auto_tracing
 from logfire._internal.auto_trace import (
     AutoTraceModuleAlreadyImportedException,
@@ -21,7 +22,7 @@ from logfire.testing import TestExporter
 def test_auto_trace_sample(exporter: TestExporter) -> None:
     meta_path = sys.meta_path.copy()
 
-    install_auto_tracing('tests.auto_trace_samples')
+    logfire.with_tags('testing', 'auto-tracing').install_auto_tracing('tests.auto_trace_samples')
     # Check that having multiple LogfireFinders doesn't break things
     install_auto_tracing('tests.blablabla')
 
@@ -65,6 +66,7 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
                     'code.lineno': 123,
                     'code.function': 'bar',
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.foo.bar',
+                    'logfire.tags': ('testing', 'auto-tracing'),
                     'logfire.msg': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.span_type': 'pending_span',
                     'logfire.pending_parent_id': '0000000000000000',
@@ -112,6 +114,7 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
                     'code.lineno': 123,
                     'code.function': 'bar',
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.foo.bar',
+                    'logfire.tags': ('testing', 'auto-tracing'),
                     'logfire.span_type': 'span',
                     'logfire.msg': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.level_num': 17,

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -65,7 +65,6 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.msg': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.span_type': 'pending_span',
-                    'logfire.tags': ('auto-trace',),
                     'logfire.pending_parent_id': '0000000000000000',
                 },
             },
@@ -112,7 +111,6 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
                     'code.function': 'bar',
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.span_type': 'span',
-                    'logfire.tags': ('auto-trace',),
                     'logfire.msg': 'Calling tests.auto_trace_samples.foo.bar',
                     'logfire.level_num': 17,
                 },
@@ -256,7 +254,6 @@ class Class3:
                     'code.lineno': 8,
                     'code.function': 'func.<locals>.Class.method',
                     'logfire.msg_template': 'Calling module.name.func.<locals>.Class.method',
-                    'logfire.tags': ('auto-trace',),
                 },
             ),
             (
@@ -266,7 +263,6 @@ class Class3:
                     'code.lineno': 16,
                     'code.function': 'func.<locals>.Class.method2.<locals>.Class2.method3',
                     'logfire.msg_template': 'Calling module.name.func.<locals>.Class.method2.<locals>.Class2.method3',
-                    'logfire.tags': ('auto-trace',),
                 },
             ),
             (
@@ -276,7 +272,6 @@ class Class3:
                     'code.lineno': 12,
                     'code.function': 'func.<locals>.Class.method2',
                     'logfire.msg_template': 'Calling module.name.func.<locals>.Class.method2',
-                    'logfire.tags': ('auto-trace',),
                 },
             ),
             (
@@ -286,7 +281,6 @@ class Class3:
                     'code.lineno': 2,
                     'code.function': 'func',
                     'logfire.msg_template': 'Calling module.name.func',
-                    'logfire.tags': ('auto-trace',),
                 },
             ),
             (
@@ -296,7 +290,6 @@ class Class3:
                     'code.lineno': 26,
                     'code.function': 'Class3.method4',
                     'logfire.msg_template': 'Calling module.name.Class3.method4',
-                    'logfire.tags': ('auto-trace',),
                 },
             ),
         ]
@@ -468,7 +461,6 @@ def test_min_duration(exporter: TestExporter):
                     'code.lineno': 123,
                     'code.function': 'func2',
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.simple_nesting.func2',
-                    'logfire.tags': ('auto-trace',),
                     'logfire.span_type': 'span',
                     'logfire.msg': 'Calling tests.auto_trace_samples.simple_nesting.func2',
                 },
@@ -484,7 +476,6 @@ def test_min_duration(exporter: TestExporter):
                     'code.lineno': 123,
                     'code.function': 'func1',
                     'logfire.msg_template': 'Calling tests.auto_trace_samples.simple_nesting.func1',
-                    'logfire.tags': ('auto-trace',),
                     'logfire.span_type': 'span',
                     'logfire.msg': 'Calling tests.auto_trace_samples.simple_nesting.func1',
                 },

--- a/tests/test_slow_async_callbacks.py
+++ b/tests/test_slow_async_callbacks.py
@@ -46,7 +46,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                     'duration': 2.0,
                     'name': 'callback mock_block',
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
             {
@@ -75,7 +74,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                         ]
                     ),
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
             {
@@ -109,7 +107,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                         ]
                     ),
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
             {
@@ -138,7 +135,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                         ]
                     ),
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
             {
@@ -167,7 +163,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                         ]
                     ),
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
             {
@@ -196,7 +191,6 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
                         ]
                     ),
                     'logfire.json_schema': '{"type":"object","properties":{"duration":{},"name":{},"stack":{"type":"array"}}}',
-                    'logfire.tags': ('slow-async',),
                 },
             },
         ]

--- a/tests/test_slow_async_callbacks.py
+++ b/tests/test_slow_async_callbacks.py
@@ -27,6 +27,8 @@ def test_slow_async_callbacks(exporter: TestExporter) -> None:
     # Check that the patching is no longer in effect
     assert Handle._run.__qualname__ == 'Handle._run'
 
+    assert exporter.exported_spans[0].instrumentation_scope.name == 'logfire.asyncio'  # type: ignore
+
     assert exporter.exported_spans_as_dict(fixed_line_number=None) == snapshot(
         [
             {


### PR DESCRIPTION
The OTEL instrumentation scope is a useful concept and we should use it consistently when it's appropriate. This way queries like `GROUP BY otel_scope_name` will work better for breaking down where spans are coming from.