### PR TITLE
Add newline in md docs

### DIFF
--- a/docs/how-to-guides/cloud-metrics.md
+++ b/docs/how-to-guides/cloud-metrics.md
@@ -76,7 +76,8 @@ gcloud projects add-iam-policy-binding $PROJECT_ID \
 
 Create a collector configuration file with the Google Cloud Monitoring receiver:
 
-```yaml title="gcp-metrics-collector.yaml"receivers:
+```yaml title="gcp-metrics-collector.yaml"
+receivers:
   googlecloudmonitoring:
     # Your GCP project ID
     project_id: "${env:PROJECT_ID}"


### PR DESCRIPTION
I think this missing newline was making the docs on the website not render the yaml block correctly 

![image](https://github.com/user-attachments/assets/fcc3e4d4-ffcd-4af9-b980-310dbe2f6531)

https://logfire.pydantic.dev/docs/how-to-guides/cloud-metrics/#24-configuration