### PR TITLE
Return None from LogfireSpan.context when logfire could not be imported

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -47,6 +47,9 @@ except ImportError:
 
             def is_recording(self) -> bool:  # pragma: no cover
                 return False
+            
+            @property
+            def context(self): ...  # pragma: no cover
 
         class Logfire:
             def __getattr__(self, attr):


### PR DESCRIPTION
Fixes https://github.com/pydantic/pydantic-ai/issues/1399