### PR TITLE
add `logfire.logfire_info()`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -20,10 +20,16 @@ body:
 
         **Don't worry if you can't run this command or don't have this information, we'll help you if we can.**
 
-        Please run the following command and copy the output below:
+        Please run the following command in your terminal:
 
         ```bash
         logfire info
+        ```
+
+        Or in python run:
+
+        ```python
+        import logfire; print(logfire.logfire_info())
         ```
 
       render: TOML

--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -229,3 +229,7 @@ except ImportError:
 
         class LogfireLoggingHandler:
             def __init__(self, *args, **kwargs) -> None: ...
+
+        def logfire_info() -> str:
+            """Show versions of logfire, OS and related packages."""
+            raise NotImplementedError('this method is not implement in logfire-api')

--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -232,4 +232,4 @@ except ImportError:
 
         def logfire_info() -> str:
             """Show versions of logfire, OS and related packages."""
-            raise NotImplementedError('this method is not implement in logfire-api')
+            return 'logfire_info() is not implement by logfire-api'

--- a/logfire-api/logfire_api/__init__.pyi
+++ b/logfire-api/logfire_api/__init__.pyi
@@ -1,5 +1,6 @@
 from ._internal.auto_trace import AutoTraceModule as AutoTraceModule
 from ._internal.auto_trace.rewrite_ast import no_auto_trace as no_auto_trace
+from ._internal.cli import logfire_info as logfire_info
 from ._internal.config import AdvancedOptions as AdvancedOptions, CodeSource as CodeSource, ConsoleOptions as ConsoleOptions, MetricsOptions as MetricsOptions, PydanticPlugin as PydanticPlugin, configure as configure
 from ._internal.constants import LevelName as LevelName
 from ._internal.main import Logfire as Logfire, LogfireSpan as LogfireSpan
@@ -11,7 +12,7 @@ from .version import VERSION as VERSION
 from logfire.sampling import SamplingOptions as SamplingOptions
 from typing import Any
 
-__all__ = ['Logfire', 'LogfireSpan', 'LevelName', 'AdvancedOptions', 'ConsoleOptions', 'CodeSource', 'PydanticPlugin', 'configure', 'span', 'instrument', 'log', 'trace', 'debug', 'notice', 'info', 'warn', 'warning', 'error', 'exception', 'fatal', 'force_flush', 'log_slow_async_callbacks', 'install_auto_tracing', 'instrument_asgi', 'instrument_wsgi', 'instrument_pydantic', 'instrument_fastapi', 'instrument_openai', 'instrument_anthropic', 'instrument_asyncpg', 'instrument_httpx', 'instrument_celery', 'instrument_requests', 'instrument_psycopg', 'instrument_django', 'instrument_flask', 'instrument_starlette', 'instrument_aiohttp_client', 'instrument_sqlalchemy', 'instrument_sqlite3', 'instrument_aws_lambda', 'instrument_redis', 'instrument_pymongo', 'instrument_mysql', 'instrument_system_metrics', 'AutoTraceModule', 'with_tags', 'with_settings', 'suppress_scopes', 'shutdown', 'no_auto_trace', 'ScrubMatch', 'ScrubbingOptions', 'VERSION', 'suppress_instrumentation', 'StructlogProcessor', 'LogfireLoggingHandler', 'loguru_handler', 'SamplingOptions', 'MetricsOptions']
+__all__ = ['Logfire', 'LogfireSpan', 'LevelName', 'AdvancedOptions', 'ConsoleOptions', 'CodeSource', 'PydanticPlugin', 'configure', 'span', 'instrument', 'log', 'trace', 'debug', 'notice', 'info', 'warn', 'warning', 'error', 'exception', 'fatal', 'force_flush', 'log_slow_async_callbacks', 'install_auto_tracing', 'instrument_asgi', 'instrument_wsgi', 'instrument_pydantic', 'instrument_fastapi', 'instrument_openai', 'instrument_anthropic', 'instrument_asyncpg', 'instrument_httpx', 'instrument_celery', 'instrument_requests', 'instrument_psycopg', 'instrument_django', 'instrument_flask', 'instrument_starlette', 'instrument_aiohttp_client', 'instrument_sqlalchemy', 'instrument_sqlite3', 'instrument_aws_lambda', 'instrument_redis', 'instrument_pymongo', 'instrument_mysql', 'instrument_system_metrics', 'AutoTraceModule', 'with_tags', 'with_settings', 'suppress_scopes', 'shutdown', 'no_auto_trace', 'ScrubMatch', 'ScrubbingOptions', 'VERSION', 'suppress_instrumentation', 'StructlogProcessor', 'LogfireLoggingHandler', 'loguru_handler', 'SamplingOptions', 'MetricsOptions', 'logfire_info']
 
 DEFAULT_LOGFIRE_INSTANCE = Logfire()
 span = DEFAULT_LOGFIRE_INSTANCE.span

