### PR TITLE
fix: correct false import suggestions

### DIFF
--- a/logfire-api/logfire_api/_internal/cli/run.pyi
+++ b/logfire-api/logfire_api/_internal/cli/run.pyi
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from rich.console import Console
 from rich.text import Text
 
-STANDARD_LIBRARY_PACKAGES: Incomplete
+ALWAYS_AVAILABLE_PACKAGES: Incomplete
 OTEL_INSTRUMENTATION_MAP: Incomplete
 
 @dataclass
@@ -27,13 +27,16 @@ def instrument_packages(installed_otel_packages: set[str], instrument_pkg_map: d
     Returns a list of packages that were successfully instrumented.
     """
 def instrument_package(import_name: str): ...
-def find_recommended_instrumentations_to_install(instrument_pkg_map: dict[str, str], installed_otel_pkgs: set[str], installed_pkgs: set[str]) -> set[tuple[str, str]]:
+def find_recommended_instrumentations_to_install(instrument_pkg_map: dict[str, str], installed_otel_pkgs: set[str], installed_pkgs: set[str], script_imports: set[str] | None = None) -> set[tuple[str, str]]:
     """Determine which OpenTelemetry instrumentation packages are recommended for installation.
 
     Args:
         instrument_pkg_map: Mapping of instrumentation package names to the packages they instrument.
         installed_otel_pkgs: Set of already installed instrumentation package names.
         installed_pkgs: Set of all installed package names.
+        script_imports: Set of top-level module names imported by the user's script/module.
+            Used to filter out false suggestions for packages that are always available
+            (stdlib or transitive deps) but not actually used.
 
     Returns:
         Set of tuples where each tuple is (instrumentation_package, target_package) that
@@ -45,5 +48,14 @@ def get_recommendation_texts(recommendations: set[tuple[str, str]]) -> tuple[Tex
 def print_otel_summary(*, console: Console, instrumented_packages_text: Text | None = None, recommendations: set[tuple[str, str]]) -> None: ...
 def installed_packages() -> set[str]:
     """Get a set of all installed packages."""
-def collect_instrumentation_context(exclude: set[str]) -> InstrumentationContext:
+def find_script_imports(script_path: str | None = None, module_name: str | None = None) -> set[str] | None:
+    """Extract top-level import names from a script file or module.
+
+    Uses AST parsing to find all `import X` and `from X import ...` statements,
+    returning the set of top-level module names (e.g. 'requests', 'sqlite3').
+
+    Returns None if the source cannot be determined (e.g. no script or module provided),
+    which signals that filtering should be skipped (all packages recommended as before).
+    """
+def collect_instrumentation_context(exclude: set[str], script_path: str | None = None, module_name: str | None = None) -> InstrumentationContext:
     """Collects all relevant context for instrumentation and recommendations."""

--- a/logfire/_internal/cli/run.py
+++ b/logfire/_internal/cli/run.py
@@ -1,8 +1,10 @@
 from __future__ import annotations as _annotations
 
 import argparse
+import ast
 import importlib
 import importlib.metadata
+import importlib.util
 import os
 import runpy
 import shutil
@@ -21,7 +23,9 @@ from rich.text import Text
 
 import logfire
 
-STANDARD_LIBRARY_PACKAGES = {'urllib', 'sqlite3'}
+# Packages that are always importable (stdlib or transitive deps of opentelemetry)
+# but should only be suggested for instrumentation if the user's code actually imports them.
+ALWAYS_AVAILABLE_PACKAGES = {'urllib', 'sqlite3', 'requests'}
 
 # Map of instrumentation packages to the packages they instrument
 OTEL_INSTRUMENTATION_MAP = {
@@ -84,7 +88,12 @@ def parse_run(args: argparse.Namespace) -> None:
     summary = cast(bool, args.summary)
     exclude = cast(set[str], args.exclude)
 
-    ctx = collect_instrumentation_context(exclude)
+    # Determine the script path or module name for import analysis
+    script_and_args = args.script_and_args
+    module_name = args.module
+    script_path = script_and_args[0] if script_and_args and not module_name else None
+
+    ctx = collect_instrumentation_context(exclude, script_path=script_path, module_name=module_name)
 
     instrumented_packages = instrument_packages(ctx.installed_otel_pkgs, ctx.instrument_pkg_map)
 
@@ -97,13 +106,10 @@ def parse_run(args: argparse.Namespace) -> None:
             console=console, instrumented_packages_text=instrumentation_text, recommendations=ctx.recommendations
         )
 
-    # Get arguments from the script_and_args parameter
-    script_and_args = args.script_and_args
-
     # Add the current directory to `sys.path`. This is needed for the module to be found.
     sys.path.insert(0, os.getcwd())
 
-    if module_name := args.module:
+    if module_name:
         module_args = script_and_args
 
         # We need to change the `sys.argv` to make sure the module sees the right CLI args
@@ -115,15 +121,15 @@ def parse_run(args: argparse.Namespace) -> None:
             runpy.run_module(module_name, run_name='__main__', alter_sys=True)
     elif script_and_args:
         # Script mode
-        script_path = script_and_args[0]
+        run_script_path = script_and_args[0]
 
         # Make sure the script directory is in sys.path
-        script_dir = os.path.dirname(os.path.abspath(script_path))
+        script_dir = os.path.dirname(os.path.abspath(run_script_path))
         if script_dir not in sys.path:  # pragma: no branch
             sys.path.insert(0, script_dir)
 
         with alter_sys_argv(script_and_args, f'python {" ".join(script_and_args)}'):
-            runpy.run_path(script_path, run_name='__main__')
+            runpy.run_path(run_script_path, run_name='__main__')
     else:
         print('Usage: logfire run [-m MODULE] [args...] OR logfire run SCRIPT [args...]')
         sys.exit(1)
@@ -178,6 +184,7 @@ def find_recommended_instrumentations_to_install(
     instrument_pkg_map: dict[str, str],
     installed_otel_pkgs: set[str],
     installed_pkgs: set[str],
+    script_imports: set[str] | None = None,
 ) -> set[tuple[str, str]]:
     """Determine which OpenTelemetry instrumentation packages are recommended for installation.
 
@@ -185,6 +192,9 @@ def find_recommended_instrumentations_to_install(
         instrument_pkg_map: Mapping of instrumentation package names to the packages they instrument.
         installed_otel_pkgs: Set of already installed instrumentation package names.
         installed_pkgs: Set of all installed package names.
+        script_imports: Set of top-level module names imported by the user's script/module.
+            Used to filter out false suggestions for packages that are always available
+            (stdlib or transitive deps) but not actually used.
 
     Returns:
         Set of tuples where each tuple is (instrumentation_package, target_package) that
@@ -197,8 +207,16 @@ def find_recommended_instrumentations_to_install(
         if otel_pkg in installed_otel_pkgs:
             continue
 
-        # Include only if the package it instruments is installed or in sys.stdlib_module_names
-        if required_pkg in installed_pkgs or required_pkg in STANDARD_LIBRARY_PACKAGES:
+        # For packages that are always importable (stdlib or transitive deps of otel),
+        # only recommend if the user's code actually imports them.
+        if required_pkg in ALWAYS_AVAILABLE_PACKAGES:
+            if script_imports is not None and required_pkg not in script_imports:
+                continue
+            recommendations.add((otel_pkg, required_pkg))
+            continue
+
+        # For other packages, recommend if they are installed
+        if required_pkg in installed_pkgs:
             recommendations.add((otel_pkg, required_pkg))
 
     # Special case: if fastapi is installed, don't show starlette instrumentation.
@@ -322,13 +340,64 @@ def _full_install_command(recommendations: list[tuple[str, str]]) -> str:
         return f'pip install {" ".join(package_names)}'  # pragma: no cover
 
 
-def collect_instrumentation_context(exclude: set[str]) -> InstrumentationContext:
+def find_script_imports(script_path: str | None = None, module_name: str | None = None) -> set[str] | None:
+    """Extract top-level import names from a script file or module.
+
+    Uses AST parsing to find all `import X` and `from X import ...` statements,
+    returning the set of top-level module names (e.g. 'requests', 'sqlite3').
+
+    Returns None if the source cannot be determined (e.g. no script or module provided),
+    which signals that filtering should be skipped (all packages recommended as before).
+    """
+    source: str | None = None
+
+    if script_path:
+        try:
+            with open(script_path) as f:
+                source = f.read()
+        except OSError:
+            return None
+    elif module_name:
+        try:
+            spec = importlib.util.find_spec(module_name)
+            if spec and spec.origin:
+                with open(spec.origin) as f:
+                    source = f.read()
+        except (ModuleNotFoundError, ValueError, OSError):
+            return None
+
+    if source is None:
+        return None
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # 'import urllib.request' -> top-level is 'urllib'
+                imports.add(alias.name.split('.')[0])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.add(node.module.split('.')[0])
+    return imports
+
+
+def collect_instrumentation_context(
+    exclude: set[str],
+    script_path: str | None = None,
+    module_name: str | None = None,
+) -> InstrumentationContext:
     """Collects all relevant context for instrumentation and recommendations."""
     instrument_pkg_map = {otel_pkg: pkg for otel_pkg, pkg in OTEL_INSTRUMENTATION_MAP.items() if pkg not in exclude}
     installed_pkgs = installed_packages()
     installed_otel_pkgs = {pkg for pkg in instrument_pkg_map.keys() if pkg in installed_pkgs}
+    script_imports = find_script_imports(script_path=script_path, module_name=module_name)
     recommendations = find_recommended_instrumentations_to_install(
-        instrument_pkg_map, installed_otel_pkgs, installed_pkgs
+        instrument_pkg_map, installed_otel_pkgs, installed_pkgs, script_imports=script_imports
     )
     return InstrumentationContext(
         instrument_pkg_map=instrument_pkg_map,

--- a/logfire/_internal/cli/run.py
+++ b/logfire/_internal/cli/run.py
@@ -93,6 +93,10 @@ def parse_run(args: argparse.Namespace) -> None:
     module_name = args.module
     script_path = script_and_args[0] if script_and_args and not module_name else None
 
+    # Add the current directory to `sys.path` BEFORE import analysis so that
+    # local modules (e.g. `logfire run -m myapp`) can be resolved by find_spec.
+    sys.path.insert(0, os.getcwd())
+
     ctx = collect_instrumentation_context(exclude, script_path=script_path, module_name=module_name)
 
     instrumented_packages = instrument_packages(ctx.installed_otel_pkgs, ctx.instrument_pkg_map)
@@ -105,9 +109,6 @@ def parse_run(args: argparse.Namespace) -> None:
         print_otel_summary(
             console=console, instrumented_packages_text=instrumentation_text, recommendations=ctx.recommendations
         )
-
-    # Add the current directory to `sys.path`. This is needed for the module to be found.
-    sys.path.insert(0, os.getcwd())
 
     if module_name:
         module_args = script_and_args
@@ -361,7 +362,15 @@ def find_script_imports(script_path: str | None = None, module_name: str | None 
         try:
             spec = importlib.util.find_spec(module_name)
             if spec and spec.origin:
-                with open(spec.origin) as f:
+                origin = spec.origin
+                # For packages, runtime executes __main__.py (via runpy.run_module),
+                # not __init__.py. Analyze __main__.py if it exists so that
+                # recommendations match what actually runs.
+                if origin.endswith('__init__.py'):
+                    main_py = origin.replace('__init__.py', '__main__.py')
+                    if os.path.isfile(main_py):
+                        origin = main_py
+                with open(origin) as f:
                     source = f.read()
         except (ModuleNotFoundError, ValueError, OSError):
             return None

--- a/logfire/_internal/cli/run.py
+++ b/logfire/_internal/cli/run.py
@@ -93,10 +93,6 @@ def parse_run(args: argparse.Namespace) -> None:
     module_name = args.module
     script_path = script_and_args[0] if script_and_args and not module_name else None
 
-    # Add the current directory to `sys.path` BEFORE import analysis so that
-    # local modules (e.g. `logfire run -m myapp`) can be resolved by find_spec.
-    sys.path.insert(0, os.getcwd())
-
     ctx = collect_instrumentation_context(exclude, script_path=script_path, module_name=module_name)
 
     instrumented_packages = instrument_packages(ctx.installed_otel_pkgs, ctx.instrument_pkg_map)
@@ -112,6 +108,14 @@ def parse_run(args: argparse.Namespace) -> None:
 
     if module_name:
         module_args = script_and_args
+
+        # Re-insert cwd for the actual module execution so that `python -m myapp`
+        # semantics are preserved.  This intentionally happens AFTER
+        # collect_instrumentation_context (and therefore after instrument_packages),
+        # so local modules in cwd cannot shadow logfire's own instrumentation imports.
+        cwd = os.getcwd()
+        if cwd not in sys.path:
+            sys.path.insert(0, cwd)
 
         # We need to change the `sys.argv` to make sure the module sees the right CLI args
         # e.g. in case of `logfire run -m uvicorn main:app --reload`, the application will see
@@ -359,6 +363,16 @@ def find_script_imports(script_path: str | None = None, module_name: str | None 
         except OSError:
             return None
     elif module_name:
+        # Temporarily insert cwd into sys.path so that find_spec can locate local
+        # modules (e.g. `logfire run -m myapp`). The insertion is scoped with
+        # try/finally so it is removed immediately after the analysis pass and does
+        # NOT persist into the instrumentation-import phase, preventing local modules
+        # from shadowing logfire's own dependencies.
+        cwd = os.getcwd()
+        cwd_inserted = False
+        if cwd not in sys.path:
+            sys.path.insert(0, cwd)
+            cwd_inserted = True
         try:
             spec = importlib.util.find_spec(module_name)
             if spec and spec.origin:
@@ -374,6 +388,12 @@ def find_script_imports(script_path: str | None = None, module_name: str | None 
                     source = f.read()
         except (ModuleNotFoundError, ValueError, OSError):
             return None
+        finally:
+            if cwd_inserted:
+                try:
+                    sys.path.remove(cwd)
+                except ValueError:
+                    pass
 
     if source is None:
         return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,7 @@ from logfire._internal.auth import UserToken
 from logfire._internal.cli import OrgProjectAction, SplitArgs, main
 from logfire._internal.cli.run import (
     find_recommended_instrumentations_to_install,
+    find_script_imports,
     get_recommendation_texts,
     instrument_packages,
     instrumented_packages_text,
@@ -2243,3 +2244,99 @@ def test_base_url_and_logfire_url(
 def test_main_module() -> None:
     """Test that logfire.__main__ is importable for coverage."""
     assert subprocess.run([sys.executable, '-m', 'logfire', '--help'], check=True).returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for find_script_imports and the try/finally cwd-scoping fix (Cubic P1)
+# ---------------------------------------------------------------------------
+
+
+def test_find_script_imports_local_module(tmp_dir_cwd: Path) -> None:
+    """find_script_imports resolves a local module via a cwd-scoped sys.path insertion."""
+    pkg = tmp_dir_cwd / 'fake_local_pkg'
+    pkg.mkdir()
+    (pkg / '__init__.py').write_text('import requests\nimport sqlite3\n')
+
+    sys_path_before = sys.path.copy()
+    result = find_script_imports(module_name='fake_local_pkg')
+    sys_path_after = sys.path.copy()
+
+    assert result is not None
+    assert 'requests' in result
+    assert 'sqlite3' in result
+    # cwd must NOT remain in sys.path after the analysis pass
+    assert sys_path_before == sys_path_after
+
+
+def test_find_script_imports_module_prefers_main_py(tmp_dir_cwd: Path) -> None:
+    """For packages with both __init__.py and __main__.py, find_script_imports reads __main__.py."""
+    pkg = tmp_dir_cwd / 'dual_entry_pkg'
+    pkg.mkdir()
+    (pkg / '__init__.py').write_text('import os\n')
+    (pkg / '__main__.py').write_text('import urllib.request\nimport sqlite3\n')
+
+    result = find_script_imports(module_name='dual_entry_pkg')
+
+    assert result is not None
+    # __main__.py imports should be present
+    assert 'urllib' in result
+    assert 'sqlite3' in result
+    # __init__.py-only import should NOT be present (we read __main__.py, not __init__.py)
+    assert 'os' not in result
+
+
+def test_find_script_imports_cwd_already_in_sys_path(tmp_dir_cwd: Path) -> None:
+    """When cwd is already in sys.path, find_script_imports does not insert or remove it."""
+    (tmp_dir_cwd / 'already_present_mod.py').write_text('import json\n')
+
+    # Pre-insert cwd so it is already present
+    cwd = str(tmp_dir_cwd)
+    sys.path.insert(0, cwd)
+    sys_path_before = sys.path.copy()
+    try:
+        result = find_script_imports(module_name='already_present_mod')
+        sys_path_after = sys.path.copy()
+        assert result is not None
+        assert 'json' in result
+        # sys.path unchanged — cwd was not inserted by find_script_imports
+        assert sys_path_before == sys_path_after
+    finally:
+        try:
+            sys.path.remove(cwd)
+        except ValueError:
+            pass
+
+
+def test_find_script_imports_nonexistent_module(tmp_dir_cwd: Path) -> None:
+    """Returns None (not an exception) when the module cannot be found."""
+    sys_path_before = sys.path.copy()
+    result = find_script_imports(module_name='does_not_exist_xyz_abc')
+    assert result is None
+    # cwd must NOT remain in sys.path even on failure
+    assert sys.path == sys_path_before
+
+
+def test_parse_run_module_cwd_removed_before_instrumentation(
+    tmp_dir_cwd: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """cwd is absent from sys.path during instrument_packages, preventing local shadowing."""
+    # A minimal runnable module — no argv or sys.path assertions so it works with -m.
+    (tmp_dir_cwd / 'simple_module.py').write_text('print("ok")\n')
+    monkeypatch.setattr('logfire.configure', Mock())
+    monkeypatch.setattr('logfire._internal.cli.run.OTEL_INSTRUMENTATION_MAP', {})
+
+    captured_sys_path: list[list[str]] = []
+
+    def capturing_instrument_packages(
+        installed_otel_packages: set[str], instrument_pkg_map: dict[str, str]
+    ) -> list[str]:
+        captured_sys_path.append(sys.path.copy())
+        return []
+
+    monkeypatch.setattr('logfire._internal.cli.run.instrument_packages', capturing_instrument_packages)
+
+    main(['run', '--no-summary', '-m', 'simple_module'])
+
+    # During instrument_packages, cwd must NOT be in sys.path
+    assert len(captured_sys_path) == 1
+    assert str(tmp_dir_cwd) not in captured_sys_path[0]


### PR DESCRIPTION
## Summary

Fixes #1296 — `logfire run` always suggested `requests`, `sqlite3`, and `urllib` for instrumentation, even for a simple `print('Hello, world!')` script.

**Root cause:**
- `sqlite3` and `urllib` were always recommended because they were in `STANDARD_LIBRARY_PACKAGES`, which bypassed the "is this package installed?" check
- `requests` was recommended because it's a transitive dependency of opentelemetry, so it appeared as "installed" even though the user's code doesn't use it

**Fix:**
- Added `find_script_imports()` which uses Python's `ast` module to extract top-level imports from the user's script/module
- Renamed `STANDARD_LIBRARY_PACKAGES` to `ALWAYS_AVAILABLE_PACKAGES` and added `requests` to it
- For packages in `ALWAYS_AVAILABLE_PACKAGES`, only recommend them if the user's code actually imports them
- When no script/module context is available (e.g. `logfire inspect`), behavior is unchanged — all available packages are still recommended

**Before:**
```
$ logfire run script.py  # script.py: print('Hello, world!')
☐ requests (need to install opentelemetry-instrumentation-requests)
☐ sqlite3 (need to install opentelemetry-instrumentation-sqlite3)
☐ urllib (need to install opentelemetry-instrumentation-urllib)
```

**After:**
```
$ logfire run script.py  # script.py: print('Hello, world!')
# No false suggestions
```

## Test plan

- [ ] Existing tests pass (backward compatible — `find_recommended_instrumentations_to_install` without `script_imports` param behaves identically)
- [ ] `logfire run script.py` with `print('Hello')` shows no suggestions for requests/sqlite3/urllib
- [ ] `logfire run script.py` with `import sqlite3` correctly suggests sqlite3 instrumentation
- [ ] `logfire inspect` still shows all available recommendations (no script context = no filtering)
- [ ] `logfire run -m module_name` correctly analyzes module imports


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1296 by stopping false import suggestions in `logfire run`. We now analyze the script or module entrypoint imports, so `requests`, `sqlite3`, and `urllib` are only suggested when used.

- **Bug Fixes**
  - Added `find_script_imports()` (AST) to read imports from a script or `-m` module; prefers `__main__.py` over `__init__.py` and skips filtering if source can’t be read.
  - Replaced `STANDARD_LIBRARY_PACKAGES` with `ALWAYS_AVAILABLE_PACKAGES` (adds `requests`); only recommend these if actually imported by the user’s code.
  - Moved `sys.path.insert(0, os.getcwd())` before import analysis so local `-m` modules resolve correctly.
  - Threaded script context through: `collect_instrumentation_context()` and `find_recommended_instrumentations_to_install()` now accept `script_imports`; behavior unchanged when no script/module is provided.

<sup>Written for commit 3dcf344b318012f9feaa6d44c54bd27f29322a1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

