### PR TITLE
internal: add a marker for the first span event for each exception

### DIFF
--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -195,6 +195,7 @@ def test_error_route(client: Client, exporter: TestExporter):
                             'exception.message': 'bad request',
                             'exception.stacktrace': 'django.core.exceptions.BadRequest: bad request',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/otel_integrations/test_fastapi.py
+++ b/tests/otel_integrations/test_fastapi.py
@@ -1236,6 +1236,7 @@ def test_fastapi_unhandled_exception(client: TestClient, exporter: TestExporter)
                             'exception.message': 'test exception',
                             'exception.stacktrace': 'ValueError: test exception',
                             'exception.escaped': 'True',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],
@@ -1344,6 +1345,7 @@ def test_fastapi_handled_exception(client: TestClient, exporter: TestExporter) -
                             'exception.message': '[]',
                             'exception.stacktrace': 'fastapi.exceptions.RequestValidationError: []',
                             'exception.escaped': 'True',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/otel_integrations/test_starlette.py
+++ b/tests/otel_integrations/test_starlette.py
@@ -224,6 +224,7 @@ def test_scrubbing(client: TestClient, exporter: TestExporter) -> None:
                             'exception.message': 'test exception',
                             'exception.stacktrace': 'ValueError: test exception',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -130,6 +130,7 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
                             'exception.message': 'list index out of range',
                             'exception.stacktrace': 'IndexError: list index out of range',
                             'exception.escaped': 'True',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_console_exporter.py
+++ b/tests/test_console_exporter.py
@@ -728,6 +728,7 @@ def test_exception(exporter: TestExporter) -> None:
                             'exception.message': 'division by zero',
                             'exception.stacktrace': 'ZeroDivisionError: division by zero',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -1194,6 +1194,7 @@ def test_validation_error_on_instrument(exporter: TestExporter):
                                     }
                                 ]
                             ),
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],
@@ -1265,6 +1266,7 @@ def test_validation_error_on_span(exporter: TestExporter) -> None:
                                     }
                                 ]
                             ),
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -2110,6 +2110,7 @@ def test_exc_info(exporter: TestExporter):
 
     for span_dict in span_dicts[2:4]:
         [event] = span_dict['events']
+        event['attributes'].pop('logfire.exception_first_recorded', None)
         assert event['attributes'] == {
             'exception.type': 'TypeError',
             'exception.message': 'other error',

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -2120,6 +2120,7 @@ def test_exc_info(exporter: TestExporter):
 
     for span_dict in span_dicts[4:]:
         [event] = span_dict['events']
+        event['attributes'].pop('logfire.exception_first_recorded', None)
         assert event['attributes'] == {
             'exception.type': 'ValueError',
             'exception.message': 'an error',

--- a/tests/test_loguru.py
+++ b/tests/test_loguru.py
@@ -94,6 +94,7 @@ def test_loguru(exporter: TestExporter) -> None:
                             'exception.message': 'This is a test exception',
                             'exception.stacktrace': 'ValueError: This is a test exception',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -895,6 +895,7 @@ def test_pydantic_plugin_python_exception(exporter: TestExporter) -> None:
                             'exception.message': 'My error',
                             'exception.stacktrace': 'TypeError: My error',
                             'exception.escaped': 'True',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],
@@ -943,6 +944,7 @@ def test_pydantic_plugin_python_exception_record_failure(exporter: TestExporter)
                             'exception.message': 'My error',
                             'exception.stacktrace': 'TypeError: My error',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],
@@ -1054,6 +1056,7 @@ def test_old_plugin_style(exporter: TestExporter) -> None:
                                 'exception.message': 'My error',
                                 'exception.stacktrace': 'TypeError: My error',
                                 'exception.escaped': 'True',
+                                'logfire.exception_first_recorded': True,
                             },
                         }
                     ],

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -175,6 +175,7 @@ def test_scrub_events(exporter: TestExporter):
                             'exception.message': 'Password: hunter2',
                             'exception.stacktrace': 'wrong and secret',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     },
                     {

--- a/tests/test_structlog.py
+++ b/tests/test_structlog.py
@@ -99,6 +99,7 @@ def test_structlog(exporter: TestExporter, logger: Logger) -> None:
                             'exception.message': 'division by zero',
                             'exception.stacktrace': 'ZeroDivisionError: division by zero',
                             'exception.escaped': 'False',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -73,6 +73,7 @@ def test_capfire_fixture(capfire: CaptureLogfire) -> None:
                             'exception.message': 'an exception!',
                             'exception.stacktrace': 'Exception: an exception!',
                             'exception.escaped': 'True',
+                            'logfire.exception_first_recorded': True,
                         },
                     }
                 ],


### PR DESCRIPTION
This will allow us to differentiate in the backend if this is the span an exception originated inside of vs. subsequent spans it tears through as it goes up the stack