### PR TITLE
Fix typos

### DIFF
--- a/docs/guides/advanced/alternative-clients.md
+++ b/docs/guides/advanced/alternative-clients.md
@@ -6,7 +6,7 @@
     - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://logfire-api.pydantic.dev/v1/traces` for just traces
     - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://logfire-api.pydantic.dev/v1/metrics` for just metrics
 - `OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` - see [Creating Write Tokens](./creating-write-tokens.md) to obtain a write token and replace `your-write-token` with it.
-- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to export in Protobuf format over HTTP (not gRPC). The **Logfire** backend supports both Protobuf and JSON, but only over HTTP for now. Some SDKs (such as Python) already use this value as the default so setting this isn't required, but other SDKs use `grpc` as the defult.
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to export in Protobuf format over HTTP (not gRPC). The **Logfire** backend supports both Protobuf and JSON, but only over HTTP for now. Some SDKs (such as Python) already use this value as the default so setting this isn't required, but other SDKs use `grpc` as the default.
 
 ## Example with Python
 

--- a/docs/guides/advanced/creating-write-tokens.md
+++ b/docs/guides/advanced/creating-write-tokens.md
@@ -26,5 +26,5 @@ To do this we provide the parameter `send_to_logfire='if-token-present'` in the 
 If you set it to `'if-token-present'`, logfire will only send data to logfire if a write token is present in the environment variable `LOGFIRE_TOKEN` or there is a token saved locally.
 If you run tests in CI no data will be sent.
 
-You can also set the environmnet variable `LOGFIRE_SEND_TO_LOGFIRE` to configure this option.
+You can also set the environment variable `LOGFIRE_SEND_TO_LOGFIRE` to configure this option.
 For example, you can set it to `LOGFIRE_SEND_TO_LOGFIRE=true` in your deployed application and `LOGFIRE_SEND_TO_LOGFIRE=false` in your tests setup.

--- a/tests/auto_trace_samples/foo.py
+++ b/tests/auto_trace_samples/foo.py
@@ -12,7 +12,7 @@ def gen() -> Iterator[int]:
     yield from range(3)
 
 
-# @instrument oerrides auto-tracing
+# @instrument overrides auto-tracing
 @logfire.instrument('Calling async_gen via @instrument')
 async def async_gen():
     def inner():

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -917,7 +917,7 @@ def test_pydantic_plugin_python_exception_record_failure(exporter: TestExporter)
 
 
 def test_old_plugin_style(exporter: TestExporter) -> None:
-    # Test that plguins for the old API still work together with the logfire plugin.
+    # Test that plugins for the old API still work together with the logfire plugin.
 
     events: list[str] = []
 


### PR DESCRIPTION
Hello,
Here are 4 typos I found when looking in the documentation of Logfire.
I hope that's fine with you.

Thanks,
Avi