### PR TITLE
Make slack more prominent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,25 @@
 # Pydantic Logfire — Uncomplicated Observability
 
-[![CI](https://github.com/pydantic/logfire/actions/workflows/main.yml/badge.svg?event=push)](https://github.com/pydantic/logfire/actions?query=event%3Apush+branch%3Amain+workflow%3ACI)
-[![codecov](https://codecov.io/gh/pydantic/logfire/graph/badge.svg?token=735CNGCGFD)](https://codecov.io/gh/pydantic/logfire)
-[![pypi](https://img.shields.io/pypi/v/logfire.svg)](https://pypi.python.org/pypi/logfire)
-[![license](https://img.shields.io/github/license/pydantic/logfire.svg)](https://github.com/pydantic/logfire/blob/main/LICENSE)
-[![versions](https://img.shields.io/pypi/pyversions/logfire.svg)](https://github.com/pydantic/logfire)
+<p align="center">
+  <a href="https://github.com/pydantic/logfire/actions?query=event%3Apush+branch%3Amain+workflow%3ACI">
+    <img src="https://github.com/pydantic/logfire/actions/workflows/main.yml/badge.svg?event=push" alt="CI" />
+  </a>
+  <a href="https://codecov.io/gh/pydantic/logfire">
+    <img src="https://codecov.io/gh/pydantic/logfire/graph/badge.svg?token=735CNGCGFD" alt="codecov" />
+  </a>
+  <a href="https://pypi.python.org/pypi/logfire">
+    <img src="https://img.shields.io/pypi/v/logfire.svg" alt="pypi" />
+  </a>
+  <a href="https://github.com/pydantic/logfire/blob/main/LICENSE">
+    <img src="https://img.shields.io/github/license/pydantic/logfire.svg" alt="license" />
+  </a>
+  <a href="https://github.com/pydantic/logfire">
+    <img src="https://img.shields.io/pypi/pyversions/logfire.svg" alt="versions" />
+  </a>
+  <a href="https://logfire.pydantic.dev/docs/help/">
+    <img src="https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack" alt="Join Slack" />
+  </a>
+</p>
 
 From the team behind Pydantic, **Logfire** is an observability platform built on the same belief as our
 open source library — that the most powerful tools can be easy to use.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,14 @@
-# Pydantic Logfire
+# Getting Started
+
+## About Logfire
 
 From the team behind **Pydantic**, **Logfire** is a new type of observability platform built on
 the same belief as our open source library — that the most powerful tools can be easy to use.
 
-**Logfire** is built on OpenTelemetry, and supports monitoring your application from any language,
+**Logfire** is built on OpenTelemetry, and supports monitoring your application from **any language**,
 with particularly great support for Python! [Read more](why.md).
 
-## Getting Started
+## Overview
 
 This page is a quick walk-through for setting up a Python app:
 

--- a/docs/plugins/main.py
+++ b/docs/plugins/main.py
@@ -92,7 +92,6 @@ def install_logfire(markdown: str, page: Page) -> str:
         # Split them and strip quotes for each one separately.
         extras = [arg.strip('\'"') for arg in arguments[1].strip('[]').split(',')] if len(arguments) > 1 else []
         package = 'logfire' if not extras else f"'logfire[{','.join(extras)}]'"
-        extras_arg = ' '.join(f'-E {extra}' for extra in extras)
         instructions = [
             '=== "pip"',
             '    ```bash',
@@ -101,10 +100,6 @@ def install_logfire(markdown: str, page: Page) -> str:
             '=== "uv"',
             '    ```bash',
             f'    uv add {package}',
-            '    ```',
-            '=== "rye"',
-            '    ```bash',
-            f'    rye add logfire {extras_arg}',
             '    ```',
             '=== "poetry"',
             '    ```bash',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,10 +64,11 @@ extra_javascript:
   - "/flarelytics/client.js"
 
 nav:
-  - Logfire:
+  - Getting Started:
       - Logfire: index.md
       - Why Logfire?: why.md
       - Concepts: concepts.md
+      - Join Slack: help.md
       - Onboarding Checklist:
           - Onboarding Checklist: guides/onboarding-checklist/index.md
           - Integrate Logfire: guides/onboarding-checklist/integrate.md
@@ -148,7 +149,6 @@ nav:
           - Propagate: reference/api/propagate.md
           - Exceptions: reference/api/exceptions.md
           - Pydantic: reference/api/pydantic.md
-  - Help: help.md
   - Roadmap: roadmap.md
   - Release Notes: release-notes.md
 


### PR DESCRIPTION
- Lifts slack link near to the top of the sidebar and renames for visibility
- Removes `rye` from code snippets (SC suggestion)
- Adds slack badge to readme

Slight wording tweak
<img width="1503" alt="image" src="https://github.com/user-attachments/assets/84aced30-2e31-493a-9556-9b8114c1940d" />
