### PR TITLE
Add Pydantic social links to docs footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,9 +21,6 @@ extra:
     - icon: fontawesome/brands/linkedin
       link: https://www.linkedin.com/company/pydantic/
       name: Pydantic on LinkedIn
-    - icon: fontawesome/brands/mastodon
-      link: https://fosstodon.org/@pydantic
-      name: Pydantic on Mastodon
     - icon: fontawesome/brands/bluesky
       link: https://bsky.app/profile/pydantic.dev
       name: Pydantic on Bluesky


### PR DESCRIPTION
## Summary
- Add social media icons (GitHub, X, LinkedIn, Mastodon, Bluesky) to the docs footer via mkdocs Material's `extra.social` config
- Links match the socials listed on pydantic.dev