### PR TITLE
Re-seed random ID generator after `os.fork()`

### DIFF
--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -374,6 +374,8 @@ class SeededRandomIdGenerator(IdGenerator):
 
     def __post_init__(self) -> None:
         self.random = random.Random(self.seed)
+        if self.seed is None:
+            os.register_at_fork(after_in_child=self.random.seed)
 
     def generate_span_id(self) -> int:
         span_id = self.random.getrandbits(64)


### PR DESCRIPTION
`os.fork()` copied the `SeededRandomIdGenerator` state so that the parent and child processes would generate the same pseudorandom trace/span IDs, which is very bad. Demo script that this PR fixes:

```python
import os
import logfire

logfire.configure()

logfire.info('log', pids=(os.fork(), os.getpid()))
```