### PR TITLE
Release v4.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## [v4.27.0] (2026-03-06)
+
+* Add `gen_ai.system` attribute to anthropic spans, enabling token/cost badges by @alexmojaki in [#1760](https://github.com/pydantic/logfire/pull/1760)
+* Set `operation.cost` attribute on anthropic spans when `genai-prices` is installed by @alexmojaki in [#1761](https://github.com/pydantic/logfire/pull/1761)
+
 ## [v4.26.0] (2026-03-06)
 
 * feat: add browser proxy helpers: `forward_export_request` and `logfire_proxy` by @AlanPonnachan in [#1697](https://github.com/pydantic/logfire/pull/1697)
@@ -1055,3 +1060,4 @@ First release from new repo!
 [v4.24.0]: https://github.com/pydantic/logfire/compare/v4.23.0...v4.24.0
 [v4.25.0]: https://github.com/pydantic/logfire/compare/v4.24.0...v4.25.0
 [v4.26.0]: https://github.com/pydantic/logfire/compare/v4.25.0...v4.26.0
+[v4.27.0]: https://github.com/pydantic/logfire/compare/v4.26.0...v4.27.0

--- a/docs/guides/web-ui/llm-panels.md
+++ b/docs/guides/web-ui/llm-panels.md
@@ -52,7 +52,7 @@ Click an LLM span to open the details panel.
 | [Google Gen AI](../../integrations/llms/google-genai.md)                              | ✅            | ✅     | ✅                 |
 | [LangChain](../../integrations/llms/langchain.md)                                     | ✅            | ✅     | ✅                 |
 | [LiteLLM](../../integrations/llms/litellm.md)                                         | ✅            | ✅     | ✅                 |
-| [Anthropic](../../integrations/llms/anthropic.md)                                     |              |       | ✅                 |
+| [Anthropic](../../integrations/llms/anthropic.md)                                     | ✅            | ✅     | ✅                 |
 | [Claude Agent SDK](../../integrations/llms/claude-agent-sdk.md)                       |              |       | ✅                 |
 | [Google ADK](https://github.com/pydantic/logfire/issues/1201#issuecomment-3012423974) | ✅            |       |                   |
 

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "4.26.0"
+version = "4.27.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "4.26.0"
+version = "4.27.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3220,7 +3220,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.26.0"
+version = "4.27.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -3608,7 +3608,7 @@ docs = [
 
 [[package]]
 name = "logfire-api"
-version = "4.26.0"
+version = "4.27.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]


### PR DESCRIPTION
Bumping version to v4.27.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v4.27.0 enables token and cost badges for Anthropic LLM spans and updates the UI docs. Also bumps package versions.

- **New Features**
  - Add gen_ai.system on Anthropic spans to enable token and cost badges in the UI.
  - Set operation.cost on Anthropic spans when genai-prices is installed.

<sup>Written for commit e54ecf682286e6a987eeb7d06cce6ade450f9a48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

