### PR TITLE
Avoid double shutdown of logger provider

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1017,9 +1017,9 @@ class LogfireConfig(_LogfireConfigData):
             logger_provider.add_log_record_processor(root_log_processor)
 
             with contextlib.suppress(Exception):
+                # This also shuts down the underlying self._logger_provider
                 self._event_logger_provider.shutdown()
-            with contextlib.suppress(Exception):
-                self._logger_provider.shutdown()
+
             self._logger_provider.set_provider(logger_provider)
 
             if self is GLOBAL_CONFIG and not self._has_set_providers:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -72,6 +72,11 @@ from logfire.testing import TestExporter
 PROCESS_RUNTIME_VERSION_REGEX = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
 
 
+@pytest.fixture(autouse=True)
+def no_log_on_config(config: None, caplog: pytest.LogCaptureFixture) -> None:
+    assert not caplog.messages
+
+
 def test_propagate_config_to_tags(exporter: TestExporter) -> None:
     tags1 = logfire.with_tags('tag1', 'tag2')
     tags2 = logfire.with_tags('tag3', 'tag4')


### PR DESCRIPTION
Prevents `Exporter already shutdown, ignoring call` from being logged when `configure` is called twice.