### PR TITLE
Datasets SDK: upload dataset-level + report-level evaluators

### DIFF
--- a/docs/evaluate/datasets/sdk.md
+++ b/docs/evaluate/datasets/sdk.md
@@ -144,8 +144,6 @@ with LogfireAPIClient(api_key='your-api-key') as client:
     )
     ```
 
-    Both case-level and dataset-level evaluators can also be edited from the Logfire UI; report-level evaluators are managed from the dataset edit page.
-
 ## Manual Dataset Management
 
 If you need lower-level control, the SDK still exposes `create_dataset(...)`, `add_cases(...)`, `update_dataset(...)`, and the other primitives directly.

--- a/docs/evaluate/datasets/sdk.md
+++ b/docs/evaluate/datasets/sdk.md
@@ -127,9 +127,24 @@ with LogfireAPIClient(api_key='your-api-key') as client:
 - it uploads all cases through the existing import/upsert API
 - it uses `on_case_conflict='update'` by default, so named cases are updated on repeat pushes
 
-!!! note "Dataset-level evaluators are not uploaded yet"
+!!! note "Round-tripping evaluators"
 
-    `push_dataset(...)` uploads case-level evaluators with their cases, but it currently rejects dataset-level `evaluators` and `report_evaluators` because hosted datasets do not store them yet. Case-level evaluators are also not yet surfaced in the Logfire UI, so they round-trip through `get_dataset(..., custom_evaluator_types=[...])` but won't show up when browsing cases in the web app. We're working on this!
+    `push_dataset(...)` uploads case-level evaluators with their cases, plus dataset-level `evaluators` and `report_evaluators` from the `Dataset` itself. Each push overwrites the hosted values, so removing an evaluator locally and re-pushing also clears it on the server.
+
+    To deserialize the hosted values back into typed instances, pass the same custom types you would to `Dataset.from_file(...)`:
+
+    ```python skip="true" skip-reason="external-connection"
+    dataset = client.get_dataset(
+        'qa-golden-set',
+        QuestionInput,
+        AnswerOutput,
+        CaseMetadata,
+        custom_evaluator_types=[MyEvaluator],
+        custom_report_evaluator_types=[MyReportEvaluator],
+    )
+    ```
+
+    Both case-level and dataset-level evaluators can also be edited from the Logfire UI; report-level evaluators are managed from the dataset edit page.
 
 ## Manual Dataset Management
 

--- a/logfire-api/logfire_api/experimental/api_client.pyi
+++ b/logfire-api/logfire_api/experimental/api_client.pyi
@@ -90,7 +90,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         Returns:
             List of dataset summaries with id, name, description, case_count, etc.
         """
-    def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None) -> dict[str, Any]:
+    def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: list[dict[str, Any]] | None = None, report_evaluators: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         '''Create a new dataset with optional type schemas.
 
         Args:
@@ -99,6 +99,12 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: Type for expected outputs. JSON schema will be generated from this type.
             metadata_type: Type for case metadata. JSON schema will be generated from this type.
             description: Optional description of the dataset.
+            evaluators: Optional dataset-level evaluator specs in
+                `[{"name": "...", "arguments": {...}}]` format. Use
+                `_serialize_evaluators(dataset.evaluators)` to build from a
+                pydantic-evals Dataset.
+            report_evaluators: Optional report-level evaluator specs. Same shape
+                as `evaluators`.
 
         Returns:
             The created dataset.
@@ -125,8 +131,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             )
             ```
         '''
-    def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ...) -> dict[str, Any]:
-        """Update an existing dataset.
+    def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: list[dict[str, Any]] | None = ..., report_evaluators: list[dict[str, Any]] | None = ...) -> dict[str, Any]:
+        '''Update an existing dataset.
 
         Args:
             id_or_name: The dataset ID (UUID) or name.
@@ -135,13 +141,17 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: New output type (generates schema).
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
+            evaluators: New dataset-level evaluator specs (`[{"name": ...,
+                "arguments": ...}]`). Pass `[]` to clear.
+            report_evaluators: New report-level evaluator specs. Pass `[]` to
+                clear.
 
         Returns:
             The updated dataset.
 
         Raises:
             DatasetNotFoundError: If the dataset does not exist.
-        """
+        '''
     def delete_dataset(self, id_or_name: str) -> None:
         """Delete a dataset and all its cases.
 
@@ -193,9 +203,9 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
 
         Args:
             dataset: The local `pydantic_evals.Dataset` to publish. Case-level
-                evaluators are uploaded with their cases. Dataset-level
-                `evaluators` and `report_evaluators` are not supported yet and
-                will raise `ValueError`.
+                evaluators are uploaded with their cases; dataset-level
+                `evaluators` and `report_evaluators` are uploaded as part of the
+                dataset itself and overwrite the hosted values on each push.
             name: Optional hosted dataset name override. Defaults to
                 `dataset.name`.
             description: Hosted dataset description. Omit this argument to leave
@@ -212,8 +222,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             `get_dataset(..., include_cases=False)`.
 
         Raises:
-            ValueError: If neither `dataset.name` nor `name` is provided, or if
-                the dataset contains unsupported dataset-level evaluators.
+            ValueError: If neither `dataset.name` nor `name` is provided.
             DatasetApiError: If the API returns an error other than the expected
                 `409` conflict used to trigger an update flow.
             DatasetNotFoundError: If the hosted dataset cannot be fetched after
@@ -316,7 +325,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
     @overload
     def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
     @overload
