### PR TITLE
fix: use of deprecated tool.uv.dev-dependencies

### DIFF
--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -23,10 +23,12 @@ requires-python = ">= 3.8"
 
 [tool.uv]
 managed = true
-dev-dependencies = []
 
 [tool.hatch.metadata]
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["logfire_api"]
+
+[dependency-groups]
+dev = []


### PR DESCRIPTION
Switch from the deprecated `tool.uv.dev-dependencies` field to `dependency-groups.dev` to fix the warning during commit.