### PR TITLE
Fix reST double backticks in db_api docstrings

### DIFF
--- a/logfire/db_api.py
+++ b/logfire/db_api.py
@@ -28,6 +28,7 @@ from logfire.experimental.query_client import LogfireQueryClient
 if TYPE_CHECKING:
     from logfire.experimental.query_client import ColumnDetails
 
+# TODO: make use of PEP 661 sentinels once accepted.
 _UNSET = Enum('_UNSET', 'UNSET').UNSET
 """Sentinel to distinguish 'not set' from an explicit `None`."""
 


### PR DESCRIPTION
## Summary
- Replace reStructuredText-style double backticks (` `` `) with Markdown single backticks in `logfire/db_api.py` docstrings

Spotted by @Viicos in https://github.com/pydantic/logfire/pull/1692.