### PR TITLE
Remove UTC timezone defaults for console logs

### DIFF
--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -195,7 +195,7 @@ class SimpleConsoleSpanExporter(SpanExporter):
         """
         parts: TextParts = []
         if self._include_timestamp:
-            ts = datetime.fromtimestamp(span.timestamp / ONE_SECOND_IN_NANOSECONDS, tz=timezone.utc)
+            ts = datetime.fromtimestamp(span.timestamp / ONE_SECOND_IN_NANOSECONDS)
             # ugly though it is, `[:-3]` is the simplest way to convert microseconds -> milliseconds
             ts_str = f'{ts:%H:%M:%S.%f}'[:-3]
             parts += [(ts_str, 'green'), (' ', '')]


### PR DESCRIPTION
Current logfire console using utc time for logs, as in **/logfire/_internal/exporters/console.py:198**
So, I have removed the code part `tz=timezone.utc` and now tz set as datetime defaults (local time).

Fixes: https://github.com/pydantic/logfire/issues/710