### PR TITLE
Initial OTEL logs infra

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -166,6 +166,7 @@ class AdvancedOptions:
     """Generator for nanosecond start and end timestamps of spans."""
 
     log_record_processors: Sequence[LogRecordProcessor] = ()
+    """Configuration for OpenTelemetry logging. This is experimental and may be removed."""
 
 
 @dataclass

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -976,7 +976,7 @@ class LogfireConfig(_LogfireConfigData):
             )  # note: this may raise an Exception if it times out, call `logfire.shutdown` first
             self._meter_provider.set_meter_provider(meter_provider)
 
-            logger_provider = SDKLoggerProvider()
+            logger_provider = SDKLoggerProvider(resource)
             for processor in self.advanced.log_record_processors:
                 logger_provider.add_log_record_processor(processor)
 

--- a/logfire/_internal/logs.py
+++ b/logfire/_internal/logs.py
@@ -74,3 +74,6 @@ class ProxyLogger(Logger):
 
     def set_logger(self, provider: LoggerProvider) -> None:
         self.logger = provider.get_logger(self.name, self.version, self.schema_url, self.attributes)
+
+    def __getattr__(self, item: str):
+        return getattr(self.logger, item)

--- a/logfire/_internal/logs.py
+++ b/logfire/_internal/logs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import dataclasses
+import functools
+from dataclasses import dataclass
+from threading import Lock
+from typing import Any
+from weakref import WeakSet
+
+from opentelemetry._logs import Logger, LoggerProvider, LogRecord, NoOpLoggerProvider
+from opentelemetry.util.types import Attributes
+
+
+@dataclass
+class ProxyLoggerProvider(LoggerProvider):
+    """A logger provider that wraps another internal logger provider allowing it to be re-assigned."""
+
+    provider: LoggerProvider
+
+    loggers: WeakSet[ProxyLogger] = dataclasses.field(default_factory=WeakSet)
+    lock: Lock = dataclasses.field(default_factory=Lock)
+    suppressed_scopes: set[str] = dataclasses.field(default_factory=set)
+
+    def get_logger(
+        self, name: str, version: str | None = None, schema_url: str | None = None, attributes: Attributes | None = None
+    ) -> Logger:
+        with self.lock:
+            if name in self.suppressed_scopes:
+                provider = NoOpLoggerProvider()
+            else:
+                provider = self.provider
+            inner_logger = provider.get_logger(name, version, schema_url, attributes)
+            logger = ProxyLogger(inner_logger, name, version, schema_url, attributes)
+            self.loggers.add(logger)
+            return logger
+
+    def suppress_scopes(self, *scopes: str) -> None:
+        with self.lock:
+            self.suppressed_scopes.update(scopes)
+            for logger in self.loggers:
+                if logger.name in scopes:
+                    logger.set_logger(NoOpLoggerProvider())
+
+    def set_provider(self, logger_provider: LoggerProvider) -> None:
+        with self.lock:
+            self.provider = logger_provider
+            for logger in self.loggers:
+                logger.set_logger(NoOpLoggerProvider() if logger.name in self.suppressed_scopes else logger_provider)
+
+    def __getattr__(self, item: str):
+        result = getattr(self.provider, item)
+        if callable(result):
+
+            @functools.wraps(result)
+            def wrapper(*args: Any, **kwargs: Any):
+                with self.lock:
+                    return result(*args, **kwargs)
+
+            return wrapper
+        else:
+            return result
+
+
+@dataclass(eq=False)
+class ProxyLogger(Logger):
+    logger: Logger
+    name: str
+    version: str | None = None
+    schema_url: str | None = None
+    attributes: Attributes | None = None
+
+    def emit(self, record: LogRecord) -> None:
+        self.logger.emit(record)
+
+    def set_logger(self, provider: LoggerProvider) -> None:
+        self.logger = provider.get_logger(self.name, self.version, self.schema_url, self.attributes)

--- a/logfire/_internal/metrics.py
+++ b/logfire/_internal/metrics.py
@@ -67,7 +67,7 @@ class ProxyMeterProvider(MeterProvider):
         with self.lock:
             self.provider = meter_provider
             for meter in self.meters:
-                meter.set_meter(meter_provider)
+                meter.set_meter(NoOpMeterProvider() if meter.name in self.suppressed_scopes else meter_provider)
 
     def shutdown(self, timeout_millis: float = 30_000) -> None:
         with self.lock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from typing import Any
 import anyio._backends._asyncio  # noqa  # type: ignore
 import pytest
 from opentelemetry import trace
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.id_generator import IdGenerator
@@ -54,8 +55,14 @@ def metrics_reader() -> InMemoryMetricReader:
 
 
 @pytest.fixture
