### PR TITLE
Fix Responses API streaming error handling to not mask original errors

### DIFF
--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -222,14 +222,13 @@ class OpenaiResponsesStreamState(StreamState):
 
     def get_response_data(self) -> Any:
         response = self._state._completed_response  # pyright: ignore[reportPrivateUsage]
-        if not response:  # pragma: no cover
-            raise RuntimeError("Didn't receive a `response.completed` event.")
 
         return response
 
     def get_attributes(self, span_data: dict[str, Any]) -> dict[str, Any]:
         response = self.get_response_data()
-        span_data['events'] = span_data['events'] + responses_output_events(response)
+        if response:
+            span_data['events'] = span_data['events'] + responses_output_events(response)
         return span_data
 
 


### PR DESCRIPTION
When streaming fails (e.g., API connection lost), the `response.completed` event is never received. Previously, `get_response_data()` would raise a `RuntimeError` in this case, which would mask the original streaming error. Now it returns `None` and `get_attributes()` handles this gracefully, allowing the original error to propagate.