### PR TITLE
Support Instrumenting Async SqlAlchemy Engines

### DIFF
--- a/logfire-api/logfire_api/_internal/integrations/sqlalchemy.pyi
+++ b/logfire-api/logfire_api/_internal/integrations/sqlalchemy.pyi
@@ -1,9 +1,9 @@
 from logfire.integrations.sqlalchemy import CommenterOptions as CommenterOptions
 from sqlalchemy import Engine
 from sqlalchemy.ext.asyncio import AsyncEngine
-from typing import Any
+from typing import Any, Iterable
 
-def instrument_sqlalchemy(engine: AsyncEngine | Engine | None, enable_commenter: bool, commenter_options: CommenterOptions, **kwargs: Any) -> None:
+def instrument_sqlalchemy(engine: AsyncEngine | Engine | None, engines: Iterable[AsyncEngine | Engine] | None, enable_commenter: bool, commenter_options: CommenterOptions, **kwargs: Any) -> None:
     """Instrument the `sqlalchemy` module so that spans are automatically created for each query.
 
     See the `Logfire.instrument_sqlalchemy` method for details.

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -777,7 +777,7 @@ class Logfire:
         [OpenTelemetry aiohttp server Instrumentation](https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/aiohttp_server/aiohttp_server.html)
         library, specifically `AioHttpServerInstrumentor().instrument()`, to which it passes `**kwargs`.
         """
-    def instrument_sqlalchemy(self, engine: AsyncEngine | Engine | None = None, enable_commenter: bool = False, commenter_options: SQLAlchemyCommenterOptions | None = None, **kwargs: Any) -> None:
+    def instrument_sqlalchemy(self, engine: AsyncEngine | Engine | None = None, engines: Iterable[AsyncEngine | Engine] | None = None, enable_commenter: bool = False, commenter_options: SQLAlchemyCommenterOptions | None = None, **kwargs: Any) -> None:
         """Instrument the `sqlalchemy` module so that spans are automatically created for each query.
 
         Uses the

--- a/logfire/_internal/integrations/sqlalchemy.py
+++ b/logfire/_internal/integrations/sqlalchemy.py
@@ -30,9 +30,9 @@ def _convert_to_sync_engine(engine: AsyncEngine | Engine | None) -> Engine | Non
 
 def instrument_sqlalchemy(
     engine: AsyncEngine | Engine | None,
+    engines: Iterable[AsyncEngine | Engine] | None,
     enable_commenter: bool,
     commenter_options: CommenterOptions,
-    engines: Iterable[AsyncEngine | Engine] | None,
     **kwargs: Any,
 ) -> None:
     """Instrument the `sqlalchemy` module so that spans are automatically created for each query.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1816,9 +1816,9 @@ class Logfire:
     def instrument_sqlalchemy(
         self,
         engine: AsyncEngine | Engine | None = None,
+        engines: Iterable[AsyncEngine | Engine] | None = None,
         enable_commenter: bool = False,
         commenter_options: SQLAlchemyCommenterOptions | None = None,
-        engines: Iterable[AsyncEngine | Engine] | None = None,
         **kwargs: Any,
     ) -> None:
         """Instrument the `sqlalchemy` module so that spans are automatically created for each query.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1828,8 +1828,8 @@ class Logfire:
         library, specifically `SQLAlchemyInstrumentor().instrument()`, to which it passes `**kwargs`.
 
         Args:
-            engine: The `sqlalchemy` engine to instrument, or `None` to instrument all engines.
-            engines: The `sqlalchemy` engines to instrument, or `None` to instrument all engines.
+            engine: The `sqlalchemy` engine to instrument.
+            engines: An iterable of `sqlalchemy` engines to instrument.
             enable_commenter: Adds comments to SQL queries performed by SQLAlchemy, so that database logs have additional context.
             commenter_options: Configure the tags to be added to the SQL comments.
             **kwargs: Additional keyword arguments to pass to the OpenTelemetry `instrument` methods.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1818,6 +1818,7 @@ class Logfire:
         engine: AsyncEngine | Engine | None = None,
         enable_commenter: bool = False,
         commenter_options: SQLAlchemyCommenterOptions | None = None,
+        engines: Iterable[AsyncEngine | Engine] | None = None,
         **kwargs: Any,
     ) -> None:
         """Instrument the `sqlalchemy` module so that spans are automatically created for each query.
@@ -1828,6 +1829,7 @@ class Logfire:
 
         Args:
             engine: The `sqlalchemy` engine to instrument, or `None` to instrument all engines.
+            engines: The `sqlalchemy` engines to instrument, or `None` to instrument all engines.
             enable_commenter: Adds comments to SQL queries performed by SQLAlchemy, so that database logs have additional context.
             commenter_options: Configure the tags to be added to the SQL comments.
             **kwargs: Additional keyword arguments to pass to the OpenTelemetry `instrument` methods.
@@ -1837,6 +1839,7 @@ class Logfire:
         self._warn_if_not_initialized_for_instrumentation()
         return instrument_sqlalchemy(
             engine=engine,
+            engines=engines,
             enable_commenter=enable_commenter,
             commenter_options=commenter_options or {},
             **{

--- a/tests/otel_integrations/test_sqlalchemy.py
+++ b/tests/otel_integrations/test_sqlalchemy.py
@@ -46,11 +46,6 @@ def sqlite_engine(path: Path) -> Iterator[Engine]:
         path.unlink()
 
 
-def test_sqlalchemy_invalid_engines_parameter():
-    with pytest.raises(ValueError, match='`engines` must be passed as a list'):
-        logfire.instrument_sqlalchemy(engines='invalid')
-
-
 def test_sqlalchemy_instrumentation(exporter: TestExporter):
     with sqlite_engine(Path('example1.db')) as engine:
         logfire.instrument_sqlalchemy(engine=engine)
@@ -396,16 +391,10 @@ def sqlite_async_engine(path: Path) -> Iterator[AsyncEngine]:
 @pytest.mark.parametrize('parameter', ['engine', 'engines'])
 async def test_sqlalchemy_async_instrumentation(parameter: str, exporter: TestExporter):
     with sqlite_async_engine(Path('example2.db')) as engine:
-        instrumentation_parameters: dict[str, Any] = {
-            'enable_commenter': True,
-            'commenter_options': {'db_framework': False},
-        }
         if parameter == 'engine':
-            instrumentation_parameters['engine'] = engine
+            logfire.instrument_sqlalchemy(engine=engine)
         else:
-            instrumentation_parameters['engines'] = [engine]
-
-        logfire.instrument_sqlalchemy(**instrumentation_parameters)
+            logfire.instrument_sqlalchemy(engines=[engine])
 
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)

--- a/tests/otel_integrations/test_sqlalchemy.py
+++ b/tests/otel_integrations/test_sqlalchemy.py
@@ -46,6 +46,11 @@ def sqlite_engine(path: Path) -> Iterator[Engine]:
         path.unlink()
 
 
+def test_sqlalchemy_invalid_engines_parameter():
+    with pytest.raises(ValueError, match='`engines` must be passed as a list'):
+        logfire.instrument_sqlalchemy(engines='invalid')
+
+
 def test_sqlalchemy_instrumentation(exporter: TestExporter):
     with sqlite_engine(Path('example1.db')) as engine:
         logfire.instrument_sqlalchemy(engine=engine)


### PR DESCRIPTION
This PR addresses the need to properly instrument async `engines` values, as  mentioned in #1402's  review comment.