### PR TITLE
Fix error in checking for generators in auto-tracing

### DIFF
--- a/logfire-api/logfire_api/_internal/auto_trace/rewrite_ast.pyi
+++ b/logfire-api/logfire_api/_internal/auto_trace/rewrite_ast.pyi
@@ -1,7 +1,6 @@
 import ast
 from ..ast_utils import BaseTransformer as BaseTransformer, LogfireArgs as LogfireArgs
 from ..main import Logfire as Logfire
-from _typeshed import Incomplete
 from dataclasses import dataclass
 from typing import Any, Callable, ContextManager, TypeVar
 
@@ -51,7 +50,4 @@ def no_auto_trace(x: T) -> T:
 
     This decorator simply returns the argument unchanged, so there is zero runtime overhead.
     """
-
-GENERATOR_CODE_FLAGS: Incomplete
-
-def is_generator_function(func_def: ast.FunctionDef | ast.AsyncFunctionDef): ...
+def has_yield(node: ast.AST): ...

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -417,13 +417,12 @@ def test_no_auto_trace():
     )
 
 
-# language=Python
 generators_sample = """
 def make_gen():
     def gen():
         async def foo():
             async def bar():
-                pass
+                return lambda: (yield 1)
             yield bar()
         yield from foo()
     return gen


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/495

Trying to compile a function in isolation caused an error when the function had `nonlocal`. So instead we just look for `yield` in the function definition AST.