### PR TITLE
fix(openai): capture token usage for Responses API streaming

### DIFF
--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -229,6 +229,13 @@ class OpenaiResponsesStreamState(StreamState):
         response = self.get_response_data()
         if response:
             span_data['events'] = span_data['events'] + responses_output_events(response)
+            usage = getattr(response, 'usage', None)
+            input_tokens = getattr(usage, 'input_tokens', None)
+            output_tokens = getattr(usage, 'output_tokens', None)
+            if isinstance(input_tokens, int):
+                span_data[INPUT_TOKENS] = input_tokens
+            if isinstance(output_tokens, int):
+                span_data[OUTPUT_TOKENS] = output_tokens
         return span_data
 
 

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -1954,6 +1954,8 @@ def test_responses_stream(exporter: TestExporter) -> None:
                     'async': False,
                     'gen_ai.operation.name': 'chat',
                     'duration': 1.0,
+                    'gen_ai.usage.input_tokens': 13,
+                    'gen_ai.usage.output_tokens': 9,
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -1964,6 +1966,8 @@ def test_responses_stream(exporter: TestExporter) -> None:
                             'async': {},
                             'gen_ai.operation.name': {},
                             'duration': {},
+                            'gen_ai.usage.input_tokens': {},
+                            'gen_ai.usage.output_tokens': {},
                         },
                     },
                     'logfire.tags': ('LLM',),


### PR DESCRIPTION
Closes #1651

## Summary
When using the OpenAI Responses API with streaming (`client.responses.stream()`), logfire did not capture token usage attributes (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`) on the span. Non-streaming calls worked correctly.

## Change
`OpenaiResponsesStreamState.get_attributes()` now extracts `usage` from the response and sets `INPUT_TOKENS` and `OUTPUT_TOKENS` on the span, matching the non-streaming path and the pattern used in `on_response()` (lines 298–304).