### PR TITLE
Change `logfire_pytest` fixture scope to session

### DIFF
--- a/logfire/_internal/integrations/pytest.py
+++ b/logfire/_internal/integrations/pytest.py
@@ -572,7 +572,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     logfire_instance.force_flush(timeout_millis=5000)
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def logfire_pytest(request: pytest.FixtureRequest) -> Logfire:
     """Provide a Logfire instance configured for the pytest plugin.
 


### PR DESCRIPTION
The `logfire_pytest` fixture is changed from function to session scope since it provides a Logfire instance configured for the plugin which doesn't need to be recreated per test.