### PR TITLE
fix: add gen_ai.system to OpenAI streaming logs

### DIFF
--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -99,16 +99,17 @@ def get_endpoint_config(
     model = json_data.get('model')
     request_data = json_data if 1 in versions else {'model': model}
 
-    def common_attrs(operation: str) -> dict[str, Any]:
-        return {
-            'request_data': request_data,
-            **provider_attrs('anthropic'),
-            OPERATION_NAME: operation,
-            REQUEST_MODEL: model,
-        }
+    common_attrs = {
+        'request_data': request_data,
+        **provider_attrs('anthropic'),
+    }
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
-        span_data: dict[str, Any] = {**common_attrs('chat')}
+        span_data: dict[str, Any] = {
+            **common_attrs,
+            OPERATION_NAME: 'chat',
+            REQUEST_MODEL: model,
+        }
         _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -103,12 +103,13 @@ def get_endpoint_config(
         'request_data': request_data,
         **provider_attrs('anthropic'),
     }
+    if model:  # pragma: no branch
+        common_attrs[REQUEST_MODEL] = model
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
         span_data: dict[str, Any] = {
             **common_attrs,
             OPERATION_NAME: 'chat',
-            REQUEST_MODEL: model,
         }
         _extract_request_parameters(json_data, span_data)
 
@@ -128,15 +129,9 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(AnthropicMessageStreamState, versions),
         )
     else:
