### PR TITLE
fix: replace assert with proper exception in query client

### DIFF
--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -109,7 +109,7 @@ class _BaseLogfireQueryClient(Generic[T]):
         if response.status_code == 422:  # pragma: no cover
             raise QueryRequestError(response.json())
         if response.status_code != 200:
-            raise QueryExecutionError(f'Unexpected response status code: {response.status_code}')
+            raise QueryExecutionError(f'Unexpected response status code: {response.status_code}, body: {response.text}')
 
 
 class LogfireQueryClient(_BaseLogfireQueryClient[Client]):

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -108,7 +108,8 @@ class _BaseLogfireQueryClient(Generic[T]):
             raise QueryExecutionError(response.json())
         if response.status_code == 422:  # pragma: no cover
             raise QueryRequestError(response.json())
-        assert response.status_code == 200, response.content
+        if response.status_code != 200:
+            raise QueryExecutionError(f'Unexpected response status code: {response.status_code}')
 
 
 class LogfireQueryClient(_BaseLogfireQueryClient[Client]):


### PR DESCRIPTION
## Summary

- Replace `assert response.status_code == 200` with an explicit `if` check raising `QueryExecutionError` in `_BaseLogfireQueryClient.handle_response_errors`
- The `assert` is stripped when Python runs with `-O` (optimize flag), causing unexpected HTTP status codes (401, 403, 500, 503, etc.) to silently pass through instead of raising an error — downstream code then fails with a confusing `JSONDecodeError` or similar

## Test plan

- [ ] Existing VCR-based query client tests continue to pass (they exercise the 200 success path through `handle_response_errors`)
- [ ] Verify with `python -O -c "assert False"` that asserts are indeed stripped, confirming the bug exists
- [ ] Manually confirm that a non-200/400/422 response now raises `QueryExecutionError` with a clear message