### PR TITLE
Add Live Evaluations web UI guide

### DIFF
--- a/docs/evaluate/datasets/evaluations.md
+++ b/docs/evaluate/datasets/evaluations.md
@@ -10,7 +10,7 @@ Evaluations in Logfire are powered by [pydantic-evals](https://pydantic.dev/docs
 - **Local datasets** --- defined in code (or loaded from a YAML file) as a [`pydantic_evals.Dataset`][pydantic_evals.Dataset]. No server round-trip required. This is the simplest way to get started and is all you need for many projects.
 - **Hosted datasets** --- stored on Logfire, editable in the [Web UI](ui.md), and fetchable as a typed `Dataset`. Useful when you want to curate cases from production traces or collaborate with teammates.
 
-Either way, once you have a `Dataset` in hand the evaluation step is identical, and results show up in the [Evals](../../guides/web-ui/evals.md) tab as long as Logfire tracing is configured.
+Either way, once you have a `Dataset` in hand the evaluation step is identical, and results show up on the [Evals: Datasets & Experiments](../../guides/web-ui/evals.md) page as long as Logfire tracing is configured.
 
 !!! note "Experimental SDK"
 
@@ -27,7 +27,7 @@ from pydantic_evals import Case, Dataset
 
 import logfire
 
-# Configure Logfire so the evaluation shows up in the Evals tab in the Logfire UI.
+# Configure Logfire so the evaluation shows up on the Evals: Datasets & Experiments page in the Logfire UI.
 # Without this, the evaluation still runs but its results will not be sent to Logfire.
 logfire.configure()
 logfire.instrument_pydantic_ai()  # optional, traces the AI task under test
@@ -71,7 +71,7 @@ async def run_evaluation():
 
     Whether you *store* the dataset on Logfire and whether you *send* the evaluation results to Logfire are two independent choices. You can fetch a hosted dataset (see below) and then run a purely local evaluation that only prints to the console — just omit the `logfire.configure()` call. That said, we recommend configuring Logfire during evaluation so that runs show up alongside your dataset in the UI for comparison over time.
 
-You can also load local datasets from YAML files --- see the [pydantic-evals documentation](https://pydantic.dev/docs/ai/evals/evals/) for details. With Logfire tracing enabled, runs against local datasets still appear in the [Evals](../../guides/web-ui/evals.md) tab (as **Local** datasets --- see [Hosted vs Local Datasets](index.md#hosted-vs-local-datasets)).
+You can also load local datasets from YAML files --- see the [pydantic-evals documentation](https://pydantic.dev/docs/ai/evals/evals/) for details. With Logfire tracing enabled, runs against local datasets still appear on the [Evals: Datasets & Experiments](../../guides/web-ui/evals.md) page (as **Local** datasets --- see [Hosted vs Local Datasets](index.md#hosted-vs-local-datasets)).
 
 ## Evaluating a Hosted Dataset
 
@@ -151,7 +151,7 @@ from pydantic_evals import Dataset
 import logfire
 from logfire.experimental.api_client import LogfireAPIClient
 
-# Send evaluation results to the Logfire Evals tab.
+# Send evaluation results to the Evals: Datasets & Experiments page in Logfire.
 logfire.configure()
 # You can instrument libraries here for richer information in the evaluation traces
 # e.g., via `logfire.instrument_pydantic_ai()`
@@ -178,9 +178,9 @@ async def run_evaluation():
     report.print()
 ```
 
-## Viewing Results in the Evals Tab
+## Viewing Results on the Evals Page
 
-With Logfire tracing enabled, the evaluation results appear automatically in the [Evals](../../guides/web-ui/evals.md) tab, where you can compare experiments and analyze performance over time.
+With Logfire tracing enabled, the evaluation results appear automatically on the [Evals: Datasets & Experiments](../../guides/web-ui/evals.md) page, where you can compare experiments and analyze performance over time.
 
 ## The Evaluation Workflow
 
@@ -189,5 +189,5 @@ This creates a continuous improvement loop:
 1. **Observe** production behavior in Live View.
 2. **Curate** test cases by adding interesting traces to a dataset.
 3. **Evaluate** your system against the dataset using pydantic-evals.
-4. **Analyze** the results in the Logfire Evals tab.
+4. **Analyze** the results on the Logfire **Evals: Datasets & Experiments** page.
 5. **Improve** your system and repeat.

--- a/docs/evaluate/datasets/index.md
+++ b/docs/evaluate/datasets/index.md
@@ -13,7 +13,7 @@ Datasets let you build and maintain collections of test cases for evaluating you
 
 ## Hosted vs Local Datasets
 
-When you open the **Evals** page, you'll see two types of datasets:
+When you open the **Evals: Datasets & Experiments** page, you'll see two types of datasets:
 
 - **Hosted** datasets have their cases stored and editable on Logfire. You create these through the UI or SDK, and can add, edit, and delete individual test cases.
 - **Local** datasets are discovered automatically from experiment runs in your code (via `pydantic-evals`). They appear in the list alongside hosted datasets but their cases are read-only --- they reflect what your code defined. If you run an experiment without defining a `dataset_name` in code, it still appears in the list using the experiment ID as a fallback name.
@@ -38,7 +38,7 @@ Datasets fit into a continuous evaluation loop:
 1. **Observe** production behavior in Live View.
 2. **Curate** test cases by adding interesting traces to a dataset.
 3. **Evaluate** your system against the dataset using pydantic-evals.
-4. **Analyze** the results in the Logfire Evals tab.
+4. **Analyze** the results on the Logfire **Evals: Datasets & Experiments** page.
 5. **Improve** your system and repeat.
 
 ## Next Steps

--- a/docs/evaluate/datasets/ui.md
+++ b/docs/evaluate/datasets/ui.md
@@ -7,9 +7,9 @@ description: "Create and manage evaluation datasets through the Logfire web inte
 
 This guide covers creating and managing datasets through the Logfire web interface. For programmatic access, see the [SDK Guide](sdk.md).
 
-## Navigating Evals
+## Navigating Datasets
 
-Click **Evals** in the sidebar to open the datasets list. From there:
+Click **Evals: Datasets & Experiments** in the sidebar to open the datasets list. From there:
 
 - Click a dataset name to see its detail page (experiments, cases, schema).
 - Click **Edit** to modify the dataset's name, description, and schemas.
@@ -17,7 +17,7 @@ Click **Evals** in the sidebar to open the datasets list. From there:
 - Click **+ Add case** to add a new test case.
 - Select experiments and click **Compare** to compare multiple runs side by side.
 
-Breadcrumbs at the top of each page show your current location (e.g., `Evals / Datasets / my-dataset / Edit`).
+Use the **Back to Datasets** link at the top of any dataset detail or edit page to return to the list.
 
 ## Creating a New Dataset
 

--- a/docs/evaluate/datasets/ui.md
+++ b/docs/evaluate/datasets/ui.md
@@ -5,19 +5,11 @@ description: "Create and manage evaluation datasets through the Logfire web inte
 
 # Web UI Guide
 
-This guide covers creating and managing datasets through the Logfire web interface. For programmatic access, see the [SDK Guide](sdk.md).
+This guide covers creating, editing, and managing datasets through the Logfire web interface. It's task-oriented: each section below is a specific lifecycle action (create, edit, add cases, export).
 
-## Navigating Datasets
+For a reference of the **Evals: Datasets & Experiments** page itself (list layout, experiment viewing, comparison workflow, trace integration), see [Evals: Datasets & Experiments](../../guides/web-ui/evals.md). For programmatic dataset access, see the [SDK Guide](sdk.md).
 
-Click **Evals: Datasets & Experiments** in the sidebar to open the datasets list. From there:
-
-- Click a dataset name to see its detail page (experiments, cases, schema).
-- Click **Edit** to modify the dataset's name, description, and schemas.
-- Click **`<> SDK`** to view code snippets for working with the dataset programmatically.
-- Click **+ Add case** to add a new test case.
-- Select experiments and click **Compare** to compare multiple runs side by side.
-
-Use the **Back to Datasets** link at the top of any dataset detail or edit page to return to the list.
+All tasks below start from the **Evals: Datasets & Experiments** page in the sidebar.
 
 ## Creating a New Dataset
 
@@ -144,14 +136,9 @@ From the dataset detail page, click **Export** to download the dataset in one of
 - **JSON**: Raw JSON representation of all cases.
 - **pydantic-evals**: A YAML format compatible with `pydantic_evals.Dataset.from_file()`.
 
-## Viewing Experiments
-
-The **Experiments** tab on the dataset detail page shows all evaluation runs against this dataset. You can:
-
-- Click any experiment row to see detailed results (inputs, outputs, scores, assertions).
-- Select multiple experiments and click **Compare** to view them side by side.
-- See pass rates, scores, labels, and metrics at a glance.
-
 ## What's Next?
 
-Once you have cases in a dataset, you can export them and run evaluations. See [Running Evaluations](evaluations.md) to get started.
+Once you have cases in a dataset, you can:
+
+- Run evaluations against it — see [Running Evaluations](evaluations.md).
+- View and compare experiment results — see [Evals: Datasets & Experiments](../../guides/web-ui/evals.md#viewing-experiments).

--- a/docs/guides/web-ui/evals.md
+++ b/docs/guides/web-ui/evals.md
@@ -4,9 +4,13 @@ description: "Logfire Evals provides observability into how your AI systems perf
 ---
 # Evals
 
-View and analyze your evaluation results in Pydantic Logfire's web interface. Evals provide observability into how your AI systems perform across different test cases and experiments over time.
+This is the reference for the **Evals: Datasets & Experiments** page in the Logfire web UI — use it to view and compare your dataset and experiment results. For live, per-request evaluation activity streaming in from production or staging traffic, see [Live Evaluations](./live-evals.md) instead.
 
-To get started with creating and running evals, see the [Pydantic Evals docs](https://ai.pydantic.dev/evals/). For managing datasets in Logfire, see the [Datasets guide](../../evaluate/datasets/index.md).
+**Where to go next:**
+
+- To get started with creating and running evals in code, see the [Pydantic Evals docs](https://ai.pydantic.dev/evals/).
+- To create or edit datasets through the Logfire UI, see the [Datasets Web UI Guide](../../evaluate/datasets/ui.md). This page covers what you see on the Evals page itself; the Web UI Guide covers dataset/case lifecycle tasks (create, edit, manage cases, export).
+- For programmatic dataset access, see the [SDK Guide](../../evaluate/datasets/sdk.md).
 
 ## The Datasets List
 

--- a/docs/guides/web-ui/evals.md
+++ b/docs/guides/web-ui/evals.md
@@ -10,7 +10,7 @@ To get started with creating and running evals, see the [Pydantic Evals docs](ht
 
 ## The Datasets List
 
-Click **Evals** in the sidebar to open the datasets list. This is the top-level view for all evaluation activity in your project.
+Click **Evals: Datasets & Experiments** in the sidebar to open the datasets list. This is the top-level view for all dataset-and-experiment evaluation activity in your project. For live, per-request evaluation activity streaming in from production or staging, see [Live Evaluations](./live-evals.md) instead.
 
 Each dataset row shows:
 

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -14,8 +14,8 @@ Click **Evals: Live** in the sidebar to open the directory. Each row is one **ta
 
 Each row shows:
 
-- **Target** --- the target name, with an agent or function icon derived from the parent span
-- **Type** --- `agent` if the parent span carries `gen_ai.agent.name`, otherwise `function`
+- **Target** --- the target name, with an agent or function icon
+- **Type** --- `agent` if the evaluation event carries `gen_ai.agent.name`, otherwise `function`. The `OnlineEvaluation` capability on a Pydantic AI agent stamps this automatically (via OTel baggage inherited from the agent run); the `@evaluate` decorator path does not, so decorator-wrapped targets always show as `function`
 - **Evaluations** --- one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
 - **Events** --- total number of evaluation events in the window
 - **Last activity** --- when the most recent event arrived
@@ -30,8 +30,8 @@ If you haven't wired up any evaluators yet, the empty state shows getting-starte
 
 Click a target row to open its detail page. The page shows:
 
-- Each evaluator attached to the target as its own row, with a larger sparkline, numeric/pass-rate/categorical summary, and a failure count when evaluators raised
-- A **Recent events** table with the 20 most recent evaluation events for the target
+- Each evaluator attached to the target as its own row, with a larger sparkline, numeric/pass-rate/categorical summary, and an error count when evaluators raised
+- A **Recent events** table with the 50 most recent evaluation events for the target
 
 The **Evaluator** filter dropdown narrows the recent-events table to a single evaluator. The time-window tabs behave the same as on the directory.
 
@@ -44,7 +44,7 @@ The **Evaluations** cell adapts to the shape of scores an evaluator produces:
 - **Pass rate** --- evaluators that return `bool`. The cell shows a percentage and colors a dot based on health (≥95% green, ≥80% amber, otherwise red).
 - **Numeric average** --- evaluators that return `int` or `float`. The cell shows the average score over the window.
 - **Categorical labels** --- evaluators that return a string. The cell shows the most common label with a **`+N`** badge indicating how many other distinct labels were seen.
-- **Error-only** --- evaluators that only raised in the window. The cell shows the failure count in red.
+- **Error-only** --- evaluators that only raised in the window. The cell shows the error count in red.
 
 Evaluators that emit multiple score keys (a mapping return type) show up as one row per key.
 
@@ -58,5 +58,7 @@ The event attributes follow the OTel GenAI semantic conventions:
 - `gen_ai.evaluation.name` --- the evaluator name
 - `gen_ai.evaluation.score.value` / `gen_ai.evaluation.score.label` --- score payload
 - `gen_ai.evaluation.explanation` --- optional free-text reason
-- `gen_ai.evaluation.evaluator_version` --- optional version tag so retired evaluator revisions can be filtered out
+- `gen_ai.evaluation.evaluator.source` --- JSON-serialized `EvaluatorSpec`, lets us distinguish two evaluators with the same name but different configs
+- `gen_ai.evaluation.evaluator.version` --- optional version tag so retired evaluator revisions can be filtered out
+- `gen_ai.agent.name` --- set automatically by the `OnlineEvaluation` capability, drives the agent/function classification in the directory
 - `error.type` --- set when the evaluator raised

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -4,7 +4,7 @@ description: "View real-time online-evaluation activity for your agents and func
 ---
 # Live Evaluations
 
-The **Evals: Live Monitoring** page streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window. This is the Logfire view of what Pydantic AI calls [online evaluation](https://ai.pydantic.dev/evals/online-evaluation/).
+The **Evals: Live Monitoring** page streams evaluator results from live application traffic (e.g., from a production deployment) into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window. This is the Logfire view of what Pydantic AI calls [online evaluation](https://ai.pydantic.dev/evals/online-evaluation/).
 
 To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. The page renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the [GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult) — the [`@evaluate`](https://ai.pydantic.dev/evals/online-evaluation/#quick-start) decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
 
@@ -15,7 +15,7 @@ Click **Evals: Live Monitoring** in the sidebar to open the directory. Each row 
 Each row shows:
 
 - **Target** — the target name, with an agent or function icon
-- **Type** — `agent` if the evaluation event carries `gen_ai.agent.name`, otherwise `function`. The `OnlineEvaluation` capability on a Pydantic AI agent stamps this automatically (via OTel baggage inherited from the agent run). The `@evaluate` decorator itself doesn't stamp it, so a standalone decorated function shows as `function` — but if the decorated function runs inside a Pydantic AI agent call, the same baggage propagates and the target is classified as `agent`
+- **Type** — `agent` or `function`. Evaluations dispatched by the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) capability on a Pydantic AI agent appear as `agent`; `@evaluate`-decorated functions appear as `function`, even when the decorated function runs inside an agent
 - **Evaluations** — one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
 - **Events** — total number of evaluation events in the window
 - **Last activity** — when the most recent event arrived
@@ -62,5 +62,5 @@ The event attributes follow the [OTel GenAI evaluation semantic conventions](htt
 - `gen_ai.evaluation.explanation` — optional free-text reason
 - `gen_ai.evaluation.evaluator.source` — JSON-serialized `EvaluatorSpec` (evaluator class + constructor args). Live Evaluations groups by `(target, name)`, so two events with the same target and name but different sources land in the same row; the `source` is visible on individual events in the trace view so you can tell them apart there
 - `gen_ai.evaluation.evaluator.version` — optional version tag so retired evaluator revisions can be filtered out
-- `gen_ai.agent.name` — set automatically by the `OnlineEvaluation` capability or inherited from an enclosing Pydantic AI agent run via OTel baggage; drives the agent/function classification in the directory
+- `gen_ai.agent.name` — set by the `OnlineEvaluation` capability, and also propagated via OTel baggage onto any evaluation emitted inside a Pydantic AI agent run (useful for drill-down, but not used to classify the target — see the Type column above)
 - `error.type` — set when the evaluator raised

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -4,9 +4,9 @@ description: "View real-time online-evaluation activity for your agents and func
 ---
 # Live Evaluations
 
-Live Evaluations streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window.
+The **Evals: Live Monitoring** page streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window. This is the Logfire view of what Pydantic AI calls [online evaluation](https://ai.pydantic.dev/evals/online-evaluation/).
 
-To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. Live Evaluations renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the GenAI semantic conventions — the `@evaluate` decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
+To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. The page renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the [GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult) — the [`@evaluate`](https://ai.pydantic.dev/evals/online-evaluation/#quick-start) decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
 
 ## The Directory
 
@@ -14,15 +14,15 @@ Click **Evals: Live Monitoring** in the sidebar to open the directory. Each row 
 
 Each row shows:
 
-- **Target** --- the target name, with an agent or function icon
-- **Type** --- `agent` if the evaluation event carries `gen_ai.agent.name`, otherwise `function`. The `OnlineEvaluation` capability on a Pydantic AI agent stamps this automatically (via OTel baggage inherited from the agent run); the `@evaluate` decorator path does not, so decorator-wrapped targets always show as `function`
-- **Evaluations** --- one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
-- **Events** --- total number of evaluation events in the window
-- **Last activity** --- when the most recent event arrived
+- **Target** — the target name, with an agent or function icon
+- **Type** — `agent` if the evaluation event carries `gen_ai.agent.name`, otherwise `function`. The `OnlineEvaluation` capability on a Pydantic AI agent stamps this automatically (via OTel baggage inherited from the agent run). The `@evaluate` decorator itself doesn't stamp it, so a standalone decorated function shows as `function` — but if the decorated function runs inside a Pydantic AI agent call, the same baggage propagates and the target is classified as `agent`
+- **Evaluations** — one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
+- **Events** — total number of evaluation events in the window
+- **Last activity** — when the most recent event arrived
 
 Use the time-window tabs in the page header (**1h**, **6h**, **24h**, **7d**, **30d**) to adjust the range. Narrowing the window never empties the page: a target that was active anywhere in the last 30 days still appears as a silent row so you can see that evaluators are configured even if traffic is quiet right now.
 
-The column headers are sortable --- click **Target**, **Type**, **Events**, or **Last activity** to re-order. The sort state is persisted in the URL so you can share a specific view.
+The column headers are sortable — click **Target**, **Type**, **Events**, or **Last activity** to re-order. The sort state is persisted in the URL so you can share a specific view.
 
 If you haven't wired up any evaluators yet, the empty state shows getting-started snippets for the two entry points (the `@evaluate` decorator for any function, and the `OnlineEvaluation` capability for a Pydantic AI agent). Once events arrive, the same snippets remain accessible via the collapsible **How do I send events here?** strip above the directory.
 
@@ -35,18 +35,18 @@ Click a target row to open its detail page. The page shows:
 
 The **Evaluator** filter dropdown narrows the recent-events table to a single evaluator. The time-window tabs behave the same as on the directory.
 
-Each recent-events row includes an **Open trace in live view** link that jumps to the live trace view for the span the evaluation was attached to --- useful for seeing the full context of a low-scoring call.
+Each recent-events row includes an **Open trace in live view** link that jumps to the live trace view for the span the evaluation was attached to — useful for seeing the full context of a low-scoring call.
 
-Each evaluator row also shows the distinct `evaluator_version` values seen in the window as small version badges. During a deploy rollout where two versions of the same evaluator are live at once, both versions appear side-by-side.
+Each evaluator row also shows the distinct `evaluator_version` values seen in the window as small version badges. During a deploy rollout where two versions of the same evaluator are live at once, both versions appear side-by-side. See [Evaluator Versioning](https://ai.pydantic.dev/evals/online-evaluation/#evaluator-versioning) in the Pydantic AI docs for how to set the version tag.
 
 ## Evaluator Shapes
 
 The **Evaluations** cell adapts to the shape of scores an evaluator produces:
 
-- **Pass rate** --- evaluators that return `bool`. The cell shows a percentage and colors a dot based on health (≥95% green, ≥80% amber, otherwise red).
-- **Numeric average** --- evaluators that return `int` or `float`. The cell shows the average score over the window.
-- **Categorical labels** --- evaluators that return a string. The cell shows the most common label with a **`+N`** badge indicating how many other distinct labels were seen.
-- **Error-only** --- evaluators that only raised in the window. The cell shows the error count in red.
+- **Pass rate** — evaluators that return `bool`. The cell shows a percentage and colors a dot based on health (≥95% green, ≥80% amber, otherwise red).
+- **Numeric average** — evaluators that return `int` or `float`. The cell shows the average score over the window.
+- **Categorical labels** — evaluators that return a string. The cell shows the most common label with a **`+N`** badge indicating how many other distinct labels were seen.
+- **Error-only** — evaluators that only raised in the window. The cell shows the error count in red.
 
 Evaluators that emit multiple score keys (a mapping return type) show up as one row per key.
 
@@ -54,13 +54,13 @@ Evaluators that emit multiple score keys (a mapping return type) show up as one 
 
 Each `gen_ai.evaluation.result` event is parented to the span whose call was evaluated, so the evaluation appears nested inside the original function call in the trace view. This makes it easy to jump from a failing evaluator back to the exact prompt, tool calls, and response that produced the result.
 
-The event attributes follow the OTel GenAI semantic conventions:
+The event attributes follow the [OTel GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult):
 
-- `gen_ai.evaluation.target` --- the function or agent name
-- `gen_ai.evaluation.name` --- the evaluator name
-- `gen_ai.evaluation.score.value` / `gen_ai.evaluation.score.label` --- score payload
-- `gen_ai.evaluation.explanation` --- optional free-text reason
-- `gen_ai.evaluation.evaluator.source` --- JSON-serialized `EvaluatorSpec`, lets us distinguish two evaluators with the same name but different configs
-- `gen_ai.evaluation.evaluator.version` --- optional version tag so retired evaluator revisions can be filtered out
-- `gen_ai.agent.name` --- set automatically by the `OnlineEvaluation` capability, drives the agent/function classification in the directory
-- `error.type` --- set when the evaluator raised
+- `gen_ai.evaluation.target` — the function or agent name
+- `gen_ai.evaluation.name` — the evaluator name
+- `gen_ai.evaluation.score.value` / `gen_ai.evaluation.score.label` — score payload
+- `gen_ai.evaluation.explanation` — optional free-text reason
+- `gen_ai.evaluation.evaluator.source` — JSON-serialized `EvaluatorSpec` (evaluator class + constructor args). Live Evaluations groups by `(target, name)`, so two events with the same target and name but different sources land in the same row; the `source` is visible on individual events in the trace view so you can tell them apart there
+- `gen_ai.evaluation.evaluator.version` — optional version tag so retired evaluator revisions can be filtered out
+- `gen_ai.agent.name` — set automatically by the `OnlineEvaluation` capability or inherited from an enclosing Pydantic AI agent run via OTel baggage; drives the agent/function classification in the directory
+- `error.type` — set when the evaluator raised

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -1,0 +1,62 @@
+---
+title: "Live Evaluations: Monitor AI Systems in Production"
+description: "View real-time online-evaluation activity for your agents and functions in Pydantic Logfire. Track pass rates, categorical labels, and numeric scores across production traffic."
+---
+# Live Evaluations
+
+Live Evaluations streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here, grouped by the target's name, with one row per evaluator and a sparkline showing activity over the selected time window.
+
+To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. Live Evaluations renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the GenAI semantic conventions — the `@evaluate` decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
+
+## The Directory
+
+Click **Evals: Live** in the sidebar to open the directory. Each row is one **target** — the name of the function or agent that produced the evaluation event.
+
+Each row shows:
+
+- **Target** --- the target name, with an agent or function icon derived from the parent span
+- **Type** --- `agent` if the parent span carries `gen_ai.agent.name`, otherwise `function`
+- **Evaluations** --- one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
+- **Events** --- total number of evaluation events in the window
+- **Last activity** --- when the most recent event arrived
+
+Use the time-window tabs in the page header (**1h**, **6h**, **24h**, **7d**, **30d**) to adjust the range. Narrowing the window never empties the page: a target that was active anywhere in the last 30 days still appears as a silent row so you can see that evaluators are configured even if traffic is quiet right now.
+
+The column headers are sortable --- click **Target**, **Type**, **Events**, or **Last activity** to re-order. The sort state is persisted in the URL so you can share a specific view.
+
+If you haven't wired up any evaluators yet, the empty state shows getting-started snippets for the two entry points (the `@evaluate` decorator for any function, and the `OnlineEvaluation` capability for a Pydantic AI agent). Once events arrive, the same snippets remain accessible via the collapsible **How do I send events here?** strip above the directory.
+
+## Target Detail Page
+
+Click a target row to open its detail page. The page shows:
+
+- Each evaluator attached to the target as its own row, with a larger sparkline, numeric/pass-rate/categorical summary, and a failure count when evaluators raised
+- A **Recent events** table with the 20 most recent evaluation events for the target
+
+The **Evaluator** filter dropdown narrows the recent-events table to a single evaluator. The time-window tabs behave the same as on the directory.
+
+Each recent-events row includes an **open trace** link that jumps to the live trace view for the span the evaluation was attached to --- useful for seeing the full context of a low-scoring call.
+
+## Evaluator Shapes
+
+The **Evaluations** cell adapts to the shape of scores an evaluator produces:
+
+- **Pass rate** --- evaluators that return `bool`. The cell shows a percentage and colors a dot based on health (≥95% green, ≥80% amber, otherwise red).
+- **Numeric average** --- evaluators that return `int` or `float`. The cell shows the average score over the window.
+- **Categorical labels** --- evaluators that return a string. The cell shows the most common label with a **`+N`** badge indicating how many other distinct labels were seen.
+- **Error-only** --- evaluators that only raised in the window. The cell shows the failure count in red.
+
+Evaluators that emit multiple score keys (a mapping return type) show up as one row per key.
+
+## Integration with Traces
+
+Each `gen_ai.evaluation.result` event is parented to the span whose call was evaluated, so the evaluation appears nested inside the original function call in the trace view. This makes it easy to jump from a failing evaluator back to the exact prompt, tool calls, and response that produced the result.
+
+The event attributes follow the OTel GenAI semantic conventions:
+
+- `gen_ai.evaluation.target` --- the function or agent name
+- `gen_ai.evaluation.name` --- the evaluator name
+- `gen_ai.evaluation.score.value` / `gen_ai.evaluation.score.label` --- score payload
+- `gen_ai.evaluation.explanation` --- optional free-text reason
+- `gen_ai.evaluation.evaluator_version` --- optional version tag so retired evaluator revisions can be filtered out
+- `error.type` --- set when the evaluator raised

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -4,13 +4,13 @@ description: "View real-time online-evaluation activity for your agents and func
 ---
 # Live Evaluations
 
-Live Evaluations streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here, grouped by the target's name, with one row per evaluator and a sparkline showing activity over the selected time window.
+Live Evaluations streams evaluator results from production (or staging) traffic into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window.
 
 To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. Live Evaluations renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the GenAI semantic conventions — the `@evaluate` decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
 
 ## The Directory
 
-Click **Evals: Live** in the sidebar to open the directory. Each row is one **target** — the name of the function or agent that produced the evaluation event.
+Click **Evals: Live Monitoring** in the sidebar to open the directory. Each row is one **target** — the name of the function or agent that produced the evaluation event. Expanding a row (via the chevron on the left) reveals a larger sparkline for each of its evaluators.
 
 Each row shows:
 
@@ -35,7 +35,9 @@ Click a target row to open its detail page. The page shows:
 
 The **Evaluator** filter dropdown narrows the recent-events table to a single evaluator. The time-window tabs behave the same as on the directory.
 
-Each recent-events row includes an **open trace** link that jumps to the live trace view for the span the evaluation was attached to --- useful for seeing the full context of a low-scoring call.
+Each recent-events row includes an **Open trace in live view** link that jumps to the live trace view for the span the evaluation was attached to --- useful for seeing the full context of a low-scoring call.
+
+Each evaluator row also shows the distinct `evaluator_version` values seen in the window as small version badges. During a deploy rollout where two versions of the same evaluator are live at once, both versions appear side-by-side.
 
 ## Evaluator Shapes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,6 +197,7 @@ nav:
           - Detect Service is Down: how-to-guides/detect-service-is-down.md
       - Evaluate:
           - Evals: guides/web-ui/evals.md
+          - Live Evaluations: guides/web-ui/live-evals.md
           - Datasets:
               - Datasets: evaluate/datasets/index.md
               - Web UI Guide: evaluate/datasets/ui.md
@@ -466,6 +467,7 @@ plugins:
           - how-to-guides/detect-service-is-down.md
         Evaluate:
           - guides/web-ui/evals.md
+          - guides/web-ui/live-evals.md
           - evaluate/datasets/*.md
         Manage & Configure:
           - guides/web-ui/organizations-and-projects.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -196,8 +196,8 @@ nav:
           - Setup Slack Alerts: how-to-guides/setup-slack-alerts.md
           - Detect Service is Down: how-to-guides/detect-service-is-down.md
       - Evaluate:
-          - Evals: guides/web-ui/evals.md
-          - Live Evaluations: guides/web-ui/live-evals.md
+          - "Evals: Datasets & Experiments": guides/web-ui/evals.md
+          - "Evals: Live Monitoring": guides/web-ui/live-evals.md
           - Datasets:
               - Datasets: evaluate/datasets/index.md
               - Web UI Guide: evaluate/datasets/ui.md


### PR DESCRIPTION
## Summary
- Add `docs/guides/web-ui/live-evals.md` — a walkthrough of the Live Evaluations page (directory, target detail, time window, sort, evaluator shapes, trace integration). Mirrors the shape of the existing `evals.md` doc.
- Register the new page in `mkdocs.yml` under the `Evaluate:` nav section (right after the Evals guide) and in the search-grouping list.

The Python side is already documented in `ai.pydantic.dev/evals/online-evaluation/`, so this guide links out there rather than duplicating it.

## Test plan
- [ ] `uv run mkdocs build` succeeds with no warnings
- [ ] New page renders at `/guides/web-ui/live-evals/`
- [ ] Sidebar nav shows **Live Evaluations** directly below **Evals**