### PR TITLE
docs: add more detail on `instrument_x` calls

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,66 +1,85 @@
 # Integrations
 
-If a package you are using is not listed here, please let us know on our [Slack][slack]!
+**Pydantic Logfire** supports first-class integration with many popular Python packages using a single `logfire.instrument_<package>()`
+function call. Each of these should be called exactly once after `logfire.configure()`
 
-## OpenTelemetry Integrations
+For example, to instrument FastAPI and HTTPX, you would do:
 
-Since **Pydantic Logfire** is [OpenTelemetry][opentelemetry] compatible, it can be used with any OpenTelemetry
-instrumentation package. You can find the list of all OpenTelemetry instrumentation packages
-[here](https://opentelemetry-python-contrib.readthedocs.io/en/latest/).
+```python
+import logfire
 
-Below you can see more details on how to use Logfire with some of the most popular Python packages.
+logfire.configure()
+logfire.instrument_fastapi()
+logfire.instrument_httpx()
 
-| Package                                  | Type                    |
-|------------------------------------------|-------------------------|
-| [FastAPI](web-frameworks/fastapi.md)     | Web Framework           |
-| [Django](web-frameworks/django.md)       | Web Framework           |
-| [Flask](web-frameworks/flask.md)         | Web Framework           |
-| [Starlette](web-frameworks/starlette.md) | Web Framework           |
-| [ASGI](web-frameworks/asgi.md)           | Web Framework Interface |
-| [WSGI](web-frameworks/wsgi.md)           | Web Framework Interface |
-| [HTTPX](http-clients/httpx.md)           | HTTP Client             |
-| [Requests](http-clients/requests.md)     | HTTP Client             |
-| [AIOHTTP](http-clients/aiohttp.md)       | HTTP Client             |
-| [SQLAlchemy](databases/sqlalchemy.md)    | Databases               |
-| [Asyncpg](databases/asyncpg.md)          | Databases               |
-| [Psycopg](databases/psycopg.md)          | Databases               |
-| [PyMongo](databases/pymongo.md)          | Databases               |
-| [MySQL](databases/mysql.md)              | Databases               |
-| [SQLite3](databases/sqlite3.md)          | Databases               |
-| [Redis](databases/redis.md)              | Databases               |
-| [BigQuery](databases/bigquery.md)        | Databases               |
-| [Airflow](event-streams/airflow.md)      | Task Scheduler          |
-| [FastStream](event-streams/faststream.md)| Task Queue              |
-| [Celery](event-streams/celery.md)        | Task Queue              |
-| [Stripe](stripe.md)                      | Payment Gateway         |
-| [System Metrics](system-metrics.md)      | System Metrics          |
+# ... your application code here ...
+```
+
+If a package you are using is not listed in this documentation, please let us know on our [Slack][slack]!
+
+## Documented Integrations
+
+**Logfire** has documented integrations with many technologies, including:
+- *LLM Clients and AI Frameworks*: PydanticAI, OpenAI, Anthropic, LangChain, LlamaIndex, Mirascope, LiteLLM, Magentic
+- *Web Frameworks*: FastAPI, Django, Flask, Starlette, AIOHTTP, ASGI, WSGI
+- *Database Clients*: Psycopg, SQLAlchemy, Asyncpg, PyMongo, MySQL, SQLite3, Redis, BigQuery
+- *HTTP Clients*: HTTPX, Requests, AIOHTTP
+- *Task Queues and Schedulers*: Airflow, FastStream, Celery
+- *Logging Libraries*: Standard Library Logging, Loguru, Structlog
+- and more, such as Stripe, AWS Lambda, and system metrics.
+
+The below table lists these integrations and any corresponding `logfire.instrument_<package>()` calls:
+
+| Package                                  | Type                    | Logfire Instrument Call / Notes                                  |
+|-------------------------------------------|-------------------------|------------------------------------------------------------------|
+| [AIOHTTP](http-clients/aiohttp.md)        | HTTP Client             | `logfire.instrument_aiohttp_client()`, `logfire.instrument_aiohttp_server()` |
+| [Airflow](event-streams/airflow.md)       | Task Scheduler          | N/A (built in, config needed)                                    |
+| [Anthropic](llms/anthropic.md)            | AI                      | `logfire.instrument_anthropic()`                                 |
+| [ASGI](web-frameworks/asgi.md)            | Web Framework Interface | `logfire.instrument_asgi()`                                      |
+| [AWS Lambda](aws-lambda.md)               | Cloud Function          | `logfire.instrument_aws_lambda()`                                |
+| [Asyncpg](databases/asyncpg.md)           | Database                | `logfire.instrument_asyncpg()`                                   |
+| [BigQuery](databases/bigquery.md)         | Database                | N/A (built in, no config needed)                                 |
+| [Celery](event-streams/celery.md)         | Task Queue              | `logfire.instrument_celery()`                                    |
+| [Django](web-frameworks/django.md)        | Web Framework           | `logfire.instrument_django()`                                    |
+| [FastAPI](web-frameworks/fastapi.md)      | Web Framework           | `logfire.instrument_fastapi()`                                   |
+| [FastStream](event-streams/faststream.md) | Task Queue              | N/A (built in, config needed)                                    |
+| [Flask](web-frameworks/flask.md)          | Web Framework           | `logfire.instrument_flask()`                                     |
+| [HTTPX](http-clients/httpx.md)            | HTTP Client             | `logfire.instrument_httpx()`                                     |
+| [LangChain](llms/langchain.md)            | AI Framework            | N/A (built-in OpenTelemetry support)                             |
+| [LlamaIndex](llms/llamaindex.md)          | AI Framework            | N/A (requires LlamaIndex Otel package)                           |
+| [LiteLLM](llms/litellm.md)                | AI Gateway              | N/A (requires LiteLLM callback setup)                            |
+| [Loguru](loguru.md)                       | Logging                 | See documentation                                                |
+| [Magentic](llms/magentic.md)              | AI Framework            | N/A (built-in Logfire support)                                   |
+| [Mirascope](llms/mirascope.md)            | AI Framework            | N/A (use mirascope `@with_logfire` decorator)                    |
+| [MySQL](databases/mysql.md)               | Database                | `logfire.instrument_mysql()`                                     |
+| [OpenAI](llms/openai.md)                  | AI                      | `logfire.instrument_openai()`                                    |
+| [Psycopg](databases/psycopg.md)           | Database                | `logfire.instrument_psycopg()`                                   |
+| [Pydantic](pydantic.md)                   | Data Validation         | `logfire.instrument_pydantic()`                                  |
+| [PydanticAI](llms/pydanticai.md)          | AI                      | `logfire.instrument_pydantic_ai()`                               |
+| [PyMongo](databases/pymongo.md)           | Database                | `logfire.instrument_pymongo()`                                   |
+| [Redis](databases/redis.md)               | Database                | `logfire.instrument_redis()`                                     |
+| [Requests](http-clients/requests.md)      | HTTP Client             | `logfire.instrument_requests()`                                  |
+| [SQLAlchemy](databases/sqlalchemy.md)     | Database                | `logfire.instrument_sqlalchemy()`                                |
+| [SQLite3](databases/sqlite3.md)           | Database                | `logfire.instrument_sqlite3()`                                   |
+| [Standard Library Logging](logging.md)    | Logging                 | See documentation                                                |
+| [Starlette](web-frameworks/starlette.md)  | Web Framework           | `logfire.instrument_starlette()`                                 |
+| [Stripe](stripe.md)                       | Payment Gateway         | N/A (requires other instrumentations)                            |
+| [Structlog](structlog.md)                 | Logging                 | See documentation                                                |
+| [System Metrics](system-metrics.md)       | System Metrics          | `logfire.instrument_system_metrics()`                            |
+| [WSGI](web-frameworks/wsgi.md)            | Web Framework Interface | `logfire.instrument_wsgi()`                                      |
 
 If you are using Logfire with a web application, we also recommend reviewing
 our [Web Frameworks](web-frameworks/index.md)
 documentation.
 
-## Custom Integrations
+## OpenTelemetry Integrations
 
-We have special integration with the Pydantic library and the OpenAI SDK:
+Since **Logfire** is [OpenTelemetry][opentelemetry] compatible, it can be used with any OpenTelemetry
+instrumentation package. You can find the list of all OpenTelemetry instrumentation packages
+[here](https://opentelemetry-python-contrib.readthedocs.io/en/latest/).
 
-| Package                        | Type            |
-|--------------------------------|-----------------|
-| [Pydantic](pydantic.md)        | Data Validation |
-| [OpenAI](llms/openai.md)       | AI              |
-| [Anthropic](llms/anthropic.md) | AI              |
-
-## Logging Integrations
-
-Finally, we also have documentation for how to use Logfire with existing logging libraries:
-
-| Package                                | Type    |
-|----------------------------------------|---------|
-| [Standard Library Logging](logging.md) | Logging |
-| [Loguru](loguru.md)                    | Logging |
-| [Structlog](structlog.md)              | Logging |
-
-[slack]: https://logfire.pydantic.dev/docs/join-slack/
-[opentelemetry]: https://opentelemetry.io/
+Many of the integrations documented in the previous section are based upon the OpenTelemetry instrumentation packages
+with first-class support built into **Logfire**.
 
 ## Creating Custom Integrations
 
@@ -89,3 +108,6 @@ logfire.info("Hello, Logfire!")
     `logfire.configure()` if they want to use the integration.
 
 All the **Logfire** API methods are available in `logfire-api`.
+
+[slack]: https://logfire.pydantic.dev/docs/join-slack/
+[opentelemetry]: https://opentelemetry.io/

--- a/docs/integrations/llms/mirascope.md
+++ b/docs/integrations/llms/mirascope.md
@@ -4,7 +4,7 @@ integration: third-party
 
 [Mirascope][mirascope-repo] is a developer tool for building with LLMs. Their library focuses on abstractions that aren't obstructions and integrates with Logfire to make observability and monitoring for LLMs easy and seamless.
 
-You can enable it using their [`@with_logire`][mirascope-logfire] decorator, which will work with all of the [model providers that they support][mirascope-supported-providers] (e.g. OpenAI, Anthropic, Gemini, Mistral, Groq, and more).
+You can enable it using their [`@with_logfire`][mirascope-logfire] decorator, which will work with all of the [model providers that they support][mirascope-supported-providers] (e.g. OpenAI, Anthropic, Gemini, Mistral, Groq, and more).
 
 ```py hl_lines="1 3 5 8"
 import logfire


### PR DESCRIPTION
This is an attempt to close #599

In particular, the key problem in that issue is that `logfire.instrument_system_metrics` should only be called once.

This is true of any of the `instrument_x()` calls; rather than add specific copy to each of their docs I decided to start by revamping the `Integrations` root page a bit to add missing detail and try to make it clear that each `instrument_x()` should only be called once.