### PR TITLE
Deprecate `project_name` in `logfire.configure()`, remove old kwargs from signature 

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from threading import RLock, Thread
-from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, TypedDict, Unpack, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, TypedDict, cast
 from urllib.parse import urljoin
 from uuid import uuid4
 from weakref import WeakSet
@@ -50,7 +50,7 @@ from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
 from opentelemetry.semconv.resource import ResourceAttributes
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
-from typing_extensions import Self
+from typing_extensions import Self, Unpack
 
 from logfire.exceptions import LogfireConfigError
 from logfire.version import VERSION

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -145,6 +145,7 @@ class PydanticPlugin:
 
 
 class DeprecatedKwargs(TypedDict):
+    # Empty so that passing any additional kwargs makes static type checkers complain.
     pass
 
 

--- a/logfire/_internal/config_params.py
+++ b/logfire/_internal/config_params.py
@@ -59,8 +59,6 @@ SEND_TO_LOGFIRE = ConfigParam(env_vars=['LOGFIRE_SEND_TO_LOGFIRE'], allow_file_c
 """Whether to send spans to Logfire."""
 TOKEN = ConfigParam(env_vars=['LOGFIRE_TOKEN'])
 """Token for the Logfire API."""
-PROJECT_NAME = ConfigParam(env_vars=['LOGFIRE_PROJECT_NAME'], allow_file_config=True)
-"""Name of the project. Project name accepts a string value containing alphanumeric characters and hyphens (-). The hyphen character must not be located at the beginning or end of the string and should appear in between alphanumeric characters."""
 SERVICE_NAME = ConfigParam(env_vars=['LOGFIRE_SERVICE_NAME', OTEL_SERVICE_NAME], allow_file_config=True, default='')
 """Name of the service emitting spans. For further details, please refer to the [Service section](https://opentelemetry.io/docs/specs/semconv/resource/#service)."""
 SERVICE_VERSION = ConfigParam(env_vars=['LOGFIRE_SERVICE_VERSION', 'OTEL_SERVICE_VERSION'], allow_file_config=True)
@@ -104,7 +102,6 @@ CONFIG_PARAMS = {
     'base_url': BASE_URL,
     'send_to_logfire': SEND_TO_LOGFIRE,
     'token': TOKEN,
-    'project_name': PROJECT_NAME,
     'service_name': SERVICE_NAME,
     'service_version': SERVICE_VERSION,
     'trace_sample_rate': TRACE_SAMPLE_RATE,

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -53,7 +53,7 @@ JsonPath: typing_extensions.TypeAlias = 'tuple[str | int, ...]'
 
 @dataclass
 class ScrubMatch:
-    """An object passed to the [`scrubbing_callback`][logfire.configure(scrubbing_callback)] function."""
+    """An object passed to a [`ScrubbingOptions.callback`][logfire.ScrubbingOptions.callback] function."""
 
     path: JsonPath
     """The path to the value in the span being considered for redaction, e.g. `('attributes', 'password')`."""
@@ -68,7 +68,6 @@ class ScrubMatch:
     """
 
 
-# See scrubbing_callback in logfire.configure for more info on this type.
 ScrubCallback = Callable[[ScrubMatch], Any]
 
 
@@ -152,7 +151,7 @@ class Scrubber(BaseScrubber):
     """Redacts potentially sensitive data."""
 
     def __init__(self, patterns: Sequence[str] | None, callback: ScrubCallback | None = None):
-        # See scrubbing_patterns and scrubbing_callback in logfire.configure for more info on these parameters.
+        # See ScrubbingOptions for more info on these parameters.
         patterns = [*DEFAULT_PATTERNS, *(patterns or [])]
         self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
         self._callback = callback

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -688,7 +688,7 @@ def test_projects_new_invalid_project_name(tmp_dir_cwd: Path, default_credential
                 '  * may contain single hyphens\n'
                 '  * may not start or end with a hyphen\n\n'
                 'Enter the project name you want to use:',
-                default='invalid name',
+                default='testprojectsnewinvalidproj0',
             ),
         ]
         console_calls = [re.sub(r'^call(\(\).)?', '', str(call)) for call in console.mock_calls]

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -476,7 +476,6 @@ def test_read_config_from_pyproject_toml(tmp_path: Path) -> None:
 
     assert GLOBAL_CONFIG.base_url == 'https://api.logfire.io'
     assert GLOBAL_CONFIG.send_to_logfire is False
-    assert GLOBAL_CONFIG.project_name == 'test'
     assert GLOBAL_CONFIG.console
     assert GLOBAL_CONFIG.console.colors == 'never'
     assert GLOBAL_CONFIG.console.include_timestamps is False
@@ -1546,3 +1545,15 @@ def test_collect_system_metrics_true():
         )
     ):
         logfire.configure(collect_system_metrics=True)  # type: ignore
+
+
+def test_unknown_kwargs():
+    with inline_snapshot.extra.raises(snapshot('TypeError: configure() got unexpected keyword arguments: foo, bar')):
+        logfire.configure(foo=1, bar=2)  # type: ignore
+
+
+def test_project_name_deprecated():
+    with inline_snapshot.extra.raises(
+        snapshot('DeprecationWarning: The `project_name` argument is deprecated and not needed.')
+    ):
+        logfire.configure(project_name='foo')  # type: ignore

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -1253,10 +1253,10 @@ def test_format_attribute_added_after_pending_span_sent(exporter: TestExporter) 
     )
 
 
-def check_project_name(expected_project_name: str) -> None:
+def check_service_name(expected_service_name: str) -> None:
     from logfire._internal.config import GLOBAL_CONFIG
 
-    assert GLOBAL_CONFIG.project_name == expected_project_name
+    assert GLOBAL_CONFIG.service_name == expected_service_name
 
 
 @pytest.mark.parametrize(
@@ -1273,12 +1273,12 @@ def test_config_preserved_across_thread_or_process(
     configure(
         send_to_logfire=False,
         console=False,
-        project_name='foobar!',
+        service_name='foobar!',
         additional_metric_readers=[InMemoryMetricReader()],
     )
 
     with executor_factory() as executor:
-        executor.submit(check_project_name, 'foobar!')
+        executor.submit(check_service_name, 'foobar!')
         executor.shutdown(wait=True)
 
 

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -331,7 +331,7 @@ def test_scrubbing_deprecated_args(config_kwargs: dict[str, Any]):
     with pytest.warns(
         DeprecationWarning, match='The `scrubbing_callback` and `scrubbing_patterns` arguments are deprecated.'
     ):
-        logfire.configure(**config_kwargs, scrubbing_patterns=['my_pattern'], scrubbing_callback=callback)
+        logfire.configure(**config_kwargs, scrubbing_patterns=['my_pattern'], scrubbing_callback=callback)  # type: ignore
 
     config = logfire.DEFAULT_LOGFIRE_INSTANCE.config
     assert config.scrubbing
@@ -344,7 +344,7 @@ def test_scrubbing_deprecated_args_combined_with_new_options():
         ValueError,
         match='Cannot specify `scrubbing` and `scrubbing_callback` or `scrubbing_patterns` at the same time.',
     ):
-        logfire.configure(scrubbing_patterns=['my_pattern'], scrubbing=logfire.ScrubbingOptions())
+        logfire.configure(scrubbing_patterns=['my_pattern'], scrubbing=logfire.ScrubbingOptions())  # type: ignore
 
 
 @pytest.mark.skipif(sys.version_info[:2] < (3, 9), reason='f-string magic is not allowed in 3.8')


### PR DESCRIPTION
Deprecated kwargs are now moved into `**kwargs: DeprecatedKwargs` and undocumented to leave the remaining docs cleaner.

Internal discussion: https://pydantic.slack.com/archives/C05AF4A4WRM/p1725302678666539