### PR TITLE
`capture_request_text_body`

### DIFF
--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -177,7 +177,7 @@ class LogfireHttpxRequestInfo(RequestInfo):
         return not isinstance(self.stream, httpx.ByteStream)
 
     @property
-    def content_type_header(self) -> ContentTypeHeader:
+    def content_type_header_object(self) -> ContentTypeHeader:
         return content_type_header_from_string(self.content_type_header_string)
 
     @property
@@ -194,8 +194,8 @@ class LogfireHttpxRequestInfo(RequestInfo):
         return content_type == 'application/x-www-form-urlencoded'
 
     @property
-    def charset(self):
-        return self.content_type_header.params.get('charset', 'utf-8')
+    def content_type_charset(self):
+        return self.content_type_header_object.params.get('charset', 'utf-8')
 
     @property
     def content(self) -> bytes:
@@ -205,7 +205,7 @@ class LogfireHttpxRequestInfo(RequestInfo):
 
     @property
     def text(self) -> str:
-        return decode_body(self.content, self.charset)
+        return decode_body(self.content, self.content_type_charset)
 
     @property
     def form_data(self) -> Mapping[str, Any] | None:

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -224,7 +224,7 @@ class LogfireHttpxRequestInfo(RequestInfo):
 
     @property
     def content(self) -> bytes:
-        if self.body_is_streaming:
+        if self.body_is_streaming:  # pragma: no cover
             raise ValueError('Cannot read content from a streaming body')
         return list(self.stream)[0]  # type: ignore
 

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -188,7 +188,7 @@ class LogfireHttpxRequestInfo(RequestInfo):
         self.set_complex_span_attributes({attr_name: data})
 
     def capture_text_as_json(self, attr_name: str = 'http.request.body.json', text: str | None = None):
-        if text is None:
+        if text is None:  # pragma: no branch
             text = self.text
         self.set_complex_span_attributes({attr_name: {}})  # Set the JSON schema
         self.span.set_attribute(attr_name, text)

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1157,6 +1157,7 @@ class Logfire:
         client: httpx.Client,
         *,
         capture_headers: bool = False,
+        capture_request_text_body: bool = False,
         capture_request_json_body: bool = False,
         capture_response_json_body: bool = False,
         capture_request_form_data: bool = False,
@@ -1170,6 +1171,7 @@ class Logfire:
         *,
         capture_headers: bool = False,
         capture_request_json_body: bool = False,
+        capture_request_text_body: bool = False,
         capture_response_json_body: bool = False,
         capture_request_form_data: bool = False,
         **kwargs: Unpack[AsyncClientKwargs],
@@ -1182,6 +1184,7 @@ class Logfire:
         *,
         capture_headers: bool = False,
         capture_request_json_body: bool = False,
+        capture_request_text_body: bool = False,
         capture_response_json_body: bool = False,
         capture_request_form_data: bool = False,
         **kwargs: Unpack[HTTPXInstrumentKwargs],
@@ -1193,6 +1196,7 @@ class Logfire:
         *,
         capture_headers: bool = False,
         capture_request_json_body: bool = False,
+        capture_request_text_body: bool = False,
         capture_response_json_body: bool = False,
         capture_request_form_data: bool = False,
         **kwargs: Any,
@@ -1212,6 +1216,9 @@ class Logfire:
 
                 If you don't want to capture all headers, you can customize the headers captured. See the
                 [Capture Headers](https://logfire.pydantic.dev/docs/guides/advanced/capture_headers/) section for more info.
+            capture_request_text_body: Set to `True` to capture the request text body
+                if the content type is either `text/*`
+                or `application/` followed by a known human-readable text format, e.g. XML.
             capture_request_json_body: Set to `True` to capture the request JSON body.
                 Specifically captures the raw request body whenever the content type is `application/json`.
                 Doesn't check if the body is actually JSON.
@@ -1234,6 +1241,7 @@ class Logfire:
             client,
             capture_headers=capture_headers,
             capture_request_json_body=capture_request_json_body,
+            capture_request_text_body=capture_request_text_body,
             capture_response_json_body=capture_response_json_body,
             capture_request_form_data=capture_request_form_data,
             **kwargs,

--- a/tests/otel_integrations/test_httpx.py
+++ b/tests/otel_integrations/test_httpx.py
@@ -566,7 +566,7 @@ def test_httpx_client_capture_request_form_data(exporter: TestExporter):
     assert [code.co_name for code in CODES_FOR_METHODS_WITH_DATA_PARAM] == ['request', 'stream', 'request', 'stream']
 
     with httpx.Client(transport=create_transport()) as client:
-        logfire.instrument_httpx(client, capture_request_form_data=True)
+        logfire.instrument_httpx(client, capture_request_form_data=True, capture_request_text_body=True)
         client.post('https://example.org/', data={'form': 'values'})
 
     assert exporter.exported_spans_as_dict() == snapshot(

--- a/tests/otel_integrations/test_httpx.py
+++ b/tests/otel_integrations/test_httpx.py
@@ -355,6 +355,7 @@ def test_httpx_client_capture_full(exporter: TestExporter):
                 client,
                 capture_request_headers=True,
                 capture_request_json_body=True,
+                capture_request_text_body=True,
                 capture_response_headers=True,
                 capture_response_json_body=True,
             )
@@ -448,6 +449,7 @@ async def test_async_httpx_client_capture_full(exporter: TestExporter):
                 client,
                 capture_request_headers=True,
                 capture_request_json_body=True,
+                capture_request_text_body=True,
                 capture_response_headers=True,
                 capture_response_json_body=True,
                 capture_request_form_data=True,
@@ -587,6 +589,41 @@ def test_httpx_client_capture_request_form_data(exporter: TestExporter):
                     'logfire.msg': 'POST /',
                     'http.request.body.form': '{"form":"values"}',
                     'logfire.json_schema': '{"type":"object","properties":{"http.request.body.form":{"type":"object"}}}',
+                    'http.status_code': 200,
+                    'http.response.status_code': 200,
+                    'http.flavor': '1.1',
+                    'network.protocol.version': '1.1',
+                    'http.target': '/',
+                },
+            }
+        ]
+    )
+
+
+def test_httpx_client_capture_request_text_body(exporter: TestExporter):
+    with httpx.Client(transport=create_transport()) as client:
+        logfire.instrument_httpx(client, capture_request_text_body=True)
+        client.post('https://example.org/', headers={'Content-Type': 'text/plain'}, content='hello')
+
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'POST',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'http.method': 'POST',
+                    'http.request.method': 'POST',
+                    'http.url': 'https://example.org/',
+                    'url.full': 'https://example.org/',
+                    'http.host': 'example.org',
+                    'server.address': 'example.org',
+                    'network.peer.address': 'example.org',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'POST /',
+                    'http.request.body.text': 'hello',
                     'http.status_code': 200,
                     'http.response.status_code': 200,
                     'http.flavor': '1.1',


### PR DESCRIPTION
Also added a new class `LogfireHttpxRequestInfo` that wraps the original OTEL `RequestInfo` and adds lots of tiny methods and properties breaking down the logic of capturing various things. The idea is that users could use this to easily build their own variations in hooks. Planning to do the same for responses.