### PR TITLE
Add span links

### DIFF
--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -15,7 +15,7 @@ import opentelemetry.trace as trace_api
 from opentelemetry.metrics import CallbackT, Counter, Histogram, UpDownCounter
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.semconv.trace import SpanAttributes
-from opentelemetry.trace import StatusCode, Tracer
+from opentelemetry.trace import SpanContext, StatusCode, Tracer
 from opentelemetry.util import types as otel_types
 from typing_extensions import LiteralString, ParamSpec
 
@@ -1862,6 +1862,10 @@ class LogfireSpan(ReadableSpan):
         """Sets the given attributes on the span."""
         for key, value in attributes.items():
             self.set_attribute(key, value)
+
+    def add_link(self, context: SpanContext, attributes: otel_types.Attributes = None) -> None:
+        if self._span is not None:  # pragma: no branch
+            return self._span.add_link(context, attributes)
 
     # TODO(Marcelo): We should add a test for `record_exception`.
     def record_exception(

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -106,6 +106,9 @@ class _MaybeDeterministicTimestampSpan(trace_api.Span, ReadableSpan):
     def set_attribute(self, key: str, value: otel_types.AttributeValue) -> None:
         self.span.set_attribute(key, value)
 
+    def add_link(self, context: SpanContext, attributes: otel_types.Attributes = None) -> None:
+        return self.span.add_link(context, attributes)
+
     def add_event(
         self,
         name: str,


### PR DESCRIPTION
I need to add tests, but I'll wait for @alexmojaki 's review.

I've implemented both `logfire.span(_links=...)` and `span.add_link`. I was planning to only implement `add_link` because it's easier to use, since you don't need to create a `Link`, but the `add_link` docstring from the OTel package actually recommends to use `_links`... So I've implemented both.

We can already see the links on Logfire itself:

<img width="728" alt="Screenshot 2024-11-13 at 12 21 04" src="https://github.com/user-attachments/assets/e8b5033f-9eda-4a79-b377-af02c2bb2a0b">

## Checklist

- [x] Tests
- [ ] Documentation