### PR TITLE
Keep `METRICS_PREFERRED_TEMPORALITY` private

### DIFF
--- a/logfire-api/logfire_api/__init__.pyi
+++ b/logfire-api/logfire_api/__init__.pyi
@@ -1,6 +1,6 @@
 from ._internal.auto_trace import AutoTraceModule as AutoTraceModule
 from ._internal.auto_trace.rewrite_ast import no_auto_trace as no_auto_trace
-from ._internal.config import AdvancedOptions as AdvancedOptions, ConsoleOptions as ConsoleOptions, METRICS_PREFERRED_TEMPORALITY as METRICS_PREFERRED_TEMPORALITY, MetricsOptions as MetricsOptions, PydanticPlugin as PydanticPlugin, configure as configure
+from ._internal.config import AdvancedOptions as AdvancedOptions, ConsoleOptions as ConsoleOptions, MetricsOptions as MetricsOptions, PydanticPlugin as PydanticPlugin, configure as configure
 from ._internal.constants import LevelName as LevelName
 from ._internal.exporters.file import load_file as load_spans_from_file
 from ._internal.main import Logfire as Logfire, LogfireSpan as LogfireSpan
@@ -11,7 +11,7 @@ from .integrations.structlog import LogfireProcessor as StructlogProcessor
 from .version import VERSION as VERSION
 from logfire.sampling import SamplingOptions as SamplingOptions
 
-__all__ = ['Logfire', 'LogfireSpan', 'LevelName', 'AdvancedOptions', 'ConsoleOptions', 'PydanticPlugin', 'configure', 'span', 'instrument', 'log', 'trace', 'debug', 'notice', 'info', 'warn', 'error', 'exception', 'fatal', 'force_flush', 'log_slow_async_callbacks', 'install_auto_tracing', 'instrument_fastapi', 'instrument_openai', 'instrument_anthropic', 'instrument_asyncpg', 'instrument_httpx', 'instrument_celery', 'instrument_requests', 'instrument_psycopg', 'instrument_django', 'instrument_flask', 'instrument_starlette', 'instrument_aiohttp_client', 'instrument_sqlalchemy', 'instrument_redis', 'instrument_pymongo', 'instrument_mysql', 'instrument_system_metrics', 'AutoTraceModule', 'with_tags', 'with_settings', 'shutdown', 'load_spans_from_file', 'no_auto_trace', 'METRICS_PREFERRED_TEMPORALITY', 'ScrubMatch', 'ScrubbingOptions', 'VERSION', 'suppress_instrumentation', 'StructlogProcessor', 'LogfireLoggingHandler', 'SamplingOptions', 'MetricsOptions']
+__all__ = ['Logfire', 'LogfireSpan', 'LevelName', 'AdvancedOptions', 'ConsoleOptions', 'PydanticPlugin', 'configure', 'span', 'instrument', 'log', 'trace', 'debug', 'notice', 'info', 'warn', 'error', 'exception', 'fatal', 'force_flush', 'log_slow_async_callbacks', 'install_auto_tracing', 'instrument_fastapi', 'instrument_openai', 'instrument_anthropic', 'instrument_asyncpg', 'instrument_httpx', 'instrument_celery', 'instrument_requests', 'instrument_psycopg', 'instrument_django', 'instrument_flask', 'instrument_starlette', 'instrument_aiohttp_client', 'instrument_sqlalchemy', 'instrument_redis', 'instrument_pymongo', 'instrument_mysql', 'instrument_system_metrics', 'AutoTraceModule', 'with_tags', 'with_settings', 'shutdown', 'load_spans_from_file', 'no_auto_trace', 'ScrubMatch', 'ScrubbingOptions', 'VERSION', 'suppress_instrumentation', 'StructlogProcessor', 'LogfireLoggingHandler', 'SamplingOptions', 'MetricsOptions']
 
 DEFAULT_LOGFIRE_INSTANCE = Logfire()
 span = DEFAULT_LOGFIRE_INSTANCE.span

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -9,7 +9,6 @@ from logfire.sampling import SamplingOptions
 from ._internal.auto_trace import AutoTraceModule
 from ._internal.auto_trace.rewrite_ast import no_auto_trace
 from ._internal.config import (
-    METRICS_PREFERRED_TEMPORALITY,
     AdvancedOptions,
     ConsoleOptions,
     MetricsOptions,
@@ -133,7 +132,6 @@ __all__ = (
     'shutdown',
     'load_spans_from_file',
     'no_auto_trace',
-    'METRICS_PREFERRED_TEMPORALITY',
     'ScrubMatch',
     'ScrubbingOptions',
     'VERSION',

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -105,7 +105,10 @@ METRICS_PREFERRED_TEMPORALITY = {
     ObservableUpDownCounter: AggregationTemporality.CUMULATIVE,
     ObservableGauge: AggregationTemporality.CUMULATIVE,
 }
-"""This should be passed as the `preferred_temporality` argument of metric readers and exporters."""
+"""
+This should be passed as the `preferred_temporality` argument of metric readers and exporters
+which send to the Logfire backend.
+"""
 
 
 @dataclass

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -172,9 +172,6 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire_api.MetricsOptions()
     logfire__all__.remove('MetricsOptions')
 
-    assert hasattr(logfire_api, 'METRICS_PREFERRED_TEMPORALITY')
-    logfire__all__.remove('METRICS_PREFERRED_TEMPORALITY')
-
     assert hasattr(logfire_api, 'load_spans_from_file')
     logfire_api.load_spans_from_file(file_path='test')
     logfire__all__.remove('load_spans_from_file')


### PR DESCRIPTION
Users shouldn't generally use `METRICS_PREFERRED_TEMPORALITY`, it's only for exporting to the logfire backend. I previously removed the recommendation to use it, this is finishing that off. Other backends may or may not work best with this aggregation temporality, that's up to the user doing that kind of advanced configuration.