-    def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
+    def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (), custom_report_evaluator_types: Sequence[type[Any]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
 
 class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     """Asynchronous client for managing Logfire datasets.
@@ -328,9 +337,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     async def __aexit__(self, exc_type: type[BaseException] | None = None, exc_value: BaseException | None = None, traceback: TracebackType | None = None) -> None: ...
     async def list_datasets(self) -> list[dict[str, Any]]:
         """List all datasets."""
-    async def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None) -> dict[str, Any]:
+    async def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: list[dict[str, Any]] | None = None, report_evaluators: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         """Create a new dataset."""
-    async def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ...) -> dict[str, Any]:
+    async def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: list[dict[str, Any]] | None = ..., report_evaluators: list[dict[str, Any]] | None = ...) -> dict[str, Any]:
         """Update an existing dataset."""
     async def delete_dataset(self, id_or_name: str) -> None:
         """Delete a dataset."""
@@ -343,9 +352,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
 
         Args:
             dataset: The local `pydantic_evals.Dataset` to publish. Case-level
-                evaluators are uploaded with their cases. Dataset-level
-                `evaluators` and `report_evaluators` are not supported yet and
-                will raise `ValueError`.
+                evaluators are uploaded with their cases; dataset-level
+                `evaluators` and `report_evaluators` are uploaded as part of the
+                dataset itself and overwrite the hosted values on each push.
             name: Optional hosted dataset name override. Defaults to
                 `dataset.name`.
             description: Hosted dataset description. Omit this argument to leave
@@ -362,8 +371,7 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
             `get_dataset(..., include_cases=False)`.
 
         Raises:
-            ValueError: If neither `dataset.name` nor `name` is provided, or if
-                the dataset contains unsupported dataset-level evaluators.
+            ValueError: If neither `dataset.name` nor `name` is provided.
             DatasetApiError: If the API returns an error other than the expected
                 `409` conflict used to trigger an update flow.
             DatasetNotFoundError: If the hosted dataset cannot be fetched after
@@ -385,4 +393,4 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     @overload
     async def get_dataset(self, id_or_name: str, *, include_cases: bool = True) -> dict[str, Any]: ...
     @overload
-    async def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...
+    async def get_dataset(self, id_or_name: str, input_type: type[InputsT], output_type: type[OutputT] | None = None, metadata_type: type[MetadataT] | None = None, *, custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (), custom_report_evaluator_types: Sequence[type[Any]] = ()) -> Dataset[InputsT, OutputT, MetadataT]: ...

--- a/logfire-api/logfire_api/experimental/api_client.pyi
+++ b/logfire-api/logfire_api/experimental/api_client.pyi
@@ -4,7 +4,7 @@ from httpx import AsyncClient, Client, Timeout
 from httpx._client import BaseClient
 from logfire._internal.config import get_base_url_from_token as get_base_url_from_token
 from pydantic_evals import Case, Dataset
-from pydantic_evals.evaluators import Evaluator
+from pydantic_evals.evaluators import Evaluator, ReportEvaluator
 from types import TracebackType
 from typing import Any, Generic, Literal, TypeVar, overload
 from typing_extensions import Self
@@ -12,6 +12,7 @@ from typing_extensions import Self
 Case = Any
 Dataset = Any
 Evaluator = Any
+ReportEvaluator = Any
 DEFAULT_TIMEOUT: Incomplete
 T = TypeVar('T', bound=BaseClient)
 InputsT = TypeVar('InputsT')
@@ -90,7 +91,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         Returns:
             List of dataset summaries with id, name, description, case_count, etc.
         """
-    def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: list[dict[str, Any]] | None = None, report_evaluators: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: Sequence[Evaluator[Any, Any, Any]] | None = None, report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = None) -> dict[str, Any]:
         '''Create a new dataset with optional type schemas.
 
         Args:
@@ -99,12 +100,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: Type for expected outputs. JSON schema will be generated from this type.
             metadata_type: Type for case metadata. JSON schema will be generated from this type.
             description: Optional description of the dataset.
-            evaluators: Optional dataset-level evaluator specs in
-                `[{"name": "...", "arguments": {...}}]` format. Use
-                `_serialize_evaluators(dataset.evaluators)` to build from a
-                pydantic-evals Dataset.
-            report_evaluators: Optional report-level evaluator specs. Same shape
-                as `evaluators`.
+            evaluators: Optional dataset-level evaluators. Instances are serialized
+                to the hosted `{"name": ..., "arguments": ...}` format.
+            report_evaluators: Optional report-level evaluators, serialized the
+                same way.
 
         Returns:
             The created dataset.
@@ -131,8 +130,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             )
             ```
         '''
-    def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: list[dict[str, Any]] | None = ..., report_evaluators: list[dict[str, Any]] | None = ...) -> dict[str, Any]:
-        '''Update an existing dataset.
+    def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: Sequence[Evaluator[Any, Any, Any]] | None = ..., report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = ...) -> dict[str, Any]:
+        """Update an existing dataset.
 
         Args:
             id_or_name: The dataset ID (UUID) or name.
@@ -141,17 +140,17 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: New output type (generates schema).
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
-            evaluators: New dataset-level evaluator specs (`[{"name": ...,
-                "arguments": ...}]`). Pass None to clear.
-            report_evaluators: New report-level evaluator specs. Pass None to
-                clear.
+            evaluators: New dataset-level evaluators. Instances are serialized
+                for you. Pass None to clear.
+            report_evaluators: New report-level evaluators, serialized the same
+                way. Pass None to clear.
 
         Returns:
             The updated dataset.
 
         Raises:
             DatasetNotFoundError: If the dataset does not exist.
-        '''
+        """
     def delete_dataset(self, id_or_name: str) -> None:
         """Delete a dataset and all its cases.
 
@@ -337,9 +336,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     async def __aexit__(self, exc_type: type[BaseException] | None = None, exc_value: BaseException | None = None, traceback: TracebackType | None = None) -> None: ...
     async def list_datasets(self) -> list[dict[str, Any]]:
         """List all datasets."""
-    async def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: list[dict[str, Any]] | None = None, report_evaluators: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    async def create_dataset(self, name: str, *, input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = None, evaluators: Sequence[Evaluator[Any, Any, Any]] | None = None, report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = None) -> dict[str, Any]:
         """Create a new dataset."""
-    async def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: list[dict[str, Any]] | None = ..., report_evaluators: list[dict[str, Any]] | None = ...) -> dict[str, Any]:
+    async def update_dataset(self, id_or_name: str, *, name: str = ..., input_type: type[Any] | None = None, output_type: type[Any] | None = None, metadata_type: type[Any] | None = None, description: str | None = ..., evaluators: Sequence[Evaluator[Any, Any, Any]] | None = ..., report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = ...) -> dict[str, Any]:
         """Update an existing dataset."""
     async def delete_dataset(self, id_or_name: str) -> None:
         """Delete a dataset."""

