### PR TITLE
Fix patching of ProcessPoolExecutor

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -579,7 +579,7 @@ class _LogfireConfigData:
             # This is particularly for deserializing from a dict as in executors.py
             advanced = AdvancedOptions(**advanced)  # type: ignore
             id_generator = advanced.id_generator
-            if isinstance(id_generator, dict) and list(id_generator.keys()) == ['seed']:  # type: ignore
+            if isinstance(id_generator, dict) and list(id_generator.keys()) == ['seed']:  # type: ignore  # pragma: no branch
                 advanced.id_generator = SeededRandomIdGenerator(**id_generator)  # type: ignore
         elif advanced is None:
             advanced = AdvancedOptions(base_url=param_manager.load_param('base_url'))

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -578,6 +578,9 @@ class _LogfireConfigData:
         if isinstance(advanced, dict):
             # This is particularly for deserializing from a dict as in executors.py
             advanced = AdvancedOptions(**advanced)  # type: ignore
+            id_generator = advanced.id_generator
+            if isinstance(id_generator, dict) and list(id_generator.keys()) == ['seed']:  # type: ignore
+                advanced.id_generator = SeededRandomIdGenerator(**id_generator)  # type: ignore
         elif advanced is None:
             advanced = AdvancedOptions(base_url=param_manager.load_param('base_url'))
         self.advanced = advanced

--- a/logfire/_internal/integrations/executors.py
+++ b/logfire/_internal/integrations/executors.py
@@ -63,6 +63,7 @@ def serialize_config() -> dict[str, Any]:
 
 
 def deserialize_config(config: dict[str, Any]) -> None:
-    from ..config import configure
+    from ..config import GLOBAL_CONFIG, configure
 
-    configure(**config)
+    if not GLOBAL_CONFIG._initialized:  # type: ignore
+        configure(**config)


### PR DESCRIPTION
1. Deserialize `advanced.id_generator`
2. Only call `configure` once per process, not once per submitted job