### PR TITLE
Fix PyCharm type hinting

### DIFF
--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -19,7 +19,7 @@ from .integrations.logging import LogfireLoggingHandler
 from .integrations.structlog import LogfireProcessor as StructlogProcessor
 from .version import VERSION
 
-DEFAULT_LOGFIRE_INSTANCE = Logfire()
+DEFAULT_LOGFIRE_INSTANCE: Logfire = Logfire()
 span = DEFAULT_LOGFIRE_INSTANCE.span
 instrument = DEFAULT_LOGFIRE_INSTANCE.instrument
 force_flush = DEFAULT_LOGFIRE_INSTANCE.force_flush


### PR DESCRIPTION
Some stupid bug means that this is required for PyCharm to give warnings that would prevent mistakes like https://github.com/pydantic/logfire/issues/867