### PR TITLE
Add level param to @logfire.instrument()

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -131,7 +131,7 @@ except ImportError:
 
             def install_auto_tracing(self, *args, **kwargs) -> None: ...
 
-            def instrument(self, *args, _level=None, **kwargs):
+            def instrument(self, *args, **kwargs):
                 def decorator(func):
                     return func
 
@@ -322,5 +322,5 @@ except ImportError:
         def get_context(*args, **kwargs) -> dict[str, Any]:
             return {}
 
-        def attach_context(*args, **kwargs)-> ContextManager[None]:
+        def attach_context(*args, **kwargs) -> ContextManager[None]:
             return nullcontext()

--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -131,7 +131,7 @@ except ImportError:
 
             def install_auto_tracing(self, *args, **kwargs) -> None: ...
 
-            def instrument(self, *args, **kwargs):
+            def instrument(self, *args, _level=None, **kwargs):
                 def decorator(func):
                     return func
 

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -58,7 +58,7 @@ def instrument(
     record_return: bool,
     allow_generator: bool,
     new_trace: bool,
-    _level: LevelName | int | None = None,
+    level: LevelName | int | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     from .main import set_user_attributes_on_raw_span
 
@@ -70,7 +70,7 @@ def instrument(
             )
 
         attributes = get_attributes(func, msg_template, tags)
-        open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, _level=_level)
+        open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, level=level)
 
         if inspect.isgeneratorfunction(func):
             if not allow_generator:
@@ -129,15 +129,15 @@ def get_open_span(
     extract_args: bool | Iterable[str],
     func: Callable[P, R],
     new_trace: bool,
-    _level: LevelName | int | None = None,
+    level: LevelName | int | None = None,
 ) -> Callable[P, AbstractContextManager[Any]]:
     final_span_name: str = span_name or attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]  # pyright: ignore[reportAssignmentType]
 
     level_num: int | None = None
-    if _level is not None:
-        _level_attrs = log_level_attributes(_level)
-        level_num = int(_level_attrs[ATTRIBUTES_LOG_LEVEL_NUM_KEY])
-        attributes = {**attributes, **_level_attrs}
+    if level is not None:
+        level_attrs = log_level_attributes(level)
+        level_num = int(level_attrs[ATTRIBUTES_LOG_LEVEL_NUM_KEY])
+        attributes = {**attributes, **level_attrs}
 
     def get_logfire():
         # This avoids having a `logfire` closure variable, which would make the instrumented

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -131,6 +131,8 @@ def get_open_span(
     new_trace: bool,
     level: LevelName | int | None = None,
 ) -> Callable[P, AbstractContextManager[Any]]:
+    from .main import NoopSpan
+
     final_span_name: str = span_name or attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]  # pyright: ignore[reportAssignmentType]
 
     level_num: int | None = None
