### PR TITLE
Add codespell to pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+    - id: codespell
+      additional_dependencies:
+        - tomli
+      exclude: '^uv\.lock$'
+
   - repo: local
     hooks:
       - id: ruff


### PR DESCRIPTION
Integrate codespell to prevent future typos.