### PR TITLE
Add APIs for getting the current logfire span

### DIFF
--- a/logfire-api/logfire_api/_internal/config.pyi
+++ b/logfire-api/logfire_api/_internal/config.pyi
@@ -30,9 +30,10 @@ from opentelemetry.sdk.trace.id_generator import IdGenerator
 from pathlib import Path
 from typing import Any, Callable, Literal, Sequence, TypedDict
 from typing_extensions import Self, Unpack
-from weakref import WeakSet
+from weakref import WeakSet, WeakValueDictionary
 
 OPEN_SPANS: WeakSet[LogfireSpan | FastLogfireSpan]
+OPEN_SPANS_BY_ID: WeakValueDictionary[tuple[int, int], LogfireSpan | FastLogfireSpan]
 CREDENTIALS_FILENAME: str
 COMMON_REQUEST_HEADERS: Incomplete
 PROJECT_NAME_PATTERN: str

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -21,6 +21,7 @@ from ._internal.exporters.file import load_file as load_spans_from_file
 from ._internal.main import Logfire, LogfireSpan
 from ._internal.scrubbing import ScrubbingOptions, ScrubMatch
 from ._internal.utils import suppress_instrumentation
+from .current_span import current_logfire_span, current_span
 from .integrations.logging import LogfireLoggingHandler
 from .integrations.structlog import LogfireProcessor as StructlogProcessor
 from .version import VERSION
@@ -101,6 +102,8 @@ __all__ = (
     'ConsoleOptions',
     'CodeSource',
     'PydanticPlugin',
+    'current_span',
+    'current_logfire_span',
     'configure',
     'span',
     'instrument',

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -16,7 +16,7 @@ from threading import RLock, Thread
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence, TypedDict, cast
 from urllib.parse import urljoin
 from uuid import uuid4
-from weakref import WeakSet
+from weakref import WeakSet, WeakValueDictionary
 
 import requests
 from opentelemetry import trace
@@ -102,6 +102,7 @@ if TYPE_CHECKING:
 
 # NOTE: this WeakSet is the reason that FastLogfireSpan.__slots__ has a __weakref__ slot.
 OPEN_SPANS: WeakSet[LogfireSpan | FastLogfireSpan] = WeakSet()
+OPEN_LOGFIRE_SPANS_BY_ID: WeakValueDictionary[tuple[int, int], LogfireSpan] = WeakValueDictionary()
 
 CREDENTIALS_FILENAME = 'logfire_credentials.json'
 """Default base URL for the Logfire API."""

--- a/logfire/current_span.py
+++ b/logfire/current_span.py
@@ -1,0 +1,55 @@
+from __future__ import annotations as _annotations
+
+import warnings
+from typing import TYPE_CHECKING
+
+from opentelemetry.trace import get_current_span
+from opentelemetry.trace.span import Span
+
+from logfire._internal.config import OPEN_LOGFIRE_SPANS_BY_ID
+from logfire._internal.main import NoopSpan
+
+if TYPE_CHECKING:
+    from logfire import LogfireSpan
+
+__all__ = ('current_span', 'current_logfire_span')
+
+
+class _BestEffortSpan:
+    def __init__(self, span: Span):
+        self.__span = span
+        self.__noop_span = NoopSpan()
+
+    def __getattr__(self, name: str):
+        try:
+            return getattr(self.__span, name)
+        except AttributeError:
+            value = getattr(self.__noop_span, name)
+            # Emit the warning _after_ grabbing the value so we don't emit a warning if an AttributeError will be raised
+            warnings.warn(
+                'A logfire-specific attribute is being accessed on a non-logfire span,'
+                ' the value is not meaningful and method calls will not do anything.',
+                stacklevel=2,
+            )
+            return value
+
+
+current_span = get_current_span
+
+
+def current_logfire_span() -> LogfireSpan:
+    """Return the LogfireSpan corresponding to the current otel span.
+
+    If the current otel span was not created as a LogfireSpan, we warn and return
+    something API-compatible which delegates to the otel span as much as possible.
+
+    Note: If we eventually rework the SDK so `opentelemetry.trace.get_current_span` returns a `LogfireSpan`, we should
+    make this an alias for `current_span` and deprecate this method. There are some good reasons to do that, but there
+    are also some good reasons not to, such as reducing overhead in calls made by third-party instrumentations.
+    """
+    otel_span = get_current_span()
+    span_context = otel_span.get_span_context()
+    logfire_span = OPEN_LOGFIRE_SPANS_BY_ID.get((span_context.trace_id, span_context.span_id))
+    if isinstance(logfire_span, LogfireSpan):
+        return logfire_span
+    return _BestEffortSpan(otel_span)  # type: ignore


### PR DESCRIPTION
This is a proposed implementation for how we can make it possible to get access to the current `LogfireSpan`, for making use of the various methods/etc. on it that aren't on the result of `opentelemetry.trace.get_current_span()` when you don't have access to the value.

The motivating use case for this is having access to methods of `LogfireSpan` inside functions instrumented with `@logfire.instrument`. Right now, there is no way to get access to the `LogfireSpan`, as `opentelemetry.trace.get_current_span` doesn't return that. This PR makes it so that `logfire.current_logfire_span()` returns the `LogfireSpan` if the current otel span corresponds to a `LogfireSpan`, and something API-compatible if it does not. (I also added `logfire.current_span()` as a more easily discovered re-export of `opentelemetry.trace.get_current_span`, don't necessarily need to keep that.)

----

Note that we've discussed making it so that when you call `opentelemetry.trace.get_current_span()` you get a `LogfireSpan` back, but the naive approach to this would have the consequence that spans created by other instrumentations would also end up being `LogfireSpan`s, with the associated modified method behaviors/overhead/etc. This may be a good idea, but it's not immediately clear to me.

The good news is that the implementation in this PR would be backwards compatible if we were to make that change, and most of the logic brought in in this PR would just get removed, just the `current_span` and `current_logfire_span` functions would remain.