--- a/logfire-api/logfire_api/experimental/api_client.pyi
+++ b/logfire-api/logfire_api/experimental/api_client.pyi
@@ -142,8 +142,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
             evaluators: New dataset-level evaluator specs (`[{"name": ...,
-                "arguments": ...}]`). Pass `[]` to clear.
-            report_evaluators: New report-level evaluator specs. Pass `[]` to
+                "arguments": ...}]`). Pass None to clear.
+            report_evaluators: New report-level evaluator specs. Pass None to
                 clear.
 
         Returns:

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -66,9 +66,9 @@ except ImportError as e:  # pragma: no cover
 
 if TYPE_CHECKING:
     from pydantic_evals import Case, Dataset
-    from pydantic_evals.evaluators import Evaluator
+    from pydantic_evals.evaluators import Evaluator, ReportEvaluator
 else:
-    Case = Dataset = Evaluator = Any  # type: ignore[assignment]
+    Case = Dataset = Evaluator = ReportEvaluator = Any  # type: ignore[assignment]
 
 DEFAULT_TIMEOUT = Timeout(30.0)
 
@@ -268,14 +268,15 @@ def _build_push_dataset_kwargs(
         create_kwargs['description'] = description
         update_kwargs['description'] = description
 
-    # Always pass `evaluators` / `report_evaluators` so subsequent pushes can clear
-    # them by sending []. `_serialize_evaluators` returns [] for an empty sequence.
-    dataset_evaluators = getattr(dataset, 'evaluators', None) or ()
-    dataset_report_evaluators = getattr(dataset, 'report_evaluators', None) or ()
-    create_kwargs['evaluators'] = _serialize_evaluators(dataset_evaluators)
-    update_kwargs['evaluators'] = _serialize_evaluators(dataset_evaluators)
-    create_kwargs['report_evaluators'] = _serialize_evaluators(dataset_report_evaluators)
-    update_kwargs['report_evaluators'] = _serialize_evaluators(dataset_report_evaluators)
+    # Always pass `evaluators` / `report_evaluators` so subsequent pushes can
+    # clear them by sending an empty sequence. `create_dataset` /
+    # `update_dataset` serialize the instances for us.
+    dataset_evaluators: Sequence[Any] = getattr(dataset, 'evaluators', None) or ()
+    dataset_report_evaluators: Sequence[Any] = getattr(dataset, 'report_evaluators', None) or ()
+    create_kwargs['evaluators'] = dataset_evaluators
+    update_kwargs['evaluators'] = dataset_evaluators
+    create_kwargs['report_evaluators'] = dataset_report_evaluators
+    update_kwargs['report_evaluators'] = dataset_report_evaluators
 
     return create_kwargs, update_kwargs
 
@@ -402,8 +403,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = None,
-        evaluators: list[dict[str, Any]] | None = None,
-        report_evaluators: list[dict[str, Any]] | None = None,
+        evaluators: Sequence[Evaluator[Any, Any, Any]] | None = None,
+        report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = None,
     ) -> dict[str, Any]:
         """Create a new dataset with optional type schemas.
 
@@ -413,12 +414,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: Type for expected outputs. JSON schema will be generated from this type.
             metadata_type: Type for case metadata. JSON schema will be generated from this type.
             description: Optional description of the dataset.
-            evaluators: Optional dataset-level evaluator specs in
-                `[{"name": "...", "arguments": {...}}]` format. Use
-                `_serialize_evaluators(dataset.evaluators)` to build from a
-                pydantic-evals Dataset.
-            report_evaluators: Optional report-level evaluator specs. Same shape
-                as `evaluators`.
+            evaluators: Optional dataset-level evaluators. Instances are serialized
+                to the hosted `{"name": ..., "arguments": ...}` format.
+            report_evaluators: Optional report-level evaluators, serialized the
+                same way.
 
         Returns:
             The created dataset.
@@ -458,9 +457,9 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
         if evaluators is not None:
-            data['evaluators'] = evaluators
+            data['evaluators'] = _serialize_evaluators(evaluators)
         if report_evaluators is not None:
-            data['report_evaluators'] = report_evaluators
+            data['report_evaluators'] = _serialize_evaluators(report_evaluators)
 
         response = self.client.post('/v1/datasets/', json=data)
         return self._handle_response(response)
@@ -474,8 +473,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = _UNSET,
-        evaluators: list[dict[str, Any]] | None = _UNSET,
-        report_evaluators: list[dict[str, Any]] | None = _UNSET,
+        evaluators: Sequence[Evaluator[Any, Any, Any]] | None = _UNSET,
+        report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = _UNSET,
     ) -> dict[str, Any]:
         """Update an existing dataset.
 
@@ -486,10 +485,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: New output type (generates schema).
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
-            evaluators: New dataset-level evaluator specs (`[{"name": ...,
-                "arguments": ...}]`). Pass None to clear.
-            report_evaluators: New report-level evaluator specs. Pass None to
-                clear.
+            evaluators: New dataset-level evaluators. Instances are serialized
+                for you. Pass None to clear.
+            report_evaluators: New report-level evaluators, serialized the same
+                way. Pass None to clear.
 
         Returns:
             The updated dataset.
@@ -510,9 +509,11 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
         if evaluators is not _UNSET:
-            data['evaluators'] = evaluators
+            data['evaluators'] = _serialize_evaluators(evaluators) if evaluators is not None else None
         if report_evaluators is not _UNSET:
-            data['report_evaluators'] = report_evaluators
+            data['report_evaluators'] = (
+                _serialize_evaluators(report_evaluators) if report_evaluators is not None else None
+            )
 
         response = self.client.patch(f'/v1/datasets/{id_or_name}/', json=data)
         return self._handle_response(response)
@@ -934,8 +935,8 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = None,
-        evaluators: list[dict[str, Any]] | None = None,
-        report_evaluators: list[dict[str, Any]] | None = None,
+        evaluators: Sequence[Evaluator[Any, Any, Any]] | None = None,
+        report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = None,
     ) -> dict[str, Any]:
         """Create a new dataset."""
         _validate_dataset_name(name)
@@ -949,9 +950,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
         if evaluators is not None:
-            data['evaluators'] = evaluators
+            data['evaluators'] = _serialize_evaluators(evaluators)
         if report_evaluators is not None:
-            data['report_evaluators'] = report_evaluators
+            data['report_evaluators'] = _serialize_evaluators(report_evaluators)
 
         response = await self.client.post('/v1/datasets/', json=data)
         return self._handle_response(response)
@@ -965,8 +966,8 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = _UNSET,
-        evaluators: list[dict[str, Any]] | None = _UNSET,
-        report_evaluators: list[dict[str, Any]] | None = _UNSET,
+        evaluators: Sequence[Evaluator[Any, Any, Any]] | None = _UNSET,
+        report_evaluators: Sequence[ReportEvaluator[Any, Any, Any]] | None = _UNSET,
     ) -> dict[str, Any]:
         """Update an existing dataset."""
         data: dict[str, Any] = {}
@@ -982,9 +983,11 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
         if evaluators is not _UNSET:
-            data['evaluators'] = evaluators
+            data['evaluators'] = _serialize_evaluators(evaluators) if evaluators is not None else None
         if report_evaluators is not _UNSET:
-            data['report_evaluators'] = report_evaluators
+            data['report_evaluators'] = (
+                _serialize_evaluators(report_evaluators) if report_evaluators is not None else None
+            )
 
         response = await self.client.patch(f'/v1/datasets/{id_or_name}/', json=data)
         return self._handle_response(response)

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -48,8 +48,11 @@ Example usage:
 
 from __future__ import annotations
 
+import inspect
 import re
+import warnings
 from collections.abc import Sequence
+from functools import cache
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
 
@@ -101,6 +104,51 @@ def _import_pydantic_evals() -> tuple[type, type]:
         return Dataset, Case
     except ImportError:
         raise ImportError('pydantic-evals is required for this operation. Install with: pip install pydantic-evals')
+
+
+@cache
+def _from_dict_supports_report_evaluators(dataset_cls: type) -> bool:
+    """Whether `Dataset.from_dict` accepts `custom_report_evaluator_types=` (added in pydantic-evals 1.58.0)."""
+    from_dict = getattr(dataset_cls, 'from_dict', None)
+    if from_dict is None:
+        return False
+    try:
+        params = inspect.signature(from_dict).parameters
+    except (TypeError, ValueError):
+        return False
+    return 'custom_report_evaluator_types' in params
+
+
+def _from_dict_compat(
+    typed_dataset_cls: Any,
+    data: dict[str, Any],
+    custom_evaluator_types: Sequence[type[Any]],
+    custom_report_evaluator_types: Sequence[type[Any]],
+) -> Any:
+    """Call `Dataset.from_dict` with best-effort compatibility for pre-1.58.0 pydantic-evals.
+
+    Older versions don't accept `custom_report_evaluator_types` and reject the
+    `report_evaluators` field on the input dict (`_DatasetModel` uses `extra='forbid'`).
+    On those installs we strip the field before calling `from_dict`, warning if the
+    server returned a non-empty list (the report evaluators are silently dropped).
+    """
+    if _from_dict_supports_report_evaluators(typed_dataset_cls):
+        return typed_dataset_cls.from_dict(
+            data,
+            custom_evaluator_types=list(custom_evaluator_types),
+            custom_report_evaluator_types=list(custom_report_evaluator_types),
+        )
+
+    if data.get('report_evaluators'):
+        warnings.warn(
+            'Hosted dataset has report_evaluators but the installed pydantic-evals does not '
+            'support them. Upgrade to pydantic-evals>=1.58.0 to deserialize report-level evaluators. '
+            'Dropping the field for now.',
+            UserWarning,
+            stacklevel=4,
+        )
+    stripped = {k: v for k, v in data.items() if k != 'report_evaluators'}
+    return typed_dataset_cls.from_dict(stripped, custom_evaluator_types=list(custom_evaluator_types))
 
 
 class DatasetNotFoundError(Exception):
@@ -875,11 +923,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
 
         Dataset, _ = _import_pydantic_evals()
         typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return typed_dataset_cls.from_dict(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-            data,
-            custom_evaluator_types=list(custom_evaluator_types),
-            custom_report_evaluator_types=list(custom_report_evaluator_types),
-        )
+        return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)
 
 
 class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
@@ -1184,8 +1228,4 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
 
         Dataset, _ = _import_pydantic_evals()
         typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return typed_dataset_cls.from_dict(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
-            data,
-            custom_evaluator_types=list(custom_evaluator_types),
-            custom_report_evaluator_types=list(custom_report_evaluator_types),
-        )
+        return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -242,17 +242,9 @@ def _get_dataset_type_args(dataset: Dataset[Any, Any, Any]) -> tuple[Any | None,
     return input_type, output_type, metadata_type
 
 
-def _validate_push_dataset(dataset: Dataset[Any, Any, Any]) -> None:
-    """Reject dataset-level features that hosted datasets do not yet support."""
-    if getattr(dataset, 'evaluators', ()) or getattr(dataset, 'report_evaluators', ()):
-        raise ValueError(
-            'push_dataset() does not support dataset-level evaluators or report_evaluators yet. '
-            'Only case-level evaluators are uploaded.'
-        )
-
-
 def _build_push_dataset_kwargs(
     *,
+    dataset: Dataset[Any, Any, Any],
     target_name: str,
     input_type: Any | None,
     output_type: Any | None,
@@ -275,6 +267,15 @@ def _build_push_dataset_kwargs(
     if description is not _UNSET:
         create_kwargs['description'] = description
         update_kwargs['description'] = description
+
+    # Always pass `evaluators` / `report_evaluators` so subsequent pushes can clear
+    # them by sending []. `_serialize_evaluators` returns [] for an empty sequence.
+    dataset_evaluators = getattr(dataset, 'evaluators', None) or ()
+    dataset_report_evaluators = getattr(dataset, 'report_evaluators', None) or ()
+    create_kwargs['evaluators'] = _serialize_evaluators(dataset_evaluators)
+    update_kwargs['evaluators'] = _serialize_evaluators(dataset_evaluators)
+    create_kwargs['report_evaluators'] = _serialize_evaluators(dataset_report_evaluators)
+    update_kwargs['report_evaluators'] = _serialize_evaluators(dataset_report_evaluators)
 
     return create_kwargs, update_kwargs
 
@@ -401,6 +402,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = None,
+        evaluators: list[dict[str, Any]] | None = None,
+        report_evaluators: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Create a new dataset with optional type schemas.
 
@@ -410,6 +413,12 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: Type for expected outputs. JSON schema will be generated from this type.
             metadata_type: Type for case metadata. JSON schema will be generated from this type.
             description: Optional description of the dataset.
+            evaluators: Optional dataset-level evaluator specs in
+                `[{"name": "...", "arguments": {...}}]` format. Use
+                `_serialize_evaluators(dataset.evaluators)` to build from a
+                pydantic-evals Dataset.
+            report_evaluators: Optional report-level evaluator specs. Same shape
+                as `evaluators`.
 
         Returns:
             The created dataset.
@@ -448,6 +457,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             data['output_schema'] = _type_to_schema(output_type)
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
+        if evaluators is not None:
+            data['evaluators'] = evaluators
+        if report_evaluators is not None:
+            data['report_evaluators'] = report_evaluators
 
         response = self.client.post('/v1/datasets/', json=data)
         return self._handle_response(response)
@@ -461,6 +474,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = _UNSET,
+        evaluators: list[dict[str, Any]] | None = _UNSET,
+        report_evaluators: list[dict[str, Any]] | None = _UNSET,
     ) -> dict[str, Any]:
         """Update an existing dataset.
 
@@ -471,6 +486,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             output_type: New output type (generates schema).
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
+            evaluators: New dataset-level evaluator specs (`[{"name": ...,
+                "arguments": ...}]`). Pass `[]` to clear.
+            report_evaluators: New report-level evaluator specs. Pass `[]` to
+                clear.
 
         Returns:
             The updated dataset.
@@ -490,6 +509,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             data['output_schema'] = _type_to_schema(output_type)
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
+        if evaluators is not _UNSET:
+            data['evaluators'] = evaluators
+        if report_evaluators is not _UNSET:
+            data['report_evaluators'] = report_evaluators
 
         response = self.client.patch(f'/v1/datasets/{id_or_name}/', json=data)
         return self._handle_response(response)
@@ -563,9 +586,9 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
 
         Args:
             dataset: The local `pydantic_evals.Dataset` to publish. Case-level
-                evaluators are uploaded with their cases. Dataset-level
-                `evaluators` and `report_evaluators` are not supported yet and
-                will raise `ValueError`.
+                evaluators are uploaded with their cases; dataset-level
+                `evaluators` and `report_evaluators` are uploaded as part of the
+                dataset itself and overwrite the hosted values on each push.
             name: Optional hosted dataset name override. Defaults to
                 `dataset.name`.
             description: Hosted dataset description. Omit this argument to leave
@@ -582,8 +605,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             `get_dataset(..., include_cases=False)`.
 
         Raises:
-            ValueError: If neither `dataset.name` nor `name` is provided, or if
-                the dataset contains unsupported dataset-level evaluators.
+            ValueError: If neither `dataset.name` nor `name` is provided.
             DatasetApiError: If the API returns an error other than the expected
                 `409` conflict used to trigger an update flow.
             DatasetNotFoundError: If the hosted dataset cannot be fetched after
@@ -619,14 +641,13 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             )
             ```
         """
-        _validate_push_dataset(dataset)
-
         target_name = dataset.name if name is None else name
         if not target_name:
             raise ValueError('push_dataset() requires a dataset name either on dataset.name or via name=')
 
         input_type, output_type, metadata_type = _get_dataset_type_args(dataset)
         create_kwargs, update_kwargs = _build_push_dataset_kwargs(
+            dataset=dataset,
             target_name=target_name,
             input_type=input_type,
             output_type=output_type,
@@ -781,6 +802,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         metadata_type: type[MetadataT] | None = None,
         *,
         custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (),
+        custom_report_evaluator_types: Sequence[type[Any]] = (),
     ) -> Dataset[InputsT, OutputT, MetadataT]: ...
 
     def get_dataset(
@@ -792,6 +814,7 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
         *,
         include_cases: bool = True,
         custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]] = (),
+        custom_report_evaluator_types: Sequence[type[Any]] = (),
     ) -> Dataset[InputsT, OutputT, MetadataT] | dict[str, Any]:
         """Get a dataset by ID or name.
 
