### PR TITLE
fix: handle bare MCP request types for fastmcp 3.x compatibility

### DIFF
--- a/logfire/_internal/integrations/mcp.py
+++ b/logfire/_internal/integrations/mcp.py
@@ -73,8 +73,11 @@ def instrument_mcp(logfire_instance: Logfire, propagate_otel_context: bool):
     @functools.wraps(original_received_notification)
     async def _received_notification(self: Any, notification: Any, *args: Any, **kwargs: Any):
         with handle_internal_errors:
-            if isinstance(notification.root, LoggingMessageNotification):  # pragma: no branch
-                params = notification.root.params
+            # Use getattr to handle both RootModel wrappers and bare notification types,
+            # consistent with the pattern used in send_request, send_notification, and _received_request_client.
+            root = getattr(notification, 'root', notification)
+            if isinstance(root, LoggingMessageNotification):  # pragma: no branch
+                params = root.params
                 level: LevelName
                 if params.level in ('critical', 'alert', 'emergency'):
                     level = 'fatal'
@@ -83,7 +86,7 @@ def instrument_mcp(logfire_instance: Logfire, propagate_otel_context: bool):
                 span_name = 'MCP server log'
                 if params.logger:
                     span_name += f' from {params.logger}'
-                with _request_context(notification.root):
+                with _request_context(root):
                     logfire_instance.log(level, span_name, attributes=dict(data=params.data))
         await original_received_notification(self, notification, *args, **kwargs)
 


### PR DESCRIPTION
## Summary

- Fix `AttributeError: 'ReadResourceRequest' object has no attribute 'root'` when using `logfire.instrument_mcp()` with fastmcp 3.x
- The MCP integration assumed requests always have a `.root` attribute (RootModel wrappers like `ClientRequest`), but fastmcp 3.x can send bare request types directly when OTel context propagation is active
- Use `getattr(request, 'root', request)` fallback to handle both RootModel wrappers and bare request types

## Test plan

- [ ] Existing MCP integration tests should continue to pass
- [ ] Manual testing with fastmcp 3.x using the reproduction script from the Slack thread

Slack thread: https://pydantic.slack.com/archives/C08KLDX918V/p1774633203047079?thread_ts=1774364407.066059&cid=C08KLDX918V

https://claude.ai/code/session_01BRaoRh5qKYjqJxMrxDpxJQ