### PR TITLE
Fix auto-tracing Python 3.12 ParamSpec syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ include = ["/README.md", "CHANGELOG.md", "/Makefile", "/logfire", "/tests"]
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
 line-length = 120
-extend-exclude = ["logfire-api/logfire_api/*"]
+extend-exclude = ["logfire-api/logfire_api/*", "tests/auto_trace_samples/param_spec.py"]
 
 [tool.ruff.lint]
 extend-select = [

--- a/tests/auto_trace_samples/param_spec.py
+++ b/tests/auto_trace_samples/param_spec.py
@@ -1,0 +1,2 @@
+def check_param_spec_syntax[**P](*args: P.args, **kwargs: P.kwargs):
+    return args, kwargs

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -185,6 +185,11 @@ def test_auto_trace_sample(exporter: TestExporter) -> None:
         ]
     )
 
+    if sys.version_info >= (3, 12):
+        from tests.auto_trace_samples import param_spec
+
+        assert param_spec.check_param_spec_syntax(1, 2, a=3, b=4) == ((1, 2), {'a': 3, 'b': 4})  # type: ignore
+
 
 def test_check_already_imported() -> None:
     # Check that nothing gets imported during this test,


### PR DESCRIPTION
Closes #1244 