### PR TITLE
Fix typing errors involving `handle_internal_errors`

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -994,7 +994,7 @@ class LogfireConfig(_LogfireConfigData):
             if hasattr(os, 'register_at_fork'):  # pragma: no branch
 
                 def fix_pid():  # pragma: no cover
-                    with handle_internal_errors():
+                    with handle_internal_errors:
                         new_resource = resource.merge(Resource({ResourceAttributes.PROCESS_PID: os.getpid()}))
                         tracer_provider._resource = new_resource  # type: ignore
                         meter_provider._resource = new_resource  # type: ignore

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -317,14 +317,14 @@ def configure(  # noqa: D417
     """
     from .. import DEFAULT_LOGFIRE_INSTANCE, Logfire
 
-    processors = deprecated_kwargs.pop('processors', None)  # type: ignore
+    processors = deprecated_kwargs.pop('processors', None)
     if processors is not None:  # pragma: no cover
         raise ValueError(
             'The `processors` argument has been replaced by `additional_span_processors`. '
             'Set `send_to_logfire=False` to disable the default processor.'
         )
 
-    metric_readers = deprecated_kwargs.pop('metric_readers', None)  # type: ignore
+    metric_readers = deprecated_kwargs.pop('metric_readers', None)
     if metric_readers is not None:  # pragma: no cover
         raise ValueError(
             'The `metric_readers` argument has been replaced by '
@@ -332,7 +332,7 @@ def configure(  # noqa: D417
             'Set `send_to_logfire=False` to disable the default metric reader.'
         )
 
-    collect_system_metrics = deprecated_kwargs.pop('collect_system_metrics', None)  # type: ignore
+    collect_system_metrics = deprecated_kwargs.pop('collect_system_metrics', None)
     if collect_system_metrics is False:
         raise ValueError(
             'The `collect_system_metrics` argument has been removed. System metrics are no longer collected by default.'
@@ -343,8 +343,8 @@ def configure(  # noqa: D417
             'The `collect_system_metrics` argument has been removed. Use `logfire.instrument_system_metrics()` instead.'
         )
 
-    scrubbing_callback = deprecated_kwargs.pop('scrubbing_callback', None)  # type: ignore
-    scrubbing_patterns = deprecated_kwargs.pop('scrubbing_patterns', None)  # type: ignore
+    scrubbing_callback = deprecated_kwargs.pop('scrubbing_callback', None)
+    scrubbing_patterns = deprecated_kwargs.pop('scrubbing_patterns', None)
     if scrubbing_callback or scrubbing_patterns:
         if scrubbing is not None:
             raise ValueError(
@@ -357,7 +357,7 @@ def configure(  # noqa: D417
         )
         scrubbing = ScrubbingOptions(callback=scrubbing_callback, extra_patterns=scrubbing_patterns)  # type: ignore
 
-    project_name = deprecated_kwargs.pop('project_name', None)  # type: ignore
+    project_name = deprecated_kwargs.pop('project_name', None)
     if project_name is not None:
         warnings.warn(
             'The `project_name` argument is deprecated and not needed.',
@@ -377,7 +377,7 @@ def configure(  # noqa: D417
                 'Use `sampling=logfire.SamplingOptions(head=...)` instead.',
             )
 
-    show_summary = deprecated_kwargs.pop('show_summary', None)  # type: ignore
+    show_summary = deprecated_kwargs.pop('show_summary', None)
     if show_summary is not None:  # pragma: no cover
         warnings.warn(
             'The `show_summary` argument is deprecated. '
@@ -385,7 +385,7 @@ def configure(  # noqa: D417
         )
 
     for key in ('base_url', 'id_generator', 'ns_timestamp_generator'):
-        value: Any = deprecated_kwargs.pop(key, None)  # type: ignore
+        value: Any = deprecated_kwargs.pop(key, None)
         if value is None:
             continue
         if advanced is not None:
@@ -397,7 +397,7 @@ def configure(  # noqa: D417
             stacklevel=2,
         )
 
-    additional_metric_readers: Any = deprecated_kwargs.pop('additional_metric_readers', None)  # type: ignore
+    additional_metric_readers: Any = deprecated_kwargs.pop('additional_metric_readers', None)
     if additional_metric_readers:
         if metrics is not None:
             raise ValueError(
@@ -410,7 +410,7 @@ def configure(  # noqa: D417
         )
         metrics = MetricsOptions(additional_readers=additional_metric_readers)
 
-    pydantic_plugin: Any = deprecated_kwargs.pop('pydantic_plugin', None)  # type: ignore
+    pydantic_plugin: Any = deprecated_kwargs.pop('pydantic_plugin', None)
     if pydantic_plugin is not None:
         warnings.warn(
             'The `pydantic_plugin` argument is deprecated. Use `logfire.instrument_pydantic()` instead.',

--- a/logfire/_internal/integrations/fastapi.py
+++ b/logfire/_internal/integrations/fastapi.py
@@ -167,7 +167,7 @@ class FastAPIInstrumentation:
             return await original
 
         with self.logfire_instance.span('FastAPI arguments') as span:
-            with handle_internal_errors():
+            with handle_internal_errors:
                 if isinstance(request, Request):  # pragma: no branch
                     span.set_attribute(SpanAttributes.HTTP_METHOD, request.method)
                 route: APIRoute | APIWebSocketRoute | None = request.scope.get('route')
@@ -181,7 +181,7 @@ class FastAPIInstrumentation:
 
             result: Any = await original
 
-            with handle_internal_errors():
+            with handle_internal_errors:
                 solved_values: dict[str, Any]
                 solved_errors: list[Any]
 

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -322,7 +322,7 @@ def make_request_hook(hook: RequestHook | None, capture_headers: bool, capture_b
         return None
 
     def new_hook(span: Span, request: RequestInfo) -> None:
-        with handle_internal_errors():
+        with handle_internal_errors:
             request = capture_request(span, request, capture_headers, capture_body)
             run_hook(hook, span, request)
 
@@ -338,7 +338,7 @@ def make_async_request_hook(
         return None
 
     async def new_hook(span: Span, request: RequestInfo) -> None:
-        with handle_internal_errors():
+        with handle_internal_errors:
             request = capture_request(span, request, should_capture_headers, should_capture_body)
             await run_async_hook(hook, span, request)
 
@@ -355,7 +355,7 @@ def make_response_hook(
         return None
 
     def new_hook(span: Span, request: RequestInfo, response: ResponseInfo) -> None:
-        with handle_internal_errors():
+        with handle_internal_errors:
             request, response = capture_response(
                 span,
                 request,
@@ -380,7 +380,7 @@ def make_async_response_hook(
         return None
 
     async def new_hook(span: Span, request: RequestInfo, response: ResponseInfo) -> None:
-        with handle_internal_errors():
+        with handle_internal_errors:
             request, response = capture_response(
                 span,
                 request,

--- a/logfire/_internal/integrations/psycopg.py
+++ b/logfire/_internal/integrations/psycopg.py
@@ -41,6 +41,7 @@ def instrument_psycopg(
                 instrument_psycopg(logfire_instance, package, **kwargs)
         return
     elif conn_or_module in PACKAGE_NAMES:
+        assert isinstance(conn_or_module, str)
         _instrument_psycopg(logfire_instance, name=conn_or_module, **kwargs)
         return
     elif isinstance(conn_or_module, ModuleType):

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -662,7 +662,7 @@ class Logfire:
                 Set to `True` to use the currently handled exception.
             console_log: Whether to log to the console, defaults to `True`.
         """
-        with handle_internal_errors():
+        with handle_internal_errors:
             stack_info = get_user_stack_info()
 
             attributes = attributes or {}
@@ -2107,7 +2107,7 @@ class FastLogfireSpan:
     def __enter__(self) -> FastLogfireSpan:
         return self
 
-    @handle_internal_errors()
+    @handle_internal_errors
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None:
         context_api.detach(self._token)
         self._span.__exit__(exc_type, exc_value, traceback)
@@ -2139,7 +2139,7 @@ class LogfireSpan(ReadableSpan):
             return getattr(self._span, name)
 
     def __enter__(self) -> LogfireSpan:
-        with handle_internal_errors():
+        with handle_internal_errors:
             if self._span is None:  # pragma: no branch
                 self._span = self._tracer.start_span(
                     name=self._span_name,
@@ -2152,7 +2152,7 @@ class LogfireSpan(ReadableSpan):
 
         return self
 
-    @handle_internal_errors()
+    @handle_internal_errors
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None:
         if self._token is None:  # pragma: no cover
             return
@@ -2161,7 +2161,7 @@ class LogfireSpan(ReadableSpan):
         context_api.detach(self._token)
         self._token = None
         if self._span.is_recording():
-            with handle_internal_errors():
+            with handle_internal_errors:
                 if self._added_attributes:
                     self._span.set_attribute(
                         ATTRIBUTES_JSON_SCHEMA_KEY, attributes_json_schema(self._json_schema_properties)
@@ -2177,7 +2177,7 @@ class LogfireSpan(ReadableSpan):
         return self._get_attribute(ATTRIBUTES_TAGS_KEY, ())
 
     @tags.setter
-    @handle_internal_errors()
+    @handle_internal_errors
     def tags(self, new_tags: Sequence[str]) -> None:
         """Set or add tags to the span."""
         if isinstance(new_tags, str):
@@ -2192,7 +2192,7 @@ class LogfireSpan(ReadableSpan):
     def message(self, message: str):
         self._set_attribute(ATTRIBUTES_MESSAGE_KEY, message)
 
-    @handle_internal_errors()
+    @handle_internal_errors
     def set_attribute(self, key: str, value: Any) -> None:
         """Sets an attribute on the span.
 
@@ -2247,7 +2247,7 @@ class LogfireSpan(ReadableSpan):
     def is_recording(self) -> bool:
         return self._span is not None and self._span.is_recording()
 
-    @handle_internal_errors()
+    @handle_internal_errors
     def set_level(self, level: LevelName | int):
         """Set the log level of this span."""
         attributes = log_level_attributes(level)

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -345,7 +345,7 @@ def get_sample_rate_from_attributes(attributes: otel_types.Attributes) -> float 
     return cast('float | None', attributes.get(ATTRIBUTES_SAMPLE_RATE_KEY))
 
 
-@handle_internal_errors()
+@handle_internal_errors
 def record_exception(
     span: trace_api.Span,
     exception: BaseException,

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -323,14 +323,10 @@ def _internal_error_exc_info() -> SysExcInfo:
 
             if frame.f_code in _HANDLE_INTERNAL_ERRORS_CODES:
                 while frame and frame.f_code in _HANDLE_INTERNAL_ERRORS_CODES:
-                    if frame.f_code.co_name == '__exit__':
+                    is_exit = frame.f_code.co_name == '__exit__'
+                    frame = frame.f_back
+                    if is_exit and frame:
                         frame = frame.f_back
-                        frame = frame.f_back  # type: ignore
-                        break
-                    else:
-                        frame = frame.f_back
-                else:
-                    frame = frame.f_back  # type: ignore
             else:
                 # `log_internal_error()` was called directly, so just skip that frame. No context manager stuff.
                 frame = frame.f_back

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -364,7 +364,7 @@ class HandleInternalErrors:
 
 handle_internal_errors = HandleInternalErrors()
 
-_HANDLE_INTERNAL_ERRORS_WRAPPER_CODE = handle_internal_errors(lambda: 0).__code__
+_HANDLE_INTERNAL_ERRORS_WRAPPER_CODE = handle_internal_errors(log_internal_error).__code__
 assert _HANDLE_INTERNAL_ERRORS_WRAPPER_CODE.co_name == 'wrapper'
 _HANDLE_INTERNAL_ERRORS_EXIT_CODE = HandleInternalErrors.__exit__.__code__
 

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -41,12 +41,16 @@ from logfire._internal.stack_info import is_user_code
 from logfire._internal.ulid import ulid
 
 if TYPE_CHECKING:
+    from typing import ParamSpec
+
     from packaging.version import Version
 
     SysExcInfo = Union[tuple[type[BaseException], BaseException, TracebackType | None], tuple[None, None, None]]
     """
     The return type of sys.exc_info(): exc_type, exc_val, exc_tb.
     """
+
+    P = ParamSpec('P')
 
 T = TypeVar('T')
 
@@ -339,9 +343,6 @@ def _internal_error_exc_info() -> SysExcInfo:
         return exc_type, exc_val, tb
     except Exception:  # pragma: no cover
         return original_exc_info
-
-
-P = ParamSpec('P')
 
 
 class HandleInternalErrors:

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from time import time
-from types import TracebackType
+from types import CodeType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -368,11 +368,7 @@ _HANDLE_INTERNAL_ERRORS_CALL_CODE = inspect.unwrap(HandleInternalErrors.__call__
 _HANDLE_INTERNAL_ERRORS_CODES = [
     HandleInternalErrors.__exit__.__code__,
     _HANDLE_INTERNAL_ERRORS_CALL_CODE,
-    *[
-        const
-        for const in _HANDLE_INTERNAL_ERRORS_CALL_CODE.co_consts
-        if isinstance(const, type(_HANDLE_INTERNAL_ERRORS_CALL_CODE))
-    ],
+    *[const for const in _HANDLE_INTERNAL_ERRORS_CALL_CODE.co_consts if isinstance(const, CodeType)],
 ]
 
 

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -378,17 +378,16 @@ class HandleInternalErrors:
 
 handle_internal_errors = HandleInternalErrors
 
-_HANDLE_INTERNAL_ERRORS_CODES = list(
-    [
-        inspect.unwrap(handle_internal_errors.__call__).__code__,
-        handle_internal_errors.__exit__.__code__,
-    ]
-)
-_HANDLE_INTERNAL_ERRORS_CODES.append(
-    const
-    for const in _HANDLE_INTERNAL_ERRORS_CODES[0].co_consts
-    if isinstance(const, type(_HANDLE_INTERNAL_ERRORS_CODES[0]))
-)
+_HANDLE_INTERNAL_ERRORS_CALL_CODE = inspect.unwrap(handle_internal_errors.__call__).__code__
+_HANDLE_INTERNAL_ERRORS_CODES = [
+    handle_internal_errors.__exit__.__code__,
+    _HANDLE_INTERNAL_ERRORS_CALL_CODE,
+    *[
+        const
+        for const in _HANDLE_INTERNAL_ERRORS_CALL_CODE.co_consts
+        if isinstance(const, type(_HANDLE_INTERNAL_ERRORS_CALL_CODE))
+    ],
+]
 
 
 def maybe_capture_server_headers(capture: bool):

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -376,11 +376,11 @@ class HandleInternalErrors:
         return wrapper
 
 
-handle_internal_errors = HandleInternalErrors
+handle_internal_errors = HandleInternalErrors()
 
-_HANDLE_INTERNAL_ERRORS_CALL_CODE = inspect.unwrap(handle_internal_errors.__call__).__code__
+_HANDLE_INTERNAL_ERRORS_CALL_CODE = inspect.unwrap(HandleInternalErrors.__call__).__code__
 _HANDLE_INTERNAL_ERRORS_CODES = [
-    handle_internal_errors.__exit__.__code__,
+    HandleInternalErrors.__exit__.__code__,
     _HANDLE_INTERNAL_ERRORS_CALL_CODE,
     *[
         const

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -20,7 +20,6 @@ from typing import (
     Dict,
     List,
     Mapping,
-    ParamSpec,
     Sequence,
     Tuple,
     TypedDict,

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -349,10 +349,10 @@ class HandleInternalErrors:
     def __enter__(self):
         pass
 
-    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> bool:
+    def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> bool | None:
         if isinstance(exc_val, Exception):
             log_internal_error()
-        return True
+            return True
 
     def __call__(self, func: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(func)

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -326,6 +326,7 @@ def _internal_error_exc_info() -> SysExcInfo:
                     is_exit = frame.f_code.co_name == '__exit__'
                     frame = frame.f_back
                     if is_exit and frame:
+                        # Skip the line that says `with handle_internal_errors:`
                         frame = frame.f_back
             else:
                 # `log_internal_error()` was called directly, so just skip that frame. No context manager stuff.

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -297,17 +297,6 @@ def _internal_error_exc_info() -> SysExcInfo:
         # First remove redundant frames already in the traceback about where the error was raised.
         tb = original_tb
         while tb and tb.tb_frame and tb.tb_frame.f_code in _HANDLE_INTERNAL_ERRORS_CODES:
-            # Skip the 'yield' line in _handle_internal_errors
-            tb = tb.tb_next
-
-        if (
-            tb
-            and tb.tb_frame
-            and tb.tb_frame.f_code.co_filename == contextmanager.__code__.co_filename
-            and tb.tb_frame.f_code.co_name == 'inner'
-        ):
-            # Skip the 'inner' function frame when handle_internal_errors is used as a decorator.
-            # It looks like `return func(*args, **kwds)`
             tb = tb.tb_next
 
         # Now add useful outer frames that give context, but skipping frames that are just about handling the error.

--- a/tests/import_used_for_tests/internal_error_handling/internal_logfire_code_example.py
+++ b/tests/import_used_for_tests/internal_error_handling/internal_logfire_code_example.py
@@ -11,13 +11,13 @@ def inner2():
     inner1()
 
 
-@handle_internal_errors()
+@handle_internal_errors
 def using_decorator():
     inner2()
 
 
 def using_context_manager():
-    with handle_internal_errors():
+    with handle_internal_errors:
         inner2()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,3 +122,9 @@ ValueError: inner1\
 """,
         ]
     )
+
+
+def test_internal_error_base_exception():
+    with pytest.raises(BaseException):
+        with handle_internal_errors:
+            raise BaseException('base exception')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ def test_raise_for_status() -> None:
 
 def test_reraise_internal_exception():
     with pytest.raises(ZeroDivisionError):
-        with handle_internal_errors():
+        with handle_internal_errors:
             str(1 / 0)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.8"
 resolution-markers = [
     "python_full_version < '3.9' and platform_python_implementation == 'PyPy'",
@@ -1672,6 +1673,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "typing-extensions", specifier = ">=4.1.0" },
 ]
