### PR TITLE
Fix importlib resources with auto tracing

### DIFF
--- a/logfire/_internal/auto_trace/import_hook.py
+++ b/logfire/_internal/auto_trace/import_hook.py
@@ -133,7 +133,5 @@ class LogfireLoader(Loader):
         return compile(source, '<string>', 'exec', dont_inherit=True)
 
     def __getattr__(self, item: str):
-        """Forward some methods to the plain spec's loader (likely a `SourceFileLoader`) if they exist."""
-        if item in {'get_filename', 'is_package'}:
-            return getattr(self.plain_spec.loader, item)
-        raise AttributeError(item)
+        """Forward to the plain spec's loader (likely a `SourceFileLoader`)."""
+        return getattr(self.plain_spec.loader, item)

--- a/tests/auto_trace_samples/dir/resource.txt
+++ b/tests/auto_trace_samples/dir/resource.txt
@@ -1,0 +1,1 @@
+example resource

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -1,5 +1,6 @@
 import ast
 import asyncio
+import importlib.resources
 import runpy
 import sys
 from contextlib import AbstractContextManager
@@ -49,6 +50,8 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
     # The exact plain loader here isn't that essential.
     assert isinstance(loader.plain_spec.loader, SourceFileLoader)
     assert loader.plain_spec.name == foo.__name__ == foo.__spec__.name == 'tests.auto_trace_samples.foo'
+
+    assert (importlib.resources.files(foo.__name__) / 'dir/resource.txt').read_text() == 'example resource\n'
 
     with pytest.raises(IndexError):  # foo.bar intentionally raises an error to test that it's recorded below
         asyncio.run(foo.bar())


### PR DESCRIPTION
Fixes https://github.com/pydantic/logfire/issues/1211

In general just forwards everything to the underlying loader (probably a `SourceFileLoader`) instead of only specific methods, which probably fixes other things too.