### PR TITLE
pin deps in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.12"
+          version: "0.4.30"
           enable-cache: true
 
       - name: Set up Python 3.12
@@ -42,13 +42,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.12"
+          version: "0.4.30"
           enable-cache: true
 
       - name: Set up Python 3.12
         run: uv python install 3.12
 
-      - run: uv sync --python 3.12 --frozen
+      - run: uv sync --python 3.12 --frozen --group docs
       - run: uv pip install --upgrade mkdocs-material mkdocstrings-python griffe==0.48.0
         env:
           UV_EXTRA_INDEX_URL: ${{ secrets.UV_EXTRA_INDEX_URL }}
@@ -97,13 +97,13 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.12"
+          version: "0.4.30"
           enable-cache: true
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
-      - run: uv sync --python ${{ matrix.python-version }} --upgrade
+      - run: uv sync --python ${{ matrix.python-version }}
 
       - name: Install pydantic ${{ matrix.pydantic-version }}
         if: matrix.pydantic-version != 'main'
@@ -130,7 +130,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.12"
+          version: "0.4.30"
           enable-cache: true
 
       - name: Set up Python 3.12
@@ -181,7 +181,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.12"
+          version: "0.4.30"
           enable-cache: true
 
       - name: Set up Python 3.12

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,6 @@ all: format lint test
 cf-pages-build:
 	curl -LsSf https://astral.sh/uv/0.4.12/install.sh | sh
 	${HOME}/.cargo/bin/uv python install 3.12
-	${HOME}/.cargo/bin/uv sync --python 3.12 --frozen
+	${HOME}/.cargo/bin/uv sync --python 3.12 --frozen --group docs
 	${HOME}/.cargo/bin/uv pip install --upgrade --extra-index-url $(PPPR_URL) mkdocs-material mkdocstrings-python griffe==0.48.0
 	${HOME}/.cargo/bin/uv run --no-sync mkdocs build

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ all: format lint test
 
 .PHONY: cf-pages-build  # Build the docs for GitHub Pages
 cf-pages-build:
