### PR TITLE
Improve Span Links API

### DIFF
--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2108,7 +2108,7 @@ class LogfireSpan(ReadableSpan):
 
     def add_link(self, context: SpanContext, attributes: otel_types.Attributes = None) -> None:
         if self._span is None:
-            self._links += [trace_api.Link(context=context)]
+            self._links += [trace_api.Link(context=context, attributes=attributes)]
         else:
             self._span.add_link(context, attributes)
 


### PR DESCRIPTION
Currently, it's not very ergonomic to create a span link.

Let's assume we have 2 services:

<details>
<summary>Main Service</summary>

```py
from typing import Any

from opentelemetry import trace
from opentelemetry.propagate import extract
from pydantic import TypeAdapter
from redis import Redis

import logfire
import logfire.propagate

logfire.configure(service_name='subscriber')
logfire.instrument_redis()

TA = TypeAdapter[Any](Any)


def main():
    client = Redis()
    logfire.info('Subscriber is running')

    def watch_key(key: str):
        pubsub = client.pubsub()
        pubsub.subscribe(key)

        for message in pubsub.listen():
            if message['type'] == 'message':
                with logfire.span('process_message'):
                    data = TA.validate_json(message['data'])
                    context = extract(data.pop('headers', {}))
                    span = next(iter(context.values()))
                    with logfire.span('process_data', _links=[(span.get_span_context(), None)]):
                        logfire.info(f'Received data: {data}')

    watch_key('key')


main()
```

</details>

And...

<details>
<summary>Service A</summary>

```py
from typing import Any

from pydantic import TypeAdapter
from redis import Redis

import logfire
import logfire.propagate

logfire.configure(service_name='service_a')
logfire.instrument_redis()

TA = TypeAdapter[Any](Any)

client = Redis()


@logfire.instrument()
def service_a():
    logfire.info('Service A is running')

    data: dict[str, Any] = {'data': 'Hello from Service A', 'headers': logfire.propagate.get_context()}
    client.publish('key', TA.dump_json(data))


service_a()
```

</details>

As you see, in the code, we set the headers with `logfire.propagate.get_context()`, and then on the subscriber, we need to run:

```py
context = extract(data.pop('headers', {}))
span = next(iter(context.values()))
with logfire.span('process_data', _links=[(span.get_span_context(), None)]):
    ...
```

We can for sure improve this. Either by passing `SpanContext` to `_links`, or a `Link`.

This PR proposes creating:
1. `logfire.propagate.build_span_link`: Creates a span link from a `ContextCarrier`, so it makes easier to use the propagate API we created. But... We can also build a `span_context`, instead of `Link` itself. It may be a bit more useful. I'm open to rework this.
2. Adds `Link` and `SpanContext` to the `_links` parameter.

---

I need to add tests here. I've first implemented this to bring back the discussion.

- Closes #158