### PR TITLE
Remove attributes from `http.server.active_requests` metric to prevent emitting too many

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1024,7 +1024,12 @@ class LogfireConfig(_LogfireConfigData):
                         View(
                             instrument_type=Histogram,
                             aggregation=ExponentialBucketHistogramAggregation(),
-                        )
+                        ),
+                        View(
+                            instrument_type=UpDownCounter,
+                            instrument_name='http.server.active_requests',
+                            attribute_keys={'http.flavor', 'http.method', 'http.scheme'},
+                        ),
                     ],
                 )
             else:

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1028,7 +1028,13 @@ class LogfireConfig(_LogfireConfigData):
                         View(
                             instrument_type=UpDownCounter,
                             instrument_name='http.server.active_requests',
-                            attribute_keys={'http.flavor', 'http.method', 'http.scheme'},
+                            attribute_keys={
+                                'url.scheme',
+                                'http.scheme',
+                                'http.flavor',
+                                'http.method',
+                                'http.request.method',
+                            },
                         ),
                     ],
                 )

--- a/tests/otel_integrations/test_django.py
+++ b/tests/otel_integrations/test_django.py
@@ -35,7 +35,6 @@ def test_good_route(client: Client, exporter: TestExporter, metrics_reader: InMe
                         {
                             'attributes': {
                                 'http.method': 'GET',
-                                'http.server_name': 'testserver',
                                 'http.scheme': 'http',
                                 'http.flavor': '1.1',
                                 'http.request.method': 'GET',


### PR DESCRIPTION
Removed `http.server_name` and `http.host` attributes since for some users they are high cardinality. Since `http.server.active_requests` is an `UpDownCounter` and we use `AggregationTemporality.CUMULATIVE` for it, once an attribute combination is seen, it gets exported every minute even if the value is 0. This can result in a lot of data that most users don't know or care about.