### PR TITLE
Docs: Correct getLogger import path in logging example

### DIFF
--- a/docs/integrations/logging.md
+++ b/docs/integrations/logging.md
@@ -26,7 +26,8 @@ every standard library log record.
 === "Using [`dictConfig()`][logging.config.dictConfig]"
 
     ```py title="main.py"
-    from logging.config import dictConfig, getLogger
+    from logging import getLogger
+    from logging.config import dictConfig
 
     import logfire
 


### PR DESCRIPTION
This PR corrects a mistake in my previous PR (#1546).

I accidentally imported `getLogger` from `logging.config` instead of `logging`.
This change fixes the import path to ensure the example code runs correctly.

- **Before:** `from logging.config import dictConfig, getLogger` (Incorrect)
- **After:** `from logging import getLogger` and `from logging.config import dictConfig`

Sorry for the oversight!