### PR TITLE
Ignore trivial/empty functions in auto-tracing

### DIFF
--- a/logfire/_internal/ast_utils.py
+++ b/logfire/_internal/ast_utils.py
@@ -80,6 +80,19 @@ class BaseTransformer(ast.NodeTransformer):
             # so it's still recognized as a docstring.
             new_body.append(body.pop(0))
 
+        # Ignore functions with a trivial/empty body:
+        # - If `body` is empty, that means it originally was just a docstring that got popped above.
+        # - If `body` is just a single `pass` statement
+        # - If `body` is just a constant expression, particularly an ellipsis (`...`)
+        if not body or (
+            len(body) == 1
+            and (
+                isinstance(body[0], ast.Pass)
+                or (isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant))
+            )
+        ):
+            return node
+
         span = ast.With(
             items=[
                 ast.withitem(

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -195,6 +195,16 @@ class Class3:
     def method4(self):
         b = 7
         return b
+
+def only_docstring_function():
+    """Empty body"""
+
+def only_pass_function():
+    """Trivial body"""
+    pass
+
+def only_ellipsis_function():
+    ...
 '''
 
 
@@ -243,6 +253,16 @@ class Class3:
         with logfire_span[4]():
             b = 7
             return b
+
+def only_docstring_function():
+    """Empty body"""
+
+def only_pass_function():
+    """Trivial body"""
+    pass
+
+def only_ellipsis_function():
+    ...
 '''
 
     if sys.version_info >= (3, 9):  # pragma: no branch
@@ -336,7 +356,7 @@ from logfire import no_auto_trace
 @str
 def traced_func():
     async def inner():
-        pass
+        return 1
     return inner
 
 
@@ -345,18 +365,18 @@ def traced_func():
 @str
 def not_traced_func():
     async def inner():
-        pass
+        return 1
     return inner
 
 
 @str
 class TracedClass:
     async def traced_method(self):
-        pass
+        return 1
 
     @no_auto_trace
     def not_traced_method(self):
-        pass
+        return 1
 
 
 @no_auto_trace
@@ -364,12 +384,12 @@ class TracedClass:
 class NotTracedClass:
     async def would_be_traced_method(self):
         def inner():
-            pass
+            return 1
         return inner
 
     @no_auto_trace
     def definitely_not_traced_method(self):
-        pass
+        return 1
 """
 
 


### PR DESCRIPTION
Closes https://github.com/pydantic/logfire/issues/595