### PR TITLE
docs: update MCP server guide to use remote server configs

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -24,32 +24,6 @@ To use the remote MCP server, add the following configuration to your MCP client
 - **US region** — `logfire-us.pydantic.dev`
 - **EU region** — `logfire-eu.pydantic.dev`
 
-For **US region** (`logfire-us.pydantic.dev`):
-
-```json
-{
-  "mcpServers": {
-    "logfire": {
-      "type": "http",
-      "url": "https://logfire-us.pydantic.dev/mcp"
-    }
-  }
-}
-```
-
-For **EU region** (`logfire-eu.pydantic.dev`):
-
-```json
-{
-  "mcpServers": {
-    "logfire": {
-      "type": "http",
-      "url": "https://logfire-eu.pydantic.dev/mcp"
-    }
-  }
-}
-```
-
 !!! note
     The remote MCP server handles authentication automatically through your browser. When you first connect,
     you'll be prompted to authenticate with your Pydantic Logfire account.


### PR DESCRIPTION
Replace local server setup instructions with remote MCP server configurations for all clients (Cursor, Claude Code, Claude Desktop, Cline, VS Code, Zed). Deprecate local server section and point to the logfire-mcp repo's OLD_README.md for legacy instructions.