### PR TITLE
Remove wrong scopes from api keys docs

### DIFF
--- a/docs/reference/advanced/use-api-keys.md
+++ b/docs/reference/advanced/use-api-keys.md
@@ -48,8 +48,6 @@ Available scopes depend on whether you're creating an organization or project AP
 | Scope                                | Organization API Key | Project API Key |
 | ------------------------------------ | -------------------- | --------------- |
 | Organization management (read/write) | ✓                    | —               |
-| Member management                    | ✓                    | —               |
-| Billing access                       | ✓                    | —               |
 | Project settings (read/write)        | ✓                    | ✓               |
 | Write tokens management              | ✓                    | ✓               |
 | Read tokens management               | ✓                    | ✓               |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the API key scopes table in the docs to match actual permissions. Removed "Member management" and "Billing access" from Organization API Key scopes to avoid confusion.

<sup>Written for commit 0a18c5a0bc579a6d3ff09270ab9003f7dbb852de. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

