### PR TITLE
fix(openai): recognize Responses API input_text/input_image/input_file content parts

### DIFF
--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -282,17 +282,28 @@ def _convert_content_part(part: object) -> MessagePart:
 
     part = cast('dict[str, Any]', part)
     part_type = part.get('type', 'unknown')
-    if part_type in ('text', 'output_text'):
+    if part_type in ('text', 'output_text', 'input_text'):
         return TextPart(type='text', content=part.get('text', ''))
     elif part_type == 'image_url':  # pragma: no cover
         url = part.get('image_url', {}).get('url', '')
         return UriPart(type='uri', uri=url, modality='image')
+    elif part_type == 'input_image':
+        # Responses API: image_url is a flat string (URL or data URI),
+        # not the nested {url: ...} dict used by Chat Completions.
+        return UriPart(type='uri', uri=part.get('image_url', ''), modality='image')
     elif part_type == 'input_audio':  # pragma: no cover
         return BlobPart(
             type='blob',
             content=part.get('input_audio', {}).get('data', ''),
             modality='audio',
         )
+    elif part_type == 'input_file':
+        # Responses API input_file may carry file_url, file_data (data URI),
+        # or just file_id. Prefer URI-bearing fields; fall through for file_id.
+        uri = part.get('file_url') or part.get('file_data')
+        if uri:
+            return UriPart(type='uri', uri=uri, modality='document')
+        return {**part, 'type': part_type}
     else:  # pragma: no cover
         # Return as generic dict for unknown types
         return {**part, 'type': part_type}
@@ -728,10 +739,10 @@ def input_to_events(inp: dict[str, Any], tool_call_id_to_name: dict[str, str]):
             else:
                 for content_item in content:
                     with contextlib.suppress(KeyError):
-                        if content_item['type'] == 'output_text':
+                        if content_item['type'] in ('output_text', 'input_text'):
                             events.append({'event.name': event_name, 'content': content_item['text'], 'role': role})
                             continue
-                    events.append(unknown_event(content_item))  # pragma: no cover
+                    events.append(unknown_event(content_item))
         elif typ == 'function_call':
             tool_call_id_to_name[inp['call_id']] = inp['name']
             events.append(

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -4319,6 +4319,95 @@ def test_convert_responses_inputs_no_inputs() -> None:
     assert (input_messages, system_instructions) == snapshot(([], [{'type': 'text', 'content': 'Be helpful'}]))
 
 
+def test_convert_responses_inputs_input_text() -> None:
+    """Responses API `input_text` content parts should map to TextPart."""
+    from logfire._internal.integrations.llm_providers.openai import convert_responses_inputs_to_semconv
+
+    inputs: list[dict[str, Any]] = [{'role': 'user', 'content': [{'type': 'input_text', 'text': 'Hello there'}]}]
+    input_messages, system_instructions = convert_responses_inputs_to_semconv(inputs, None)
+    assert (input_messages, system_instructions) == snapshot(
+        ([{'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello there'}]}], [])
+    )
+
+
+def test_convert_responses_inputs_input_image() -> None:
+    """Responses API `input_image` content parts should map to UriPart with modality=image."""
+    from logfire._internal.integrations.llm_providers.openai import convert_responses_inputs_to_semconv
+
+    inputs: list[dict[str, Any]] = [
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'input_text', 'text': 'What is in this image?'},
+                {'type': 'input_image', 'image_url': 'https://example.com/cat.jpg'},
+            ],
+        }
+    ]
+    input_messages, system_instructions = convert_responses_inputs_to_semconv(inputs, None)
+    assert (input_messages, system_instructions) == snapshot(
+        (
+            [
+                {
+                    'role': 'user',
+                    'parts': [
+                        {'type': 'text', 'content': 'What is in this image?'},
+                        {'type': 'uri', 'uri': 'https://example.com/cat.jpg', 'modality': 'image'},
+                    ],
+                }
+            ],
+            [],
+        )
+    )
+
+
+def test_convert_responses_inputs_input_file() -> None:
+    """Responses API `input_file` should map to UriPart for file_url / file_data, dict for file_id-only."""
+    from logfire._internal.integrations.llm_providers.openai import convert_responses_inputs_to_semconv
+
+    inputs: list[dict[str, Any]] = [
+        {
+            'role': 'user',
+            'content': [
+                {'type': 'input_file', 'file_url': 'https://example.com/doc.pdf'},
+                {'type': 'input_file', 'file_data': 'data:application/pdf;base64,JVBERi0x'},
+                {'type': 'input_file', 'file_id': 'file-abc123'},
+            ],
+        }
+    ]
+    input_messages, system_instructions = convert_responses_inputs_to_semconv(inputs, None)
+    assert (input_messages, system_instructions) == snapshot(
+        (
+            [
+                {
+                    'role': 'user',
+                    'parts': [
+                        {'type': 'uri', 'uri': 'https://example.com/doc.pdf', 'modality': 'document'},
+                        {
+                            'type': 'uri',
+                            'uri': 'data:application/pdf;base64,JVBERi0x',
+                            'modality': 'document',
+                        },
+                        {'type': 'input_file', 'file_id': 'file-abc123'},
+                    ],
+                }
+            ],
+            [],
+        )
+    )
+
+
+def test_input_to_events_input_text() -> None:
+    """input_to_events should recognize Responses API `input_text` (legacy semconv path)."""
+    from logfire._internal.integrations.llm_providers.openai import input_to_events
+
+    inp: dict[str, Any] = {
+        'role': 'user',
+        'content': [{'type': 'input_text', 'text': 'Hello there'}],
+    }
+    events = input_to_events(inp, {})
+    assert events == snapshot([{'event.name': 'gen_ai.user.message', 'content': 'Hello there', 'role': 'user'}])
+
+
 def test_convert_responses_inputs_function_call_non_string_args() -> None:
     """Test convert_responses_inputs_to_semconv with function_call with dict arguments."""
     from logfire._internal.integrations.llm_providers.openai import convert_responses_inputs_to_semconv


