### PR TITLE
Mark various genai attributes as safe from scrubbing

### DIFF
--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -29,6 +29,7 @@ from .constants import (
     MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT,
     RESOURCE_ATTRIBUTES_PACKAGE_VERSIONS,
 )
+from .integrations.llm_providers import semconv as gen_ai_semconv
 from .stack_info import STACK_INFO_KEYS
 from .utils import ReadableSpanDict, truncate_string
 
@@ -138,7 +139,6 @@ class BaseScrubber(ABC):
         'db.plan',
         'fastapi.route.name',
         'fastapi.route.operation_id',
-        # Newer semantic conventions
         'url.full',
         'url.path',
         'url.query',
@@ -146,17 +146,27 @@ class BaseScrubber(ABC):
         'agent_session_id',
         'do_not_scrub',
         'binary_content',
-        'gen_ai.input.messages',
-        'gen_ai.output.messages',
-        'gen_ai.system_instructions',
         'pydantic_ai.all_messages',
-        'gen_ai.tool.name',
-        'gen_ai.tool.call.id',
         'rpc.method',
-        'gen_ai.system',
         'model_request_parameters',
         'langsmith.metadata.session_id',
         'langsmith.trace.session_name',
+        gen_ai_semconv.INPUT_MESSAGES,
+        gen_ai_semconv.OUTPUT_MESSAGES,
+        gen_ai_semconv.SYSTEM_INSTRUCTIONS,
+        gen_ai_semconv.TOOL_DEFINITIONS,
+        gen_ai_semconv.TOOL_NAME,
+        gen_ai_semconv.TOOL_CALL_ID,
+        gen_ai_semconv.INPUT_TOKENS,
+        gen_ai_semconv.OUTPUT_TOKENS,
+        gen_ai_semconv.CACHE_READ_INPUT_TOKENS,
+        gen_ai_semconv.CACHE_CREATION_INPUT_TOKENS,
+        gen_ai_semconv.USAGE_RAW,
+        gen_ai_semconv.CONVERSATION_ID,
+        gen_ai_semconv.SYSTEM,
+        gen_ai_semconv.PROVIDER_NAME,
+        gen_ai_semconv.REQUEST_MODEL,
+        gen_ai_semconv.RESPONSE_MODEL,
     }
 
     @abstractmethod


### PR DESCRIPTION
Particularly because there's been some problems when token usage attributes have been scrubbed.