### PR TITLE
Test without `PROCESS_RUNTIME_DESCRIPTION_REGEX`

### DIFF
--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -64,7 +64,6 @@ from logfire.propagate import NoExtractTraceContextPropagator, WarnOnExtractTrac
 from logfire.testing import TestExporter
 
 PROCESS_RUNTIME_VERSION_REGEX = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
-PROCESS_RUNTIME_DESCRIPTION_REGEX = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) \((?P<branch>\w+), (?P<month>[A-Za-z]{3})\s+(?P<day>\d{1,2}) (?P<year>\d{4}), (?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})\)\s*\[\w+ (?P<clang_version>[\d.]+)\s*\]'
 
 
 def test_propagate_config_to_tags(exporter: TestExporter) -> None:
@@ -679,7 +678,7 @@ def test_otel_service_name_env_var(config_kwargs: dict[str, Any], exporter: Test
                         'service.instance.id': '00000000000000000000000000000000',
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                         'process.pid': 1234,
                     }
                 },
@@ -725,7 +724,7 @@ def test_otel_otel_resource_attributes_env_var(config_kwargs: dict[str, Any], ex
                         'process.pid': 1234,
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                     }
                 },
             }
@@ -772,7 +771,7 @@ def test_otel_service_name_has_priority_on_otel_resource_attributes_service_name
                         'process.pid': 1234,
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                     }
                 },
             }
@@ -1673,7 +1672,7 @@ def test_environment(config_kwargs: dict[str, Any], exporter: TestExporter):
                         'process.pid': 1234,
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                         'service.version': '1.2.3',
                         'deployment.environment.name': 'production',
                     }
@@ -1723,7 +1722,7 @@ def test_code_source(config_kwargs: dict[str, Any], exporter: TestExporter):
                         'process.pid': 1234,
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                         'logfire.code.root_path': 'logfire',
                         'logfire.code.work_dir': os.getcwd(),
                         'vcs.repository.url.full': 'https://github.com/pydantic/logfire',
@@ -1775,7 +1774,7 @@ def test_code_source_without_root_path(config_kwargs: dict[str, Any], exporter: 
                         'process.pid': 1234,
                         'process.runtime.name': 'cpython',
                         'process.runtime.version': IsStr(regex=PROCESS_RUNTIME_VERSION_REGEX),
-                        'process.runtime.description': IsStr(regex=PROCESS_RUNTIME_DESCRIPTION_REGEX),
+                        'process.runtime.description': sys.version,
                         'logfire.code.work_dir': os.getcwd(),
                         'vcs.repository.url.full': 'https://github.com/pydantic/logfire',
                         'vcs.repository.ref.revision': 'main',


### PR DESCRIPTION
These tests were failing locally for me. FWIW:

```
>>> sys.version
'3.12.6 (main, Oct  6 2024, 20:30:11) [Clang 15.0.0 (clang-1500.3.9.4)]'
```

I didn't investigate why the regex doesn't work, this approach seems simpler and maybe better.