### PR TITLE
add logger name to `LogfireLoggingHandler` spans

### DIFF
--- a/logfire/_internal/constants.py
+++ b/logfire/_internal/constants.py
@@ -126,6 +126,10 @@ ATTRIBUTES_JSON_SCHEMA_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.json_schema'
 """Key in OTEL attributes that collects the JSON schema."""
 
 ATTRIBUTES_LOGGING_ARGS_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.logging_args'
+"""Key in OTEL attributes that collects the arguments from standard library logging."""
+
+ATTRIBUTES_LOGGING_NAME = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.logger_name'
+"""Key in OTEL attributes that collects the standard library logger name."""
 
 ATTRIBUTES_VALIDATION_ERROR_KEY = 'exception.logfire.data'
 """The key within OTEL attributes where logfire puts validation errors."""

--- a/logfire/integrations/logging.py
+++ b/logfire/integrations/logging.py
@@ -9,6 +9,7 @@ import logfire
 
 from .._internal.constants import (
     ATTRIBUTES_LOGGING_ARGS_KEY,
+    ATTRIBUTES_LOGGING_NAME,
     ATTRIBUTES_MESSAGE_KEY,
     ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
     LOGGING_TO_OTEL_LEVEL_NUMBERS,
@@ -100,6 +101,7 @@ class LogfireLoggingHandler(LoggingHandler):
         attributes['code.filepath'] = record.pathname
         attributes['code.lineno'] = record.lineno
         attributes['code.function'] = record.funcName
+        attributes[ATTRIBUTES_LOGGING_NAME] = record.name
 
         attributes[ATTRIBUTES_MESSAGE_KEY], args = _format_message(record)
         attributes.update(args)

--- a/tests/test_loguru.py
+++ b/tests/test_loguru.py
@@ -43,8 +43,9 @@ def test_loguru(exporter: TestExporter) -> None:
                     'code.filepath': 'test_loguru.py',
                     'code.function': 'test_loguru',
                     'code.lineno': 20,
+                    'logfire.logger_name': 'tests.test_loguru',
                     'logfire.logging_args': '["positional"]',
-                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
                 },
             },
             {
@@ -61,8 +62,9 @@ def test_loguru(exporter: TestExporter) -> None:
                     'code.filepath': 'test_loguru.py',
                     'code.function': 'test_loguru',
                     'code.lineno': 21,
+                    'logfire.logger_name': 'tests.test_loguru',
                     'name': 'named',
-                    'logfire.json_schema': '{"type":"object","properties":{"name":{}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"name":{}}}',
                 },
             },
             {
@@ -79,8 +81,9 @@ def test_loguru(exporter: TestExporter) -> None:
                     'code.filepath': 'test_loguru.py',
                     'code.function': 'test_loguru',
                     'code.lineno': 26,
+                    'logfire.logger_name': 'tests.test_loguru',
                     'foo': 'bar',
-                    'logfire.json_schema': '{"type":"object","properties":{"foo":{}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"foo":{}}}',
                 },
                 'events': [
                     {
@@ -109,6 +112,8 @@ def test_loguru(exporter: TestExporter) -> None:
                     'code.filepath': 'test_loguru.py',
                     'code.function': 'test_loguru',
                     'code.lineno': 28,
+                    'logfire.logger_name': 'tests.test_loguru',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{}}}',
                 },
             },
         ]

--- a/tests/test_stdlib_logging.py
+++ b/tests/test_stdlib_logging.py
@@ -6,7 +6,7 @@ from logging import Logger, getLogger
 from typing import Any, Sequence
 
 import pytest
-from dirty_equals import IsJson, IsPositiveInt
+from dirty_equals import IsPositiveInt
 from inline_snapshot import snapshot
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor, SpanExporter
@@ -44,7 +44,8 @@ def test_stdlib_logging(exporter: TestExporter, logger: Logger) -> None:
                     'code.function': 'test_stdlib_logging',
                     'code.lineno': IsPositiveInt(),
                     'first_name': 'Fred',
-                    'logfire.json_schema': '{"type":"object","properties":{"first_name":{}}}',
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
+                    'logfire.json_schema': '{"type":"object","properties":{"first_name":{},"logfire.logger_name":{}}}',
                 },
             }
         ]
@@ -70,8 +71,9 @@ def test_stdlib_logging_with_positional_params(exporter: TestExporter, logger: L
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_stdlib_logging_with_positional_params',
                     'code.lineno': IsPositiveInt(),
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
                     'logfire.logging_args': '["with a parameter"]',
-                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
                 },
             }
         ]
@@ -97,8 +99,9 @@ def test_stdlib_logging_with_positional_dict_param(exporter: TestExporter, logge
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_stdlib_logging_with_positional_dict_param',
                     'code.lineno': 123,
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
                     'logfire.logging_args': '[{"param":"with a parameter"}]',
-                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
                 },
             }
         ]
@@ -124,6 +127,8 @@ def test_stdlib_logging_with_parenthesis_params(exporter: TestExporter, logger: 
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_stdlib_logging_with_parenthesis_params',
                     'code.lineno': IsPositiveInt(),
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{}}}',
                 },
             }
         ]
@@ -149,8 +154,9 @@ def test_stdlib_logging_with_custom_parenthesis_params(exporter: TestExporter, l
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_stdlib_logging_with_custom_parenthesis_params',
                     'code.lineno': IsPositiveInt(),
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
                     'blah': 'blah',
-                    'logfire.json_schema': '{"type":"object","properties":{"blah":{}}}',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"blah":{}}}',
                 },
             }
         ]
@@ -176,13 +182,9 @@ def test_stdlib_logging_warning(exporter: TestExporter, logger: Logger) -> None:
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_stdlib_logging_warning',
                     'code.lineno': IsPositiveInt(),
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
                     'logfire.logging_args': '["Fred"]',
-                    'logfire.json_schema': IsJson(
-                        {
-                            'type': 'object',
-                            'properties': {'logfire.logging_args': {'type': 'array', 'x-python-datatype': 'tuple'}},
-                        }
-                    ),
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{},"logfire.logging_args":{"type":"array","x-python-datatype":"tuple"}}}',
                 },
             }
         ]
@@ -303,6 +305,8 @@ def test_logging_from_opentelemetry(exporter: TestExporter) -> None:
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_logging_from_opentelemetry',
                     'code.lineno': 123,
+                    'logfire.logger_name': 'root',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{}}}',
                 },
             },
             {
@@ -319,6 +323,8 @@ def test_logging_from_opentelemetry(exporter: TestExporter) -> None:
                     'code.filepath': 'status.py',
                     'code.function': '__init__',
                     'code.lineno': 123,
+                    'logfire.logger_name': 'opentelemetry.trace.status',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{}}}',
                 },
             },
         ]
@@ -347,6 +353,8 @@ def test_logging_non_string(exporter: TestExporter, logger: Logger):
                     'code.filepath': 'test_stdlib_logging.py',
                     'code.function': 'test_logging_non_string',
                     'code.lineno': 123,
+                    'logfire.logger_name': 'tests.test_stdlib_logging',
+                    'logfire.json_schema': '{"type":"object","properties":{"logfire.logger_name":{}}}',
                 },
             }
         ]


### PR DESCRIPTION
As requested by @OliverFarren today on our call earlier today.

@OliverFarren I checked and, and attributes sent through via the `extra` kwarg do get set as attributes.