@@ -813,7 +836,10 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             include_cases: Whether to include cases in the response. Defaults
                 to True. Set to False to retrieve only dataset metadata.
             custom_evaluator_types: Custom evaluator classes for deserializing
-                case-level evaluators stored in the dataset.
+                case-level and dataset-level evaluators stored in the dataset.
+            custom_report_evaluator_types: Custom report-evaluator classes for
+                deserializing report-level evaluators stored in the dataset.
+                Mirror of `Dataset.from_file(custom_report_evaluator_types=)`.
 
         Returns:
             A `pydantic_evals.Dataset` when `input_type` is provided, otherwise
@@ -848,7 +874,11 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
 
         Dataset, _ = _import_pydantic_evals()
         typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return typed_dataset_cls.from_dict(data, custom_evaluator_types=list(custom_evaluator_types))  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        return typed_dataset_cls.from_dict(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            data,
+            custom_evaluator_types=list(custom_evaluator_types),
+            custom_report_evaluator_types=list(custom_report_evaluator_types),
+        )
 
 
 class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
@@ -904,6 +934,8 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = None,
+        evaluators: list[dict[str, Any]] | None = None,
+        report_evaluators: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """Create a new dataset."""
         _validate_dataset_name(name)
@@ -916,6 +948,10 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
             data['output_schema'] = _type_to_schema(output_type)
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
+        if evaluators is not None:
+            data['evaluators'] = evaluators
+        if report_evaluators is not None:
+            data['report_evaluators'] = report_evaluators
 
         response = await self.client.post('/v1/datasets/', json=data)
         return self._handle_response(response)
