### PR TITLE
Update Slack invite link

### DIFF
--- a/docs/join-slack/index.html
+++ b/docs/join-slack/index.html
@@ -5,13 +5,13 @@
     <meta charset="utf-8">
     <title>Redirecting to slack...</title>
     <script>
-      location.href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-3kkfnpjsl-DCt9R8GJs4IY3Aej9tIBYg"
+      location.href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-3lttjc9qr-Ak3PSnRldLvZ9QsWjzylWg"
     </script>
-    <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30nu5u4c0-kKihQCzbaFF7_NQa_dxMUQ">
+    <meta http-equiv="refresh" content="0; url=https://join.slack.com/t/pydanticlogfire/shared_invite/zt-3lttjc9qr-Ak3PSnRldLvZ9QsWjzylWg">
 </head>
 <body>
 You're being redirected to
-<a href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-30nu5u4c0-kKihQCzbaFF7_NQa_dxMUQ">
+<a href="https://join.slack.com/t/pydanticlogfire/shared_invite/zt-3lttjc9qr-Ak3PSnRldLvZ9QsWjzylWg">
   a slack invitation link
 </a>.
 </body>


### PR DESCRIPTION
## Summary
- Updates the Slack invite redirect at `docs/join-slack/index.html` to use the new shared invite link
- Fixes inconsistency where the JS `location.href` redirect and the `<meta http-equiv="refresh">` fallback were using different (both expired) invite links — now all three references point to the same new URL

## Test plan
- [ ] Visit https://logfire.pydantic.dev/docs/join-slack/ after deploy and verify it redirects to the new Slack invite