### PR TITLE
Drop model_info warning filter; catch UserWarning in conftest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,15 +334,6 @@ filterwarnings = [
     "ignore:Inheritance class _InstrumentedApplication from web.Application is discouraged:DeprecationWarning",
     # anthropic SDK warns when using older models that are still recorded in test cassettes
     "ignore:The model 'claude-.*' is deprecated.*:DeprecationWarning",
-    # openai-agents 0.14+ defines a `DynamicCompactionPolicy` model with a `model_info` field.
-    # Pydantic 2.4–2.9 emit a UserWarning at class-definition time about its `model_` protected
-    # namespace; the wording changed in 2.9 to include the class name (hence the `.*` in the
-    # middle of the pattern), and 2.10+ no longer emit it at all. Without this filter,
-    # `import agents` aborts test collection on those older versions because
-    # `filterwarnings=error` above turns it into an exception. Older pydantic versions are
-    # only exercised by the weekly job (.github/workflows/weekly_deps_test.yml). Upstream fix
-    # would be `model_config['protected_namespaces'] = ()` in agents itself.
-    'ignore:Field "model_info".*has conflict with protected namespace "model_".*:UserWarning',
 ]
 DJANGO_SETTINGS_MODULE = "tests.otel_integrations.django_test_project.django_test_site.settings"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,11 @@ try:
 
     get_trace_provider().shutdown()
     get_trace_provider().set_processors([])
-except ImportError:
+except (ImportError, UserWarning):
+    # On pydantic <2.10, openai-agents 0.14+ emits a `model_info` protected-namespace
+    # UserWarning during class construction that gets promoted to an exception by
+    # `filterwarnings=error`. Test modules that need the agents API guard themselves
+    # with `pytest.importorskip`, which silences warnings inside its own catch_warnings.
     pass
 
 logfire.configure(send_to_logfire=False)


### PR DESCRIPTION
On pydantic <2.10, openai-agents 0.14+ emits a `model_info` protected-namespace `UserWarning` during `DynamicCompactionPolicy`'s class construction, which `filterwarnings=error` promotes to an exception. That aborts test collection in `conftest.py` at `from agents.tracing import get_trace_provider`.

Catching `UserWarning` alongside `ImportError` is enough — `pytest.importorskip` in the test modules that need the agents API already silences warnings inside its own `catch_warnings` block, so the warning fires (and is silenced) exactly once when those tests load. No global `filterwarnings` entry needed.

Only exercised by `.github/workflows/weekly_deps_test.yml` (pydantic 2.4–2.9 jobs).