### PR TITLE
Catch more errors when checking for sqlalchemy objects

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -299,17 +299,17 @@ def logfire_json_dumps(obj: Any) -> str:
 
 
 def is_sqlalchemy(obj: Any) -> bool:
-    if not hasattr(obj, '__mapper__'):
-        # A SQLModel without `table=True` will pass `isinstance(obj.__class__, DeclarativeMeta)` (I don't know how)
-        # but will fail when retrieving data, specifically when calling `sqlalchemy.inspect`
-        # or when getting the `__mapper__` attribute.
-        return False
-
     try:
+        if not hasattr(obj, '__mapper__'):
+            # A SQLModel without `table=True` will pass `isinstance(obj.__class__, DeclarativeMeta)` (I don't know how)
+            # but will fail when retrieving data, specifically when calling `sqlalchemy.inspect`
+            # or when getting the `__mapper__` attribute.
+            return False
+
         from sqlalchemy.orm import DeclarativeBase, DeclarativeMeta
 
         return isinstance(obj, DeclarativeBase) or isinstance(obj.__class__, DeclarativeMeta)
-    except ImportError:  # pragma: no cover
+    except Exception:
         return False
 
 


### PR DESCRIPTION
https://pydanticlogfire.slack.com/archives/C06EDRBSAH3/p1739205757483649

In general I think we need to start being more aggressive with catching exceptions here, we're working with arbitrary objects that may have all sorts of weirdness, and logging tracebacks about internal errors doesn't look good.