@@ -153,6 +155,13 @@ def get_open_span(
         def get_logfire():
             return logfire
 
+    if level_num is not None and level_num < get_logfire().config.min_level:
+
+        def open_span(*_: P.args, **__: P.kwargs):  # pyright: ignore[reportRedeclaration]
+            return NoopSpan()
+
+        return open_span
+
     if new_trace:
 
         def extra_span_kwargs() -> dict[str, Any]:
@@ -170,10 +179,6 @@ def get_open_span(
 
     # This is the fast case for when there are no arguments to extract
     def open_span(*_: P.args, **__: P.kwargs):  # pyright: ignore[reportRedeclaration]
-        if level_num is not None and level_num < get_logfire().config.min_level:
-            from .main import NoopSpan
-
-            return NoopSpan()
         return get_logfire()._fast_span(final_span_name, attributes, **extra_span_kwargs())  # pyright: ignore[reportPrivateUsage]
 
     if extract_args is True:
@@ -181,10 +186,6 @@ def get_open_span(
         if sig.parameters:  # only extract args if there are any
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
-                if level_num is not None and level_num < get_logfire().config.min_level:
-                    from .main import NoopSpan
-
-                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments
@@ -212,10 +213,6 @@ def get_open_span(
         if extract_args_final:  # check that there are still arguments to extract
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
-                if level_num is not None and level_num < get_logfire().config.min_level:
-                    from .main import NoopSpan
-
-                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -12,7 +12,12 @@ from opentelemetry import trace
 from opentelemetry.util import types as otel_types
 from typing_extensions import LiteralString, ParamSpec
 
-from .constants import ATTRIBUTES_MESSAGE_TEMPLATE_KEY, ATTRIBUTES_TAGS_KEY
+from .constants import (
+    ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
+    ATTRIBUTES_TAGS_KEY,
+    LevelName,
+    log_level_attributes,
+)
 from .stack_info import get_filepath_attribute
 from .utils import safe_repr, uniquify_sequence
 
@@ -52,6 +57,7 @@ def instrument(
     record_return: bool,
     allow_generator: bool,
     new_trace: bool,
+    _level: LevelName | int | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     from .main import set_user_attributes_on_raw_span
 
@@ -63,7 +69,7 @@ def instrument(
             )
 
         attributes = get_attributes(func, msg_template, tags)
-        open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace)
+        open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, _level=_level)
 
         if inspect.isgeneratorfunction(func):
             if not allow_generator:
@@ -122,8 +128,12 @@ def get_open_span(
     extract_args: bool | Iterable[str],
     func: Callable[P, R],
     new_trace: bool,
+    _level: LevelName | int | None = None,
 ) -> Callable[P, AbstractContextManager[Any]]:
     final_span_name: str = span_name or attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]  # pyright: ignore[reportAssignmentType]
+
+    if _level is not None:
+        attributes = {**attributes, **log_level_attributes(_level)}
 
     def get_logfire():
         # This avoids having a `logfire` closure variable, which would make the instrumented

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -155,13 +155,6 @@ def get_open_span(
         def get_logfire():
             return logfire
 
-    if level_num is not None and level_num < get_logfire().config.min_level:
-
-        def open_span(*_: P.args, **__: P.kwargs):  # pyright: ignore[reportRedeclaration]
-            return NoopSpan()
-
-        return open_span
-
     if new_trace:
 
         def extra_span_kwargs() -> dict[str, Any]:
@@ -179,6 +172,8 @@ def get_open_span(
 
     # This is the fast case for when there are no arguments to extract
     def open_span(*_: P.args, **__: P.kwargs):  # pyright: ignore[reportRedeclaration]
+        if level_num is not None and level_num < get_logfire().config.min_level:
+            return NoopSpan()
         return get_logfire()._fast_span(final_span_name, attributes, **extra_span_kwargs())  # pyright: ignore[reportPrivateUsage]
 
     if extract_args is True:
@@ -186,6 +181,8 @@ def get_open_span(
         if sig.parameters:  # only extract args if there are any
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
+                if level_num is not None and level_num < get_logfire().config.min_level:
+                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments
@@ -213,6 +210,8 @@ def get_open_span(
         if extract_args_final:  # check that there are still arguments to extract
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
+                if level_num is not None and level_num < get_logfire().config.min_level:
+                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -13,6 +13,7 @@ from opentelemetry.util import types as otel_types
 from typing_extensions import LiteralString, ParamSpec
 
 from .constants import (
+    ATTRIBUTES_LOG_LEVEL_NUM_KEY,
     ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
     ATTRIBUTES_TAGS_KEY,
     LevelName,
@@ -132,8 +133,11 @@ def get_open_span(
 ) -> Callable[P, AbstractContextManager[Any]]:
     final_span_name: str = span_name or attributes[ATTRIBUTES_MESSAGE_TEMPLATE_KEY]  # pyright: ignore[reportAssignmentType]
 
+    level_num: int | None = None
     if _level is not None:
-        attributes = {**attributes, **log_level_attributes(_level)}
+        _level_attrs = log_level_attributes(_level)
+        level_num = int(_level_attrs[ATTRIBUTES_LOG_LEVEL_NUM_KEY])
+        attributes = {**attributes, **_level_attrs}
 
     def get_logfire():
         # This avoids having a `logfire` closure variable, which would make the instrumented
@@ -166,6 +170,10 @@ def get_open_span(
 
     # This is the fast case for when there are no arguments to extract
     def open_span(*_: P.args, **__: P.kwargs):  # pyright: ignore[reportRedeclaration]
+        if level_num is not None and level_num < get_logfire().config.min_level:
+            from .main import NoopSpan
+
+            return NoopSpan()
         return get_logfire()._fast_span(final_span_name, attributes, **extra_span_kwargs())  # pyright: ignore[reportPrivateUsage]
 
     if extract_args is True:
@@ -173,6 +181,10 @@ def get_open_span(
         if sig.parameters:  # only extract args if there are any
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
+                if level_num is not None and level_num < get_logfire().config.min_level:
+                    from .main import NoopSpan
+
+                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments
@@ -200,6 +212,10 @@ def get_open_span(
         if extract_args_final:  # check that there are still arguments to extract
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
+                if level_num is not None and level_num < get_logfire().config.min_level:
+                    from .main import NoopSpan
+
+                    return NoopSpan()
                 bound = sig.bind(*func_args, **func_kwargs)
                 bound.apply_defaults()
                 args_dict = bound.arguments

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -608,7 +608,7 @@ class Logfire:
         record_return: bool = False,
         allow_generator: bool = False,
         new_trace: bool = False,
-        _level: LevelName | int | None = None,
+        level: LevelName | int | None = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """Decorator for instrumenting a function as a span.
 
@@ -634,7 +634,7 @@ class Logfire:
                 Read https://logfire.pydantic.dev/docs/guides/advanced/generators/#using-logfireinstrument first.
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
-            _level: The log level for the span. If provided, the span will be tagged with this level
+            level: The log level for the span. If provided, the span will be tagged with this level
                 and suppressed if the level is below the configured `min_level`.
         """
 
@@ -663,7 +663,7 @@ class Logfire:
         record_return: bool = False,
         allow_generator: bool = False,
         new_trace: bool = False,
-        _level: LevelName | int | None = None,
+        level: LevelName | int | None = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]] | Callable[P, R]:
         """Decorator for instrumenting a function as a span.
 
@@ -689,7 +689,7 @@ class Logfire:
                 Read https://logfire.pydantic.dev/docs/guides/advanced/generators/#using-logfireinstrument first.
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
-            _level: The log level for the span. If provided, the span will be tagged with this level
+            level: The log level for the span. If provided, the span will be tagged with this level
                 and suppressed if the level is below the configured `min_level`.
         """
         if callable(msg_template):
@@ -703,7 +703,7 @@ class Logfire:
             record_return,
             allow_generator,
             new_trace,
-            _level=_level,
+            level=level,
         )
 
     def log(

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3097,6 +3097,11 @@ class NoopSpan:
     def message(self, message: str):
         pass
 
+    @property
+    def _span(self) -> Any:
+        # set_user_attributes_on_raw_span checks is_recording() first; INVALID_SPAN returns False
+        return trace_api.INVALID_SPAN
+
     def is_recording(self) -> bool:
         return False
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -608,6 +608,7 @@ class Logfire:
         record_return: bool = False,
         allow_generator: bool = False,
         new_trace: bool = False,
+        _level: LevelName | int | None = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]]:
         """Decorator for instrumenting a function as a span.
 
@@ -633,6 +634,8 @@ class Logfire:
                 Read https://logfire.pydantic.dev/docs/guides/advanced/generators/#using-logfireinstrument first.
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
+            _level: The log level for the span. If provided, the span will be tagged with this level
+                and suppressed if the level is below the configured `min_log_level`.
         """
 
     @overload
@@ -660,6 +663,7 @@ class Logfire:
         record_return: bool = False,
         allow_generator: bool = False,
         new_trace: bool = False,
+        _level: LevelName | int | None = None,
     ) -> Callable[[Callable[P, R]], Callable[P, R]] | Callable[P, R]:
         """Decorator for instrumenting a function as a span.
 
@@ -685,11 +689,21 @@ class Logfire:
                 Read https://logfire.pydantic.dev/docs/guides/advanced/generators/#using-logfireinstrument first.
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
+            _level: The log level for the span. If provided, the span will be tagged with this level
+                and suppressed if the level is below the configured `min_log_level`.
         """
         if callable(msg_template):
             return self.instrument()(msg_template)
         return instrument(
-            self, tuple(self._tags), msg_template, span_name, extract_args, record_return, allow_generator, new_trace
+            self,
+            tuple(self._tags),
+            msg_template,
+            span_name,
+            extract_args,
+            record_return,
+            allow_generator,
+            new_trace,
+            _level=_level,
         )
 
     def log(

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3099,7 +3099,6 @@ class NoopSpan:
 
     @property
     def _span(self) -> Any:
-        # set_user_attributes_on_raw_span checks is_recording() first; INVALID_SPAN returns False
         return trace_api.INVALID_SPAN
 
     def is_recording(self) -> bool:

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -635,7 +635,7 @@ class Logfire:
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
             _level: The log level for the span. If provided, the span will be tagged with this level
-                and suppressed if the level is below the configured `min_log_level`.
+                and suppressed if the level is below the configured `min_level`.
         """
 
     @overload
@@ -690,7 +690,7 @@ class Logfire:
             new_trace: Set to `True` to start a new trace with a span link to the current span
                 instead of creating a child of the current span.
             _level: The log level for the span. If provided, the span will be tagged with this level
-                and suppressed if the level is below the configured `min_log_level`.
+                and suppressed if the level is below the configured `min_level`.
         """
         if callable(msg_template):
             return self.instrument()(msg_template)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -71,7 +71,7 @@ def test_instrument_with_level(exporter: TestExporter) -> None:
         return 'ok'
 
     assert my_func() == 'ok'
-    assert exporter.exported_spans_as_dict() == snapshot(
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False) == snapshot(
         [
             {
                 'name': 'my span',
@@ -80,7 +80,7 @@ def test_instrument_with_level(exporter: TestExporter) -> None:
                 'start_time': 1000000000,
                 'end_time': 2000000000,
                 'attributes': {
-                    'code.function': 'my_func',
+                    'code.function': 'test_instrument_with_level.<locals>.my_func',
                     'logfire.msg_template': 'my span',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -124,7 +124,7 @@ async def test_instrument_with_level_async(exporter: TestExporter) -> None:
         return 'ok'
 
     assert await my_async_func() == 'ok'
-    assert exporter.exported_spans_as_dict() == snapshot(
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False) == snapshot(
         [
             {
                 'name': 'async span',
@@ -133,7 +133,7 @@ async def test_instrument_with_level_async(exporter: TestExporter) -> None:
                 'start_time': 1000000000,
                 'end_time': 2000000000,
                 'attributes': {
-                    'code.function': 'my_async_func',
+                    'code.function': 'test_instrument_with_level_async.<locals>.my_async_func',
                     'logfire.msg_template': 'async span',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -152,7 +152,7 @@ def test_instrument_with_level_and_extract_args(exporter: TestExporter) -> None:
         return x * 2
 
     assert my_func(5) == 10
-    assert exporter.exported_spans_as_dict() == snapshot(
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False) == snapshot(
         [
             {
                 'name': 'span {x=}',
@@ -161,7 +161,7 @@ def test_instrument_with_level_and_extract_args(exporter: TestExporter) -> None:
                 'start_time': 1000000000,
                 'end_time': 2000000000,
                 'attributes': {
-                    'code.function': 'my_func',
+                    'code.function': 'test_instrument_with_level_and_extract_args.<locals>.my_func',
                     'logfire.msg_template': 'span {x=}',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -93,6 +93,30 @@ def test_instrument_with_level(exporter: TestExporter) -> None:
     )
 
 
+def test_instrument_level_filtered(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['min_level'] = 'info'
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument('my span', _level='debug', extract_args=False)
+    def my_func() -> str:
+        return 'ok'
+
+    assert my_func() == 'ok'
+    assert exporter.exported_spans_as_dict() == []
+
+
+def test_instrument_level_filtered_record_return(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['min_level'] = 'info'
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument('my span', _level='debug', extract_args=False, record_return=True)
+    def my_func() -> str:
+        return 'ok'
+
+    assert my_func() == 'ok'
+    assert exporter.exported_spans_as_dict() == []
+
+
 def test_instrument_with_no_args(exporter: TestExporter) -> None:
     @logfire.instrument()
     def foo(x: int):

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -66,7 +66,7 @@ def test_log_methods_without_kwargs(method: str):
 
 
 def test_instrument_with_level(exporter: TestExporter) -> None:
-    @logfire.instrument('my span', _level='warn', extract_args=False)
+    @logfire.instrument('my span', level='warn', extract_args=False)
     def my_func() -> str:
         return 'ok'
 
@@ -97,7 +97,7 @@ def test_instrument_level_filtered(exporter: TestExporter, config_kwargs: dict[s
     config_kwargs['min_level'] = 'info'
     logfire.configure(**config_kwargs)
 
-    @logfire.instrument('my span', _level='debug', extract_args=False)
+    @logfire.instrument('my span', level='debug', extract_args=False)
     def my_func() -> str:
         return 'ok'
 
@@ -109,7 +109,7 @@ def test_instrument_level_filtered_record_return(exporter: TestExporter, config_
     config_kwargs['min_level'] = 'info'
     logfire.configure(**config_kwargs)
 
-    @logfire.instrument('my span', _level='debug', extract_args=False, record_return=True)
+    @logfire.instrument('my span', level='debug', extract_args=False, record_return=True)
     def my_func() -> str:
         return 'ok'
 
@@ -121,7 +121,7 @@ def test_instrument_level_filtered_extract_args(exporter: TestExporter, config_k
     config_kwargs['min_level'] = 'info'
     logfire.configure(**config_kwargs)
 
-    @logfire.instrument('my span {x=}', _level='debug', extract_args=True)
+    @logfire.instrument('my span {x=}', level='debug', extract_args=True)
     def my_func(x: int) -> int:
         return x * 2
 
@@ -133,7 +133,7 @@ def test_instrument_level_filtered_extract_args_iterable(exporter: TestExporter,
     config_kwargs['min_level'] = 'info'
     logfire.configure(**config_kwargs)
 
-    @logfire.instrument('my span', _level='debug', extract_args=('x',))
+    @logfire.instrument('my span', level='debug', extract_args=('x',))
     def my_func(x: int) -> int:
         return x * 2
 
@@ -143,7 +143,7 @@ def test_instrument_level_filtered_extract_args_iterable(exporter: TestExporter,
 
 @pytest.mark.anyio
 async def test_instrument_with_level_async(exporter: TestExporter) -> None:
-    @logfire.instrument('async span', _level='warn', extract_args=False)
+    @logfire.instrument('async span', level='warn', extract_args=False)
     async def my_async_func() -> str:
         return 'ok'
 
@@ -171,7 +171,7 @@ async def test_instrument_with_level_async(exporter: TestExporter) -> None:
 
 
 def test_instrument_with_level_and_extract_args(exporter: TestExporter) -> None:
-    @logfire.instrument('span {x=}', _level='warn')
+    @logfire.instrument('span {x=}', level='warn')
     def my_func(x: int) -> int:
         return x * 2
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -117,6 +117,30 @@ def test_instrument_level_filtered_record_return(exporter: TestExporter, config_
     assert exporter.exported_spans_as_dict() == []
 
 
+def test_instrument_level_filtered_extract_args(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['min_level'] = 'info'
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument('my span {x=}', _level='debug', extract_args=True)
+    def my_func(x: int) -> int:
+        return x * 2
+
+    assert my_func(5) == 10
+    assert exporter.exported_spans_as_dict() == []
+
+
+def test_instrument_level_filtered_extract_args_iterable(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['min_level'] = 'info'
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument('my span', _level='debug', extract_args=('x',))
+    def my_func(x: int) -> int:
+        return x * 2
+
+    assert my_func(5) == 10
+    assert exporter.exported_spans_as_dict() == []
+
+
 @pytest.mark.anyio
 async def test_instrument_with_level_async(exporter: TestExporter) -> None:
     @logfire.instrument('async span', _level='warn', extract_args=False)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -65,6 +65,34 @@ def test_log_methods_without_kwargs(method: str):
 """)
 
 
+def test_instrument_with_level(exporter: TestExporter) -> None:
+    @logfire.instrument('my span', _level='warn', extract_args=False)
+    def my_func() -> str:
+        return 'ok'
+
+    assert my_func() == 'ok'
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'my span',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.function': 'my_func',
+                    'logfire.msg_template': 'my span',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.level_num': 13,
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'my span',
+                },
+            }
+        ]
+    )
+
+
 def test_instrument_with_no_args(exporter: TestExporter) -> None:
     @logfire.instrument()
     def foo(x: int):

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -117,6 +117,65 @@ def test_instrument_level_filtered_record_return(exporter: TestExporter, config_
     assert exporter.exported_spans_as_dict() == []
 
 
+@pytest.mark.anyio
+async def test_instrument_with_level_async(exporter: TestExporter) -> None:
+    @logfire.instrument('async span', _level='warn', extract_args=False)
+    async def my_async_func() -> str:
+        return 'ok'
+
+    assert await my_async_func() == 'ok'
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'async span',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.function': 'my_async_func',
+                    'logfire.msg_template': 'async span',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.level_num': 13,
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'async span',
+                },
+            }
+        ]
+    )
+
+
+def test_instrument_with_level_and_extract_args(exporter: TestExporter) -> None:
+    @logfire.instrument('span {x=}', _level='warn')
+    def my_func(x: int) -> int:
+        return x * 2
+
+    assert my_func(5) == 10
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'span {x=}',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.function': 'my_func',
+                    'logfire.msg_template': 'span {x=}',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.level_num': 13,
+                    'logfire.msg': 'span x=5',
+                    'logfire.json_schema': '{"type":"object","properties":{"x":{}}}',
+                    'x': 5,
+                    'logfire.span_type': 'span',
+                },
+            }
+        ]
+    )
+
+
 def test_instrument_with_no_args(exporter: TestExporter) -> None:
     @logfire.instrument()
     def foo(x: int):


### PR DESCRIPTION
Closes #1452.

Logfire's span APIs (`logfire.span`, `logfire.debug`, `logfire.warn`, etc.) all let you record a span with a log level attached, which `min_level` then filters against. `@logfire.instrument()` was the only one that didn't. This PR closes that gap.

## What changed

You can now do:

```python
@logfire.instrument("my span", level="warn")
def my_func(): ...
```

and it behaves exactly like tagging a manual `with logfire.span("my span"):` block at warn level. The span gets the warn-level attributes, and if your `min_level` is above warn, the span is suppressed entirely.

The `level=None` default is completely untouched, no overhead on existing code.

<details>
<summary>Implementation note</summary>

`log_level_attributes(level)` runs once at decoration time and merges into the attribute dict. The `level_num < config.min_level` check runs at each call so it picks up any `logfire.configure()` that happens after decoration; if the level is below `min_level`, `open_span` returns a `NoopSpan` and skips the work.

</details>

## NoopSpan._span (pre-existing bug, fixed here)

When `open_span` returns a `NoopSpan` (now an intentional code path, not just an error case), `record_return=True` would crash trying to call `.is_recording()` on a lambda returned by `__getattr__`. Added `_span` as an explicit property returning `trace_api.INVALID_SPAN` so `set_user_attributes_on_raw_span` exits cleanly.

## Tests

- `test_instrument_with_level` - warn level, verifies `logfire.level_num: 13` on the span
- `test_instrument_level_filtered` - debug with `min_level="info"`, nothing exported
- `test_instrument_level_filtered_record_return` - same but with `record_return=True` (exercises the NoopSpan fix)
- `test_instrument_with_level_async` - async path
- `test_instrument_with_level_and_extract_args` - level attrs and function args coexist
- `test_instrument_level_filtered_extract_args` - filtering with `extract_args=True`
- `test_instrument_level_filtered_extract_args_iterable` - filtering with `extract_args=('x',)`
