### PR TITLE
Fix exporting of very large spans and payloads

### DIFF
--- a/logfire/_internal/constants.py
+++ b/logfire/_internal/constants.py
@@ -173,9 +173,6 @@ CONTEXT_ATTRIBUTES_KEY = create_key('logfire.attributes')  # note this has a ran
 CONTEXT_SAMPLE_RATE_KEY = create_key('logfire.sample-rate')  # note this has a random suffix that OTEL adds
 """Key in the OTEL context that contains the current sample rate."""
 
-OTLP_MAX_BODY_SIZE = 1024 * 1024 * 5  # 5MB
-"""Maximum body size for an OTLP request. Both our backend and SDK enforce this limit."""
-
 MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT = 128
 """Maximum number of characters for formatted values in a logfire message."""
 

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -197,6 +197,8 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             return super().export(spans)
         except BodyTooLargeError:
             half = len(spans) // 2
+            # BodySizeCheckingOTLPSpanExporter should only raise BodyTooLargeError for >1 span,
+            # otherwise it should just try exporting it.
             assert half > 0
             res1 = self.export(spans[:half])
             res2 = self.export(spans[half:])

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -6,7 +6,9 @@ import requests.exceptions
 from requests.models import PreparedRequest, Response as Response
 from requests.sessions import HTTPAdapter
 
-from logfire._internal.exporters.otlp import BodyTooLargeError, OTLPExporterHttpSession
+from logfire._internal.exporters.otlp import (
+    OTLPExporterHttpSession,
+)
 
 
 class SinkHTTPAdapter(HTTPAdapter):
@@ -16,15 +18,6 @@ class SinkHTTPAdapter(HTTPAdapter):
         resp = Response()
         resp.status_code = 200
         return resp
-
-
-def test_max_body_size_bytes() -> None:
-    s = OTLPExporterHttpSession(max_body_size=10)
-    s.mount('http://', SinkHTTPAdapter())
-    s.post('http://example.com', data=b'1234567890')
-    with pytest.raises(BodyTooLargeError) as e:
-        s.post('http://example.com', data=b'1234567890XXX')
-    assert str(e.value) == 'Request body is too large (13 bytes), must be less than 10 bytes.'
 
 
 def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
@@ -45,7 +38,7 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
             assert request.headers['Authorization'] == 'Bearer 123'
             return self.mock()
 
-    session = OTLPExporterHttpSession(max_body_size=10)
+    session = OTLPExporterHttpSession()
     headers = {'User-Agent': 'logfire', 'Authorization': 'Bearer 123'}
     session.headers.update(headers)
 

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -58,6 +58,7 @@ class SomeSpansTooLargeExporter(TestExporter):
                 if len(spans) > 1:
                     raise BodyTooLargeError(20_000_000, 5_000_000)
                 else:
+                    # RetryFewerSpansSpanExporter can only split if there's >1 span.
                     return SpanExportResult.FAILURE
         return super().export(spans)
 

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Sequence
 
 import pytest
