### PR TITLE
Use `SeededRandomIdGenerator` by default to prevent interference from `random.seed`

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -46,7 +46,7 @@ from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor, TracerProvider as SDKTracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
-from opentelemetry.sdk.trace.id_generator import IdGenerator, RandomIdGenerator
+from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio, Sampler
 from opentelemetry.semconv.resource import ResourceAttributes
 from rich.console import Console
@@ -83,7 +83,14 @@ from .metrics import ProxyMeterProvider
 from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions
 from .stack_info import warn_at_user_stacklevel
 from .tracer import PendingSpanProcessor, ProxyTracerProvider
-from .utils import UnexpectedResponse, ensure_data_dir_exists, get_version, read_toml_file, suppress_instrumentation
+from .utils import (
+    SeededRandomIdGenerator,
+    UnexpectedResponse,
+    ensure_data_dir_exists,
+    get_version,
+    read_toml_file,
+    suppress_instrumentation,
+)
 
 if TYPE_CHECKING:
     from .main import FastLogfireSpan, LogfireSpan
@@ -136,8 +143,11 @@ class AdvancedOptions:
     base_url: str = 'https://logfire-api.pydantic.dev'
     """Root URL for the Logfire API."""
 
-    id_generator: IdGenerator = dataclasses.field(default_factory=RandomIdGenerator)
-    """Generator for trace and span IDs."""
+    id_generator: IdGenerator = dataclasses.field(default_factory=lambda: SeededRandomIdGenerator(None))
+    """Generator for trace and span IDs.
+
+    The default generates random IDs and is unaffected by calls to `random.seed()`.
+    """
 
     ns_timestamp_generator: Callable[[], int] = time.time_ns
     """Generator for nanosecond start and end timestamps of spans."""

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -372,12 +372,12 @@ class SeededRandomIdGenerator(IdGenerator):
 
     def generate_span_id(self) -> int:
         span_id = self.random.getrandbits(64)
-        while span_id == trace_api.INVALID_SPAN_ID:
+        while span_id == trace_api.INVALID_SPAN_ID:  # pragma: no cover
             span_id = self.random.getrandbits(64)
         return span_id
 
     def generate_trace_id(self) -> int:
         trace_id = self.random.getrandbits(128)
-        while trace_id == trace_api.INVALID_TRACE_ID:
+        while trace_id == trace_api.INVALID_TRACE_ID:  # pragma: no cover
             trace_id = self.random.getrandbits(128)
         return trace_id

--- a/logfire/testing.py
+++ b/logfire/testing.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import random
 from dataclasses import dataclass
 
 import pytest
@@ -14,6 +13,7 @@ import logfire
 
 from ._internal.constants import ONE_SECOND_IN_NANOSECONDS
 from ._internal.exporters.test import TestExporter
+from ._internal.utils import SeededRandomIdGenerator
 
 __all__ = [
     'capfire',
@@ -54,28 +54,6 @@ class IncrementalIdGenerator(IdGenerator):
         if self.trace_id_counter > 2**128 - 1:  # pragma: no branch
             raise OverflowError('Trace ID overflow')  # pragma: no cover
         return self.trace_id_counter
-
-
-@dataclass(repr=True)
-class SeededRandomIdGenerator(IdGenerator):
-    """Generate random span/trace IDs from a random seed for deterministic tests.
-
-    Trace IDs are 64-bit integers.
-    Span IDs are 32-bit integers.
-    """
-
-    seed: int = 0
-
-    def __post_init__(self) -> None:
-        self.random = random.Random(self.seed)
-
-    def generate_span_id(self) -> int:
-        """Generates a random span id."""
-        return self.random.getrandbits(64)
-
-    def generate_trace_id(self) -> int:
-        """Generates a random trace id."""
-        return self.random.getrandbits(128)
 
 
 # Making this a dataclass causes errors in the process pool end-to-end tests


### PR DESCRIPTION
Fixes https://github.com/pydantic/logfire/issues/437. It was closed already, but the request was reasonable, and I recently saw very different spans having the same trace and span ID in user data which was concerning. My best guess is that this was caused by a call to `random.seed`, so this should prevent that.