### PR TITLE
chore: Test latest deps weekly, not daily

### DIFF
--- a/.github/workflows/weekly_deps_test.yml
+++ b/.github/workflows/weekly_deps_test.yml
@@ -1,8 +1,8 @@
-name: Daily CI Job
+name: Weekly CI Job
 
 on:
   schedule:
-    - cron: '0 12 * * *' # Daily at midnight UTC
+    - cron: '0 12 * * MON' # Every monday noon UTC
 
   # Can be triggered manually from the actions tab, if needed
   workflow_dispatch:
@@ -67,7 +67,7 @@ jobs:
           version: "0.6.2"
           enable-cache: true
 
-        # upgrade deps to the latest versions for this daily test
+        # upgrade deps to the latest versions for this test
       - run: uv sync --python ${{ matrix.python-version }} --upgrade
 
       - name: Install pydantic ${{ matrix.pydantic-version }}
@@ -97,5 +97,5 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload: |
-            heading: Logfire daily CI deps test ${{github.repository}} failed!
+            heading: Logfire Weekly CI deps test ${{github.repository}} failed!
             body: See details at ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}


### PR DESCRIPTION
This has become a burden to keep up with, and the failures are usually not that important.