### PR TITLE
Update more documentation about plans

### DIFF
--- a/docs/comparisons/datadog.md
+++ b/docs/comparisons/datadog.md
@@ -26,7 +26,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 | Scale-up (50-150 hosts, 500M spans) | $9,860/mo  | $1,229/mo         | 87%     |
 | High-volume (500 hosts, 2B spans) | $33,550/mo | $4,229/mo         | 87%     |
 
-*Logfire Cloud Pro pricing (Team or Growth plans -> $2/million spans). Enterprise pricing (self-hosting, SSO, custom retention) available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5).
+*Logfire Cloud pricing (Team or Growth plans -> $2/million spans). Enterprise pricing (self-hosting, SSO, custom retention) available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5).
 
 ## When to Choose Logfire
 

--- a/docs/comparisons/langsmith.md
+++ b/docs/comparisons/langsmith.md
@@ -21,7 +21,7 @@ LangSmith is the observability and evaluation platform from the LangChain team. 
 | Standard (14 days retention) | ~$500/1M traces | ~$6-10/1M traces |
 | Extended (400 days retention) | ~$5,000/1M traces | ~$6-10/1M traces |
 
-*Logfire Cloud Pro pricing. Enterprise pricing available on request.
+*Logfire Cloud pricing. Enterprise pricing available on request.
 
 At scale, Logfire can be 50-100X cheaper than LangSmith. This isn't about Logfire being a "budget option". It's about architectural efficiency. Logfire's OpenTelemetry-native design avoids the overhead of proprietary trace formats, and our query engine (DataFusion) retrieves traces significantly faster.
 

--- a/docs/how-to-guides/otel-collector/otel-collector-overview.md
+++ b/docs/how-to-guides/otel-collector/otel-collector-overview.md
@@ -27,7 +27,8 @@ For more information on the collector please see the [official documentation](ht
 
 ## Back up data in AWS S3
 
-Data older than **30 days** is pruned from our backend (except for customers on our [enterprise plans](../../enterprise.md)).
+Unless you are under the [Growth or Enterprise plan](https://pydantic.dev/pricing),
+data older than **30 days** is pruned from our backend.
 If you want to keep your data stored long-term, you can configure the **Logfire** SDK to also send data to the
 OpenTelemetry Collector, which will then forward the data to AWS S3.
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated pricing references and retention details to match current plans and reduce confusion.

Replaced "Logfire Cloud Pro" with "Logfire Cloud" in the Datadog and LangSmith comparison pages. Clarified that only Growth and Enterprise avoid the 30-day pruning in the OTEL Collector guide and added a link to the pricing page.

<sup>Written for commit af581049a96664b92dbf5e3bf05ef5ed25d99920. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

