### PR TITLE
update slack link with 2k invite allowance

### DIFF
--- a/docs/join-slack/index.html
+++ b/docs/join-slack/index.html
@@ -5,13 +5,13 @@
     <meta charset="utf-8">
     <title>Redirecting to slack...</title>
     <script>
-      location.href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30d22hpy9-w4jS9yCz6yeM4Z1yQujl9w"
+      location.href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30nu5u4c0-kKihQCzbaFF7_NQa_dxMUQ"
     </script>
-    <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30d22hpy9-w4jS9yCz6yeM4Z1yQujl9w">
+    <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30nu5u4c0-kKihQCzbaFF7_NQa_dxMUQ">
 </head>
 <body>
 You're being redirected to
-<a href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30d22hpy9-w4jS9yCz6yeM4Z1yQujl9w">
+<a href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30nu5u4c0-kKihQCzbaFF7_NQa_dxMUQ">
   a slack invitation link
 </a>.
 </body>


### PR DESCRIPTION
Got this new link from slack support. Should be good for 2k uses (as opposed to 400 default). Expires in 1 year.