### PR TITLE
Document sample usage in docs for Opentelemetry AIOHTTP URL filter

### DIFF
--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 The keyword arguments of `logfire.instrument_aiohttp_client()` are passed to the `AioHttpClientInstrumentor().instrument()` method of the OpenTelemetry aiohttp client Instrumentation package, read more about it [here][opentelemetry-aiohttp].
 
 ## Masking URL in AIOHTTP span
-To mask a URL for sensitive data you create add a AIOHTTP OpenTelemetry request hook.
+To mask a URL for sensitive data you add an AIOHTTP OpenTelemetry URL filter.
 
 ```python
 import aiohttp
@@ -51,17 +51,11 @@ from yarl import URL
 def mask_url(url: URL) -> str:
     ...
 
-
-def otel_request_hook(span: Span, params: aiohttp.TraceRequestStartParams):
-    if span and span.is_recording():
-        masked_url = mask_url(params.url)
-        span.set_attribute("http.url", masked_url)
-
 ```
 
-Now configure logfire to use this request hook
+Now configure logfire to use this URL filter
 ```python
-logfire.instrument_aiohttp_client(request_hook=otel_request_hook)
+logfire.instrument_aiohttp_client(url_filter=mask_url)
 ```
 
 [aiohttp]: https://docs.aiohttp.org/en/stable/

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -40,7 +40,7 @@ if __name__ == "__main__":
 The keyword arguments of `logfire.instrument_aiohttp_client()` are passed to the `AioHttpClientInstrumentor().instrument()` method of the OpenTelemetry aiohttp client Instrumentation package, read more about it [here][opentelemetry-aiohttp].
 
 ## Masking URL in AIOHTTP span
-To mask a URL for sensitive data you create add a AIOHTTP opentelemetry request hook.
+To mask a URL for sensitive data you create add a AIOHTTP OpenTelemetry request hook.
 
 ```python
 import aiohttp

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -47,8 +47,9 @@ from yarl import URL
 
 
 def mask_url(url: URL) -> str:
-    ...
-
+    sensitive_keys = {"username", "password", "token", "api_key", "api_secret", "apikey"}
+    masked_query = {key: "*****" if key in sensitive_keys else value for key, value in url.query.items()}
+    return str(url.with_query(masked_query))
 ```
 
 Now configure logfire to use this URL filter

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -39,6 +39,31 @@ if __name__ == "__main__":
 
 The keyword arguments of `logfire.instrument_aiohttp_client()` are passed to the `AioHttpClientInstrumentor().instrument()` method of the OpenTelemetry aiohttp client Instrumentation package, read more about it [here][opentelemetry-aiohttp].
 
+## Masking URL in AIOHTTP span
+To mask a URL for sensitive data you create add a AIOHTTP opentelemetry request hook.
+
+```python
+import aiohttp
+from opentelemetry.trace import Span
+from yarl import URL
+
+
+def mask_url(url: URL) -> str:
+    ...
+
+
+def otel_request_hook(span: Span, params: aiohttp.TraceRequestStartParams):
+    if span and span.is_recording():
+        masked_url = mask_url(params.url)
+        span.set_attribute("http.url", masked_url)
+
+```
+
+Now configure logfire to use this request hook
+```python
+logfire.instrument_aiohttp_client(request_hook=otel_request_hook)
+```
+
 [aiohttp]: https://docs.aiohttp.org/en/stable/
 [aiohttp-server]: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/501
 [opentelemetry-aiohttp]: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/aiohttp_client/aiohttp_client.html

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -43,8 +43,6 @@ The keyword arguments of `logfire.instrument_aiohttp_client()` are passed to the
 To mask a URL for sensitive data you add an AIOHTTP OpenTelemetry URL filter.
 
 ```python
-import aiohttp
-from opentelemetry.trace import Span
 from yarl import URL
 
 

--- a/docs/integrations/aiohttp.md
+++ b/docs/integrations/aiohttp.md
@@ -39,23 +39,19 @@ if __name__ == "__main__":
 
 The keyword arguments of `logfire.instrument_aiohttp_client()` are passed to the `AioHttpClientInstrumentor().instrument()` method of the OpenTelemetry aiohttp client Instrumentation package, read more about it [here][opentelemetry-aiohttp].
 
-## Masking URL in AIOHTTP span
-To mask a URL for sensitive data you add an AIOHTTP OpenTelemetry URL filter.
+## Hiding sensitive URL parameters
+
+The `url_filter` keyword argument can be used to modify the URL that's recorded in spans. Here's an example of how to use this to redact query parameters:
 
 ```python
 from yarl import URL
-
 
 def mask_url(url: URL) -> str:
     sensitive_keys = {"username", "password", "token", "api_key", "api_secret", "apikey"}
     masked_query = {key: "*****" if key in sensitive_keys else value for key, value in url.query.items()}
     return str(url.with_query(masked_query))
-```
 
-Now configure logfire to use this URL filter
-```python
 logfire.instrument_aiohttp_client(url_filter=mask_url)
-```
 
 [aiohttp]: https://docs.aiohttp.org/en/stable/
 [aiohttp-server]: https://github.com/open-telemetry/opentelemetry-python-contrib/issues/501


### PR DESCRIPTION
Add documentation demonstrating how to use AIOHTTP OpenTelemetry request hooks with a sample.