### PR TITLE
docs: Update hightlighted lines in structlog documentation

### DIFF
--- a/docs/integrations/structlog.md
+++ b/docs/integrations/structlog.md
@@ -2,7 +2,7 @@
 
 **Logfire** has a built-in [structlog][structlog] processor that can be used to emit Logfire logs for every structlog event.
 
-```py title="main.py" hl_lines="5 14"
+```py title="main.py" hl_lines="6 15"
 from dataclasses import dataclass
 
 import structlog


### PR DESCRIPTION
Small change, highlighted lines in https://logfire.pydantic.dev/docs/integrations/structlog/ are not consistent after a new line was added in b94bfc3