### PR TITLE
Do row→column transformation client-side in query client

### DIFF
--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -74,10 +74,7 @@ class RowQueryResults(TypedDict):
 
 def _rows_to_columns(result: RowQueryResults) -> QueryResults:
     """Convert a row-oriented JSON query result to a column-oriented one."""
-    columns_by_name: dict[str, ColumnData] = {
-        col['name']: {'name': col['name'], 'datatype': col['datatype'], 'nullable': col['nullable'], 'values': []}
-        for col in result['columns']
-    }
+    columns_by_name: dict[str, ColumnData] = {col['name']: {**col, 'values': []} for col in result['columns']}
     for row in result['rows']:
         for key, value in row.items():
             columns_by_name[key]['values'].append(value)
@@ -102,8 +99,11 @@ class _BaseLogfireQueryClient(Generic[T]):
         min_timestamp: datetime | None = None,
         max_timestamp: datetime | None = None,
         limit: int | None = None,
+        accept: str = 'application/json',
     ) -> dict[str, str]:
         params: dict[str, str] = {'sql': sql}
+        if accept == 'application/json':
+            params['json_rows'] = 'true'
         if limit is not None:
             params['limit'] = str(limit)
         if min_timestamp:
@@ -251,9 +251,7 @@ class LogfireQueryClient(_BaseLogfireQueryClient[Client]):
         max_timestamp: datetime | None = None,
         limit: int | None = None,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit)
-        if accept == 'application/json':
-            params['json_rows'] = 'true'
+        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, accept)
         response = self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response
@@ -390,9 +388,7 @@ class AsyncLogfireQueryClient(_BaseLogfireQueryClient[AsyncClient]):
         max_timestamp: datetime | None = None,
         limit: int | None = None,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit)
-        if accept == 'application/json':
-            params['json_rows'] = 'true'
+        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, accept)
         response = await self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -72,6 +72,18 @@ class RowQueryResults(TypedDict):
     rows: list[dict[str, Any]]
 
 
+def _rows_to_columns(result: RowQueryResults) -> QueryResults:
+    """Convert a row-oriented JSON query result to a column-oriented one."""
+    columns_by_name: dict[str, ColumnData] = {
+        col['name']: {'name': col['name'], 'datatype': col['datatype'], 'nullable': col['nullable'], 'values': []}
+        for col in result['columns']
+    }
+    for row in result['rows']:
+        for key, value in row.items():
+            columns_by_name[key]['values'].append(value)
+    return {'columns': list(columns_by_name.values())}
+
+
 T = TypeVar('T', bound=BaseClient)
 
 
@@ -90,13 +102,10 @@ class _BaseLogfireQueryClient(Generic[T]):
         min_timestamp: datetime | None = None,
         max_timestamp: datetime | None = None,
         limit: int | None = None,
-        row_oriented: bool = False,
     ) -> dict[str, str]:
         params: dict[str, str] = {'sql': sql}
         if limit is not None:
             params['limit'] = str(limit)
-        if row_oriented:
-            params['json_rows'] = 'true'
         if min_timestamp:
             params['min_timestamp'] = min_timestamp.isoformat()
         if max_timestamp:
@@ -160,15 +169,13 @@ class LogfireQueryClient(_BaseLogfireQueryClient[Client]):
         limit: int | None = None,
     ) -> QueryResults:
         """Query Logfire data and return the results as a column-oriented dictionary."""
-        response = self._query(
-            accept='application/json',
+        row_results = self.query_json_rows(
             sql=sql,
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,
             limit=limit,
-            row_oriented=False,
         )
-        return response.json()
+        return _rows_to_columns(row_results)
 
     def query_json_rows(
         self,
@@ -184,7 +191,6 @@ class LogfireQueryClient(_BaseLogfireQueryClient[Client]):
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,
             limit=limit,
-            row_oriented=True,
         )
         return response.json()
 
@@ -244,9 +250,10 @@ class LogfireQueryClient(_BaseLogfireQueryClient[Client]):
         min_timestamp: datetime | None = None,
         max_timestamp: datetime | None = None,
         limit: int | None = None,
-        row_oriented: bool = False,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, row_oriented)
+        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit)
+        if accept == 'application/json':
+            params['json_rows'] = 'true'
         response = self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response
@@ -301,15 +308,13 @@ class AsyncLogfireQueryClient(_BaseLogfireQueryClient[AsyncClient]):
         limit: int | None = None,
     ) -> QueryResults:
         """Query Logfire data and return the results as a column-oriented dictionary."""
