### PR TITLE
Remove choice wrapper from response events in OpenAI Agents instrumentation

### DIFF
--- a/logfire/_internal/integrations/openai_agents.py
+++ b/logfire/_internal/integrations/openai_agents.py
@@ -426,14 +426,7 @@ def get_response_span_events(span: ResponseSpanData):
     if response and response.output:
         for out in response.output:
             for message in input_to_events(out.model_dump(), tool_call_id_to_name):
-                message.pop('event.name', None)
-                events.append(
-                    {
-                        'event.name': 'gen_ai.choice',
-                        'index': 0,
-                        'message': {**message, 'role': 'assistant'},
-                    },
-                )
+                events.append({**message, 'role': 'assistant'})
     return events
 
 

--- a/tests/otel_integrations/test_openai_agents.py
+++ b/tests/otel_integrations/test_openai_agents.py
@@ -545,32 +545,26 @@ async def test_responses(exporter: TestExporter):
                             'role': 'user',
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'tool_calls': [
-                                    {
-                                        'id': 'call_vwqy7HyGGnNht9NNfxMnnouY',
-                                        'type': 'function',
-                                        'function': {'name': 'random_number', 'arguments': '{}'},
-                                    }
-                                ],
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': 'call_vwqy7HyGGnNht9NNfxMnnouY',
+                                    'type': 'function',
+                                    'function': {'name': 'random_number', 'arguments': '{}'},
+                                }
+                            ],
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'tool_calls': [
-                                    {
-                                        'id': 'call_oEA0MnUXCwKevx8txteoopNL',
-                                        'type': 'function',
-                                        'function': {'name': 'transfer_to_agent2', 'arguments': '{}'},
-                                    }
-                                ],
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': 'call_oEA0MnUXCwKevx8txteoopNL',
+                                    'type': 'function',
+                                    'function': {'name': 'transfer_to_agent2', 'arguments': '{}'},
+                                }
+                            ],
                         },
                     ],
                     'logfire.json_schema': {
@@ -880,12 +874,9 @@ async def test_responses(exporter: TestExporter):
                             'name': 'transfer_to_agent2',
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'content': "The random number generated is 4, and it's been handed off to agent2.",
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': "The random number generated is 4, and it's been handed off to agent2.",
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 89,
@@ -1153,11 +1144,7 @@ async def test_input_guardrails(exporter: TestExporter):
                     'raw_input': [{'content': '1+1?', 'role': 'user'}],
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': '1+1?', 'role': 'user'},
-                        {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': '1 + 1 equals 2.', 'role': 'assistant'},
-                        },
+                        {'event.name': 'gen_ai.assistant.message', 'content': '1 + 1 equals 2.', 'role': 'assistant'},
                     ],
                     'gen_ai.usage.input_tokens': 29,
                     'gen_ai.usage.output_tokens': 9,
@@ -1841,11 +1828,7 @@ async def test_responses_simple(exporter: TestExporter):
                     'raw_input': [{'content': '2+2?', 'role': 'user'}],
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': '2+2?', 'role': 'user'},
-                        {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': '2 + 2 equals 4.', 'role': 'assistant'},
-                        },
+                        {'event.name': 'gen_ai.assistant.message', 'content': '2 + 2 equals 4.', 'role': 'assistant'},
                     ],
                     'gen_ai.usage.input_tokens': 29,
                     'gen_ai.usage.output_tokens': 9,