### PR DESCRIPTION
## Summary

Fixes #1901.

`logfire.instrument_openai()` currently produces `gen_ai.unknown` events for the standard Responses API content types — `input_text`, `input_image`, `input_file` — because `_convert_content_part` (latest semconv path) and `input_to_events` (legacy semconv path) only know about Chat Completions types (`text`, `output_text`, `image_url`, `input_audio`). Any non-trivial Responses API call (multi-part user message, image input, file input) ends up with most of its content as `gen_ai.unknown`, even though the payload is exactly what the [OpenAI docs](https://developers.openai.com/api/docs/guides/images-vision?format=base64-encoded) prescribe.

This PR teaches both code paths the three missing types.

### Mapping

| Responses API part | semconv mapping | Notes |
|---|---|---|
| `input_text` | `TextPart` (latest) / `gen_ai.{role}.message` (legacy) | Same shape as `output_text`, just on the input side. |
| `input_image` | `UriPart(modality='image')` | `image_url` here is a **flat string** (URL or data URI), distinct from Chat Completions where it's a nested `{url: ...}` dict. |
| `input_file` | `UriPart(modality='document')` when `file_url` or `file_data` is present | `file_id`-only inputs fall through to a generic dict, since there's no URI to point at and no obvious semconv mapping for an opaque ID. |

### Test plan

- [x] Added 4 unit tests covering the three new types in `_convert_content_part_or_parts` and the `input_text` branch in `input_to_events`.
- [x] Full `tests/otel_integrations/test_openai.py` passes (65 tests).
- [x] `tests/otel_integrations/test_openai_agents.py` and `tests/otel_integrations/test_litellm.py` (which share `input_to_events`) pass.
- [x] `ruff check` + `ruff format --check` clean.

I deliberately kept the legacy `input_to_events` change to just `input_text` (mirroring how `output_text` is the only recognized non-string content there) — adding image/file support to the legacy semconv path would require designing a new event shape for media, and that path is on its way out per #1586. Happy to extend if you'd prefer.

Related: #1476, #1586, #1769.