+provides-extras = ["system-metrics", "asgi", "wsgi", "aiohttp", "celery", "django", "fastapi", "flask", "httpx", "starlette", "sqlalchemy", "asyncpg", "psycopg", "psycopg2", "pymongo", "redis", "requests", "mysql", "sqlite3", "aws-lambda"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3773,15 +3775,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.393"
+version = "1.1.394"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/c1/aede6c74e664ab103673e4f1b7fd3d058fef32276be5c43572f4067d4a8e/pyright-1.1.393.tar.gz", hash = "sha256:aeeb7ff4e0364775ef416a80111613f91a05c8e01e58ecfefc370ca0db7aed9c", size = 3790430 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/e4/79f4d8a342eed6790fdebdb500e95062f319ee3d7d75ae27304ff995ae8c/pyright-1.1.394.tar.gz", hash = "sha256:56f2a3ab88c5214a451eb71d8f2792b7700434f841ea219119ade7f42ca93608", size = 3809348 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/47/f0dd0f8afce13d92e406421ecac6df0990daee84335fc36717678577d3e0/pyright-1.1.393-py3-none-any.whl", hash = "sha256:8320629bb7a44ca90944ba599390162bf59307f3d9fb6e27da3b7011b8c17ae5", size = 5646057 },
+    { url = "https://files.pythonhosted.org/packages/d6/4c/50c74e3d589517a9712a61a26143b587dba6285434a17aebf2ce6b82d2c3/pyright-1.1.394-py3-none-any.whl", hash = "sha256:5f74cce0a795a295fb768759bbeeec62561215dea657edcaab48a932b031ddbb", size = 5679540 },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://github.com/pydantic/logfire/issues/884 by making a context manager 'manually'. This should also be a bit faster, `contextlib._GeneratorContextManager` does a bunch of extra stuff internally.