### PR TITLE
Forward 'get_code' attribute in LogfireLoader

### DIFF
--- a/logfire/_internal/auto_trace/import_hook.py
+++ b/logfire/_internal/auto_trace/import_hook.py
@@ -126,6 +126,6 @@ class LogfireLoader(Loader):
 
     def __getattr__(self, item: str):
         """Forward some methods to the plain spec's loader (likely a `SourceFileLoader`) if they exist."""
-        if item in {'get_filename', 'is_package'}:
+        if item in {'get_filename', 'is_package', 'get_code'}:
             return getattr(self.plain_spec.loader, item)
         raise AttributeError(item)


### PR DESCRIPTION
Reproduction:

```shell
mkdir -p package/subpackage

touch package/subpackage/__init__.py

cat >  package/__init__.py << 'EOL'
import logfire

logfire.configure()
logfire.install_auto_tracing(modules=["package.subpackage"], min_duration=0.01)
EOL

cat >  package/subpackage/__main__.py << 'EOL'
print("Hello world")
EOL

python -m package.subpackage
```

```py
Traceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 148, in _get_module_details
  File "<frozen runpy>", line 159, in _get_module_details
  File ".venv/lib/python3.12/site-packages/logfire/_internal/auto_trace/import_hook.py", line 131, in __getattr__
    raise AttributeError(item)
AttributeError: get_code
```

Adding `get_code` resolves the issue. However, maybe a better fix would be to forward any attribute and let it the original instance raise the `AttributeError` in case it doesn't have required attribute. 


