### PR TITLE
Add API Keys section to managed variables docs

### DIFF
--- a/docs/reference/advanced/managed-variables/index.md
+++ b/docs/reference/advanced/managed-variables/index.md
@@ -125,6 +125,21 @@ Here's the typical workflow using the `AgentConfig` example from above:
 7. **Monitor in real-time**: filter traces by label to compare response quality, latency, and token usage
 8. **Adjust based on data**: if the canary version performs better, move the `production` label to that version
 
+## API Keys {#api-keys}
+
+Managed variables require API keys with the appropriate scopes. There are two scenarios that each require a key with a different scope:
+
+- **Reading variables at runtime** (in your application): an API key with the `project:read_variables` scope (or `project:read_external_variables` if you only need access to external variables, e.g. in client-side apps), set via the `LOGFIRE_API_KEY` environment variable.
+- **Pushing variable definitions** (syncing schemas from code): an API key with the `project:write_variables` scope, used with `logfire.variables_push()` and other related write APIs. This is separate from the write token (`LOGFIRE_TOKEN`) used to send traces.
+
+| Scope | Purpose |
+|-------|---------|
+| `project:read_variables` | Read all variables via SDK or OFREP |
+| `project:write_variables` | Create, update, and delete variables and variable types |
+| `project:read_external_variables` | Read only external variables via OFREP (for client-side apps) |
+
+You can create and manage API keys in your project's **Settings > API Keys** page. For more details on external variables and client-side access patterns, see [External Variables and OFREP](external.md#api-key-scopes-for-variables).
+
 ## Quick Start
 
 ### Define a Variable


### PR DESCRIPTION
## Summary
- Add a dedicated "API Keys" section with `#api-keys` anchor to the main managed variables docs page
- Lists the three variable-related scopes (`project:read_variables`, `project:write_variables`, `project:read_external_variables`) with their purposes
- Explains which keys are needed for reading vs. pushing variables
- Provides a direct link target for the Logfire UI's "appropriate scopes" link

Companion UI PR: https://github.com/pydantic/platform/pull/18029

## Test plan
- [ ] Build docs locally and verify the `#api-keys` anchor works
- [ ] Check the scope table renders correctly