### PR TITLE
Remove Rich link styling from project URL output

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1843,19 +1843,15 @@ class LogfireCredentials:
         """Print a summary of the existing project."""
         if self.project_url:  # pragma: no branch
             _print_summary(
-                f'[bold]Logfire[/bold] project URL: [link={self.project_url} cyan]{self.project_url}[/link]',
+                f'[bold]Logfire[/bold] project URL: [cyan]{self.project_url}[/cyan]',
                 min_content_width=len(self.project_url),
             )
 
 
 def _print_summary(message: str, min_content_width: int) -> None:
     from rich.console import Console
-    from rich.style import Style
-    from rich.theme import Theme
 
-    # customise the link color since the default `blue` is too dark for me to read.
-    custom_theme = Theme({'markdown.link_url': Style(color='cyan')})
-    console = Console(stderr=True, theme=custom_theme)
+    console = Console(stderr=True)
     if console.width < min_content_width + 4:  # pragma: no cover
         console.width = min_content_width + 4
     console.print(message)


### PR DESCRIPTION
## Summary

Remove the Rich `[link=...]` markup from the project URL console output, replacing it with plain `[cyan]` styling.

## Problem

Rich's `[link=...]` markup emits OSC 8 terminal hyperlink escape sequences. These escape sequences break output in Google Colab and IPython environments — particularly when the project URL is printed from a background thread during `logfire.configure()`, the escape sequences interfere with Colab's output handling and can swallow subsequent `print()` output entirely.

See the detailed investigation in #1267.

## Fix

- Replace `[link={url} cyan]{url}[/link]` with `[cyan]{url}[/cyan]` in `print_token_summary()`
- Remove the now-unnecessary custom `Theme` and `Style` imports from `_print_summary()` (they were only used to customize the link color)

The URL remains visible and cyan-colored in terminals that support Rich markup, but no longer emits hyperlink escape sequences.

## Test plan

- [x] All existing tests in `test_configure.py` and `test_cli.py` pass (162/162) — they assert on the rendered text via `capsys`, which is unchanged
- [x] Full non-Docker test suite passes (1262 passed)
- [x] `ruff format`, `ruff check`, and `pyright` all pass
- [x] All pre-commit hooks pass

Fixes #1267

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove Rich hyperlink markup from the project URL output. Use plain cyan text to avoid OSC 8 sequences that break Google Colab and IPython output.

- **Bug Fixes**
  - Use `[cyan]{url}[/cyan]` instead of `[link={url} cyan]{url}[/link]` in `print_token_summary()`.
  - Remove custom `Theme`/`Style`; use default `Console`.
  - URL stays visible and colored; notebook output is no longer swallowed.

<sup>Written for commit 17be3c864b4867f8cf41c3d486ff430f81ed8551. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

