### PR TITLE
Use Depot 4-core runners for CI test jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,19 @@ jobs:
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
-    runs-on: ubuntu-latest
+    # Use Depot 4-core runners for maintainer PRs (faster CPUs/more cores)
+    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Depot outages)
+    # Use 'ci:fast' label to opt-in fork PRs to Depot runners
+    runs-on: >-
+      ${{
+        !contains(github.event.pull_request.labels.*.name, 'ci:slow')
+        && (
+          github.event.pull_request.head.repo.full_name == github.repository
+          || contains(github.event.pull_request.labels.*.name, 'ci:fast')
+        )
+        && 'depot-ubuntu-24.04-4'
+        || 'ubuntu-latest'
+      }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Switch the `test` matrix jobs from `ubuntu-latest` to `depot-ubuntu-24.04-4` (4-core) runners for maintainer PRs
- All other jobs (`lint`, `docs`, `test-pyodide`, `coverage`, `check`, `release`) remain on `ubuntu-latest` since they're already fast

## Why

Test jobs are the CI bottleneck, averaging **4.6-6.3 minutes each** on standard 2-core GitHub runners. With Depot's 4-core runners (faster CPUs and more cores), these should be significantly faster.

Current stats: ~174 maintainer CI runs/month, with 7 test matrix entries each, making this the highest-impact optimization target.

## How it works

The `runs-on` uses a conditional expression:

- **Maintainer PRs** (head repo matches base repo): automatically use Depot runners
- **`ci:slow` label**: forces standard GitHub runners (useful during Depot outages)
- **`ci:fast` label**: opts fork PRs into Depot runners
- **Push to main/tags**: uses `ubuntu-latest` (no PR context, so the condition falls through)

This is modeled after [pydantic/pydantic-ai#4346](https://github.com/pydantic/pydantic-ai/pull/4346).

## Test plan

- [ ] CI passes on this PR (the branch is from a maintainer, so it should use Depot runners)
- [ ] Verify test jobs show `depot-ubuntu-24.04-4` as the runner in the Actions UI
- [ ] Compare test job durations against recent `main` runs to confirm speedup
- [ ] Verify non-test jobs still run on `ubuntu-latest`