### PR TITLE
Fix kwargs in proxy metric instruments, preventing warning about duplicate histograms

### DIFF
--- a/logfire/_internal/metrics.py
+++ b/logfire/_internal/metrics.py
@@ -113,16 +113,19 @@ class _ProxyMeter(Meter):
             for instrument in self._instruments:
                 instrument.on_meter_set(real_meter)
 
+    def _add_proxy_instrument(self, instrument_type: type[_ProxyInstrument[InstrumentT]], **kwargs: Any) -> InstrumentT:
+        with self._lock:
+            proxy = instrument_type(self._meter, **kwargs)
+            self._instruments.add(proxy)
+            return proxy  # type: ignore
+
     def create_counter(
         self,
         name: str,
         unit: str = '',
         description: str = '',
     ) -> Counter:
-        with self._lock:
-            proxy = _ProxyCounter(self._meter, name=name, unit=unit, description=description)
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(_ProxyCounter, name=name, unit=unit, description=description)
 
     def create_up_down_counter(
         self,
@@ -130,10 +133,7 @@ class _ProxyMeter(Meter):
         unit: str = '',
         description: str = '',
     ) -> UpDownCounter:
-        with self._lock:
-            proxy = _ProxyUpDownCounter(self._meter, name=name, unit=unit, description=description)
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(_ProxyUpDownCounter, name=name, unit=unit, description=description)
 
     def create_observable_counter(
         self,
@@ -142,12 +142,9 @@ class _ProxyMeter(Meter):
         unit: str = '',
         description: str = '',
     ) -> ObservableCounter:
-        with self._lock:
-            proxy = _ProxyObservableCounter(
-                self._meter, name=name, unit=unit, description=description, callbacks=callbacks
-            )
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(
+            _ProxyObservableCounter, name=name, unit=unit, description=description, callbacks=callbacks
+        )
 
     def create_histogram(
         self,
@@ -156,10 +153,7 @@ class _ProxyMeter(Meter):
         description: str = '',
         **kwargs: Any,
     ) -> Histogram:
-        with self._lock:
-            proxy = _ProxyHistogram(self._meter, name=name, unit=unit, description=description, **kwargs)
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(_ProxyHistogram, name=name, unit=unit, description=description, **kwargs)
 
     def create_gauge(
         self,
@@ -174,10 +168,7 @@ class _ProxyMeter(Meter):
                 'You should upgrade to 1.23.0 or newer:\n'
                 '   pip install opentelemetry-sdk>=1.23.0'
             )
-        with self._lock:
-            proxy = _ProxyGauge(self._meter, name=name, unit=unit, description=description)
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(_ProxyGauge, name=name, unit=unit, description=description)
 
     def create_observable_gauge(
         self,
@@ -186,12 +177,9 @@ class _ProxyMeter(Meter):
         unit: str = '',
         description: str = '',
     ) -> ObservableGauge:
-        with self._lock:
-            proxy = _ProxyObservableGauge(
-                self._meter, name=name, unit=unit, description=description, callbacks=callbacks
-            )
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(
+            _ProxyObservableGauge, name=name, unit=unit, description=description, callbacks=callbacks
+        )
 
     def create_observable_up_down_counter(
         self,
@@ -200,12 +188,9 @@ class _ProxyMeter(Meter):
         unit: str = '',
         description: str = '',
     ) -> ObservableUpDownCounter:
-        with self._lock:
-            proxy = _ProxyObservableUpDownCounter(
-                self._meter, name=name, unit=unit, description=description, callbacks=callbacks
-            )
-            self._instruments.add(proxy)
-            return proxy
+        return self._add_proxy_instrument(
+            _ProxyObservableUpDownCounter, name=name, unit=unit, description=description, callbacks=callbacks
+        )
 
 
 InstrumentT = TypeVar('InstrumentT', bound=Instrument)

--- a/logfire/_internal/metrics.py
+++ b/logfire/_internal/metrics.py
@@ -234,10 +234,6 @@ class _ProxyInstrument(ABC, Generic[InstrumentT]):
             span.increment_metric(self._kwargs['name'], attributes or {}, amount)
 
 
-class _ProxyAsynchronousInstrument(_ProxyInstrument[InstrumentT], ABC):
-    pass
-
-
 class _ProxyCounter(_ProxyInstrument[Counter], Counter):
     def add(
         self,
@@ -270,23 +266,17 @@ class _ProxyHistogram(_ProxyInstrument[Histogram], Histogram):
         return meter.create_histogram(**self._kwargs)
 
 
-class _ProxyObservableCounter(_ProxyAsynchronousInstrument[ObservableCounter], ObservableCounter):
+class _ProxyObservableCounter(_ProxyInstrument[ObservableCounter], ObservableCounter):
     def _create_real_instrument(self, meter: Meter) -> ObservableCounter:
         return meter.create_observable_counter(**self._kwargs)
 
 
-class _ProxyObservableGauge(
-    _ProxyAsynchronousInstrument[ObservableGauge],
-    ObservableGauge,
-):
+class _ProxyObservableGauge(_ProxyInstrument[ObservableGauge], ObservableGauge):
     def _create_real_instrument(self, meter: Meter) -> ObservableGauge:
         return meter.create_observable_gauge(**self._kwargs)
 
 
-class _ProxyObservableUpDownCounter(
-    _ProxyAsynchronousInstrument[ObservableUpDownCounter],
-    ObservableUpDownCounter,
-):
+class _ProxyObservableUpDownCounter(_ProxyInstrument[ObservableUpDownCounter], ObservableUpDownCounter):
     def _create_real_instrument(self, meter: Meter) -> ObservableUpDownCounter:
         return meter.create_observable_up_down_counter(**self._kwargs)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -488,3 +488,15 @@ def test_metrics_in_non_recording_spans(exporter: TestExporter, config_kwargs: d
             }
         ]
     )
+
+
+def test_reconfigure(caplog: pytest.LogCaptureFixture):
+    for _ in range(3):
+        logfire.configure(send_to_logfire=False, console=False)
+        meter.create_histogram('foo', unit='x', description='bar', explicit_bucket_boundaries_advisory=[1, 2, 3])
+    # Previously a bug caused a warning to be logged when reconfiguring the metrics
+    assert not caplog.messages
+
+    # For comparison, this logs a warning because the advisory is different (unset)
+    meter.create_histogram('foo', unit='x', description='bar')
+    assert caplog.messages


### PR DESCRIPTION
Previously this script:

```python
import logfire

logfire.configure()
logfire.instrument_pydantic_ai()
logfire.configure()
logfire.instrument_pydantic_ai()
```

would log:

```
An instrument with name gen_ai.client.token.usage, type Histogram, unit {token} and description Measures number of input and output tokens used has been created already with a different advisory value None and will be used instead.
```

The reason was that `explicit_bucket_boundaries_advisory` was not being saved on the proxy histogram and used to recreate the real instrument when a new meter provider was set.

Also some refactoring.