### PR TITLE
Fix python/pydantic versions tested in daily CI

### DIFF
--- a/.github/workflows/daily_deps_test.yml
+++ b/.github/workflows/daily_deps_test.yml
@@ -17,15 +17,13 @@ jobs:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         pydantic-version: ['main']
         include:
-          - python-version: '3.8'
-            pydantic-version: '2.10'
           - python-version: '3.12'
             pydantic-version: '2.4'
-          - python-version: '3.13'
+          - python-version: '3.12'
             pydantic-version: '2.5'
-          - python-version: '3.13'
+          - python-version: '3.12'
             pydantic-version: '2.6'
-          - python-version: '3.13'
+          - python-version: '3.12'
             pydantic-version: '2.7'
           - python-version: '3.13'
             pydantic-version: '2.8'


### PR DESCRIPTION
Based on https://github.com/pydantic/logfire/actions/runs/14145453536:

1. Pydantic <= 2.7 doesn't support Python 3.13
2. `uv sync --python 3.8 --upgrade` insists on installing the latest from git despite what pyproject.toml says. Not worth debugging.