### PR TITLE
Handle NonRecordingSpans for fastapi arguments

### DIFF
--- a/logfire/_internal/integrations/fastapi.py
+++ b/logfire/_internal/integrations/fastapi.py
@@ -19,7 +19,7 @@ from starlette.websockets import WebSocket
 
 from ..main import Logfire, set_user_attributes_on_raw_span
 from ..stack_info import StackInfo, get_code_object_info
-from ..utils import maybe_capture_server_headers
+from ..utils import handle_internal_errors, maybe_capture_server_headers
 from .asgi import tweak_asgi_spans_tracer_provider
 
 try:
@@ -163,40 +163,41 @@ class FastAPIInstrumentation:
 
     async def solve_dependencies(self, request: Request | WebSocket, original: Awaitable[Any]) -> Any:
         root_span = request.scope.get(LOGFIRE_SPAN_SCOPE_KEY)
-        if not root_span:
-            return await original  # pragma: no cover
+        if not (root_span and root_span.is_recording()):
+            return await original
 
         with self.logfire_instance.span('FastAPI arguments') as span:
-            if isinstance(request, Request):  # pragma: no branch
-                span.set_attribute(SpanAttributes.HTTP_METHOD, request.method)
-            route: APIRoute | APIWebSocketRoute | None = request.scope.get('route')
-            if route:  # pragma: no branch
-                span.set_attribute(SpanAttributes.HTTP_ROUTE, route.path)
-                fastapi_route_attributes: dict[str, Any] = {'fastapi.route.name': route.name}
-                if isinstance(route, APIRoute):  # pragma: no branch
-                    fastapi_route_attributes['fastapi.route.operation_id'] = route.operation_id
-                set_user_attributes_on_raw_span(root_span, fastapi_route_attributes)
-                span.set_attributes(fastapi_route_attributes)
+            with handle_internal_errors():
+                if isinstance(request, Request):  # pragma: no branch
+                    span.set_attribute(SpanAttributes.HTTP_METHOD, request.method)
+                route: APIRoute | APIWebSocketRoute | None = request.scope.get('route')
+                if route:  # pragma: no branch
+                    span.set_attribute(SpanAttributes.HTTP_ROUTE, route.path)
+                    fastapi_route_attributes: dict[str, Any] = {'fastapi.route.name': route.name}
+                    if isinstance(route, APIRoute):  # pragma: no branch
+                        fastapi_route_attributes['fastapi.route.operation_id'] = route.operation_id
+                    set_user_attributes_on_raw_span(root_span, fastapi_route_attributes)
+                    span.set_attributes(fastapi_route_attributes)
 
             result: Any = await original
 
-            solved_values: dict[str, Any]
-            solved_errors: list[Any]
+            with handle_internal_errors():
+                solved_values: dict[str, Any]
+                solved_errors: list[Any]
 
-            if isinstance(result, tuple):  # pragma: no cover
-                solved_values = result[0]  # type: ignore
-                solved_errors = result[1]  # type: ignore
+                if isinstance(result, tuple):  # pragma: no cover
+                    solved_values = result[0]  # type: ignore
+                    solved_errors = result[1]  # type: ignore
 
-                def solved_with_new_values(new_values: dict[str, Any]) -> Any:
-                    return new_values, *result[1:]
-            else:
-                solved_values = result.values
-                solved_errors = result.errors
+                    def solved_with_new_values(new_values: dict[str, Any]) -> Any:
+                        return new_values, *result[1:]
+                else:
+                    solved_values = result.values
+                    solved_errors = result.errors
 
-                def solved_with_new_values(new_values: dict[str, Any]) -> Any:
-                    return dataclasses.replace(result, values=new_values)
+                    def solved_with_new_values(new_values: dict[str, Any]) -> Any:
+                        return dataclasses.replace(result, values=new_values)
 
-            try:
                 attributes: dict[str, Any] | None = {
                     # Shallow copy these so that the user can safely modify them, but we don't tell them that.
                     # We do explicitly tell them that the contents should not be modified.
@@ -233,8 +234,6 @@ class FastAPIInstrumentation:
                     if key in attributes:  # pragma: no branch
                         attributes['fastapi.arguments.' + key] = attributes.pop(key)
                 set_user_attributes_on_raw_span(root_span, attributes)
-            except Exception as e:  # pragma: no cover
-                span.record_exception(e)
 
         return result  # type: ignore
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1993,6 +1993,9 @@ def set_user_attribute(
 
 
 def set_user_attributes_on_raw_span(span: Span, attributes: dict[str, Any]) -> None:
+    if not span.is_recording():
+        return
+
     otlp_attributes = user_attributes(attributes)
     if json_schema_properties := attributes_json_schema_properties(attributes):  # pragma: no branch
         existing_properties = JsonSchemaProperties({})

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -2069,3 +2069,11 @@ def test_websocket(client: TestClient, exporter: TestExporter) -> None:
             },
         ]
     )
+
+
+def test_sampled_out(client: TestClient, exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    logfire.configure(**config_kwargs, sampling=logfire.SamplingOptions(head=0))
+    make_request_hook_spans(record_send_receive=True)
+    make_request_hook_spans(record_send_receive=False)
+
+    assert exporter.exported_spans_as_dict() == []


### PR DESCRIPTION
Multiple redundant changes to prevent errors in the patched `solve_dependencies` when a trace is excluded by sampling: 2 checks for `span.is_recording()` and wrapping in `handle_internal_errors`.