### PR TITLE
Handle mocks by calling `to_dict` on type

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -279,9 +279,12 @@ def to_json_value(o: Any, seen: set[int]) -> JsonValue:
         try:
             # Some VertexAI classes have this method. They have no common base class.
             # Seems like a sensible thing to try in general.
-            return to_json_value(o.to_dict(), seen)
+            to_dict = type(o).to_dict(o)  # type: ignore
         except Exception:  # currently redundant, but future-proof
             pass
+        else:
+            return to_json_value(to_dict, seen)
+
     except Exception:  # pragma: no cover
         pass
 


### PR DESCRIPTION
Prevents this:

```python
import unittest.mock
import logfire
logfire.configure()
logfire.info('hi', mock=unittest.mock.Mock())
```

from producing this:

![Screenshot 2025-02-25 at 15 55 05](https://github.com/user-attachments/assets/239f6cda-efca-4c88-9c98-a02556662635)

and avoiding similar problems on other objects with `__getattr__`.