@@ -929,6 +965,8 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         output_type: type[Any] | None = None,
         metadata_type: type[Any] | None = None,
         description: str | None = _UNSET,
+        evaluators: list[dict[str, Any]] | None = _UNSET,
+        report_evaluators: list[dict[str, Any]] | None = _UNSET,
     ) -> dict[str, Any]:
         """Update an existing dataset."""
         data: dict[str, Any] = {}
@@ -943,6 +981,10 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
             data['output_schema'] = _type_to_schema(output_type)
         if metadata_type is not None:
             data['metadata_schema'] = _type_to_schema(metadata_type)
+        if evaluators is not _UNSET:
+            data['evaluators'] = evaluators
+        if report_evaluators is not _UNSET:
+            data['report_evaluators'] = report_evaluators
 
         response = await self.client.patch(f'/v1/datasets/{id_or_name}/', json=data)
         return self._handle_response(response)
@@ -974,9 +1016,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
 
         Args:
             dataset: The local `pydantic_evals.Dataset` to publish. Case-level
-                evaluators are uploaded with their cases. Dataset-level
-                `evaluators` and `report_evaluators` are not supported yet and
-                will raise `ValueError`.
+                evaluators are uploaded with their cases; dataset-level
+                `evaluators` and `report_evaluators` are uploaded as part of the
+                dataset itself and overwrite the hosted values on each push.
             name: Optional hosted dataset name override. Defaults to
                 `dataset.name`.
             description: Hosted dataset description. Omit this argument to leave
@@ -993,21 +1035,19 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
             `get_dataset(..., include_cases=False)`.
 
         Raises:
-            ValueError: If neither `dataset.name` nor `name` is provided, or if
-                the dataset contains unsupported dataset-level evaluators.
+            ValueError: If neither `dataset.name` nor `name` is provided.
             DatasetApiError: If the API returns an error other than the expected
                 `409` conflict used to trigger an update flow.
             DatasetNotFoundError: If the hosted dataset cannot be fetched after
                 the push completes.
         """
-        _validate_push_dataset(dataset)
-
         target_name = dataset.name if name is None else name
         if not target_name:
             raise ValueError('push_dataset() requires a dataset name either on dataset.name or via name=')
 
         input_type, output_type, metadata_type = _get_dataset_type_args(dataset)
         create_kwargs, update_kwargs = _build_push_dataset_kwargs(
+            dataset=dataset,
             target_name=target_name,
             input_type=input_type,
             output_type=output_type,
@@ -1111,6 +1151,7 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         metadata_type: type[MetadataT] | None = None,
         *,
         custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (),
+        custom_report_evaluator_types: Sequence[type[Any]] = (),
     ) -> Dataset[InputsT, OutputT, MetadataT]: ...
 
     async def get_dataset(
@@ -1122,6 +1163,7 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
         *,
         include_cases: bool = True,
         custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]] = (),
+        custom_report_evaluator_types: Sequence[type[Any]] = (),
     ) -> Dataset[InputsT, OutputT, MetadataT] | dict[str, Any]:
         """Get a dataset by ID or name.
 
