### PR TITLE
Fix: Add output argument to ConsoleOptions in config.py

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -14,7 +14,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from threading import RLock, Thread
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Callable, Literal, TextIO, TypedDict
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -141,6 +141,7 @@ which send to the Logfire backend.
 class ConsoleOptions:
     """Options for controlling console output."""
 
+    output: TextIO | None = None
     colors: ConsoleColorsValues = 'auto'
     span_style: Literal['simple', 'indented', 'show-parents'] = 'show-parents'
     """How spans are shown in the console."""


### PR DESCRIPTION
This PR fixes an issue with the ConsoleOptions configuration where the output argument was missing from the config, causing errors when trying to redirect logs. The change adds the output argument. A proposed fix for [issue 1390](https://github.com/pydantic/logfire/issues/1390)