### PR TITLE
Add uv installation instructions to docs

### DIFF
--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -127,6 +127,11 @@ def install_logfire(markdown: str, page: Page) -> str:
     ```bash
     poetry add {package}
     ```
+
+=== "uv"
+    ```bash
+    uv add {package}
+    ```
 """
         if not extras:
             instructions += """


### PR DESCRIPTION
Adds installation commands for the [uv](https://docs.astral.sh/uv/) package manager.