--- a/logfire-api/logfire_api/_internal/cli.pyi
+++ b/logfire-api/logfire_api/_internal/cli.pyi
@@ -1,48 +1,9 @@
 import argparse
-from ..version import VERSION as VERSION
-from .auth import DEFAULT_FILE as DEFAULT_FILE, DefaultFile as DefaultFile, HOME_LOGFIRE as HOME_LOGFIRE, is_logged_in as is_logged_in, poll_for_token as poll_for_token, request_device_code as request_device_code
-from .config import LogfireCredentials as LogfireCredentials
-from .config_params import ParamManager as ParamManager
-from .constants import LOGFIRE_BASE_URL as LOGFIRE_BASE_URL
-from .tracer import SDKTracerProvider as SDKTracerProvider
-from .utils import read_toml_file as read_toml_file
-from _typeshed import Incomplete
-from logfire.exceptions import LogfireConfigError as LogfireConfigError
-from logfire.propagate import ContextCarrier as ContextCarrier, get_context as get_context
 from typing import Any, Sequence
 
-BASE_OTEL_INTEGRATION_URL: str
-BASE_DOCS_URL: str
-INTEGRATIONS_DOCS_URL: Incomplete
-LOGFIRE_LOG_FILE: Incomplete
-file_handler: Incomplete
-logger: Incomplete
+__all__ = ['main', 'logfire_info']
 
-def version_callback() -> None:
-    """Show the version and exit."""
-def parse_whoami(args: argparse.Namespace) -> None:
-    """Show user authenticated username and the URL to your Logfire project."""
-def parse_clean(args: argparse.Namespace) -> None:
-    """Remove the contents of the Logfire data directory."""
-
-STANDARD_LIBRARY_PACKAGES: Incomplete
-OTEL_PACKAGES: set[str]
-OTEL_PACKAGE_LINK: Incomplete
-
-def parse_inspect(args: argparse.Namespace) -> None:
-    """Inspect installed packages and recommend packages that might be useful."""
-def parse_auth(args: argparse.Namespace) -> None:
-    """Authenticate with Logfire.
-
-    This will authenticate your machine with Logfire and store the credentials.
-    """
-def parse_list_projects(args: argparse.Namespace) -> None:
-    """List user projects."""
-def parse_create_new_project(args: argparse.Namespace) -> None:
-    """Create a new project."""
-def parse_use_project(args: argparse.Namespace) -> None:
-    """Use an existing project."""
-def parse_info(_args: argparse.Namespace) -> None:
+def logfire_info() -> str:
     """Show versions of logfire, OS and related packages."""
 
 class SplitArgs(argparse.Action):

--- a/logfire-api/logfire_api/_internal/config.pyi
+++ b/logfire-api/logfire_api/_internal/config.pyi
@@ -16,7 +16,7 @@ from .metrics import ProxyMeterProvider as ProxyMeterProvider
 from .scrubbing import BaseScrubber as BaseScrubber, NOOP_SCRUBBER as NOOP_SCRUBBER, Scrubber as Scrubber, ScrubbingOptions as ScrubbingOptions
 from .stack_info import warn_at_user_stacklevel as warn_at_user_stacklevel
 from .tracer import OPEN_SPANS as OPEN_SPANS, PendingSpanProcessor as PendingSpanProcessor, ProxyTracerProvider as ProxyTracerProvider
-from .utils import SeededRandomIdGenerator as SeededRandomIdGenerator, UnexpectedResponse as UnexpectedResponse, ensure_data_dir_exists as ensure_data_dir_exists, handle_internal_errors as handle_internal_errors, read_toml_file as read_toml_file, suppress_instrumentation as suppress_instrumentation
+from .utils import SeededRandomIdGenerator as SeededRandomIdGenerator, UnexpectedResponse as UnexpectedResponse, ensure_data_dir_exists as ensure_data_dir_exists, handle_internal_errors as handle_internal_errors, platform_is_emscripten as platform_is_emscripten, read_toml_file as read_toml_file, suppress_instrumentation as suppress_instrumentation
 from _typeshed import Incomplete
 from dataclasses import dataclass
 from logfire.exceptions import LogfireConfigError as LogfireConfigError

