### PR TITLE
Release v4.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## [v4.28.0] (2026-03-11)
+
+* Handle anthropic beta messages and refactor by @alexmojaki in [#1774](https://github.com/pydantic/logfire/pull/1774)
+* Delete redundant `logfire.experimental.datasets` package by @alexmojaki in [#1763](https://github.com/pydantic/logfire/pull/1763)
+* Change `logfire_pytest` fixture scope to session by @jirikuncar in [#1758](https://github.com/pydantic/logfire/pull/1758)
+
 ## [v4.27.0] (2026-03-06)
 
 * Add `gen_ai.system` attribute to anthropic spans, enabling token/cost badges by @alexmojaki in [#1760](https://github.com/pydantic/logfire/pull/1760)
@@ -1061,3 +1067,4 @@ First release from new repo!
 [v4.25.0]: https://github.com/pydantic/logfire/compare/v4.24.0...v4.25.0
 [v4.26.0]: https://github.com/pydantic/logfire/compare/v4.25.0...v4.26.0
 [v4.27.0]: https://github.com/pydantic/logfire/compare/v4.26.0...v4.27.0
+[v4.28.0]: https://github.com/pydantic/logfire/compare/v4.27.0...v4.28.0

--- a/logfire-api/logfire_api/_internal/integrations/pytest.pyi
+++ b/logfire-api/logfire_api/_internal/integrations/pytest.pyi
@@ -48,7 +48,6 @@ def pytest_runtest_teardown(item: pytest.Item) -> Generator[None]:
     """Trace test teardown phase if --logfire-trace-phases is enabled."""
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     """End the session span and flush traces."""
-@pytest.fixture
 def logfire_pytest(request: pytest.FixtureRequest) -> Logfire:
     """Provide a Logfire instance configured for the pytest plugin.
 

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "4.27.0"
+version = "4.28.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "4.27.0"
+version = "4.28.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3220,7 +3220,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.27.0"
+version = "4.28.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -3608,7 +3608,7 @@ docs = [
 
 [[package]]
 name = "logfire-api"
-version = "4.27.0"
+version = "4.28.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]


### PR DESCRIPTION
Bumping version to v4.28.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v4.28.0 adds support for Anthropic beta messages, removes the redundant `logfire.experimental.datasets` package, and makes the `logfire_pytest` fixture session-scoped.

- **Dependencies**
  - Bumped `logfire` and `logfire-api` to `v4.28.0` and updated `uv.lock`.

<sup>Written for commit 42fb6e078b8190ca1cac81c9e67c62a2bf1c8d0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

