### PR TITLE
Release v4.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## [v4.29.0] (2026-03-13)
+
+* Add `gen_ai.usage.raw` attribute to OpenAI Responses spans by @alexmojaki in [#1777](https://github.com/pydantic/logfire/pull/1777)
+
 ## [v4.28.0] (2026-03-11)
 
 * Handle anthropic beta messages and refactor by @alexmojaki in [#1774](https://github.com/pydantic/logfire/pull/1774)
@@ -1068,3 +1072,4 @@ First release from new repo!
 [v4.26.0]: https://github.com/pydantic/logfire/compare/v4.25.0...v4.26.0
 [v4.27.0]: https://github.com/pydantic/logfire/compare/v4.26.0...v4.27.0
 [v4.28.0]: https://github.com/pydantic/logfire/compare/v4.27.0...v4.28.0
+[v4.29.0]: https://github.com/pydantic/logfire/compare/v4.28.0...v4.29.0

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "4.28.0"
+version = "4.29.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "4.28.0"
+version = "4.29.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -3220,7 +3220,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.28.0"
+version = "4.29.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -3608,7 +3608,7 @@ docs = [
 
 [[package]]
 name = "logfire-api"
-version = "4.28.0"
+version = "4.29.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]


### PR DESCRIPTION
Bumping version to v4.29.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v4.29.0 adds `gen_ai.usage.raw` to OpenAI Responses spans for access to the raw usage payload. Also bumps `logfire` and `logfire-api` to 4.29.0.

<sup>Written for commit 358dd2ce996fcb314059889ed164e6fc7b4eb45f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