--- a/logfire-api/logfire_api/_internal/exporters/otlp.pyi
+++ b/logfire-api/logfire_api/_internal/exporters/otlp.pyi
@@ -1,6 +1,6 @@
 import requests
 from ..stack_info import STACK_INFO_KEYS as STACK_INFO_KEYS
-from ..utils import logger as logger, truncate_string as truncate_string
+from ..utils import logger as logger, platform_is_emscripten as platform_is_emscripten, truncate_string as truncate_string
 from .wrapper import WrapperSpanExporter as WrapperSpanExporter
 from _typeshed import Incomplete
 from functools import cached_property

--- a/logfire-api/logfire_api/_internal/utils.pyi
+++ b/logfire-api/logfire_api/_internal/utils.pyi
@@ -108,3 +108,9 @@ class SeededRandomIdGenerator(IdGenerator):
     def __post_init__(self) -> None: ...
     def generate_span_id(self) -> int: ...
     def generate_trace_id(self) -> int: ...
+
+def platform_is_emscripten() -> bool:
+    """Return True if the platform is Emscripten, e.g. Pyodide.
+
+    Threads cannot be created on Emscripten, so we need to avoid any code that creates threads.
+    """

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -8,6 +8,7 @@ from logfire.sampling import SamplingOptions
 
 from ._internal.auto_trace import AutoTraceModule
 from ._internal.auto_trace.rewrite_ast import no_auto_trace
+from ._internal.cli import logfire_info
 from ._internal.config import AdvancedOptions, CodeSource, ConsoleOptions, MetricsOptions, PydanticPlugin, configure
 from ._internal.constants import LevelName
 from ._internal.main import Logfire, LogfireSpan
@@ -148,4 +149,5 @@ __all__ = (
     'loguru_handler',
     'SamplingOptions',
     'MetricsOptions',
+    'logfire_info',
 )

--- a/logfire/_internal/cli.py
+++ b/logfire/_internal/cli.py
@@ -43,6 +43,7 @@ file_handler.setLevel(logging.DEBUG)
 logging.basicConfig(handlers=[file_handler], level=logging.DEBUG)
 
 logger = logging.getLogger(__name__)
+__all__ = 'main', 'logfire_info'
 
 
 def version_callback() -> None:
@@ -318,7 +319,7 @@ def parse_use_project(args: argparse.Namespace) -> None:
         )
 
 
-def parse_info(_args: argparse.Namespace) -> None:
+def logfire_info() -> str:
     """Show versions of logfire, OS and related packages."""
     import importlib.metadata as importlib_metadata
 
@@ -363,7 +364,12 @@ def parse_info(_args: argparse.Namespace) -> None:
         '[related_packages]',
         *(f'{name}="{version}"' for _, name, version in sorted(related_packages)),
     )
-    sys.stderr.writelines('\n'.join(toml_lines) + '\n')
+    return '\n'.join(toml_lines) + '\n'
+
+
+def parse_info(_args: argparse.Namespace) -> None:
+    """Show versions of logfire, OS and related packages."""
+    sys.stderr.writelines(logfire_info())
 
 
 def _pretty_table(header: list[str], rows: list[list[str]]):

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -203,10 +203,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire__all__.remove('MetricsOptions')
 
     assert hasattr(logfire_api, 'logfire_info')
-    try:
-        logfire_api.logfire_info()
-    except NotImplementedError:
-        pass
+    logfire_api.logfire_info()
     logfire__all__.remove('logfire_info')
 
     # If it's not empty, it means that some of the __all__ members are not tested.

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -202,6 +202,13 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire_api.MetricsOptions()
     logfire__all__.remove('MetricsOptions')
 
+    assert hasattr(logfire_api, 'logfire_info')
+    try:
+        logfire_api.logfire_info()
+    except NotImplementedError:
+        pass
+    logfire__all__.remove('logfire_info')
+
     # If it's not empty, it means that some of the __all__ members are not tested.
     assert logfire__all__ == set(), logfire__all__
 


### PR DESCRIPTION
While creating #825 I realised there's no nice way to get the `logfire info` output if you don't have a terminal.