+def logs_exporter() -> InMemoryLogExporter:
+    return InMemoryLogExporter()
+
+
+@pytest.fixture
 def config_kwargs(
     exporter: TestExporter,
+    logs_exporter: InMemoryLogExporter,
     id_generator: IdGenerator,
     time_generator: TimeGenerator,
 ) -> dict[str, Any]:
@@ -70,6 +77,7 @@ def config_kwargs(
         advanced=logfire.AdvancedOptions(
             id_generator=id_generator,
             ns_timestamp_generator=time_generator,
+            log_record_processors=[SimpleLogRecordProcessor(logs_exporter)],
         ),
         additional_span_processors=[SimpleSpanProcessor(exporter)],
         # Ensure that inspect_arguments doesn't break things in most versions

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from opentelemetry._logs import LogRecord, SeverityNumber, get_logger
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
+
+import logfire
+
+
+def test_otel_logs(config_kwargs: dict[str, Any]):
+    exporter = InMemoryLogExporter()
+    config_kwargs['advanced'].log_record_processors = [SimpleLogRecordProcessor(exporter)]
+    logfire.configure(**config_kwargs)
+    record = LogRecord(
+        timestamp=1,
+        observed_timestamp=2,
+        trace_id=3,
+        span_id=4,
+        severity_text='INFO',
+        severity_number=SeverityNumber.INFO,
+        body='body',
+        attributes={'key': 'value'},
+    )
+    get_logger(__name__).emit(record)
+    [log_data] = exporter.get_finished_logs()
+    assert log_data.log_record == record

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import json
 from typing import Any
 
+from dirty_equals import IsStr
+from inline_snapshot import snapshot
+from opentelemetry._events import Event, get_event_logger, get_event_logger_provider
 from opentelemetry._logs import LogRecord, SeverityNumber, get_logger, get_logger_provider
 from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
@@ -47,6 +51,49 @@ def test_otel_logs_supress_scopes(logs_exporter: InMemoryLogExporter, config_kwa
 
 
 def test_get_logger_provider() -> None:
-    provider = get_logger_provider()
-    assert provider is logfire.DEFAULT_LOGFIRE_INSTANCE.config.get_logger_provider()
-    assert isinstance(provider.resource, Resource)  # type: ignore
+    logger_provider = get_logger_provider()
+    event_logger_provider = get_event_logger_provider()
+    config = logfire.DEFAULT_LOGFIRE_INSTANCE.config
+    assert logger_provider is config.get_logger_provider()
+    assert event_logger_provider is config.get_event_logger_provider()
+    assert event_logger_provider._logger_provider is logger_provider  # type: ignore
+    assert isinstance(logger_provider.resource, Resource)  # type: ignore
+
+
+def test_log_events(logs_exporter: InMemoryLogExporter, config_kwargs: dict[str, Any]) -> None:
+    logger = get_event_logger('scope')
+    record = Event(
+        name='my_event',
+        timestamp=2,
+        severity_number=SeverityNumber.INFO,
+        body='body',
+        attributes={'key': 'value'},
+    )
+    with logfire.span('span'):
+        logger.emit(record)
+
+    [log_data] = logs_exporter.get_finished_logs()
+    assert log_data.instrumentation_scope.name == 'scope'
+    assert json.loads(log_data.log_record.to_json()) == snapshot(
+        {
+            'body': 'body',
+            'severity_number': 9,
+            'severity_text': None,
+            'attributes': {'key': 'value', 'event.name': 'my_event'},
+            'dropped_attributes': 0,
+            'timestamp': '1970-01-01T00:00:00.000000Z',
+            'observed_timestamp': IsStr(),
+            'trace_id': '0x00000000000000000000000000000001',
+            'span_id': '0x0000000000000001',
+            'trace_flags': 1,
+            'resource': {
+                'attributes': {
+                    'telemetry.sdk.language': 'python',
+                    'telemetry.sdk.name': 'opentelemetry',
+                    'telemetry.sdk.version': IsStr(),
+                    'service.name': 'unknown_service',
+                },
+                'schema_url': '',
+            },
+        }
+    )

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from dirty_equals import IsStr
+from dirty_equals import IsInt, IsStr
 from inline_snapshot import snapshot
 from opentelemetry._events import Event, get_event_logger, get_event_logger_provider
 from opentelemetry._logs import LogRecord, SeverityNumber, get_logger, get_logger_provider
@@ -57,7 +57,9 @@ def test_get_logger_provider() -> None:
     assert logger_provider is config.get_logger_provider()
     assert event_logger_provider is config.get_event_logger_provider()
     assert event_logger_provider._logger_provider is logger_provider  # type: ignore
-    assert isinstance(logger_provider.resource, Resource)  # type: ignore
+    resource = logger_provider.resource  # type: ignore
+    assert isinstance(resource, Resource)
+    assert get_logger('scope').resource is resource  # type: ignore
 
 
 def test_log_events(logs_exporter: InMemoryLogExporter, config_kwargs: dict[str, Any]) -> None:
@@ -88,10 +90,16 @@ def test_log_events(logs_exporter: InMemoryLogExporter, config_kwargs: dict[str,
             'trace_flags': 1,
             'resource': {
                 'attributes': {
+                    'service.instance.id': IsStr(),
                     'telemetry.sdk.language': 'python',
                     'telemetry.sdk.name': 'opentelemetry',
                     'telemetry.sdk.version': IsStr(),
                     'service.name': 'unknown_service',
+                    'process.pid': IsInt(),
+                    'process.runtime.name': 'cpython',
+                    'process.runtime.version': IsStr(),
+                    'process.runtime.description': IsStr(),
+                    'service.version': IsStr(),
                 },
                 'schema_url': '',
             },

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from opentelemetry._logs import LogRecord, SeverityNumber, get_logger, get_logger_provider
-from opentelemetry.sdk._logs.export import InMemoryLogExporter
+from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
 
 import logfire
@@ -20,15 +20,26 @@ def test_otel_logs_supress_scopes(logs_exporter: InMemoryLogExporter, config_kwa
         body='body',
         attributes={'key': 'value'},
     )
+
     logfire.suppress_scopes('scope1')
     logger1 = get_logger('scope1')
     logger2 = get_logger('scope2')
-    logger3 = get_logger('scope3')
-    logfire.configure(**config_kwargs)
     logfire.suppress_scopes('scope2')
     logger1.emit(record)
     logger2.emit(record)
     assert not logs_exporter.get_finished_logs()
+
+    logs_exporter = InMemoryLogExporter()
+    config_kwargs['advanced'].log_record_processors = [SimpleLogRecordProcessor(logs_exporter)]
+    logfire.configure(**config_kwargs)
+
+    logger1 = get_logger('scope1')
+    logger2 = get_logger('scope2')
+    logger3 = get_logger('scope3')
+    logger1.emit(record)
+    logger2.emit(record)
+    assert not logs_exporter.get_finished_logs()
+
     logger3.emit(record)
     [log_data] = logs_exporter.get_finished_logs()
     assert log_data.log_record == record

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -1,17 +1,10 @@
 from __future__ import annotations
 
-from typing import Any
-
 from opentelemetry._logs import LogRecord, SeverityNumber, get_logger
-from opentelemetry.sdk._logs.export import InMemoryLogExporter, SimpleLogRecordProcessor
-
-import logfire
+from opentelemetry.sdk._logs.export import InMemoryLogExporter
 
 
-def test_otel_logs(config_kwargs: dict[str, Any]):
-    exporter = InMemoryLogExporter()
-    config_kwargs['advanced'].log_record_processors = [SimpleLogRecordProcessor(exporter)]
-    logfire.configure(**config_kwargs)
+def test_otel_logs(logs_exporter: InMemoryLogExporter) -> None:
     record = LogRecord(
         timestamp=1,
         observed_timestamp=2,
@@ -23,5 +16,5 @@ def test_otel_logs(config_kwargs: dict[str, Any]):
         attributes={'key': 'value'},
     )
     get_logger(__name__).emit(record)
-    [log_data] = exporter.get_finished_logs()
+    [log_data] = logs_exporter.get_finished_logs()
     assert log_data.log_record == record

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -34,4 +34,8 @@ def test_otel_logs_supress_scopes(logs_exporter: InMemoryLogExporter, config_kwa
     assert log_data.log_record == record
     assert log_data.instrumentation_scope.name == 'scope3'
 
-    assert isinstance(get_logger_provider().resource, Resource)  # type: ignore
+
+def test_get_logger_provider() -> None:
+    provider = get_logger_provider()
+    assert provider is logfire.DEFAULT_LOGFIRE_INSTANCE.config.get_logger_provider()
+    assert isinstance(provider.resource, Resource)  # type: ignore


### PR DESCRIPTION
Some of the boilerplate we need to configure OTEL logs/events in logfire, similar to what we have for tracing and metrics. Does nothing by default and the configuration is tucked away in advanced options. Not comprehensive, e.g. doesn't have scrubbing.