### PR TITLE
Handle missing shutdown and force_flush on NoOpLoggerProvider better

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations as _annotations
 
 import atexit
-import contextlib
 import dataclasses
 import functools
 import json
@@ -1016,9 +1015,8 @@ class LogfireConfig(_LogfireConfigData):
             logger_provider = SDKLoggerProvider(resource)
             logger_provider.add_log_record_processor(root_log_processor)
 
-            with contextlib.suppress(Exception):
-                # This also shuts down the underlying self._logger_provider
-                self._event_logger_provider.shutdown()
+            # This also shuts down the underlying self._logger_provider
+            self._event_logger_provider.shutdown()
 
             self._logger_provider.set_provider(logger_provider)
 

--- a/logfire/_internal/logs.py
+++ b/logfire/_internal/logs.py
@@ -54,7 +54,7 @@ class ProxyLoggerProvider(LoggerProvider):
             if item in ['shutdown', 'force_flush']:
                 # These methods don't exist on the default NoOpLoggerProvider
                 return lambda *_, **__: None  # type: ignore
-            raise
+            raise  # pragma: no cover
 
         if callable(result):
 


### PR DESCRIPTION
This:

```python
import logfire

logfire.force_flush()
```

raised:

```pytb
Traceback (most recent call last):
  File "/Users/alex/Library/Application Support/JetBrains/PyCharm2024.3/scratches/scratch_1108.py", line 3, in <module>
    logfire.force_flush()
  File "/Users/alex/work/logfire/logfire/_internal/main.py", line 830, in force_flush
    return self._config.force_flush(timeout_millis)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/config.py", line 1090, in force_flush
    self._logger_provider.force_flush(timeout_millis)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/logs.py", line 51, in __getattr__
    result = getattr(self.provider, item)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoOpLoggerProvider' object has no attribute 'force_flush'
```