-        response = await self._query(
-            accept='application/json',
+        row_results = await self.query_json_rows(
             sql=sql,
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,
             limit=limit,
-            row_oriented=False,
         )
-        return response.json()
+        return _rows_to_columns(row_results)
 
     async def query_json_rows(
         self,
@@ -325,7 +330,6 @@ class AsyncLogfireQueryClient(_BaseLogfireQueryClient[AsyncClient]):
             min_timestamp=min_timestamp,
             max_timestamp=max_timestamp,
             limit=limit,
-            row_oriented=True,
         )
         return response.json()
 
@@ -385,9 +389,10 @@ class AsyncLogfireQueryClient(_BaseLogfireQueryClient[AsyncClient]):
         min_timestamp: datetime | None = None,
         max_timestamp: datetime | None = None,
         limit: int | None = None,
-        row_oriented: bool = False,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, row_oriented)
+        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit)
+        if accept == 'application/json':
+            params['json_rows'] = 'true'
         response = await self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -76,8 +76,8 @@ def _rows_to_columns(result: RowQueryResults) -> QueryResults:
     """Convert a row-oriented JSON query result to a column-oriented one."""
     columns_by_name: dict[str, ColumnData] = {col['name']: {**col, 'values': []} for col in result['columns']}
     for row in result['rows']:
-        for key, value in row.items():
-            columns_by_name[key]['values'].append(value)
+        for col_name, col_data in columns_by_name.items():
+            col_data['values'].append(row.get(col_name))
     return {'columns': list(columns_by_name.values())}
 
 

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -84,6 +84,9 @@ def _rows_to_columns(result: RowQueryResults) -> QueryResults:
 T = TypeVar('T', bound=BaseClient)
 
 
+_ACCEPT = Literal['application/json', 'application/vnd.apache.arrow.stream', 'text/csv']
+
+
 class _BaseLogfireQueryClient(Generic[T]):
     def __init__(self, base_url: str, read_token: str, timeout: Timeout, client: type[T], **client_kwargs: Any):
         self.base_url = base_url
@@ -93,22 +96,22 @@ class _BaseLogfireQueryClient(Generic[T]):
         headers['authorization'] = read_token
         self.client: T = client(timeout=timeout, base_url=base_url, headers=headers, **client_kwargs)
 
-    def build_query_params(
+    def _build_query_params(
         self,
         sql: str,
-        min_timestamp: datetime | None = None,
-        max_timestamp: datetime | None = None,
-        limit: int | None = None,
-        accept: str = 'application/json',
+        min_timestamp: datetime | None,
+        max_timestamp: datetime | None,
+        limit: int | None,
+        accept: _ACCEPT,
     ) -> dict[str, str]:
         params: dict[str, str] = {'sql': sql}
         if accept == 'application/json':
             params['json_rows'] = 'true'
         if limit is not None:
             params['limit'] = str(limit)
-        if min_timestamp:
+        if min_timestamp is not None:
             params['min_timestamp'] = min_timestamp.isoformat()
-        if max_timestamp:
+        if max_timestamp is not None:
             params['max_timestamp'] = max_timestamp.isoformat()
         return params
 
@@ -245,13 +248,15 @@ class LogfireQueryClient(_BaseLogfireQueryClient[Client]):
 
     def _query(
         self,
-        accept: Literal['application/json', 'application/vnd.apache.arrow.stream', 'text/csv'],
+        accept: _ACCEPT,
         sql: str,
         min_timestamp: datetime | None = None,
         max_timestamp: datetime | None = None,
         limit: int | None = None,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, accept)
+        params = self._build_query_params(
+            sql=sql, accept=accept, min_timestamp=min_timestamp, max_timestamp=max_timestamp, limit=limit
+        )
         response = self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response
@@ -388,7 +393,9 @@ class AsyncLogfireQueryClient(_BaseLogfireQueryClient[AsyncClient]):
         max_timestamp: datetime | None = None,
         limit: int | None = None,
     ) -> Response:
-        params = self.build_query_params(sql, min_timestamp, max_timestamp, limit, accept)
+        params = self._build_query_params(
+            sql=sql, accept=accept, min_timestamp=min_timestamp, max_timestamp=max_timestamp, limit=limit
+        )
         response = await self.client.get('/v1/query', headers={'accept': accept}, params=params)
         self.handle_response_errors(response)
         return response

--- a/tests/cassettes/test_query_client/test_read_async.yaml
+++ b/tests/cassettes/test_query_client/test_read_async.yaml
@@ -13,16 +13,17 @@ interactions:
       user-agent:
       - python-httpx/0.27.2
     method: GET
-    uri: http://localhost:8000/v1/query?sql=%0A%20%20%20%20%20%20%20%20SELECT%20kind%2C%20message%2C%20is_exception%2C%20tags%0A%20%20%20%20%20%20%20%20FROM%20records%0A%20%20%20%20%20%20%20%20ORDER%20BY%20is_exception%2C%20message%0A%20%20%20%20%20%20%20%20LIMIT%202%0A%20%20%20%20%20%20%20%20
+    uri: http://localhost:8000/v1/query?sql=%0A%20%20%20%20%20%20%20%20SELECT%20kind%2C%20message%2C%20is_exception%2C%20tags%0A%20%20%20%20%20%20%20%20FROM%20records%0A%20%20%20%20%20%20%20%20ORDER%20BY%20is_exception%2C%20message%0A%20%20%20%20%20%20%20%20LIMIT%202%0A%20%20%20%20%20%20%20%20&json_rows=true
   response:
     body:
