### PR TITLE
mcp-server.md: update token argument

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -39,7 +39,7 @@ it by creating a `.cursor/mcp.json` file in your project root:
   "mcpServers": {
     "logfire": {
       "command": "uvx",
-      "args": ["logfire-mcp", "--logfire-read-token=YOUR-TOKEN"],
+      "args": ["logfire-mcp", "--read-token=YOUR-TOKEN"],
     }
   }
 }


### PR DESCRIPTION
documentation error as the mcp argument for the read token has changed:

reference: https://github.com/pydantic/logfire-mcp?tab=readme-ov-file#configure-for-cursor