### PR TITLE
docs: update API keys page with all available public APIs

### DIFF
--- a/docs/reference/advanced/use-api-keys.md
+++ b/docs/reference/advanced/use-api-keys.md
@@ -64,6 +64,7 @@ Available scopes depend on whether you're creating an organization or project AP
 | Notification channels                | ✓                    | —               |
 | Audit logs                           | ✓                    | —               |
 | SCIM provisioning                    | ✓                    | —               |
+| Billing usage                        | ✓                    | —               |
 | Project settings                     | ✓                    | ✓               |
 | Write tokens management              | ✓                    | ✓               |
 | Read tokens management               | ✓                    | ✓               |


### PR DESCRIPTION
## Summary
- Expanded the "What you can do" section to list all available public APIs, grouped by plan availability (all plans vs enterprise/self-hosted only)
- Updated the API Key Scopes table with missing entries: notification channels, audit logs, SCIM provisioning, dashboards, and variables

## Test plan
- [x] `mkdocs build --no-strict` passes
- [ ] Visual review of rendered docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the API keys docs to list all public APIs grouped by plan (all plans vs enterprise/self-hosted) and to complete the scopes table. Adds missing scopes for notification channels, audit logs, billing usage, SCIM provisioning, dashboards, and variables.

<sup>Written for commit c16e17a22a6ae8bce5e8cdfbd60c91857523d1ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