-      string: '{"columns":[{"name":"kind","nullable":false,"datatype":"Utf8","values":["log","log"]},{"name":"message","nullable":true,"datatype":"Utf8","values":["about
-        to raise an error","aha 0"]},{"name":"is_exception","nullable":true,"datatype":"Boolean","values":[false,false]},{"name":"tags","nullable":true,"datatype":{"List":{"name":"item","nullable":true,"datatype":"Utf8"}},"values":[[],["tag1","tag2"]]}]}'
+      string: '{"columns":[{"name":"kind","nullable":false,"datatype":"Utf8"},{"name":"message","nullable":true,"datatype":"Utf8"},{"name":"is_exception","nullable":true,"datatype":"Boolean"},{"name":"tags","nullable":true,"datatype":{"List":{"name":"item","nullable":true,"datatype":"Utf8"}}}],"rows":[{"kind":"log","message":"about
+        to raise an error","is_exception":false,"tags":[]},{"kind":"log","message":"aha
+        0","is_exception":false,"tags":["tag1","tag2"]}]}'
     headers:
       access-control-expose-headers:
       - traceresponse
       content-length:
-      - '401'
+      - '448'
       content-type:
       - application/json
       date:

--- a/tests/cassettes/test_query_client/test_read_sync.yaml
+++ b/tests/cassettes/test_query_client/test_read_sync.yaml
@@ -13,16 +13,17 @@ interactions:
       user-agent:
       - python-httpx/0.27.2
     method: GET
-    uri: http://localhost:8000/v1/query?sql=%0A%20%20%20%20%20%20%20%20SELECT%20kind%2C%20message%2C%20is_exception%2C%20tags%0A%20%20%20%20%20%20%20%20FROM%20records%0A%20%20%20%20%20%20%20%20ORDER%20BY%20is_exception%2C%20message%0A%20%20%20%20%20%20%20%20LIMIT%202%0A%20%20%20%20%20%20%20%20
+    uri: http://localhost:8000/v1/query?sql=%0A%20%20%20%20%20%20%20%20SELECT%20kind%2C%20message%2C%20is_exception%2C%20tags%0A%20%20%20%20%20%20%20%20FROM%20records%0A%20%20%20%20%20%20%20%20ORDER%20BY%20is_exception%2C%20message%0A%20%20%20%20%20%20%20%20LIMIT%202%0A%20%20%20%20%20%20%20%20&json_rows=true
   response:
     body:
-      string: '{"columns":[{"name":"kind","nullable":false,"datatype":"Utf8","values":["log","log"]},{"name":"message","nullable":true,"datatype":"Utf8","values":["about
-        to raise an error","aha 0"]},{"name":"is_exception","nullable":true,"datatype":"Boolean","values":[false,false]},{"name":"tags","nullable":true,"datatype":{"List":{"name":"item","nullable":true,"datatype":"Utf8"}},"values":[[],["tag1","tag2"]]}]}'
+      string: '{"columns":[{"name":"kind","nullable":false,"datatype":"Utf8"},{"name":"message","nullable":true,"datatype":"Utf8"},{"name":"is_exception","nullable":true,"datatype":"Boolean"},{"name":"tags","nullable":true,"datatype":{"List":{"name":"item","nullable":true,"datatype":"Utf8"}}}],"rows":[{"kind":"log","message":"about
+        to raise an error","is_exception":false,"tags":[]},{"kind":"log","message":"aha
+        0","is_exception":false,"tags":["tag1","tag2"]}]}'
     headers:
       access-control-expose-headers:
       - traceresponse
       content-length:
-      - '401'
+      - '448'
       content-type:
       - application/json
       date:


### PR DESCRIPTION
## Summary
- `logfire.experimental.query_client` now always requests `json_rows=true` from the backend for JSON queries, shifting the row→column buffering cost off the shared server and onto the caller.
- `query_json` (sync + async) now delegates to `query_json_rows` and runs the transformation locally via a new module-level `_rows_to_columns` helper that mirrors the server implementation.
- `query_json_rows` is unchanged in behavior; `query_csv` / `query_arrow` still hit the same URLs (`json_rows` is only injected for `application/json` accept).

## Test plan
- [x] `uv run pytest tests/test_query_client.py` (14/14 pass with the cassettes updated for the new URL/payload of the first interaction)
- [x] `uv run pyright logfire/experimental/query_client.py`
- [x] `uv run ruff check logfire/experimental/query_client.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)