-        span_data = {
-            'url': url,
-            **common_attrs,
-        }
-        if 'model' in json_data:  # pragma: no branch
-            span_data[REQUEST_MODEL] = json_data['model']
         return EndpointConfig(
             message_template='Anthropic API call to {url!r}',
-            span_data=span_data,
+            span_data={'url': url, **common_attrs},
         )
 
 

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -129,9 +129,8 @@ def get_endpoint_config(
         )
     else:
         span_data = {
-            'request_data': request_data,
             'url': url,
-            **provider_attrs('anthropic'),
+            **common_attrs,
         }
         if 'model' in json_data:  # pragma: no branch
             span_data[REQUEST_MODEL] = json_data['model']

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -25,6 +25,7 @@ from .semconv import (
     RESPONSE_FINISH_REASONS,
     RESPONSE_ID,
     RESPONSE_MODEL,
+    SYSTEM,
     SYSTEM_INSTRUCTIONS,
     TOOL_DEFINITIONS,
     BlobPart,
@@ -100,7 +101,7 @@ def get_endpoint_config(
     if url in ('/v1/messages', '/v1/messages?beta=true'):
         span_data: dict[str, Any] = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            'gen_ai.system': 'anthropic',
+            SYSTEM: 'anthropic',
             PROVIDER_NAME: 'anthropic',
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
@@ -126,7 +127,7 @@ def get_endpoint_config(
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
             'url': url,
-            'gen_ai.system': 'anthropic',
+            SYSTEM: 'anthropic',
             PROVIDER_NAME: 'anthropic',
         }
         if 'model' in json_data:  # pragma: no branch

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -99,18 +99,12 @@ def get_endpoint_config(
     model = json_data.get('model')
     request_data = json_data if 1 in versions else {'model': model}
 
-    common_attrs = {
-        'request_data': request_data,
-        **provider_attrs('anthropic'),
-    }
+    common_attrs = {'request_data': request_data, **provider_attrs('anthropic')}
     if model:  # pragma: no branch
         common_attrs[REQUEST_MODEL] = model
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
-        span_data: dict[str, Any] = {
-            **common_attrs,
-            OPERATION_NAME: 'chat',
-        }
+        span_data: dict[str, Any] = {**common_attrs, OPERATION_NAME: 'chat'}
         _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -15,7 +15,6 @@ from .semconv import (
     INPUT_MESSAGES,
     OPERATION_NAME,
     OUTPUT_MESSAGES,
-    PROVIDER_NAME,
     REQUEST_MAX_TOKENS,
     REQUEST_MODEL,
     REQUEST_STOP_SEQUENCES,
@@ -25,7 +24,6 @@ from .semconv import (
     RESPONSE_FINISH_REASONS,
     RESPONSE_ID,
     RESPONSE_MODEL,
-    SYSTEM,
     SYSTEM_INSTRUCTIONS,
     TOOL_DEFINITIONS,
     BlobPart,
@@ -39,6 +37,7 @@ from .semconv import (
     ToolCallPart,
     ToolCallResponsePart,
     UriPart,
+    provider_attrs,
 )
 from .types import EndpointConfig, StreamState
 from .usage import get_usage_attributes
@@ -101,8 +100,7 @@ def get_endpoint_config(
     if url in ('/v1/messages', '/v1/messages?beta=true'):
         span_data: dict[str, Any] = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            SYSTEM: 'anthropic',
-            PROVIDER_NAME: 'anthropic',
+            **provider_attrs('anthropic'),
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -127,8 +125,7 @@ def get_endpoint_config(
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
             'url': url,
-            SYSTEM: 'anthropic',
-            PROVIDER_NAME: 'anthropic',
+            **provider_attrs('anthropic'),
         }
         if 'model' in json_data:  # pragma: no branch
             span_data[REQUEST_MODEL] = json_data['model']

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -97,13 +97,14 @@ def get_endpoint_config(
         raw_json_data = {}
     json_data = cast('dict[str, Any]', raw_json_data)
     model = json_data.get('model')
+    request_data = json_data if 1 in versions else {'model': model}
 
     def common_attrs(operation: str) -> dict[str, Any]:
         return {**provider_attrs('anthropic'), OPERATION_NAME: operation, REQUEST_MODEL: model}
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
         span_data: dict[str, Any] = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             **common_attrs('chat'),
         }
         _extract_request_parameters(json_data, span_data)
@@ -125,7 +126,7 @@ def get_endpoint_config(
         )
     else:
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             'url': url,
             **provider_attrs('anthropic'),
         }

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -96,13 +96,15 @@ def get_endpoint_config(
         # Ensure that `{request_data[model]!r}` doesn't raise an error, just a warning about `model` missing.
         raw_json_data = {}
     json_data = cast('dict[str, Any]', raw_json_data)
+    model = json_data.get('model')
+
+    def common_attrs(operation: str) -> dict[str, Any]:
+        return {**provider_attrs('anthropic'), OPERATION_NAME: operation, REQUEST_MODEL: model}
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
         span_data: dict[str, Any] = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            **provider_attrs('anthropic'),
-            OPERATION_NAME: 'chat',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': json_data if 1 in versions else {'model': model},
+            **common_attrs('chat'),
         }
         _extract_request_parameters(json_data, span_data)
 
@@ -123,7 +125,7 @@ def get_endpoint_config(
         )
     else:
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'request_data': json_data if 1 in versions else {'model': model},
             'url': url,
             **provider_attrs('anthropic'),
         }

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -100,13 +100,15 @@ def get_endpoint_config(
     request_data = json_data if 1 in versions else {'model': model}
 
     def common_attrs(operation: str) -> dict[str, Any]:
-        return {**provider_attrs('anthropic'), OPERATION_NAME: operation, REQUEST_MODEL: model}
+        return {
+            'request_data': request_data,
+            **provider_attrs('anthropic'),
+            OPERATION_NAME: operation,
+            REQUEST_MODEL: model,
+        }
 
     if url in ('/v1/messages', '/v1/messages?beta=true'):
-        span_data: dict[str, Any] = {
-            'request_data': request_data,
-            **common_attrs('chat'),
-        }
+        span_data: dict[str, Any] = {**common_attrs('chat')}
         _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -122,6 +122,7 @@ def get_endpoint_config(
         raw_json_data = {}
     json_data = cast('dict[str, Any]', raw_json_data)
     model = json_data.get('model')
+    request_data = json_data if 1 in versions else {'model': model}
 
     def common_attrs(operation: str) -> dict[str, Any]:
         return {**provider_attrs('openai'), OPERATION_NAME: operation, REQUEST_MODEL: model}
@@ -131,7 +132,7 @@ def get_endpoint_config(
             return EndpointConfig(message_template='', span_data={})
 
         span_data: dict[str, Any] = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             **common_attrs('chat'),
         }
         _extract_request_parameters(json_data, span_data)
@@ -178,7 +179,7 @@ def get_endpoint_config(
         )
     elif url == '/completions':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             **common_attrs('text_completion'),
         }
         _extract_request_parameters(json_data, span_data)
@@ -189,7 +190,7 @@ def get_endpoint_config(
         )
     elif url == '/embeddings':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             **common_attrs('embeddings'),
         }
         _extract_request_parameters(json_data, span_data)
@@ -199,7 +200,7 @@ def get_endpoint_config(
         )
     elif url == '/images/generations':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             **common_attrs('image_generation'),
         }
         _extract_request_parameters(json_data, span_data)
@@ -209,7 +210,7 @@ def get_endpoint_config(
         )
     else:
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': model},
+            'request_data': request_data,
             'url': url,
             **provider_attrs('openai'),
         }

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -24,7 +24,6 @@ from .semconv import (
     INPUT_MESSAGES,
     OPERATION_NAME,
     OUTPUT_MESSAGES,
-    PROVIDER_NAME,
     REQUEST_FREQUENCY_PENALTY,
     REQUEST_MAX_TOKENS,
     REQUEST_MODEL,
@@ -36,7 +35,6 @@ from .semconv import (
     RESPONSE_FINISH_REASONS,
     RESPONSE_ID,
     RESPONSE_MODEL,
-    SYSTEM,
     SYSTEM_INSTRUCTIONS,
     TOOL_DEFINITIONS,
     BlobPart,
@@ -52,6 +50,7 @@ from .semconv import (
     ToolCallPart,
     ToolCallResponsePart,
     UriPart,
+    provider_attrs,
 )
 from .types import EndpointConfig, StreamState
 from .usage import get_usage_attributes
@@ -129,8 +128,7 @@ def get_endpoint_config(
 
         span_data: dict[str, Any] = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -155,8 +153,7 @@ def get_endpoint_config(
         stream = json_data.get('stream', False)
         span_data = {
             'request_data': {'model': json_data.get('model'), 'stream': stream},
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -182,8 +179,7 @@ def get_endpoint_config(
     elif url == '/completions':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
             OPERATION_NAME: 'text_completion',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -196,8 +192,7 @@ def get_endpoint_config(
     elif url == '/embeddings':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
             OPERATION_NAME: 'embeddings',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -209,8 +204,7 @@ def get_endpoint_config(
     elif url == '/images/generations':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
             OPERATION_NAME: 'image_generation',
             REQUEST_MODEL: json_data.get('model'),
         }
@@ -223,8 +217,7 @@ def get_endpoint_config(
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
             'url': url,
-            SYSTEM: 'openai',
-            PROVIDER_NAME: 'openai',
+            **provider_attrs('openai'),
         }
         if 'model' in json_data:
             span_data[REQUEST_MODEL] = json_data['model']

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -128,6 +128,7 @@ def get_endpoint_config(
 
         span_data: dict[str, Any] = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
@@ -153,6 +154,7 @@ def get_endpoint_config(
         stream = json_data.get('stream', False)
         span_data = {
             'request_data': {'model': json_data.get('model'), 'stream': stream},
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
@@ -179,6 +181,7 @@ def get_endpoint_config(
     elif url == '/completions':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'text_completion',
             REQUEST_MODEL: json_data.get('model'),
@@ -192,6 +195,7 @@ def get_endpoint_config(
     elif url == '/embeddings':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'embeddings',
             REQUEST_MODEL: json_data.get('model'),
@@ -204,6 +208,7 @@ def get_endpoint_config(
     elif url == '/images/generations':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'image_generation',
             REQUEST_MODEL: json_data.get('model'),
@@ -217,6 +222,7 @@ def get_endpoint_config(
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
             'url': url,
+            'gen_ai.system': 'openai',
             PROVIDER_NAME: 'openai',
         }
         if 'model' in json_data:

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -36,6 +36,7 @@ from .semconv import (
     RESPONSE_FINISH_REASONS,
     RESPONSE_ID,
     RESPONSE_MODEL,
+    SYSTEM,
     SYSTEM_INSTRUCTIONS,
     TOOL_DEFINITIONS,
     BlobPart,
@@ -128,7 +129,7 @@ def get_endpoint_config(
 
         span_data: dict[str, Any] = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
@@ -154,7 +155,7 @@ def get_endpoint_config(
         stream = json_data.get('stream', False)
         span_data = {
             'request_data': {'model': json_data.get('model'), 'stream': stream},
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'chat',
             REQUEST_MODEL: json_data.get('model'),
@@ -181,7 +182,7 @@ def get_endpoint_config(
     elif url == '/completions':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'text_completion',
             REQUEST_MODEL: json_data.get('model'),
@@ -195,7 +196,7 @@ def get_endpoint_config(
     elif url == '/embeddings':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'embeddings',
             REQUEST_MODEL: json_data.get('model'),
@@ -208,7 +209,7 @@ def get_endpoint_config(
     elif url == '/images/generations':
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
             OPERATION_NAME: 'image_generation',
             REQUEST_MODEL: json_data.get('model'),
@@ -222,7 +223,7 @@ def get_endpoint_config(
         span_data = {
             'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
             'url': url,
-            'gen_ai.system': 'openai',
+            SYSTEM: 'openai',
             PROVIDER_NAME: 'openai',
         }
         if 'model' in json_data:
@@ -619,7 +620,7 @@ def on_response(
         on_response(response.parse(), span, version=versions)  # pyright: ignore[reportUnknownArgumentType]
         return cast('ResponseT', response)
 
-    span.set_attribute('gen_ai.system', 'openai')
+    span.set_attribute(SYSTEM, 'openai')
 
     if isinstance(response_model := getattr(response, 'model', None), str):
         span.set_attribute(RESPONSE_MODEL, response_model)

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -125,19 +125,20 @@ def get_endpoint_config(
     request_data = json_data if 1 in versions else {'model': model}
 
     def common_attrs(operation: str) -> dict[str, Any]:
-        return {
+        attrs: dict[str, Any] = {
             'request_data': request_data,
             **provider_attrs('openai'),
             OPERATION_NAME: operation,
             REQUEST_MODEL: model,
         }
+        _extract_request_parameters(json_data, attrs)
+        return attrs
 
     if url == '/chat/completions':
         if is_current_agent_span('Chat completion with {gen_ai.request.model!r}'):
             return EndpointConfig(message_template='', span_data={})
 
         span_data: dict[str, Any] = common_attrs('chat')
-        _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:
             # Convert messages to semantic convention format
@@ -159,7 +160,6 @@ def get_endpoint_config(
         span_data = {**common_attrs('chat'), 'request_data': {'model': model, 'stream': stream}}
         if 1 in versions:
             span_data['events'] = inputs_to_events(json_data.get('input'), json_data.get('instructions'))
-        _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:
             # Convert inputs to semantic convention format
@@ -177,26 +177,20 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(OpenaiResponsesStreamState, versions),
         )
     elif url == '/completions':
-        span_data = common_attrs('text_completion')
-        _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Completion with {request_data[model]!r}',
-            span_data=span_data,
+            span_data=common_attrs('text_completion'),
             stream_state_cls=_versioned_stream_cls(OpenaiCompletionStreamState, versions),
         )
     elif url == '/embeddings':
-        span_data = common_attrs('embeddings')
-        _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Embedding Creation with {request_data[model]!r}',
-            span_data=span_data,
+            span_data=common_attrs('embeddings'),
         )
     elif url == '/images/generations':
-        span_data = common_attrs('image_generation')
-        _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Image Generation with {request_data[model]!r}',
-            span_data=span_data,
+            span_data=common_attrs('image_generation'),
         )
     else:
         span_data = {

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -620,8 +620,6 @@ def on_response(
         on_response(response.parse(), span, version=versions)  # pyright: ignore[reportUnknownArgumentType]
         return cast('ResponseT', response)
 
-    span.set_attribute(SYSTEM, 'openai')
-
     if isinstance(response_model := getattr(response, 'model', None), str):
         span.set_attribute(RESPONSE_MODEL, response_model)
 

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -124,13 +124,15 @@ def get_endpoint_config(
     model = json_data.get('model')
     request_data = json_data if 1 in versions else {'model': model}
 
-    def common_attrs(operation: str) -> dict[str, Any]:
+    def common_attrs(operation: str = '') -> dict[str, Any]:
         attrs: dict[str, Any] = {
             'request_data': request_data,
             **provider_attrs('openai'),
-            OPERATION_NAME: operation,
-            REQUEST_MODEL: model,
         }
+        if model:
+            attrs[REQUEST_MODEL] = model
+        if operation:
+            attrs[OPERATION_NAME] = operation
         _extract_request_parameters(json_data, attrs)
         return attrs
 
@@ -138,7 +140,7 @@ def get_endpoint_config(
         if is_current_agent_span('Chat completion with {gen_ai.request.model!r}'):
             return EndpointConfig(message_template='', span_data={})
 
-        span_data: dict[str, Any] = common_attrs('chat')
+        span_data = common_attrs('chat')
 
         if 'latest' in versions:
             # Convert messages to semantic convention format
@@ -193,17 +195,9 @@ def get_endpoint_config(
             span_data=common_attrs('image_generation'),
         )
     else:
-        span_data = {
-            'request_data': request_data,
-            'url': url,
-            **provider_attrs('openai'),
-        }
-        if 'model' in json_data:
-            span_data[REQUEST_MODEL] = json_data['model']
-        _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='OpenAI API call to {url!r}',
-            span_data=span_data,
+            span_data={'url': url, **common_attrs()},
         )
 
 

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -136,7 +136,7 @@ def get_endpoint_config(
         if is_current_agent_span('Chat completion with {gen_ai.request.model!r}'):
             return EndpointConfig(message_template='', span_data={})
 
-        span_data: dict[str, Any] = {**common_attrs('chat')}
+        span_data: dict[str, Any] = common_attrs('chat')
         _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:
@@ -177,7 +177,7 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(OpenaiResponsesStreamState, versions),
         )
     elif url == '/completions':
-        span_data = {**common_attrs('text_completion')}
+        span_data = common_attrs('text_completion')
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Completion with {request_data[model]!r}',
@@ -185,14 +185,14 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(OpenaiCompletionStreamState, versions),
         )
     elif url == '/embeddings':
-        span_data = {**common_attrs('embeddings')}
+        span_data = common_attrs('embeddings')
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Embedding Creation with {request_data[model]!r}',
             span_data=span_data,
         )
     elif url == '/images/generations':
-        span_data = {**common_attrs('image_generation')}
+        span_data = common_attrs('image_generation')
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Image Generation with {request_data[model]!r}',

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -121,16 +121,18 @@ def get_endpoint_config(
         # Ensure that `{request_data[model]!r}` doesn't raise an error, just a warning about `model` missing.
         raw_json_data = {}
     json_data = cast('dict[str, Any]', raw_json_data)
+    model = json_data.get('model')
+
+    def common_attrs(operation: str) -> dict[str, Any]:
+        return {**provider_attrs('openai'), OPERATION_NAME: operation, REQUEST_MODEL: model}
 
     if url == '/chat/completions':
         if is_current_agent_span('Chat completion with {gen_ai.request.model!r}'):
             return EndpointConfig(message_template='', span_data={})
 
         span_data: dict[str, Any] = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            **provider_attrs('openai'),
-            OPERATION_NAME: 'chat',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': json_data if 1 in versions else {'model': model},
+            **common_attrs('chat'),
         }
         _extract_request_parameters(json_data, span_data)
 
@@ -152,10 +154,8 @@ def get_endpoint_config(
 
         stream = json_data.get('stream', False)
         span_data = {
-            'request_data': {'model': json_data.get('model'), 'stream': stream},
-            **provider_attrs('openai'),
-            OPERATION_NAME: 'chat',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': {'model': model, 'stream': stream},
+            **common_attrs('chat'),
         }
         if 1 in versions:
             span_data['events'] = inputs_to_events(json_data.get('input'), json_data.get('instructions'))
@@ -178,10 +178,8 @@ def get_endpoint_config(
         )
     elif url == '/completions':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            **provider_attrs('openai'),
-            OPERATION_NAME: 'text_completion',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': json_data if 1 in versions else {'model': model},
+            **common_attrs('text_completion'),
         }
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
@@ -191,10 +189,8 @@ def get_endpoint_config(
         )
     elif url == '/embeddings':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            **provider_attrs('openai'),
-            OPERATION_NAME: 'embeddings',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': json_data if 1 in versions else {'model': model},
+            **common_attrs('embeddings'),
         }
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
@@ -203,10 +199,8 @@ def get_endpoint_config(
         )
     elif url == '/images/generations':
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
-            **provider_attrs('openai'),
-            OPERATION_NAME: 'image_generation',
-            REQUEST_MODEL: json_data.get('model'),
+            'request_data': json_data if 1 in versions else {'model': model},
+            **common_attrs('image_generation'),
         }
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
@@ -215,7 +209,7 @@ def get_endpoint_config(
         )
     else:
         span_data = {
-            'request_data': json_data if 1 in versions else {'model': json_data.get('model')},
+            'request_data': json_data if 1 in versions else {'model': model},
             'url': url,
             **provider_attrs('openai'),
         }

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -125,16 +125,18 @@ def get_endpoint_config(
     request_data = json_data if 1 in versions else {'model': model}
 
     def common_attrs(operation: str) -> dict[str, Any]:
-        return {**provider_attrs('openai'), OPERATION_NAME: operation, REQUEST_MODEL: model}
+        return {
+            'request_data': request_data,
+            **provider_attrs('openai'),
+            OPERATION_NAME: operation,
+            REQUEST_MODEL: model,
+        }
 
     if url == '/chat/completions':
         if is_current_agent_span('Chat completion with {gen_ai.request.model!r}'):
             return EndpointConfig(message_template='', span_data={})
 
-        span_data: dict[str, Any] = {
-            'request_data': request_data,
-            **common_attrs('chat'),
-        }
+        span_data: dict[str, Any] = {**common_attrs('chat')}
         _extract_request_parameters(json_data, span_data)
 
         if 'latest' in versions:
@@ -154,10 +156,7 @@ def get_endpoint_config(
             return EndpointConfig(message_template='', span_data={})
 
         stream = json_data.get('stream', False)
-        span_data = {
-            'request_data': {'model': model, 'stream': stream},
-            **common_attrs('chat'),
-        }
+        span_data = {**common_attrs('chat'), 'request_data': {'model': model, 'stream': stream}}
         if 1 in versions:
             span_data['events'] = inputs_to_events(json_data.get('input'), json_data.get('instructions'))
         _extract_request_parameters(json_data, span_data)
@@ -178,10 +177,7 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(OpenaiResponsesStreamState, versions),
         )
     elif url == '/completions':
-        span_data = {
-            'request_data': request_data,
-            **common_attrs('text_completion'),
-        }
+        span_data = {**common_attrs('text_completion')}
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Completion with {request_data[model]!r}',
@@ -189,20 +185,14 @@ def get_endpoint_config(
             stream_state_cls=_versioned_stream_cls(OpenaiCompletionStreamState, versions),
         )
     elif url == '/embeddings':
-        span_data = {
-            'request_data': request_data,
-            **common_attrs('embeddings'),
-        }
+        span_data = {**common_attrs('embeddings')}
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Embedding Creation with {request_data[model]!r}',
             span_data=span_data,
         )
     elif url == '/images/generations':
-        span_data = {
-            'request_data': request_data,
-            **common_attrs('image_generation'),
-        }
+        span_data = {**common_attrs('image_generation')}
         _extract_request_parameters(json_data, span_data)
         return EndpointConfig(
             message_template='Image Generation with {request_data[model]!r}',

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -42,6 +42,12 @@ PROVIDER_NAME = 'gen_ai.provider.name'
 SYSTEM = 'gen_ai.system'
 OPERATION_NAME = 'gen_ai.operation.name'
 
+
+def provider_attrs(name: str) -> dict[str, str]:
+    """Return the common {SYSTEM: name, PROVIDER_NAME: name} dict."""
+    return {SYSTEM: name, PROVIDER_NAME: name}
+
+
 # Model information
 REQUEST_MODEL = 'gen_ai.request.model'
 RESPONSE_MODEL = 'gen_ai.response.model'

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -914,6 +914,7 @@ def test_sync_chat_empty_response_chunk(instrumented_client: openai.Client, expo
                         'model': 'gpt-4',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -927,6 +928,7 @@ def test_sync_chat_empty_response_chunk(instrumented_client: openai.Client, expo
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -959,6 +961,7 @@ def test_sync_chat_empty_response_chunk(instrumented_client: openai.Client, expo
                     'code.lineno': 123,
                     'logfire.msg': "streaming response from 'gpt-4' took 1.00s",
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'logfire.span_type': 'log',
                     'gen_ai.operation.name': 'chat',
@@ -973,6 +976,7 @@ def test_sync_chat_empty_response_chunk(instrumented_client: openai.Client, expo
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -1014,6 +1018,7 @@ def test_sync_chat_empty_response_choices(instrumented_client: openai.Client, ex
                         'model': 'gpt-4',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -1027,6 +1032,7 @@ def test_sync_chat_empty_response_choices(instrumented_client: openai.Client, ex
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -1059,6 +1065,7 @@ def test_sync_chat_empty_response_choices(instrumented_client: openai.Client, ex
                     'code.lineno': 123,
                     'logfire.msg': "streaming response from 'gpt-4' took 1.00s",
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'logfire.span_type': 'log',
                     'gen_ai.operation.name': 'chat',
@@ -1073,6 +1080,7 @@ def test_sync_chat_empty_response_choices(instrumented_client: openai.Client, ex
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -1164,6 +1172,7 @@ def test_sync_chat_tool_call_stream(instrumented_client: openai.Client, exporter
                             }
                         ],
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -1197,6 +1206,7 @@ def test_sync_chat_tool_call_stream(instrumented_client: openai.Client, exporter
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -1252,6 +1262,7 @@ def test_sync_chat_tool_call_stream(instrumented_client: openai.Client, exporter
                         ],
                     },
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'async': False,
                     'gen_ai.operation.name': 'chat',
@@ -1332,6 +1343,7 @@ def test_sync_chat_tool_call_stream(instrumented_client: openai.Client, exporter
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -1465,6 +1477,7 @@ async def test_async_chat_tool_call_stream(
                             }
                         ],
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -1498,6 +1511,7 @@ async def test_async_chat_tool_call_stream(
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -1553,6 +1567,7 @@ async def test_async_chat_tool_call_stream(
                         ],
                     },
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'async': True,
                     'gen_ai.operation.name': 'chat',
@@ -1633,6 +1648,7 @@ async def test_async_chat_tool_call_stream(
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -1717,6 +1733,7 @@ def test_sync_chat_completions_stream(instrumented_client: openai.Client, export
                         'model': 'gpt-4',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -1731,6 +1748,7 @@ def test_sync_chat_completions_stream(instrumented_client: openai.Client, export
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -1766,6 +1784,7 @@ def test_sync_chat_completions_stream(instrumented_client: openai.Client, export
                     'code.lineno': 123,
                     'logfire.msg': "streaming response from 'gpt-4' took 1.00s",
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'logfire.span_type': 'log',
                     'gen_ai.operation.name': 'chat',
@@ -1796,6 +1815,7 @@ def test_sync_chat_completions_stream(instrumented_client: openai.Client, export
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -1855,6 +1875,7 @@ async def test_async_chat_completions_stream(
                         'model': 'gpt-4',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-4',
                     'gen_ai.operation.name': 'chat',
@@ -1869,6 +1890,7 @@ async def test_async_chat_completions_stream(
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -1904,6 +1926,7 @@ async def test_async_chat_completions_stream(
                     'code.lineno': 123,
                     'logfire.msg': "streaming response from 'gpt-4' took 1.00s",
                     'gen_ai.request.model': 'gpt-4',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'logfire.span_type': 'log',
                     'gen_ai.operation.name': 'chat',
@@ -1934,6 +1957,7 @@ async def test_async_chat_completions_stream(
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -2294,6 +2318,7 @@ def test_sync_chat_completions_stream_version_latest(exporter: TestExporter) -> 
                     'code.function': 'test_sync_chat_completions_stream_version_latest',
                     'code.lineno': 123,
                     'request_data': {'model': 'gpt-4.1'},
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.request.model': 'gpt-4.1',
@@ -2308,6 +2333,7 @@ def test_sync_chat_completions_stream_version_latest(exporter: TestExporter) -> 
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.operation.name': {},
                             'gen_ai.request.model': {},
@@ -2336,6 +2362,7 @@ def test_sync_chat_completions_stream_version_latest(exporter: TestExporter) -> 
                     'code.lineno': 123,
                     'duration': 1.0,
                     'request_data': {'model': 'gpt-4.1'},
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.request.model': 'gpt-4.1',
@@ -2356,6 +2383,7 @@ def test_sync_chat_completions_stream_version_latest(exporter: TestExporter) -> 
                         'properties': {
                             'duration': {},
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.operation.name': {},
                             'gen_ai.request.model': {},
@@ -2407,6 +2435,7 @@ def test_sync_chat_completions_stream_version_v1_only(exporter: TestExporter) ->
                         'model': 'gpt-4.1',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.request.model': 'gpt-4.1',
@@ -2417,6 +2446,7 @@ def test_sync_chat_completions_stream_version_v1_only(exporter: TestExporter) ->
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.operation.name': {},
                             'gen_ai.request.model': {},
@@ -2451,6 +2481,7 @@ def test_sync_chat_completions_stream_version_v1_only(exporter: TestExporter) ->
                         'model': 'gpt-4.1',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.request.model': 'gpt-4.1',
@@ -2473,6 +2504,7 @@ def test_sync_chat_completions_stream_version_v1_only(exporter: TestExporter) ->
                         'properties': {
                             'duration': {},
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.operation.name': {},
                             'gen_ai.request.model': {},
@@ -2643,6 +2675,7 @@ def test_responses_stream(exporter: TestExporter) -> None:
                     'code.function': 'test_responses_stream',
                     'code.lineno': 123,
                     'gen_ai.provider.name': 'openai',
+                    'gen_ai.system': 'openai',
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': 'What is four plus five?', 'role': 'user'}
                     ],
@@ -2659,6 +2692,7 @@ def test_responses_stream(exporter: TestExporter) -> None:
                         'type': 'object',
                         'properties': {
                             'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
                             'events': {'type': 'array'},
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
@@ -2688,6 +2722,7 @@ def test_responses_stream(exporter: TestExporter) -> None:
                     'code.lineno': 123,
                     'request_data': {'model': 'gpt-4.1', 'stream': True},
                     'gen_ai.provider.name': 'openai',
+                    'gen_ai.system': 'openai',
                     'events': [
                         {'event.name': 'gen_ai.user.message', 'content': 'What is four plus five?', 'role': 'user'},
                         {
@@ -2721,6 +2756,7 @@ def test_responses_stream(exporter: TestExporter) -> None:
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
                             'events': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'async': {},
@@ -2797,6 +2833,7 @@ def test_completions_stream(instrumented_client: openai.Client, exporter: TestEx
                         'prompt': 'What is four plus five?',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'gpt-3.5-turbo-instruct',
                     'gen_ai.operation.name': 'text_completion',
@@ -2807,6 +2844,7 @@ def test_completions_stream(instrumented_client: openai.Client, exporter: TestEx
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -2838,6 +2876,7 @@ def test_completions_stream(instrumented_client: openai.Client, exporter: TestEx
                     'code.lineno': 123,
                     'logfire.msg': "streaming response from 'gpt-3.5-turbo-instruct' took 1.00s",
                     'gen_ai.request.model': 'gpt-3.5-turbo-instruct',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'logfire.span_type': 'log',
                     'gen_ai.operation.name': 'text_completion',
@@ -2852,6 +2891,7 @@ def test_completions_stream(instrumented_client: openai.Client, exporter: TestEx
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},
@@ -3793,6 +3833,7 @@ def test_openrouter_streaming_reasoning(exporter: TestExporter) -> None:
                         'model': 'google/gemini-2.5-flash',
                         'stream': True,
                     },
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'gen_ai.request.model': 'google/gemini-2.5-flash',
                     'gen_ai.operation.name': 'chat',
@@ -3809,6 +3850,7 @@ def test_openrouter_streaming_reasoning(exporter: TestExporter) -> None:
                         'type': 'object',
                         'properties': {
                             'request_data': {'type': 'object'},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.request.model': {},
                             'gen_ai.operation.name': {},
@@ -3841,6 +3883,7 @@ def test_openrouter_streaming_reasoning(exporter: TestExporter) -> None:
                         'stream': True,
                     },
                     'gen_ai.request.model': 'google/gemini-2.5-flash',
+                    'gen_ai.system': 'openai',
                     'gen_ai.provider.name': 'openai',
                     'async': False,
                     'gen_ai.operation.name': 'chat',
@@ -3926,6 +3969,7 @@ So, while I can't genuinely answer it for myself, how are *you* doing today, and
                         'properties': {
                             'request_data': {'type': 'object'},
                             'gen_ai.request.model': {},
+                            'gen_ai.system': {},
                             'gen_ai.provider.name': {},
                             'async': {},
                             'gen_ai.operation.name': {},


### PR DESCRIPTION
## Summary
- OpenAI streaming logs were missing the `gen_ai.system` attribute because it was only set in `on_response()` (which doesn't run for streams), not in `span_data` (which flows into the streaming log)
- Added `'gen_ai.system': 'openai'` to all `span_data` dicts in OpenAI's `get_endpoint_config()`, matching the pattern Anthropic already uses

## Test plan
- [x] All 61 OpenAI tests pass with updated snapshots
- [x] All 22 Anthropic tests still pass (no changes needed)
- [x] All 13 OpenAI agents tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)