### PR TITLE
Add `**kwargs` to `instrument_pydantic_ai` for future compatibility

### DIFF
--- a/logfire/_internal/integrations/pydantic_ai.py
+++ b/logfire/_internal/integrations/pydantic_ai.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic_ai import Agent
 from pydantic_ai.agent import InstrumentationSettings
@@ -14,6 +14,7 @@ def instrument_pydantic_ai(
     logfire_instance: Logfire,
     obj: Agent | Model | None,
     event_mode: Literal['attributes', 'logs'] | None,
+    **kwargs: Any,
 ) -> None | InstrumentedModel:
     if event_mode is None:
         event_mode = InstrumentationSettings.event_mode
@@ -21,6 +22,7 @@ def instrument_pydantic_ai(
         tracer_provider=logfire_instance.config.get_tracer_provider(),
         event_logger_provider=logfire_instance.config.get_event_logger_provider(),
         event_mode=event_mode,
+        **kwargs,
     )
     if isinstance(obj, Agent):
         obj.instrument = settings

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -962,6 +962,7 @@ class Logfire:
         /,
         *,
         event_mode: Literal['attributes', 'logs'] = 'attributes',
+        **kwargs: Any,
     ) -> None: ...
 
     @overload
@@ -971,6 +972,7 @@ class Logfire:
         /,
         *,
         event_mode: Literal['attributes', 'logs'] = 'attributes',
+        **kwargs: Any,
     ) -> pydantic_ai.models.Model: ...
 
     def instrument_pydantic_ai(
@@ -979,6 +981,7 @@ class Logfire:
         /,
         *,
         event_mode: Literal['attributes', 'logs'] | None = None,
+        **kwargs: Any,
     ) -> pydantic_ai.models.Model | None:
         """Instrument PydanticAI.
 
@@ -989,6 +992,9 @@ class Logfire:
                 If you pass a model, a new instrumented model will be returned.
             event_mode: See the [PydanticAI docs](https://ai.pydantic.dev/logfire/#data-format).
                 The default is whatever the default is in your version of PydanticAI.
+            kwargs: Additional keyword arguments to pass to
+                [`InstrumentationSettings`](https://ai.pydantic.dev/api/models/instrumented/#pydantic_ai.models.instrumented.InstrumentationSettings)
+                for future compatibility.
         """
         from .integrations.pydantic_ai import instrument_pydantic_ai
 
@@ -997,6 +1003,7 @@ class Logfire:
             self,
             obj=obj,
             event_mode=event_mode,
+            **kwargs,
         )
 
     def instrument_fastapi(


### PR DESCRIPTION
For situations like https://github.com/pydantic/pydantic-ai/pull/1739 which we don't currently support from here.