### PR TITLE
Measure body size before compression to ensure correct splitting of span payloads

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -21,7 +21,6 @@ import requests
 from opentelemetry import trace
 from opentelemetry._logs import NoOpLoggerProvider, set_logger_provider  # type: ignore
 from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
-from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter  # type: ignore
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -918,13 +917,7 @@ class LogfireConfig(_LogfireConfigData):
                         thread.start()
 
                     base_url = self.advanced.generate_base_url(self.token)
-                    headers = {
-                        'User-Agent': f'logfire/{VERSION}',
-                        'Authorization': self.token,
-                        # We compress ourselves in OTLPExporterHttpSession instead of
-                        # using `compression` in OTel exporters so that we can measure the body size before compression
-                        'Content-Encoding': Compression.Gzip.value,
-                    }
+                    headers = {'User-Agent': f'logfire/{VERSION}', 'Authorization': self.token}
                     session = OTLPExporterHttpSession(max_body_size=OTLP_MAX_BODY_SIZE)
                     session.headers.update(headers)
                     span_exporter = OTLPSpanExporter(

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -36,6 +36,9 @@ class OTLPExporterHttpSession(Session):
     def __init__(self, *args: Any, max_body_size: int, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.max_body_size = max_body_size
+        # We compress ourselves here instead of using `compression` in OTel exporters
+        # so that we can measure the body size before compression.
+        self.headers['Content-Encoding'] = 'gzip'
 
     def post(self, url: str, data: bytes, **kwargs: Any):  # type: ignore
         self._check_body_size(len(data))

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -1,3 +1,5 @@
+import gzip
+import io
 from typing import Any
 from unittest.mock import Mock
 
@@ -39,7 +41,9 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
             self.mock = mock
 
         def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
-            assert request.body == b'123'
+            assert isinstance(request.body, bytes)
+            with gzip.GzipFile(fileobj=io.BytesIO(request.body)) as f:
+                assert f.read() == b'123'
             assert request.url == 'http://example.com/'
             assert request.headers['User-Agent'] == 'logfire'
             assert request.headers['Authorization'] == 'Bearer 123'

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -47,6 +47,7 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
             assert request.url == 'http://example.com/'
             assert request.headers['User-Agent'] == 'logfire'
             assert request.headers['Authorization'] == 'Bearer 123'
+            assert request.headers['Content-Encoding'] == 'gzip'
             return self.mock()
 
     session = OTLPExporterHttpSession(max_body_size=10)


### PR DESCRIPTION
This should prevent the SDK from sending a payload of spans that the backend will reject for being too big.

Demo script:

```python
import logfire

logfire.configure(scrubbing=False, console=False)

data = 'X' * 2_000_000

with logfire.span('test run'):
    for _ in range(100):
        logfire.info('log data', data=data)
```

Before this PR it logs `Failed to export batch code: 413, reason: Failed to buffer the request body: length limit exceeded` and nothing gets sent.