@@ -1139,4 +1181,8 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
 
         Dataset, _ = _import_pydantic_evals()
         typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return typed_dataset_cls.from_dict(data, custom_evaluator_types=list(custom_evaluator_types))  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+        return typed_dataset_cls.from_dict(  # pyright: ignore[reportUnknownMemberType,reportUnknownVariableType]
+            data,
+            custom_evaluator_types=list(custom_evaluator_types),
+            custom_report_evaluator_types=list(custom_report_evaluator_types),
+        )

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -140,12 +140,13 @@ def _from_dict_compat(
         )
 
     if data.get('report_evaluators'):
+        # Stack: _from_dict_compat -> get_dataset -> user. stacklevel=3 lands on user code.
         warnings.warn(
             'Hosted dataset has report_evaluators but the installed pydantic-evals does not '
             'support them. Upgrade to pydantic-evals>=1.58.0 to deserialize report-level evaluators. '
             'Dropping the field for now.',
             UserWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     stripped = {k: v for k, v in data.items() if k != 'report_evaluators'}
     return typed_dataset_cls.from_dict(stripped, custom_evaluator_types=list(custom_evaluator_types))

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -487,8 +487,8 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             metadata_type: New metadata type (generates schema).
             description: New description. Pass None to clear.
             evaluators: New dataset-level evaluator specs (`[{"name": ...,
-                "arguments": ...}]`). Pass `[]` to clear.
-            report_evaluators: New report-level evaluator specs. Pass `[]` to
+                "arguments": ...}]`). Pass None to clear.
+            report_evaluators: New report-level evaluator specs. Pass None to
                 clear.
 
         Returns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ aws-lambda = ["opentelemetry-instrumentation-aws-lambda >= 0.42b0"]
 google-genai = ["opentelemetry-instrumentation-google-genai >= 0.4b0"]
 litellm = ["openinference-instrumentation-litellm >= 0"]
 dspy = ["openinference-instrumentation-dspy >= 0"]
-datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.0.0; python_version >= '3.10'"]
+datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.58.0; python_version >= '3.10'"]
 variables = ["pydantic>=2"]
 
 [project.urls]
@@ -182,7 +182,7 @@ dev = [
     "pytest-xdist>=3.6.1",
     "openai-agents[voice]>=0.9.0; python_version >= '3.10'",
     "pydantic-ai-slim>=0.0.39",
-    "pydantic-evals>=1.0.0; python_version >= '3.10'",
+    "pydantic-evals>=1.58.0; python_version >= '3.10'",
     "langchain>=0.0.27",
     "langchain-openai>=0.3.17",
     "langgraph >= 0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ aws-lambda = ["opentelemetry-instrumentation-aws-lambda >= 0.42b0"]
 google-genai = ["opentelemetry-instrumentation-google-genai >= 0.4b0"]
 litellm = ["openinference-instrumentation-litellm >= 0"]
 dspy = ["openinference-instrumentation-dspy >= 0"]
-datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.58.0; python_version >= '3.10'"]
+datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.0.0; python_version >= '3.10'"]
 variables = ["pydantic>=2"]
 
 [project.urls]
@@ -182,7 +182,7 @@ dev = [
     "pytest-xdist>=3.6.1",
     "openai-agents[voice]>=0.9.0; python_version >= '3.10'",
     "pydantic-ai-slim>=0.0.39",
-    "pydantic-evals>=1.58.0; python_version >= '3.10'",
+    "pydantic-evals>=1.0.0; python_version >= '3.10'",
     "langchain>=0.0.27",
     "langchain-openai>=0.3.17",
     "langgraph >= 0",

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -341,6 +341,20 @@ class TestFromDictCompat:
 
         assert _from_dict_supports_report_evaluators(Legacy) is False
 
+    def test_returns_false_when_class_has_no_from_dict(self):
+        class NoFromDict:
+            pass
+
+        assert _from_dict_supports_report_evaluators(NoFromDict) is False
+
+    def test_returns_false_when_signature_inspection_fails(self):
+        class WeirdFromDict:
+            # Set `from_dict` to a built-in whose signature can't be introspected,
+            # so `inspect.signature` raises ValueError.
+            from_dict = staticmethod(min)
+
+        assert _from_dict_supports_report_evaluators(WeirdFromDict) is False
+
     def test_modern_path_passes_through_kwarg(self):
         captured: dict[str, Any] = {}
 

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -32,7 +32,6 @@ from logfire.experimental.api_client import (
     _serialize_value,
     _type_to_schema,
     _validate_dataset_name,
-    _validate_push_dataset,
 )
 
 # --- Test types ---
@@ -364,18 +363,37 @@ class TestPushDatasetHelpers:
         assert _get_dataset_type_args(cast(Any, DatasetLike())) == (None, None, None)
 
     def test_build_push_dataset_kwargs_minimal(self):
-        create_kwargs, update_kwargs = _build_push_dataset_kwargs(
-            target_name='test-dataset', input_type=None, output_type=None, metadata_type=None
-        )
-        assert create_kwargs == {'name': 'test-dataset'}
-        assert update_kwargs == {}
-
-    def test_validate_push_dataset_report_evaluators(self):
         dataset = make_local_dataset()
-        dataset.report_evaluators = cast(Any, [object()])
+        create_kwargs, update_kwargs = _build_push_dataset_kwargs(
+            dataset=dataset, target_name='test-dataset', input_type=None, output_type=None, metadata_type=None
+        )
+        # `evaluators` / `report_evaluators` are always sent so a subsequent push that drops them
+        # locally also clears the hosted side.
+        assert create_kwargs == {'name': 'test-dataset', 'evaluators': [], 'report_evaluators': []}
+        assert update_kwargs == {'evaluators': [], 'report_evaluators': []}
 
-        with pytest.raises(ValueError, match='dataset-level evaluators or report_evaluators'):
-            _validate_push_dataset(dataset)
+    def test_build_push_dataset_kwargs_includes_dataset_and_report_evaluators(self):
+        @dataclass
+        class DatasetEval:
+            threshold: float = 0.9
+
+        @dataclass
+        class ReportEval:
+            min_pass_rate: float = 0.5
+
+        dataset = make_local_dataset()
+        dataset.evaluators = cast(Any, [DatasetEval(threshold=0.95)])
+        dataset.report_evaluators = cast(Any, [ReportEval(min_pass_rate=0.8)])
+
+        create_kwargs, update_kwargs = _build_push_dataset_kwargs(
+            dataset=dataset, target_name='test-dataset', input_type=None, output_type=None, metadata_type=None
+        )
+        expected_eval = [{'name': 'DatasetEval', 'arguments': {'threshold': 0.95}}]
+        expected_report_eval = [{'name': 'ReportEval', 'arguments': {'min_pass_rate': 0.8}}]
+        assert create_kwargs['evaluators'] == expected_eval
+        assert create_kwargs['report_evaluators'] == expected_report_eval
+        assert update_kwargs['evaluators'] == expected_eval
+        assert update_kwargs['report_evaluators'] == expected_report_eval
 
 
 # =============================================================================
@@ -729,13 +747,39 @@ class TestLogfireAPIClient:
         with pytest.raises(ValueError, match='requires a dataset name'):
             client.push_dataset(dataset)
 
-    def test_push_dataset_rejects_dataset_level_evaluators(self):
-        client = make_client()
-        dataset = make_local_dataset()
-        dataset.evaluators = cast(Any, [object()])
+    def test_push_dataset_uploads_dataset_level_evaluators(self):
+        @dataclass
+        class DatasetEval:
+            threshold: float = 0.9
 
-        with pytest.raises(ValueError, match='dataset-level evaluators or report_evaluators'):
-            client.push_dataset(dataset)
+        @dataclass
+        class ReportEval:
+            min_pass_rate: float = 0.5
+
+        requests_seen: list[httpx.Request] = []
+        dataset = make_local_dataset()
+        dataset.evaluators = cast(Any, [DatasetEval(threshold=0.95)])
+        dataset.report_evaluators = cast(Any, [ReportEval(min_pass_rate=0.8)])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requests_seen.append(request)
+            if request.method == 'POST' and request.url.path == '/v1/datasets/':
+                return httpx.Response(200, json=FAKE_DATASET)
+            if request.method == 'POST' and request.url.path.endswith('/import/'):
+                return httpx.Response(200, json=[FAKE_CASE])
+            if request.method == 'GET' and request.url.path == '/v1/datasets/local-dataset/':
+                return httpx.Response(200, json=FAKE_DATASET)
+            return httpx.Response(404, json={'detail': 'Not found'})
+
+        client = LogfireAPIClient(
+            client=httpx.Client(transport=httpx.MockTransport(handler), base_url='https://test.logfire.dev')
+        )
+        client.push_dataset(dataset)
+
+        create_request = next(r for r in requests_seen if r.method == 'POST' and r.url.path == '/v1/datasets/')
+        body = json.loads(create_request.content)
+        assert body['evaluators'] == [{'name': 'DatasetEval', 'arguments': {'threshold': 0.95}}]
+        assert body['report_evaluators'] == [{'name': 'ReportEval', 'arguments': {'min_pass_rate': 0.8}}]
 
     def test_push_dataset_propagates_non_conflict_error(self):
         client = make_client(

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -367,12 +367,16 @@ class TestPushDatasetHelpers:
         create_kwargs, update_kwargs = _build_push_dataset_kwargs(
             dataset=dataset, target_name='test-dataset', input_type=None, output_type=None, metadata_type=None
         )
-        # `evaluators` / `report_evaluators` are always sent so a subsequent push that drops them
-        # locally also clears the hosted side.
-        assert create_kwargs == {'name': 'test-dataset', 'evaluators': [], 'report_evaluators': []}
-        assert update_kwargs == {'evaluators': [], 'report_evaluators': []}
+        # `evaluators` / `report_evaluators` are always forwarded — empty sequences
+        # so a subsequent push that drops them locally also clears the hosted side.
+        # Serialization happens inside create_dataset / update_dataset.
+        assert create_kwargs['name'] == 'test-dataset'
+        assert list(create_kwargs['evaluators']) == []
+        assert list(create_kwargs['report_evaluators']) == []
+        assert list(update_kwargs['evaluators']) == []
+        assert list(update_kwargs['report_evaluators']) == []
 
-    def test_build_push_dataset_kwargs_includes_dataset_and_report_evaluators(self):
+    def test_build_push_dataset_kwargs_forwards_dataset_and_report_evaluator_instances(self):
         @dataclass
         class DatasetEval:
             threshold: float = 0.9
@@ -381,19 +385,21 @@ class TestPushDatasetHelpers:
         class ReportEval:
             min_pass_rate: float = 0.5
 
+        dataset_eval = DatasetEval(threshold=0.95)
+        report_eval = ReportEval(min_pass_rate=0.8)
         dataset = make_local_dataset()
-        dataset.evaluators = cast(Any, [DatasetEval(threshold=0.95)])
-        dataset.report_evaluators = cast(Any, [ReportEval(min_pass_rate=0.8)])
+        dataset.evaluators = cast(Any, [dataset_eval])
+        dataset.report_evaluators = cast(Any, [report_eval])
 
         create_kwargs, update_kwargs = _build_push_dataset_kwargs(
             dataset=dataset, target_name='test-dataset', input_type=None, output_type=None, metadata_type=None
         )
-        expected_eval = [{'name': 'DatasetEval', 'arguments': {'threshold': 0.95}}]
-        expected_report_eval = [{'name': 'ReportEval', 'arguments': {'min_pass_rate': 0.8}}]
-        assert create_kwargs['evaluators'] == expected_eval
-        assert create_kwargs['report_evaluators'] == expected_report_eval
-        assert update_kwargs['evaluators'] == expected_eval
-        assert update_kwargs['report_evaluators'] == expected_report_eval
+        # The helper forwards raw instances; create_dataset / update_dataset do the
+        # serialization via `_serialize_evaluators`.
+        assert list(create_kwargs['evaluators']) == [dataset_eval]
+        assert list(create_kwargs['report_evaluators']) == [report_eval]
+        assert list(update_kwargs['evaluators']) == [dataset_eval]
+        assert list(update_kwargs['report_evaluators']) == [report_eval]
 
 
 # =============================================================================

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from dataclasses import dataclass
 from typing import Any, cast
 from unittest.mock import patch
@@ -25,6 +26,8 @@ from logfire.experimental.api_client import (
     DatasetNotFoundError,
     LogfireAPIClient,
     _build_push_dataset_kwargs,
+    _from_dict_compat,
+    _from_dict_supports_report_evaluators,
     _get_dataset_type_args,
     _import_pydantic_evals,
     _serialize_case,
@@ -309,6 +312,79 @@ class TestImportPydanticEvals:
         with patch.dict('sys.modules', {'pydantic_evals': None}):
             with pytest.raises(ImportError, match='pydantic-evals is required'):
                 _import_pydantic_evals()
+
+
+class TestFromDictCompat:
+    """`get_dataset` shim that lets the SDK keep working on pydantic-evals < 1.58.0."""
+
+    def test_supports_when_kwarg_present(self):
+        class Modern:
+            @classmethod
+            def from_dict(
+                cls,
+                data: dict[str, Any],
+                custom_evaluator_types: Any = (),
+                custom_report_evaluator_types: Any = (),
+                default_name: str | None = None,
+            ) -> Any:
+                return ('called', data, list(custom_evaluator_types), list(custom_report_evaluator_types))
+
+        assert _from_dict_supports_report_evaluators(Modern) is True
+
+    def test_does_not_support_when_kwarg_absent(self):
+        class Legacy:
+            @classmethod
+            def from_dict(
+                cls, data: dict[str, Any], custom_evaluator_types: Any = (), default_name: str | None = None
+            ) -> Any:
+                return ('legacy', data, list(custom_evaluator_types))
+
+        assert _from_dict_supports_report_evaluators(Legacy) is False
+
+    def test_modern_path_passes_through_kwarg(self):
+        captured: dict[str, Any] = {}
+
+        class Modern:
+            @classmethod
+            def from_dict(
+                cls, data: dict[str, Any], custom_evaluator_types: Any = (), custom_report_evaluator_types: Any = ()
+            ) -> Any:
+                captured['custom_report_evaluator_types'] = list(custom_report_evaluator_types)
+                return ('ok', data)
+
+        result = _from_dict_compat(Modern, {'cases': [], 'report_evaluators': [{'name': 'X'}]}, [int], [str])
+        assert result == ('ok', {'cases': [], 'report_evaluators': [{'name': 'X'}]})
+        assert captured['custom_report_evaluator_types'] == [str]
+
+    def test_legacy_path_strips_report_evaluators_silently_when_empty(self):
+        seen: dict[str, Any] = {}
+
+        class Legacy:
+            @classmethod
+            def from_dict(cls, data: dict[str, Any], custom_evaluator_types: Any = ()) -> Any:
+                seen['data'] = data
+                return ('legacy', data)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            # Empty report_evaluators should not warn, just get stripped.
+            _from_dict_compat(Legacy, {'cases': [], 'report_evaluators': []}, [], [])
+        assert 'report_evaluators' not in seen['data']
+
+    def test_legacy_path_warns_when_dropping_non_empty(self):
+        class Legacy:
+            @classmethod
+            def from_dict(cls, data: dict[str, Any], custom_evaluator_types: Any = ()) -> Any:
+                return data
+
+        with pytest.warns(UserWarning, match=r'pydantic-evals>=1\.58\.0'):
+            result = _from_dict_compat(
+                Legacy,
+                {'cases': [], 'report_evaluators': [{'name': 'PassRate'}]},
+                [],
+                [],
+            )
+        assert 'report_evaluators' not in result
 
 
 class TestValidateDatasetName:

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-14T12:33:37.222577Z"
+exclude-newer = "2026-04-16T20:33:02.253206Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -717,7 +717,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy'" },
+    { name = "pycparser", version = "2.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10' and implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
     { name = "pycparser", version = "3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
@@ -1614,7 +1614,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3674,7 +3674,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=4.23.4" },
     { name = "pydantic", marker = "extra == 'datasets'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'variables'", specifier = ">=2" },
-    { name = "pydantic-evals", marker = "python_full_version >= '3.10' and extra == 'datasets'", specifier = ">=1.0.0" },
+    { name = "pydantic-evals", marker = "python_full_version >= '3.10' and extra == 'datasets'", specifier = ">=1.58.0" },
     { name = "rich", specifier = ">=13.4.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "typing-extensions", specifier = ">=4.1.0" },
@@ -3750,7 +3750,7 @@ dev = [
     { name = "pyarrow", marker = "python_full_version >= '3.13'", specifier = ">=18.1.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-ai-slim", specifier = ">=0.0.39" },
-    { name = "pydantic-evals", marker = "python_full_version >= '3.10'", specifier = ">=1.0.0" },
+    { name = "pydantic-evals", marker = "python_full_version >= '3.10'", specifier = ">=1.58.0" },
     { name = "pymongo", specifier = ">=4.10.1" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "pyright", specifier = "!=1.1.407" },

--- a/uv.lock
+++ b/uv.lock
@@ -20,7 +20,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-16T20:33:02.253206Z"
+exclude-newer = "2026-04-16T21:55:02.217004Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -3674,7 +3674,7 @@ requires-dist = [
     { name = "protobuf", specifier = ">=4.23.4" },
     { name = "pydantic", marker = "extra == 'datasets'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'variables'", specifier = ">=2" },
-    { name = "pydantic-evals", marker = "python_full_version >= '3.10' and extra == 'datasets'", specifier = ">=1.58.0" },
+    { name = "pydantic-evals", marker = "python_full_version >= '3.10' and extra == 'datasets'", specifier = ">=1.0.0" },
     { name = "rich", specifier = ">=13.4.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
     { name = "typing-extensions", specifier = ">=4.1.0" },
@@ -3750,7 +3750,7 @@ dev = [
     { name = "pyarrow", marker = "python_full_version >= '3.13'", specifier = ">=18.1.0" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pydantic-ai-slim", specifier = ">=0.0.39" },
-    { name = "pydantic-evals", marker = "python_full_version >= '3.10'", specifier = ">=1.58.0" },
+    { name = "pydantic-evals", marker = "python_full_version >= '3.10'", specifier = ">=1.0.0" },
     { name = "pymongo", specifier = ">=4.10.1" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "pyright", specifier = "!=1.1.407" },


### PR DESCRIPTION
## Summary

The hosted Datasets API now persists `Dataset.evaluators` and `Dataset.report_evaluators` (companion platform PR https://github.com/pydantic/platform/pull/20399 adds the columns + routes), so the SDK no longer has to reject them. This PR plumbs both fields through `push_dataset`, `create_dataset` / `update_dataset`, and `get_dataset`.

- Drops `_validate_push_dataset` (and the test that relied on it).
- `create_dataset` / `update_dataset` (sync + async) accept new `evaluators` / `report_evaluators` kwargs and forward them to the `/v1/datasets` endpoints.
- `_build_push_dataset_kwargs` always sends serialized `evaluators` / `report_evaluators` (empty list if none) so a subsequent push that drops them locally also clears the hosted side. New unit test covers this; existing test that asserted rejection becomes one that asserts upload.
- `get_dataset` (sync + async) gains `custom_report_evaluator_types` and threads it into `Dataset.from_dict`, mirroring `Dataset.from_file`'s signature.
- Docs (`docs/evaluate/datasets/sdk.md`) replace the "not supported yet" callout with a description of the round-trip behavior plus the new `custom_report_evaluator_types` parameter.
- Stub for `logfire_api` regenerated for the affected file.

## Test plan
- [x] `make lint` passes.
- [x] `make typecheck` passes (0 errors).
- [x] `uv run pytest tests/test_datasets_client.py` — all 101 tests pass, including the new `test_push_dataset_uploads_dataset_level_evaluators` and updated `test_build_push_dataset_kwargs_minimal`.
- [ ] After the platform PR ships and the SDK is released: re-run `platform/src/demos/logfire_demo/datasets_sdk_demo.py` to confirm `push_dataset` round-trips both fields and `get_dataset(custom_report_evaluator_types=[...])` deserializes the report evaluators.