-	curl -LsSf https://astral.sh/uv/0.4.12/install.sh | sh
+	curl -LsSf https://astral.sh/uv/0.4.30/install.sh | sh
 	${HOME}/.cargo/bin/uv python install 3.12
 	${HOME}/.cargo/bin/uv sync --python 3.12 --frozen --group docs
 	${HOME}/.cargo/bin/uv pip install --upgrade --extra-index-url $(PPPR_URL) mkdocs-material mkdocstrings-python griffe==0.48.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,7 +154,7 @@ dev = [
 docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.17",
-    "mkdocs-glightbox>=0.3.7",
+    "mkdocs-glightbox>=0.4.0",
     "mkdocstrings-python>=1.8.0",
     "mkdocs-redirects>=1.2.1",
     "griffe",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,9 +80,8 @@ logfire-plugin = "logfire.integrations.pydantic:plugin"
 [project.entry-points."pytest11"]
 logfire = "logfire.testing"
 
-[tool.uv]
-managed = true
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "anyio < 4.4.0",
     "httpx >= 0.27.2",
     "aiohttp >= 3.10.9",
@@ -148,16 +147,17 @@ dev-dependencies = [
     "numpy<1.24.4; python_version < '3.9'",
     "pytest-recording>=0.13.2",
     "uvicorn>=0.30.6",
-    # Documentation
+    # Logfire API
+    "logfire-api",
+    "requests",
+]
+docs = [
     "mkdocs>=1.5.0",
     "mkdocs-material>=9.5.17",
     "mkdocs-glightbox>=0.3.7",
     "mkdocstrings-python>=1.8.0",
     "mkdocs-redirects>=1.2.1",
     "griffe",
-    # Logfire API
-    "logfire-api",
-    "requests",
 ]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -1475,7 +1475,7 @@ wsgi = [
 ]
 
 [package.dev-dependencies]
-dev = [
+dev-dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "anyio" },
@@ -1490,16 +1490,10 @@ dev = [
     { name = "eval-type-backport" },
     { name = "fastapi" },
     { name = "flask" },
-    { name = "griffe" },
     { name = "httpx" },
     { name = "inline-snapshot" },
     { name = "logfire-api" },
     { name = "loguru" },
-    { name = "mkdocs" },
-    { name = "mkdocs-glightbox" },
-    { name = "mkdocs-material" },
-    { name = "mkdocs-redirects" },
-    { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "mysql-connector-python" },
     { name = "numpy", version = "1.24.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
@@ -1548,6 +1542,14 @@ dev = [
     { name = "testcontainers", version = "4.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "uvicorn" },
 ]
+documentation = [
+    { name = "griffe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-glightbox" },
+    { name = "mkdocs-material" },
+    { name = "mkdocs-redirects" },
+    { name = "mkdocstrings-python" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1582,7 +1584,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
+dev-dependencies = [
     { name = "aiohttp", specifier = ">=3.10.9" },
     { name = "anthropic", specifier = ">=0.27.0" },
     { name = "anyio", specifier = "<4.4.0" },
@@ -1597,16 +1599,10 @@ dev = [
     { name = "eval-type-backport" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "flask", specifier = ">=3.0.3" },
-    { name = "griffe" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "inline-snapshot" },
     { name = "logfire-api", editable = "logfire-api" },
     { name = "loguru" },
-    { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-glightbox", specifier = ">=0.3.7" },
-    { name = "mkdocs-material", specifier = ">=9.5.17" },
-    { name = "mkdocs-redirects", specifier = ">=1.2.1" },
-    { name = "mkdocstrings-python", specifier = ">=1.8.0" },
     { name = "mypy", specifier = ">=1.10.0" },
     { name = "mysql-connector-python", specifier = "~=8.0" },
     { name = "numpy", marker = "python_full_version < '3.9'", specifier = "<1.24.4" },
@@ -1655,11 +1651,24 @@ dev = [
     { name = "testcontainers", marker = "python_full_version >= '3.9'", specifier = ">3.7.1" },
     { name = "uvicorn", specifier = ">=0.30.6" },
 ]
+documentation = [
+    { name = "griffe" },
+    { name = "mkdocs", specifier = ">=1.5.0" },
+    { name = "mkdocs-glightbox", specifier = ">=0.3.7" },
+    { name = "mkdocs-material", specifier = ">=9.5.17" },
+    { name = "mkdocs-redirects", specifier = ">=1.2.1" },
+    { name = "mkdocstrings-python", specifier = ">=1.8.0" },
+]
 
 [[package]]
 name = "logfire-api"
 version = "2.1.2"
 source = { editable = "logfire-api" }
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = []
 
 [[package]]
 name = "loguru"

--- a/uv.lock
+++ b/uv.lock
@@ -1475,7 +1475,7 @@ wsgi = [
 ]
 
 [package.dev-dependencies]
-dev-dependencies = [
+dev = [
     { name = "aiohttp" },
     { name = "anthropic" },
     { name = "anyio" },
@@ -1542,7 +1542,7 @@ dev-dependencies = [
     { name = "testcontainers", version = "4.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "uvicorn" },
 ]
-documentation = [
+docs = [
     { name = "griffe" },
     { name = "mkdocs" },
     { name = "mkdocs-glightbox" },
@@ -1584,7 +1584,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev-dependencies = [
+dev = [
     { name = "aiohttp", specifier = ">=3.10.9" },
     { name = "anthropic", specifier = ">=0.27.0" },
     { name = "anyio", specifier = "<4.4.0" },
@@ -1651,10 +1651,10 @@ dev-dependencies = [
     { name = "testcontainers", marker = "python_full_version >= '3.9'", specifier = ">3.7.1" },
     { name = "uvicorn", specifier = ">=0.30.6" },
 ]
-documentation = [
+docs = [
     { name = "griffe" },
     { name = "mkdocs", specifier = ">=1.5.0" },
-    { name = "mkdocs-glightbox", specifier = ">=0.3.7" },
+    { name = "mkdocs-glightbox", specifier = ">=0.4.0" },
     { name = "mkdocs-material", specifier = ">=9.5.17" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1" },
     { name = "mkdocstrings-python", specifier = ">=1.8.0" },


### PR DESCRIPTION
Also use the new [dev dependency groups in uv](https://docs.astral.sh/uv/concepts/dependencies/#development-dependencies).

@alexmojaki @Kludex I think you’re both off today, and I need to get CI passing, so I’m going to merge this to pin dependencies and thereby get tests passing.

As I said on slack, I think pinning deps in CI is the best route anyway, but happy to discuss other routes when your back, you can consider this a temporary fix until we discuss next week.