### PR TITLE
Respect repr on fields when logging a dataclass

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -250,7 +250,7 @@ def to_json_value(o: Any, seen: set[int]) -> JsonValue:
         elif is_sqlalchemy(o):
             return _get_sqlalchemy_data(o, seen)
         elif dataclasses.is_dataclass(o):
-            return {f.name: to_json_value(getattr(o, f.name), seen) for f in dataclasses.fields(o)}
+            return {f.name: to_json_value(getattr(o, f.name), seen) for f in dataclasses.fields(o) if f.repr}
         elif is_attrs(o):
             return _get_attrs_data(o, seen)
 

--- a/logfire/_internal/json_schema.py
+++ b/logfire/_internal/json_schema.py
@@ -170,7 +170,9 @@ EXCLUDE_KEYS = STACK_INFO_KEYS | {ATTRIBUTES_SCRUBBED_KEY}
 def _dataclass_schema(obj: Any, seen: set[int]) -> JsonDict:
     # NOTE: The `x-python-datatype` is "dataclass" for both standard dataclasses and Pydantic dataclasses.
     # We don't need to distinguish between them on the frontend, or to reconstruct the type on the JSON formatter.
-    return _custom_object_schema(obj, 'dataclass', (field.name for field in dataclasses.fields(obj)), seen)
+    return _custom_object_schema(
+        obj, 'dataclass', (field.name for field in dataclasses.fields(obj) if field.repr), seen
+    )
 
 
 def _bytes_schema(obj: bytes, _seen: set[int]) -> JsonDict:

--- a/tests/test_json_args.py
+++ b/tests/test_json_args.py
@@ -5,7 +5,7 @@ import re
 import sys
 from collections import deque
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
@@ -69,6 +69,12 @@ class MyComplexDataclass:
 @pydantic_dataclass(config=pydantic_model_config)
 class MyPydanticComplexDataclass:
     t: MyPydanticDataclass
+
+
+@dataclass
+class MyReprDataclass:
+    in_repr: int
+    not_in_repr: int = field(repr=False)
 
 
 class MySQLModel(SQLModel):
@@ -576,6 +582,13 @@ ANYURL_REPR_CLASSNAME = repr(AnyUrl('http://test.com')).split('(')[0]
                 },
             },
             id='pydantic_complex_dataclass',
+        ),
+        pytest.param(
+            MyReprDataclass(in_repr=1, not_in_repr=2),
+            'MyReprDataclass(in_repr=1)',
+            '{"in_repr":1}',
+            {'type': 'object', 'title': 'MyReprDataclass', 'x-python-datatype': 'dataclass'},
+            id='repr_dataclass',
         ),
         pytest.param(
             ValueError('Test value error'),

--- a/tests/test_json_args.py
+++ b/tests/test_json_args.py
@@ -74,7 +74,7 @@ class MyPydanticComplexDataclass:
 @dataclass
 class MyReprDataclass:
     in_repr: int
-    not_in_repr: int = field(repr=False)
+    not_in_repr: MyDataclass = field(repr=False)
 
 
 class MySQLModel(SQLModel):
@@ -584,7 +584,7 @@ ANYURL_REPR_CLASSNAME = repr(AnyUrl('http://test.com')).split('(')[0]
             id='pydantic_complex_dataclass',
         ),
         pytest.param(
-            MyReprDataclass(in_repr=1, not_in_repr=2),
+            MyReprDataclass(in_repr=1, not_in_repr=MyDataclass(t=2)),
             'MyReprDataclass(in_repr=1)',
             '{"in_repr":1}',
             {'type': 'object', 'title': 'MyReprDataclass', 'x-python-datatype': 'dataclass'},


### PR DESCRIPTION
Requested by @samuelcolvin.

I think it maybe makes sense to have a way for users to control this behavior more explicitly/independently of other use cases (e.g., via a magic `__pydantic_logfire_dump__` method?). But this seems reasonable to me for now. Not sure if we need to be concerned about it being a breaking change, or need to provide a way to opt into it or something.

- Closes https://github.com/pydantic/logfire/issues/521