### PR TITLE
Don't record pydantic-ai CallDeferred exception or set level to error

### DIFF
--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -147,6 +147,7 @@ class _LogfireWrappedSpan(trace_api.Span, ReadableSpan):
     record_metrics: bool
     metrics: dict[str, SpanMetric] = field(default_factory=lambda: defaultdict(SpanMetric))
     exception_callback: ExceptionCallback | None = None
+    _skip_next_error_status: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self):
         OPEN_SPANS[self._open_spans_key()] = self
@@ -194,6 +195,11 @@ class _LogfireWrappedSpan(trace_api.Span, ReadableSpan):
         status: Status | StatusCode,
         description: str | None = None,
     ) -> None:
+        if self._skip_next_error_status:
+            self._skip_next_error_status = False
+            status_code = status.status_code if isinstance(status, Status) else status
+            if status_code == StatusCode.ERROR:
+                return
         self.span.set_status(status, description)
 
     def record_exception(
@@ -203,6 +209,11 @@ class _LogfireWrappedSpan(trace_api.Span, ReadableSpan):
         timestamp: int | None = None,
         escaped: bool = False,
     ) -> None:
+        # Flag to skip the next ERROR set_status call if this is a control flow exception.
+        # OTel's use_span calls record_exception and set_status independently,
+        # so we need to coordinate between the two.
+        if _is_pydantic_ai_control_flow_exception(exception):
+            self._skip_next_error_status = True
         timestamp = timestamp or self.ns_timestamp_generator()
         record_exception(
             self.span,

--- a/tests/otel_integrations/test_pydantic_ai.py
+++ b/tests/otel_integrations/test_pydantic_ai.py
@@ -135,3 +135,24 @@ def test_call_deferred_not_recorded_as_error(exporter: TestExporter, exc_class: 
             }
         ]
     )
+
+
+@pytest.mark.parametrize('exc_class', [CallDeferred, ApprovalRequired])
+def test_call_deferred_not_recorded_via_start_as_current_span(exporter: TestExporter, exc_class: type[Exception]):
+    """When exceptions escape through start_as_current_span (OTel SDK's use_span path),
+    both record_exception and set_status(ERROR) should be suppressed for control flow exceptions.
+    """
+    logfire_config = logfire.configure(local=True)
+    tracer = logfire_config.get_tracer_provider().get_tracer('test')
+
+    with pytest.raises(exc_class):
+        with tracer.start_as_current_span('otel tool call'):
+            raise exc_class()
+
+    spans = exporter.exported_spans_as_dict()
+    for span in spans:
+        # No exception events should be recorded
+        assert not span.get('events', []), f'Unexpected exception events: {span.get("events")}'
+        # Status should not be ERROR
+        status = span.get('status', {})
+        assert status.get('status_code', 'UNSET') != 'ERROR', f'Unexpected ERROR status: {status}'


### PR DESCRIPTION
## Summary

Skip recording pydantic-ai's `CallDeferred` and `ApprovalRequired` exceptions as errors in logfire spans. These are control flow exceptions used for deferred tool calls and human-in-the-loop approval, not actual errors.

## Changes

- **`logfire/_internal/tracer.py`**: Added `_is_pydantic_ai_control_flow_exception()` helper with lazy import (to avoid circular imports) that checks if an exception is `CallDeferred` or `ApprovalRequired`. Added an early return in `record_exception()` to skip recording these exceptions entirely — no error status, no error level, no exception event.
- **`tests/otel_integrations/test_pydantic_ai.py`**: Added parametrized test for both `CallDeferred` and `ApprovalRequired` verifying the span has no exception events and no error level.

Closes #1515