### PR TITLE
Docs: Import getLogger in logging configuration example

### DIFF
--- a/docs/integrations/logging.md
+++ b/docs/integrations/logging.md
@@ -26,7 +26,7 @@ every standard library log record.
 === "Using [`dictConfig()`][logging.config.dictConfig]"
 
     ```py title="main.py"
-    from logging.config import dictConfig
+    from logging.config import dictConfig, getLogger
 
     import logfire
 


### PR DESCRIPTION
This pull request makes a small update to the logging integration documentation.

The change adds an import for `getLogger` alongside `dictConfig` in the Python example, ensuring users have the necessary import for standard logging usage.