### PR TITLE
refactor: remove `stack_offset` from `with_setting()`

### DIFF
--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -328,14 +328,11 @@ class Logfire:
         Returns:
             A new Logfire instance with the sampling ratio applied.
         """
-    def with_settings(self, *, tags: Sequence[str] = (), stack_offset: int | None = None, console_log: bool | None = None, custom_scope_suffix: str | None = None) -> Logfire:
+    def with_settings(self, *, tags: Sequence[str] = (), console_log: bool | None = None, custom_scope_suffix: str | None = None) -> Logfire:
         """A new Logfire instance which uses the given settings.
 
         Args:
             tags: Sequence of tags to include in the log.
-            stack_offset: The stack level offset to use when collecting stack info, also affects the warning which
-                message formatting might emit, defaults to `0` which means the stack info will be collected from the
-                position where [`logfire.log`][logfire.Logfire.log] was called.
             console_log: Whether to log to the console, defaults to `True`.
             custom_scope_suffix: A custom suffix to append to `logfire.` e.g. `logfire.loguru`.
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -810,7 +810,6 @@ class Logfire:
         self,
         *,
         tags: Sequence[str] = (),
-        stack_offset: int | None = None,
         console_log: bool | None = None,
         custom_scope_suffix: str | None = None,
     ) -> Logfire:
@@ -818,9 +817,6 @@ class Logfire:
 
         Args:
             tags: Sequence of tags to include in the log.
-            stack_offset: The stack level offset to use when collecting stack info, also affects the warning which
-                message formatting might emit, defaults to `0` which means the stack info will be collected from the
-                position where [`logfire.log`][logfire.Logfire.log] was called.
             console_log: Whether to log to the console, defaults to `True`.
             custom_scope_suffix: A custom suffix to append to `logfire.` e.g. `logfire.loguru`.
 


### PR DESCRIPTION
The `stack_offset` parameter hasn’t been used anywhere, so it should be removed from both the implementation and the documentation.

## Related issue 
- closes #1326