### PR TITLE
Try `to_dict` method when encoding JSON

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -275,6 +275,13 @@ def to_json_value(o: Any, seen: set[int]) -> JsonValue:
 
         if isinstance(o, Sequence):
             return [to_json_value(item, seen) for item in o]  # type: ignore
+
+        try:
+            # Some VertexAI classes have this method. They have no common base class.
+            # Seems like a sensible thing to try in general.
+            return to_json_value(o.to_dict(), seen)
+        except Exception:  # currently redundant, but future-proof
+            pass
     except Exception:  # pragma: no cover
         pass
 


### PR DESCRIPTION
With this code:

```python
import vertexai
from vertexai.generative_models import GenerativeModel

import logfire

logfire.configure()
vertexai.init()
model = GenerativeModel('gemini-1.5-flash-002')
chat = model.start_chat()
response = chat.send_message('What is 2+2?')
logfire.info('response', response=response)
```

this PR changes the attributes from:

```json
{
  "response": "candidates {\n  content {\n    role: \"model\"\n    parts {\n      text: \"2 + 2 = 4\\n\"\n    }\n  }\n  finish_reason: STOP\n  avg_logprobs: -5.3347812354331836e-06\n}\nusage_metadata {\n  prompt_token_count: 7\n  candidates_token_count: 8\n  total_token_count: 15\n}\nmodel_version: \"gemini-1.5-flash-002\"\n"
}
```

to

```json
{
  "response": {
    "candidates": [
      {
        "content": {
          "role": "model",
          "parts": [
            {
              "text": "2 + 2 = 4\n"
            }
          ]
        },
        "finish_reason": "STOP",
        "avg_logprobs": -0.000005319886440702248
      }
    ],
    "usage_metadata": {
      "prompt_token_count": 7,
      "candidates_token_count": 8,
      "total_token_count": 15
    },
    "model_version": "gemini-1.5-flash-002"
  }
}
```