### PR TITLE
Ensure `logfire_api.LogfireSpan.context` and other attrs are None

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -64,6 +64,26 @@ except ImportError:
             def is_recording(self) -> bool:  # pragma: no cover
                 return False
 
+            @property
+            def context(self):
+                return None
+
+            @property
+            def instrumentation_scope(self):
+                return None
+
+            @property
+            def start_time(self):
+                return None
+
+            @property
+            def end_time(self):
+                return None
+
+            @property
+            def parent(self):
+                return None
+
             def set_attribute(self, key: str, value: Any) -> None: ... # pragma: no cover
 
         class Logfire:

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -73,9 +73,16 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
         assert span.name == '' if module_name == 'logfire_api.' else 'test span'
         if module_name == 'logfire_api.':
             assert span.attributes == {}
+            assert span.context is None
+            assert span.parent is None
+            assert span.start_time is None
+            assert span.end_time is None
+            assert span.instrumentation_scope is None
         assert span.events == ()
         assert span.links == ()
         assert span.resource.attributes
+        assert span.parent is None
+        assert span.end_time is None
 
     logfire__all__.remove('LogfireSpan')
     logfire__all__.remove('span')

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -74,9 +74,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
         if module_name == 'logfire_api.':
             assert span.attributes == {}
             assert span.context is None
-            assert span.parent is None
             assert span.start_time is None
-            assert span.end_time is None
             assert span.instrumentation_scope is None
         assert span.events == ()
         assert span.links == ()


### PR DESCRIPTION
See https://github.com/pydantic/logfire/pull/1288#discussion_r2270880365