@@ -2048,9 +2031,9 @@ async def test_responses_simple(exporter: TestExporter):
                         {'event.name': 'gen_ai.assistant.message', 'content': '2 + 2 equals 4.', 'role': 'assistant'},
                         {'event.name': 'gen_ai.user.message', 'content': '4?', 'role': 'user'},
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': 'Yes, 2 + 2 equals 4.', 'role': 'assistant'},
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': 'Yes, 2 + 2 equals 4.',
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 47,
@@ -2318,28 +2301,25 @@ async def test_file_search(exporter: TestExporter):
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': 'Who made Logfire?', 'role': 'user'},
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'content': """\
+                            'event.name': 'gen_ai.unknown',
+                            'role': 'assistant',
+                            'content': """\
 file_search_call
 
 See JSON for details\
 """,
-                                'data': {
-                                    'id': 'fs_67ceff3ab5b081919945a1b5a1185949',
-                                    'queries': ['Who made Logfire?'],
-                                    'status': 'completed',
-                                    'type': 'file_search_call',
-                                    'results': None,
-                                },
+                            'data': {
+                                'id': 'fs_67ceff3ab5b081919945a1b5a1185949',
+                                'queries': ['Who made Logfire?'],
+                                'status': 'completed',
+                                'type': 'file_search_call',
+                                'results': None,
                             },
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': 'Logfire is made by Pydantic.', 'role': 'assistant'},
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': 'Logfire is made by Pydantic.',
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 1974,
@@ -2622,11 +2602,7 @@ See JSON for details\
                             'role': 'assistant',
                         },
                         {'event.name': 'gen_ai.user.message', 'content': '2+2?', 'role': 'user'},
-                        {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': 'The answer is 4.', 'role': 'assistant'},
-                        },
+                        {'event.name': 'gen_ai.assistant.message', 'content': 'The answer is 4.', 'role': 'assistant'},
                     ],
                     'gen_ai.usage.input_tokens': 923,
                     'gen_ai.usage.output_tokens': 8,
@@ -2892,18 +2868,15 @@ async def test_function_tool_exception(exporter: TestExporter):
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': 'Call the tool.', 'role': 'user'},
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'tool_calls': [
-                                    {
-                                        'id': 'call_OpJ32C09GImFzxYLe01MiOOd',
-                                        'type': 'function',
-                                        'function': {'name': 'tool', 'arguments': '{}'},
-                                    }
-                                ],
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': 'call_OpJ32C09GImFzxYLe01MiOOd',
+                                    'type': 'function',
+                                    'function': {'name': 'tool', 'arguments': '{}'},
+                                }
+                            ],
                         },
                     ],
                     'gen_ai.usage.input_tokens': 244,
@@ -3164,12 +3137,9 @@ async def test_function_tool_exception(exporter: TestExporter):
                             'name': 'tool',
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'content': 'It seems there was an error when trying to call the tool. If you need help with something specific, feel free to let me know!',
-                                'role': 'assistant',
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': 'It seems there was an error when trying to call the tool. If you need help with something specific, feel free to let me know!',
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 283,
@@ -3509,9 +3479,9 @@ async def test_voice_pipeline(exporter: TestExporter, vcr_allow_bytes: None):
                             'role': 'user',
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': 'Natürlich! Wobei genau benötigen Sie Hilfe?', 'role': 'assistant'},
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': 'Natürlich! Wobei genau benötigen Sie Hilfe?',
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 33,

--- a/tests/otel_integrations/test_openai_agents_mcp.py
+++ b/tests/otel_integrations/test_openai_agents_mcp.py
@@ -387,18 +387,15 @@ async def test_mcp(exporter: TestExporter):
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': 'Give me a random number', 'role': 'user'},
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {
-                                'role': 'assistant',
-                                'tool_calls': [
-                                    {
-                                        'id': 'call_jfYaCkab5PQtyNrcrSgMdlRf',
-                                        'type': 'function',
-                                        'function': {'name': 'random_number', 'arguments': '{}'},
-                                    }
-                                ],
-                            },
+                            'event.name': 'gen_ai.assistant.message',
+                            'role': 'assistant',
+                            'tool_calls': [
+                                {
+                                    'id': 'call_jfYaCkab5PQtyNrcrSgMdlRf',
+                                    'type': 'function',
+                                    'function': {'name': 'random_number', 'arguments': '{}'},
+                                }
+                            ],
                         },
                     ],
                     'gen_ai.usage.input_tokens': 51,
@@ -731,9 +728,9 @@ async def test_mcp(exporter: TestExporter):
                             'name': 'random_number',
                         },
                         {
-                            'event.name': 'gen_ai.choice',
-                            'index': 0,
-                            'message': {'content': "Here's a random number for you: 4", 'role': 'assistant'},
+                            'event.name': 'gen_ai.assistant.message',
+                            'content': "Here's a random number for you: 4",
+                            'role': 'assistant',
                         },
                     ],
                     'gen_ai.usage.input_tokens': 83,


### PR DESCRIPTION
This was a mistake. The Responses API doesn't even support multiple choices, and each response part was being presented as a 'choice', all with index=0.