+import requests
+from inline_snapshot import snapshot
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
@@ -12,8 +14,13 @@ from opentelemetry.sdk.util.instrumentation import (
 from opentelemetry.trace import SpanContext, SpanKind
 from opentelemetry.trace.status import Status, StatusCode
 
-from logfire._internal.exporters.otlp import BodyTooLargeError, RetryFewerSpansSpanExporter
+from logfire._internal.exporters.otlp import (
+    BodySizeCheckingOTLPSpanExporter,
+    BodyTooLargeError,
+    RetryFewerSpansSpanExporter,
+)
 from logfire.testing import TestExporter
+from tests.exporters.test_otlp_session import SinkHTTPAdapter
 
 RESOURCE = Resource.create({'service.name': 'test', 'telemetry.sdk.version': '1.0.0'})
 TEST_SPANS = [
@@ -52,7 +59,10 @@ class SomeSpansTooLargeExporter(TestExporter):
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         for span in spans:
             if span.context and span.context.span_id in TOO_BIG_SPAN_IDS:
-                raise BodyTooLargeError(20_000_000, 5_000_000)
+                if len(spans) > 1:
+                    raise BodyTooLargeError(20_000_000, 5_000_000)
+                else:
+                    return SpanExportResult.FAILURE
         return super().export(spans)
 
 
@@ -68,45 +78,6 @@ def test_retry_fewer_spans_with_some_spans_too_large(exporter: TestExporter):
     assert res is SpanExportResult.FAILURE
     assert underlying_exporter.exported_spans == [
         span for span in TEST_SPANS if span.context and span.context.span_id not in TOO_BIG_SPAN_IDS
-    ]
-
-    # For the too big spans, `logfire.error` is called once each in place of exporting the original span.
-    # In this test, the `logfire.error` call sends spans to the `exporter: TestExporter` fixture,
-    # which is separate from `underlying_exporter` and `retry_exporter`.
-    # In reality, one exporter would receive both the original (not too big) spans and the error logs.
-    assert exporter.exported_spans_as_dict(fixed_line_number=None, strip_filepaths=False) == [
-        {
-            'name': 'Failed to export a span of size {size:,} bytes: {span_name}',
-            'context': {'trace_id': error_log_span_id, 'span_id': error_log_span_id, 'is_remote': False},
-            'parent': None,
-            'start_time': error_log_span_id * 1000000000,
-            'end_time': error_log_span_id * 1000000000,
-            'attributes': {
-                'logfire.span_type': 'log',
-                'logfire.level_num': 17,
-                'logfire.msg_template': 'Failed to export a span of size {size:,} bytes: {span_name}',
-                'logfire.msg': f'Failed to export a span of size 20,000,000 bytes: test span name {too_big_span_id}',
-                'code.filepath': (
-                    'super/super/super/super/super/super/super/super/super/super/super/super/'
-                    'super/super/super/super/super/super/super/super/super/super/super/super/'
-                    'supe...per/super/super/super/super/super/super/super/super/super/super/'
-                    'super/super/super/super/super/super/super/super/super/super/super/super/'
-                    'long/path.py'
-                ),
-                'code.function': 'test_function',
-                'code.lineno': 321,
-                'size': 20_000_000,
-                'max_size': 5_000_000,
-                'span_name': f'test span name {too_big_span_id}',
-                'num_attributes': 4,
-                'num_events': 2,
-                'num_links': 0,
-                'num_event_attributes': 3,
-                'num_link_attributes': 0,
-                'logfire.json_schema': '{"type":"object","properties":{"size":{},"max_size":{},"span_name":{},"num_attributes":{},"num_events":{},"num_links":{},"num_event_attributes":{},"num_link_attributes":{}}}',
-            },
-        }
-        for error_log_span_id, too_big_span_id in enumerate(TOO_BIG_SPAN_IDS, start=1)
     ]
 
     retry_exporter.force_flush()
@@ -132,3 +103,13 @@ def test_retry_fewer_spans_when_too_many():
     res = exporter.export(TEST_SPANS)
     assert res is SpanExportResult.SUCCESS
     assert test_exporter.exported_spans == TEST_SPANS
+
+
+def test_max_body_size_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = requests.Session()
+    session.mount('http://', SinkHTTPAdapter())
+    exporter = BodySizeCheckingOTLPSpanExporter(session=session)
+    exporter.max_body_size = 10
+    with pytest.raises(BodyTooLargeError) as e:
+        exporter.export(TEST_SPANS)
+    assert str(e.value) == snapshot('Request body is too large (897045 bytes), must be less than 10 bytes.')

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Sequence
 
 import pytest
-import requests
 from inline_snapshot import snapshot
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
@@ -17,6 +16,7 @@ from opentelemetry.trace.status import Status, StatusCode
 from logfire._internal.exporters.otlp import (
     BodySizeCheckingOTLPSpanExporter,
     BodyTooLargeError,
+    OTLPExporterHttpSession,
     RetryFewerSpansSpanExporter,
 )
 from logfire.testing import TestExporter
@@ -105,10 +105,13 @@ def test_retry_fewer_spans_when_too_many():
     assert test_exporter.exported_spans == TEST_SPANS
 
 
-def test_max_body_size_bytes(monkeypatch: pytest.MonkeyPatch) -> None:
-    session = requests.Session()
+def test_max_body_size_bytes() -> None:
+    session = OTLPExporterHttpSession()
     session.mount('http://', SinkHTTPAdapter())
     exporter = BodySizeCheckingOTLPSpanExporter(session=session)
+
+    assert exporter.export(TEST_SPANS) == SpanExportResult.SUCCESS
+
     exporter.max_body_size = 10
     with pytest.raises(BodyTooLargeError) as e:
         exporter.export(TEST_SPANS)


### PR DESCRIPTION
Replaces https://github.com/pydantic/logfire/pull/1026

- Measures the OTLP trace export body size before compression. This should prevent an edge case where the SDK could send a highly compressed payload of many spans that the backend would reject for being too big. Instead it will split the payload in two as usual.
- When a single span exceeds the SDK's 5MB limit, just send it.
  - The backend has since increased its limit, so we shouldn't have been dropping it. This way the limits don't have to stay in sync.
  - The SDK was supposed to be logging something in this case about the dropped span. But it was doing so with logfire, inside a context where instrumentation is suppressed. So the data was being dropped silently. Now, when the backend rejects a large payload that was otherwise not even being sent, OTel logs the following using stdlib logging: `Failed to export batch code: 413, reason: Failed to buffer the request body: length limit exceeded`. We should try to make this message clearer some other time.

