### PR TITLE
More verbose console logging fixes

### DIFF
--- a/logfire/_internal/json_formatter.py
+++ b/logfire/_internal/json_formatter.py
@@ -69,8 +69,12 @@ class JsonArgsValueFormatter:
                 if (data_type := schema.get('x-python-datatype')) is None:
                     if schema['type'] == 'object':
                         self._format_items('{', ': ', '}', True, indent_current, value, None)
-                    else:
+                    elif schema['type'] == 'array':
                         self._format_list_like('[', ']', indent_current, value, schema)
+                    else:
+                        # e.g. {'type': 'string', 'format': 'date-time'}
+                        # or {'type': 'null'}
+                        self._write('', '', False, 0, value, None)
                 else:
                     func = self._data_type_map.get(data_type)
                     assert func is not None, f'Unknown data type {data_type}'

--- a/tests/test_console_exporter.py
+++ b/tests/test_console_exporter.py
@@ -1,8 +1,10 @@
 # pyright: reportPrivateUsage=false
 from __future__ import annotations
 
+import decimal
 import io
 import sys
+from datetime import datetime
 from typing import Any
 from unittest import mock
 
@@ -933,3 +935,27 @@ def test_truncated_json(capsys: pytest.CaptureFixture[str]) -> None:
                 "│ x='[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1'",
             ]
         )
+
+
+def test_other_json_schema_types(capsys: pytest.CaptureFixture[str]) -> None:
+    logfire.configure(
+        send_to_logfire=False,
+        console=ConsoleOptions(verbose=True, colors='never', include_timestamps=False),
+    )
+
+    logfire.info(
+        'hi',
+        d=datetime(2020, 12, 31, 12, 34, 56),
+        x=None,
+        v=decimal.Decimal('1.0'),
+    )
+
+    assert capsys.readouterr().out.splitlines() == snapshot(
+        [
+            'hi',
+            IsStr(),
+            '│ d=2020-12-31T12:34:56',
+            '│ x=None',
+            '│ v=1.0',
+        ]
+    )


### PR DESCRIPTION
Example script:

```python
import datetime
import decimal

import logfire

logfire.configure(console=logfire.ConsoleOptions(verbose=True))

logfire.info('hi', d=datetime.datetime.now(), v=decimal.Decimal('1.0'))
logfire.info('hi', x=None)
```

With this PR:

```
11:04:25.386 hi
             │ scratch_1502.py:9 info
             │ d=2025-05-14T13:04:25.366639
             │ v=1.0
11:04:25.386 hi
             │ scratch_1502.py:10 info
             │ x=None
```

Before:

```
11:04:58.030 hi
             │ scratch_1502.py:8 info
             │ d=[
             │       '2',
             │       '0',
             │       '2',
             │       '5',
             │       '-',
             │       '0',
             │       '5',
             │       '-',
             │       '1',
             │       '4',
             │       'T',
             │       '1',
             │       '3',
             │       ':',
             │       '0',
             │       '4',
             │       ':',
             │       '5',
             │       '8',
             │       '.',
             │       '0',
             │       '1',
             │       '0',
             │       '7',
             │       '1',
             │       '4',
             │   ]
             │ v=[
             │       '1',
             │       '.',
             │       '0',
             │   ]
11:04:58.030 hi
             │ scratch_1502.py:9 info
Exception while exporting Span.
Traceback (most recent call last):
  File "/Users/alex/work/logfire/.venv/lib/python3.12/site-packages/opentelemetry/sdk/trace/export/__init__.py", line 114, in on_end
    self.span_exporter.export((span,))
  File "/Users/alex/work/logfire/logfire/_internal/exporters/console.py", line 148, in export
    self.export_record(Record.from_span(span))
  File "/Users/alex/work/logfire/logfire/_internal/exporters/console.py", line 417, in export_record
    self._print_span(span)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/console.py", line 181, in _print_span
    self._print_arguments(span, indent_str)
  File "/Users/alex/work/logfire/logfire/_internal/exporters/console.py", line 268, in _print_arguments
    value = json_args_value_formatter(value, schema=schema)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/alex/work/logfire/logfire/_internal/json_formatter.py", line 61, in __call__
    self._format(indent_current, True, value, schema)
  File "/Users/alex/work/logfire/logfire/_internal/json_formatter.py", line 73, in _format
    self._format_list_like('[', ']', indent_current, value, schema)
  File "/Users/alex/work/logfire/logfire/_internal/json_formatter.py", line 132, in _format_list_like
    for i, v in enumerate(value):
                ^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```