### PR TITLE
Release v4.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## [v4.30.0] (2026-03-23)
+
+* Add `logfire auth logout` command by @ai-man-codes in [#1781](https://github.com/pydantic/logfire/pull/1781)
+* Remove Rich link styling from project URL output by @ameenalkhaldi in [#1784](https://github.com/pydantic/logfire/pull/1784)
+* Fix push_config() to push labels and versions by @dmontagu in [#1785](https://github.com/pydantic/logfire/pull/1785)
+* Merge `export_dataset` into `get_dataset` with `include_cases` parameter by @Kludex in [#1792](https://github.com/pydantic/logfire/pull/1792)
+
 ## [v4.29.0] (2026-03-13)
 
 * Add `gen_ai.usage.raw` attribute to OpenAI Responses spans by @alexmojaki in [#1777](https://github.com/pydantic/logfire/pull/1777)
@@ -1073,3 +1080,4 @@ First release from new repo!
 [v4.27.0]: https://github.com/pydantic/logfire/compare/v4.26.0...v4.27.0
 [v4.28.0]: https://github.com/pydantic/logfire/compare/v4.27.0...v4.28.0
 [v4.29.0]: https://github.com/pydantic/logfire/compare/v4.28.0...v4.29.0
+[v4.30.0]: https://github.com/pydantic/logfire/compare/v4.29.0...v4.30.0

--- a/logfire-api/logfire_api/_internal/auth.pyi
+++ b/logfire-api/logfire_api/_internal/auth.pyi
@@ -71,9 +71,8 @@ class UserTokenCollection:
         """
     def add_token(self, base_url: str, token: UserTokenData) -> UserToken:
         """Add a user token to the collection."""
-
     def logout(self, base_url: str | None = None) -> list[str]:
-        """Log out from Logfire."""
+        """Remove user token(s) from the collection."""
 
 class NewDeviceFlow(TypedDict):
     """Matches model of the same name in the backend."""

--- a/logfire-api/logfire_api/_internal/cli/auth.pyi
+++ b/logfire-api/logfire_api/_internal/cli/auth.pyi
@@ -1,4 +1,5 @@
 import argparse
+from ...exceptions import LogfireConfigError as LogfireConfigError
 from ..auth import DEFAULT_FILE as DEFAULT_FILE, UserTokenCollection as UserTokenCollection, poll_for_token as poll_for_token, request_device_code as request_device_code
 from ..config import REGIONS as REGIONS
 
@@ -7,6 +8,5 @@ def parse_auth(args: argparse.Namespace) -> None:
 
     This will authenticate your machine with Logfire and store the credentials.
     """
-
 def parse_logout(args: argparse.Namespace) -> None:
     """Log out from Logfire."""

--- a/logfire-api/logfire_api/experimental/api_client.pyi
+++ b/logfire-api/logfire_api/experimental/api_client.pyi
@@ -93,10 +93,6 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         Returns:
             List of dataset summaries with id, name, description, case_count, etc.
         """
-    @overload
-    def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
-    @overload
-    def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
     def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, guidance: str | None = None, ai_managed_guidance: bool = False) -> dict[str, Any]:
         '''Create a new dataset with optional type schemas.
 
@@ -255,6 +251,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             DatasetNotFoundError: If the dataset does not exist.
             CaseNotFoundError: If the case does not exist.
         """
+    @overload
+    def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
+    @overload
+    def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
 
 class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     """Asynchronous client for managing Logfire datasets.
@@ -266,10 +266,6 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     async def __aexit__(self, exc_type: type[BaseException] | None = None, exc_value: BaseException | None = None, traceback: TracebackType | None = None) -> None: ...
     async def list_datasets(self) -> list[dict[str, Any]]:
         """List all datasets."""
-    @overload
-    async def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
-    @overload
-    async def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
     async def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, guidance: str | None = None, ai_managed_guidance: bool = False) -> dict[str, Any]:
         """Create a new dataset."""
     async def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., guidance: str | None = ..., ai_managed_guidance: bool | None = None) -> dict[str, Any]:
@@ -293,3 +289,7 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         """Update an existing case."""
     async def delete_case(self, dataset_id_or_name: str, case_id: str) -> None:
         """Delete a case from a dataset."""
+    @overload
+    async def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
+    @overload
+    async def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...

--- a/logfire-api/logfire_api/variables/remote.pyi
+++ b/logfire-api/logfire_api/variables/remote.pyi
@@ -95,9 +95,6 @@ class LogfireRemoteVariableProvider(VariableProvider):
     def update_variable(self, name: str, config: VariableConfig) -> VariableConfig:
         """Update an existing variable configuration via the remote API.
 
-        This is a metadata-only update (name, description, schema, example).
-        Labels and versions are managed through the UI.
-
         Args:
             name: The name of the variable to update.
             config: The new configuration for the variable.

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "4.29.0"
+version = "4.30.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "4.29.0"
+version = "4.30.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.9"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -669,7 +669,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
     { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
@@ -1547,7 +1547,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3264,7 +3264,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.29.0"
+version = "4.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -3652,7 +3652,7 @@ docs = [
 
 [[package]]
 name = "logfire-api"
-version = "4.29.0"
+version = "4.30.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]


### PR DESCRIPTION
Bumping version to v4.30.0.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v4.30.0 of `logfire` and `logfire-api`. Adds `logfire auth logout`, merges dataset export into `get_dataset` via `include_cases`, improves project URL output, and fixes `push_config()` to include labels and versions.

- **Migration**
  - Replace `export_dataset(...)` with `get_dataset(..., include_cases=True)` in both sync and async clients.

<sup>Written for commit 4c2231d0c7b7143621d9fe4dd96ed70e7560b1e2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

