### PR TITLE
Fix collapsible indentation in getting started page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,8 +42,8 @@ This page walks through setting up a Python app. For other languages, see the [J
 
 ??? tip "Ready to create your own projects in UI or CLI?"
 
-- In the UI, create projects by navigating to the Organization > Projects page, and click **New project**.
-- For CLI check the [SDK CLI documentation](reference/cli.md#create-projects-new).
+    - In the UI, create projects by navigating to the Organization > Projects page, and click **New project**.
+    - For CLI check the [SDK CLI documentation](reference/cli.md#create-projects-new).
 
 ## Install the SDK {#sdk}
 


### PR DESCRIPTION
## Summary

- The bullet list inside the "Ready to create your own projects in UI or CLI?" collapsible (`docs/index.md`) was at column 0 instead of 4-space indented under the `???` marker
- MkDocs collapsible syntax requires body content to be indented by 4 spaces — without it, the content renders outside the fold

Found while building the unified docs site, where the transform that converts `???` blocks faithfully enforces the indentation requirement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Getting Started" collapsible by adding the required 4‑space indent to the bullet list under "Ready to create your own projects in UI or CLI?" in `docs/index.md`. The list now renders inside the MkDocs `??? tip` fold as expected.

<sup>Written for commit 730051b22367e5fe6f7dc185b59e3877261b7284. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

