### PR TITLE
Test pydantic 2.10 regularly

### DIFF
--- a/.github/workflows/daily_deps_test.yml
+++ b/.github/workflows/daily_deps_test.yml
@@ -29,6 +29,8 @@ jobs:
             pydantic-version: '2.8'
           - python-version: '3.12'
             pydantic-version: '2.9'
+          - python-version: '3.12'
+            pydantic-version: '2.10'
     env:
       PYTHON: ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        pydantic-version: ['main']
+        pydantic-version: ['2.10']
         include:
             - python-version: '3.12'
               pydantic-version: '2.4'
@@ -85,8 +85,7 @@ jobs:
       - run: uv sync --python ${{ matrix.python-version }}
 
       - name: Install pydantic ${{ matrix.pydantic-version }}
-        if: matrix.pydantic-version != 'main'
-        # installs the most recent patch on the minor version's track, ex 2.6.0 -> 2.6.4
+        # installs the most recent patch on the minor version's track, ex 2.6.* -> 2.6.4
         run: uv pip install 'pydantic==${{ matrix.pydantic-version }}.*'
 
       - run: mkdir coverage


### PR DESCRIPTION
And only test pydantic `main` in daily CI so that regular CI is stable.