### PR TITLE
Remove text that older mypy versions don't support

### DIFF
--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -179,7 +179,7 @@ def span_to_dict(span: ReadableSpan) -> ReadableSpanDict:
 class UnexpectedResponse(RequestException):
     """An unexpected response was received from the server."""
 
-    response: Response  # type: ignore (guaranteed to exist)
+    response: Response  # type: ignore
 
     def __init__(self, response: Response) -> None:
         super().__init__(f'Unexpected response: {response.status_code}', response=response)


### PR DESCRIPTION
On older versions of `mypy`, I get this error:

```
<project-dir>/.venv/lib/python3.10/site-packages/logfire/_internal/utils.py:182: error: Invalid "type: ignore" comment  [syntax]
```