### PR TITLE
feat: add X-Logfire-Telemetry header

### DIFF
--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -22,11 +22,10 @@ from logfire.propagate import ContextCarrier, get_context
 
 from ...version import VERSION
 from ..auth import HOME_LOGFIRE
-from ..client import LogfireClient
+from ..client import UA_HEADER, LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
 from ..server_response import install_logfire_response_hook
-from ..telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from ..tracer import SDKTracerProvider
 from .auth import parse_auth, parse_logout
 from .prompt import parse_prompt
@@ -449,7 +448,7 @@ def _main(args: list[str] | None = None) -> None:
             context = get_context()
             session.hooks = {'response': [functools.partial(log_trace_id, context=context)]}
             session.headers.update(context)
-            session.headers[TELEMETRY_HEADER_NAME] = build_telemetry_header()
+            session.headers['User-Agent'] = UA_HEADER
             install_logfire_response_hook(session)
             namespace._session = session
             namespace.func(namespace)

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -26,6 +26,7 @@ from ..client import LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
 from ..server_response import install_logfire_response_hook
+from ..telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from ..tracer import SDKTracerProvider
 from .auth import parse_auth, parse_logout
 from .prompt import parse_prompt
@@ -448,6 +449,7 @@ def _main(args: list[str] | None = None) -> None:
             context = get_context()
             session.hooks = {'response': [functools.partial(log_trace_id, context=context)]}
             session.headers.update(context)
+            session.headers[TELEMETRY_HEADER_NAME] = build_telemetry_header()
             install_logfire_response_hook(session)
             namespace._session = session
             namespace.func(namespace)

--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -11,6 +11,7 @@ from logfire.version import VERSION
 
 from .auth import UserToken, UserTokenCollection
 from .server_response import ServerResponseCallback, install_logfire_response_hook
+from .telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from .utils import UnexpectedResponse
 
 UA_HEADER = f'logfire/{VERSION}'
@@ -44,7 +45,13 @@ class LogfireClient:
         self.base_url = user_token.base_url
         self._token = user_token.token
         self._session = Session()
-        self._session.headers.update({'Authorization': self._token, 'User-Agent': UA_HEADER})
+        self._session.headers.update(
+            {
+                'Authorization': self._token,
+                'User-Agent': UA_HEADER,
+                TELEMETRY_HEADER_NAME: build_telemetry_header(),
+            }
+        )
         install_logfire_response_hook(self._session, server_response_hook)
 
     @classmethod

--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 from typing import Any
 from urllib.parse import urljoin
 
@@ -11,10 +12,13 @@ from logfire.version import VERSION
 
 from .auth import UserToken, UserTokenCollection
 from .server_response import ServerResponseCallback, install_logfire_response_hook
-from .telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from .utils import UnexpectedResponse
 
-UA_HEADER = f'logfire/{VERSION}'
+UA_HEADER = (
+    f'logfire-sdk-python/{VERSION} '
+    f'({platform.python_implementation()} {platform.python_version()}, '
+    f'os {platform.platform()}, arch {platform.machine()})'
+)
 
 
 class ProjectAlreadyExists(Exception):
@@ -49,7 +53,6 @@ class LogfireClient:
             {
                 'Authorization': self._token,
                 'User-Agent': UA_HEADER,
-                TELEMETRY_HEADER_NAME: build_telemetry_header(),
             }
         )
         install_logfire_response_hook(self._session, server_response_hook)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -112,6 +112,7 @@ from .metrics import ProxyMeterProvider
 from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions
 from .server_response import ServerResponseCallback, install_logfire_response_hook
 from .stack_info import warn_at_user_stacklevel
+from .telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from .tracer import OPEN_SPANS, PendingSpanProcessor, ProxyTracerProvider
 from .utils import (
     SeededRandomIdGenerator,
@@ -935,6 +936,9 @@ class LogfireConfig(_LogfireConfigData):
         # This ensures that we only call OTEL's global set_tracer_provider once to avoid warnings.
         self._has_set_providers = False
         self._initialized = False
+        # Resolved in `_initialize` once the resource (and therefore its `service.instance.id`)
+        # exists; until then there is no value to advertise to the backend.
+        self._service_instance_id: str = ''
         self._lock = RLock()
 
     def configure(
@@ -1042,6 +1046,9 @@ class LogfireConfig(_LogfireConfigData):
             # https://github.com/open-telemetry/semantic-conventions/blob/e44693245eef815071402b88c3a44a8f7f8f24c8/docs/resource/README.md#service-experimental
             # Both recommend generating a UUID.
             resource = Resource({'service.instance.id': uuid4().hex}).merge(resource)
+            # Cache the resolved service.instance.id so the X-Logfire-Telemetry header
+            # advertises the same UUID the OTLP resource attributes carry.
+            self._service_instance_id = str(resource.attributes.get('service.instance.id', ''))
 
             head = self.sampling.head
             sampler: Sampler | None = None
@@ -1171,9 +1178,14 @@ class LogfireConfig(_LogfireConfigData):
                         thread.start()
 
                     # Create exporters for each token
+                    telemetry_header_value = build_telemetry_header(self)
                     for token in token_list:
                         base_url = self.advanced.generate_base_url(token)
-                        headers = {'User-Agent': f'logfire/{VERSION}', 'Authorization': token}
+                        headers = {
+                            'User-Agent': f'logfire/{VERSION}',
+                            'Authorization': token,
+                            TELEMETRY_HEADER_NAME: telemetry_header_value,
+                        }
                         session = OTLPExporterHttpSession()
                         install_logfire_response_hook(session, self.advanced.server_response_hook)
                         span_exporter = BodySizeCheckingOTLPSpanExporter(
@@ -1353,6 +1365,7 @@ class LogfireConfig(_LogfireConfigData):
                     token=self.api_key,
                     options=self.variables,
                     server_response_hook=self.advanced.server_response_hook,
+                    telemetry_header=build_telemetry_header(self),
                 )
             multi_log_processor = SynchronousMultiLogRecordProcessor()
             for processor in log_record_processors:
@@ -1486,6 +1499,7 @@ class LogfireConfig(_LogfireConfigData):
                 token=api_key,
                 options=options,
                 server_response_hook=self.advanced.server_response_hook,
+                telemetry_header=build_telemetry_header(self),
             )
             self._variable_provider = provider
             provider.start(Logfire(config=self))
@@ -1504,7 +1518,12 @@ class LogfireConfig(_LogfireConfigData):
     def _initialize_credentials_from_token(self, token: str) -> LogfireCredentials | None:
         session = requests.Session()
         install_logfire_response_hook(session, self.advanced.server_response_hook)
-        return LogfireCredentials.from_token(token, session, self.advanced.generate_base_url(token))
+        return LogfireCredentials.from_token(
+            token,
+            session,
+            self.advanced.generate_base_url(token),
+            telemetry_header=build_telemetry_header(self),
+        )
 
     def _ensure_flush_after_aws_lambda(self):
         """Ensure that `force_flush` is called after an AWS Lambda invocation.
@@ -1698,7 +1717,9 @@ class LogfireCredentials:
                 raise LogfireConfigError(f'Invalid credentials file: {path} - {e}') from e
 
     @classmethod
-    def from_token(cls, token: str, session: requests.Session, base_url: str) -> Self | None:
+    def from_token(
+        cls, token: str, session: requests.Session, base_url: str, telemetry_header: str | None = None
+    ) -> Self | None:
         """Check that the token is valid.
 
         Issue a warning if the Logfire API is unreachable, or we get a response other than 200 or 401.
@@ -1708,11 +1729,14 @@ class LogfireCredentials:
         Raises:
             LogfireConfigError: If the token is invalid.
         """
+        headers: dict[str, str] = {**COMMON_REQUEST_HEADERS, 'Authorization': token}
+        if telemetry_header is not None:
+            headers[TELEMETRY_HEADER_NAME] = telemetry_header
         try:
             response = session.get(
                 urljoin(base_url, '/v1/info'),
                 timeout=10,
-                headers={**COMMON_REQUEST_HEADERS, 'Authorization': token},
+                headers=headers,
             )
         except requests.RequestException as e:
             warnings.warn(f'Logfire API is unreachable, you may have trouble sending data. Error: {e}')

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -71,7 +71,7 @@ from logfire.version import VERSION
 
 from ..propagate import NoExtractTraceContextPropagator, WarnOnExtractTraceContextPropagator
 from ..types import ExceptionCallback
-from .client import InvalidProjectName, LogfireClient, ProjectAlreadyExists
+from .client import UA_HEADER, InvalidProjectName, LogfireClient, ProjectAlreadyExists
 from .config_params import ParamManager, PydanticPluginRecordValues, normalize_token
 from .constants import (
     ATTRIBUTES_CONFIG,
@@ -132,7 +132,7 @@ if TYPE_CHECKING:
 
 CREDENTIALS_FILENAME = 'logfire_credentials.json'
 """Default base URL for the Logfire API."""
-COMMON_REQUEST_HEADERS = {'User-Agent': f'logfire/{VERSION}'}
+COMMON_REQUEST_HEADERS = {'User-Agent': UA_HEADER}
 """Common request headers for requests to the Logfire API."""
 PROJECT_NAME_PATTERN = r'^[a-z0-9]+(?:-[a-z0-9]+)*$'
 
@@ -1181,11 +1181,12 @@ class LogfireConfig(_LogfireConfigData):
                     telemetry_header_value = build_telemetry_header(self)
                     for token in token_list:
                         base_url = self.advanced.generate_base_url(token)
-                        headers = {
-                            'User-Agent': f'logfire/{VERSION}',
+                        headers: dict[str, str] = {
+                            'User-Agent': UA_HEADER,
                             'Authorization': token,
-                            TELEMETRY_HEADER_NAME: telemetry_header_value,
                         }
+                        if telemetry_header_value is not None:
+                            headers[TELEMETRY_HEADER_NAME] = telemetry_header_value
                         session = OTLPExporterHttpSession()
                         install_logfire_response_hook(session, self.advanced.server_response_hook)
                         span_exporter = BodySizeCheckingOTLPSpanExporter(

--- a/logfire/_internal/telemetry_header.py
+++ b/logfire/_internal/telemetry_header.py
@@ -1,47 +1,22 @@
 """Build the `X-Logfire-Telemetry` request header.
 
-The header carries non-sensitive information about the SDK and how it is
-configured, encoded as a compact JSON object. The backend uses it to answer
-questions like which SDK versions are still in active use, which Python
-versions we can drop, and which configuration options users actually enable.
+The header carries non-sensitive, config-derived signals about how this SDK
+instance is configured, encoded as a compact JSON object. SDK/runtime identity
+(version, language, Python version, OS, etc.) lives on the standard
+`User-Agent` header instead — see `UA_HEADER` in `_internal/client.py`.
 Secrets (`token`, `api_key`, `service_name`, etc.) are never included.
 """
 
 from __future__ import annotations
 
-import functools
 import json
-import sys
 from typing import TYPE_CHECKING, Any
-
-from logfire.version import VERSION
 
 if TYPE_CHECKING:
     from .config import LogfireConfig
 
 
 TELEMETRY_HEADER_NAME = 'X-Logfire-Telemetry'
-
-
-@functools.cache
-def _base_telemetry_pairs() -> dict[str, Any]:
-    # Each field below has an explicit rationale; do not add a field unless you have one.
-    return {
-        # SDK version: the primary signal for deprecation planning — which versions
-        # are still in active use so we know when it is safe to drop one.
-        'sdk_version': VERSION,
-        # SDK language: lets the same backend ingestion logic distinguish python
-        # from future SDKs (JS, Rust) without having to parse User-Agent.
-        'sdk_language': 'python',
-        # Python version: tells us when we can drop support for an older Python.
-        'python_version': f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}',
-        # Implementation: spotting non-CPython users (pypy, graalpy) before
-        # changing anything that depends on CPython-specific behaviour.
-        'implementation': sys.implementation.name,
-        # OS: same idea — confirm Windows / Linux / macOS coverage before
-        # touching platform-sensitive code paths.
-        'os': sys.platform,
-    }
 
 
 def _config_telemetry_pairs(config: LogfireConfig) -> dict[str, Any]:
@@ -75,17 +50,21 @@ def _config_telemetry_pairs(config: LogfireConfig) -> dict[str, Any]:
     if config._service_instance_id:  # pyright: ignore[reportPrivateUsage]
         # Mirrors the OTLP resource attribute of the same name
         # (https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id).
-        # Carrying it on the header lets the backend correlate metadata with the spans
-        # this SDK instance is exporting, even on requests that don't carry an OTLP body
-        # (token validation, variables fetch, CRUD endpoints).
+        # High-cardinality per-process identifier — kept here rather than in
+        # User-Agent because user-agent strings are typically aggregated and a
+        # per-instance id would explode the cardinality of any UA-based analytics.
         pairs['service_instance_id'] = config._service_instance_id  # pyright: ignore[reportPrivateUsage]
 
     return pairs
 
 
-def build_telemetry_header(config: LogfireConfig | None = None) -> str:
-    """Return the JSON-encoded value for the `X-Logfire-Telemetry` header."""
-    pairs: dict[str, Any] = {**_base_telemetry_pairs()}
-    if config is not None:
-        pairs.update(_config_telemetry_pairs(config))
-    return json.dumps(pairs, separators=(',', ':'))
+def build_telemetry_header(config: LogfireConfig | None = None) -> str | None:
+    """Return the JSON-encoded `X-Logfire-Telemetry` value, or None if no config.
+
+    Without a `LogfireConfig` there is nothing config-specific to report — the
+    SDK/runtime identity is already in `User-Agent`, so callers should simply
+    omit the header in that case.
+    """
+    if config is None:
+        return None
+    return json.dumps(_config_telemetry_pairs(config), separators=(',', ':'))

--- a/logfire/_internal/telemetry_header.py
+++ b/logfire/_internal/telemetry_header.py
@@ -1,0 +1,91 @@
+"""Build the `X-Logfire-Telemetry` request header.
+
+The header carries non-sensitive information about the SDK and how it is
+configured, encoded as a compact JSON object. The backend uses it to answer
+questions like which SDK versions are still in active use, which Python
+versions we can drop, and which configuration options users actually enable.
+Secrets (`token`, `api_key`, `service_name`, etc.) are never included.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+from logfire.version import VERSION
+
+if TYPE_CHECKING:
+    from .config import LogfireConfig
+
+
+TELEMETRY_HEADER_NAME = 'X-Logfire-Telemetry'
+
+
+@functools.cache
+def _base_telemetry_pairs() -> dict[str, Any]:
+    # Each field below has an explicit rationale; do not add a field unless you have one.
+    return {
+        # SDK version: the primary signal for deprecation planning — which versions
+        # are still in active use so we know when it is safe to drop one.
+        'sdk_version': VERSION,
+        # SDK language: lets the same backend ingestion logic distinguish python
+        # from future SDKs (JS, Rust) without having to parse User-Agent.
+        'sdk_language': 'python',
+        # Python version: tells us when we can drop support for an older Python.
+        'python_version': f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}',
+        # Implementation: spotting non-CPython users (pypy, graalpy) before
+        # changing anything that depends on CPython-specific behaviour.
+        'implementation': sys.implementation.name,
+        # OS: same idea — confirm Windows / Linux / macOS coverage before
+        # touching platform-sensitive code paths.
+        'os': sys.platform,
+    }
+
+
+def _config_telemetry_pairs(config: LogfireConfig) -> dict[str, Any]:
+    """Pick fields of `LogfireConfig` that are useful for product analytics.
+
+    Each field below has an explicit rationale; do not add a field unless you have
+    one. Everything else either duplicates information the server already knows,
+    isn't actionable, or risks leaking sensitive data (token, api_key,
+    service_name, environment, etc.).
+    """
+    # Multi-project usage: how many users configure more than one write token in
+    # a single SDK instance. Drives auth/routing roadmap decisions.
+    token = config.token
+    if isinstance(token, list):
+        token_count = len(token)
+    elif token:
+        token_count = 1
+    else:
+        token_count = 0
+
+    pairs: dict[str, Any] = {
+        # Adoption signal for the `code_source=` option (newer feature): tells us
+        # whether the integration with the source-code link UI is worth investing in.
+        'code_source_set': config.code_source is not None,
+        # Adoption signal for the variables / feature-flag feature (newer feature):
+        # informs whether to keep building on it.
+        'variables_set': config.variables is not None,
+        'token_count': token_count,
+    }
+
+    if config._service_instance_id:  # pyright: ignore[reportPrivateUsage]
+        # Mirrors the OTLP resource attribute of the same name
+        # (https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id).
+        # Carrying it on the header lets the backend correlate metadata with the spans
+        # this SDK instance is exporting, even on requests that don't carry an OTLP body
+        # (token validation, variables fetch, CRUD endpoints).
+        pairs['service_instance_id'] = config._service_instance_id  # pyright: ignore[reportPrivateUsage]
+
+    return pairs
+
+
+def build_telemetry_header(config: LogfireConfig | None = None) -> str:
+    """Return the JSON-encoded value for the `X-Logfire-Telemetry` header."""
+    pairs: dict[str, Any] = {**_base_telemetry_pairs()}
+    if config is not None:
+        pairs.update(_config_telemetry_pairs(config))
+    return json.dumps(pairs, separators=(',', ':'))

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import platform
 from datetime import datetime
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypedDict, TypeVar
 
 from typing_extensions import Self
 
-from logfire import VERSION
 from logfire._internal.config import get_base_url_from_token
+from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 
 try:
     from httpx import AsyncClient, Client, Response, Timeout
@@ -87,7 +86,6 @@ T = TypeVar('T', bound=BaseClient)
 
 
 _ACCEPT = Literal['application/json', 'application/vnd.apache.arrow.stream', 'text/csv']
-_USER_AGENT = f'logfire-sdk-python/{VERSION} (Python {platform.python_version()}, os {platform.platform()}, arch {platform.machine()})'
 
 
 class _BaseLogfireQueryClient(Generic[T]):
@@ -97,7 +95,7 @@ class _BaseLogfireQueryClient(Generic[T]):
         self.timeout = timeout
         headers = client_kwargs.pop('headers', {})
         headers['authorization'] = read_token
-        headers.setdefault('user-agent', _USER_AGENT)
+        headers[TELEMETRY_HEADER_NAME] = build_telemetry_header()
         self.client: T = client(timeout=timeout, base_url=base_url, headers=headers, **client_kwargs)
 
     def _build_query_params(

--- a/logfire/experimental/query_client.py
+++ b/logfire/experimental/query_client.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Any, Generic, Literal, TypedDict, TypeVar
 
 from typing_extensions import Self
 
+from logfire._internal.client import UA_HEADER
 from logfire._internal.config import get_base_url_from_token
-from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 
 try:
     from httpx import AsyncClient, Client, Response, Timeout
@@ -95,7 +95,7 @@ class _BaseLogfireQueryClient(Generic[T]):
         self.timeout = timeout
         headers = client_kwargs.pop('headers', {})
         headers['authorization'] = read_token
-        headers[TELEMETRY_HEADER_NAME] = build_telemetry_header()
+        headers['user-agent'] = UA_HEADER
         self.client: T = client(timeout=timeout, base_url=base_url, headers=headers, **client_kwargs)
 
     def _build_query_params(

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -18,7 +18,7 @@ from requests import RequestException, Session
 from logfire._internal.client import UA_HEADER
 from logfire._internal.config import VariablesOptions
 from logfire._internal.server_response import ServerResponseCallback, install_logfire_response_hook
-from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
+from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME
 from logfire._internal.utils import UnexpectedResponse
 from logfire.variables.abstract import (
     ResolvedVariable,
@@ -73,9 +73,9 @@ class LogfireRemoteVariableProvider(VariableProvider):
             server_response_hook: Optional override for the API response hook
                 (see `AdvancedOptions.server_response_hook`).
             telemetry_header: Pre-built `X-Logfire-Telemetry` header value carrying the
-                SDK's `service.instance.id` so it matches the OTLP resource attribute.
-                When None (e.g. lazily instantiated outside of `_initialize`), a base
-                header without config-derived fields is built here.
+                SDK's config-derived signals (including `service.instance.id` so it
+                matches the OTLP resource attribute). When None, the header is omitted —
+                SDK/runtime identity is still sent on the standard `User-Agent` header.
         """
         block_before_first_resolve = options.block_before_first_resolve
         polling_interval = options.polling_interval
@@ -83,15 +83,11 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._base_url = base_url
         self._token = token
         self._server_response_hook = server_response_hook
-        self._telemetry_header = telemetry_header if telemetry_header is not None else build_telemetry_header()
+        self._telemetry_header = telemetry_header
         self._session = Session()
-        self._session.headers.update(
-            {
-                'Authorization': f'bearer {token}',
-                'User-Agent': UA_HEADER,
-                TELEMETRY_HEADER_NAME: self._telemetry_header,
-            }
-        )
+        self._session.headers.update({'Authorization': f'bearer {token}', 'User-Agent': UA_HEADER})
+        if self._telemetry_header is not None:
+            self._session.headers[TELEMETRY_HEADER_NAME] = self._telemetry_header
         install_logfire_response_hook(self._session, server_response_hook)
         self._timeout = options.timeout
         self._block_before_first_fetch = block_before_first_resolve
@@ -217,11 +213,12 @@ class LogfireRemoteVariableProvider(VariableProvider):
                         {
                             'Authorization': f'bearer {self._token}',
                             'User-Agent': UA_HEADER,
-                            TELEMETRY_HEADER_NAME: self._telemetry_header,
                             'Accept': 'text/event-stream',
                             'Cache-Control': 'no-cache',
                         }
                     )
+                    if self._telemetry_header is not None:
+                        sse_session.headers[TELEMETRY_HEADER_NAME] = self._telemetry_header
                     install_logfire_response_hook(sse_session, self._server_response_hook)
 
                     # Open streaming connection

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -18,6 +18,7 @@ from requests import RequestException, Session
 from logfire._internal.client import UA_HEADER
 from logfire._internal.config import VariablesOptions
 from logfire._internal.server_response import ServerResponseCallback, install_logfire_response_hook
+from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from logfire._internal.utils import UnexpectedResponse
 from logfire.variables.abstract import (
     ResolvedVariable,
@@ -61,6 +62,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
         token: str,
         options: VariablesOptions,
         server_response_hook: ServerResponseCallback | None = None,
+        telemetry_header: str | None = None,
     ):
         """Create a new remote variable provider.
 
@@ -70,6 +72,10 @@ class LogfireRemoteVariableProvider(VariableProvider):
             options: Options for retrieving remote variables.
             server_response_hook: Optional override for the API response hook
                 (see `AdvancedOptions.server_response_hook`).
+            telemetry_header: Pre-built `X-Logfire-Telemetry` header value carrying the
+                SDK's `service.instance.id` so it matches the OTLP resource attribute.
+                When None (e.g. lazily instantiated outside of `_initialize`), a base
+                header without config-derived fields is built here.
         """
         block_before_first_resolve = options.block_before_first_resolve
         polling_interval = options.polling_interval
@@ -77,8 +83,15 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._base_url = base_url
         self._token = token
         self._server_response_hook = server_response_hook
+        self._telemetry_header = telemetry_header if telemetry_header is not None else build_telemetry_header()
         self._session = Session()
-        self._session.headers.update({'Authorization': f'bearer {token}', 'User-Agent': UA_HEADER})
+        self._session.headers.update(
+            {
+                'Authorization': f'bearer {token}',
+                'User-Agent': UA_HEADER,
+                TELEMETRY_HEADER_NAME: self._telemetry_header,
+            }
+        )
         install_logfire_response_hook(self._session, server_response_hook)
         self._timeout = options.timeout
         self._block_before_first_fetch = block_before_first_resolve
@@ -204,6 +217,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
                         {
                             'Authorization': f'bearer {self._token}',
                             'User-Agent': UA_HEADER,
+                            TELEMETRY_HEADER_NAME: self._telemetry_header,
                             'Accept': 'text/event-stream',
                             'Cache-Control': 'no-cache',
                         }

--- a/tests/test_telemetry_header.py
+++ b/tests/test_telemetry_header.py
@@ -8,6 +8,7 @@ import requests
 import requests_mock
 
 import logfire
+from logfire._internal.client import UA_HEADER
 from logfire._internal.config import GLOBAL_CONFIG, LogfireCredentials
 from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
 from logfire.version import VERSION
@@ -17,18 +18,14 @@ def _parse_header(value: str) -> dict[str, Any]:
     return json.loads(value)
 
 
-def test_build_telemetry_header_without_config():
-    pairs = _parse_header(build_telemetry_header())
-    assert pairs['sdk_version'] == VERSION
-    assert pairs['sdk_language'] == 'python'
-    assert pairs['python_version']
-    assert pairs['implementation']
-    assert pairs['os']
+def test_build_telemetry_header_without_config_is_none():
+    assert build_telemetry_header() is None
 
 
 def test_build_telemetry_header_with_config():
-    pairs = _parse_header(build_telemetry_header(GLOBAL_CONFIG))
-    assert pairs['sdk_version'] == VERSION
+    header = build_telemetry_header(GLOBAL_CONFIG)
+    assert header is not None
+    pairs = _parse_header(header)
     for key in ('code_source_set', 'variables_set', 'token_count'):
         assert key in pairs
 
@@ -47,11 +44,18 @@ def test_telemetry_header_excludes_secrets():
         )
     try:
         header = build_telemetry_header(GLOBAL_CONFIG)
+        assert header is not None
         for secret in secrets:
             assert secret not in header
     finally:
         # Reset to the default test config.
         logfire.configure(send_to_logfire=False, console=False)
+
+
+def test_user_agent_carries_sdk_identity():
+    assert UA_HEADER.startswith(f'logfire-sdk-python/{VERSION} (')
+    assert 'os ' in UA_HEADER
+    assert 'arch ' in UA_HEADER
 
 
 def test_otlp_export_sends_telemetry_header():
@@ -81,9 +85,11 @@ def test_otlp_export_sends_telemetry_header():
     assert any(TELEMETRY_HEADER_NAME in headers for headers in captured)
     [headers] = [headers for headers in captured if TELEMETRY_HEADER_NAME in headers]
     pairs = _parse_header(headers[TELEMETRY_HEADER_NAME])
-    assert pairs['sdk_version'] == VERSION
     assert pairs['token_count'] == 1
     assert 'abc1' not in headers[TELEMETRY_HEADER_NAME]
+    # SDK identity travels on User-Agent, not the telemetry header.
+    assert 'sdk_version' not in pairs
+    assert headers['User-Agent'].startswith(f'logfire-sdk-python/{VERSION}')
     # The header must advertise the same `service.instance.id` carried by OTLP
     # resource attributes so the backend can correlate the two.
     resource = GLOBAL_CONFIG.get_tracer_provider().resource
@@ -98,7 +104,7 @@ def test_from_token_sends_telemetry_header():
         )
         session = requests.Session()
         LogfireCredentials.from_token(
-            'pylf_v1_us_xxx', session, 'https://logfire-us.pydantic.dev', telemetry_header='{"sdk_version":"1.2.3"}'
+            'pylf_v1_us_xxx', session, 'https://logfire-us.pydantic.dev', telemetry_header='{"token_count":1}'
         )
         [history] = m.request_history
-        assert history.headers[TELEMETRY_HEADER_NAME] == '{"sdk_version":"1.2.3"}'
+        assert history.headers[TELEMETRY_HEADER_NAME] == '{"token_count":1}'

--- a/tests/test_telemetry_header.py
+++ b/tests/test_telemetry_header.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import requests
+import requests_mock
+
+import logfire
+from logfire._internal.config import GLOBAL_CONFIG, LogfireCredentials
+from logfire._internal.telemetry_header import TELEMETRY_HEADER_NAME, build_telemetry_header
+from logfire.version import VERSION
+
+
+def _parse_header(value: str) -> dict[str, Any]:
+    return json.loads(value)
+
+
+def test_build_telemetry_header_without_config():
+    pairs = _parse_header(build_telemetry_header())
+    assert pairs['sdk_version'] == VERSION
+    assert pairs['sdk_language'] == 'python'
+    assert pairs['python_version']
+    assert pairs['implementation']
+    assert pairs['os']
+
+
+def test_build_telemetry_header_with_config():
+    pairs = _parse_header(build_telemetry_header(GLOBAL_CONFIG))
+    assert pairs['sdk_version'] == VERSION
+    for key in ('code_source_set', 'variables_set', 'token_count'):
+        assert key in pairs
+
+
+def test_telemetry_header_excludes_secrets():
+    """The header must never carry the token, api key, environment or service name."""
+    secrets = ['shhh-secret-token', 'secret-api-key', 'top-secret-env', 'secret-service-name']
+    with patch.dict('os.environ', {}, clear=False):
+        logfire.configure(
+            send_to_logfire=False,
+            token=secrets[0],
+            api_key=secrets[1],
+            environment=secrets[2],
+            service_name=secrets[3],
+            console=False,
+        )
+    try:
+        header = build_telemetry_header(GLOBAL_CONFIG)
+        for secret in secrets:
+            assert secret not in header
+    finally:
+        # Reset to the default test config.
+        logfire.configure(send_to_logfire=False, console=False)
+
+
+def test_otlp_export_sends_telemetry_header():
+    captured: list[dict[str, str]] = []
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+
+        def _capture(request: requests.PreparedRequest, _context: object) -> str:
+            captured.append(dict(request.headers))
+            return ''
+
+        m.post('https://logfire-us.pydantic.dev/v1/traces', text=_capture, status_code=200)
+
+        logfire.configure(send_to_logfire=True, token='abc1', console=False)
+        for thread in __import__('threading').enumerate():
+            if thread.name == 'check_logfire_token':  # pragma: no cover
+                thread.join()
+
+        with logfire.span('a span'):
+            pass
+        logfire.force_flush()
+
+    assert any(TELEMETRY_HEADER_NAME in headers for headers in captured)
+    [headers] = [headers for headers in captured if TELEMETRY_HEADER_NAME in headers]
+    pairs = _parse_header(headers[TELEMETRY_HEADER_NAME])
+    assert pairs['sdk_version'] == VERSION
+    assert pairs['token_count'] == 1
+    assert 'abc1' not in headers[TELEMETRY_HEADER_NAME]
+    # The header must advertise the same `service.instance.id` carried by OTLP
+    # resource attributes so the backend can correlate the two.
+    resource = GLOBAL_CONFIG.get_tracer_provider().resource
+    assert pairs['service_instance_id'] == resource.attributes['service.instance.id']
+
+
+def test_from_token_sends_telemetry_header():
+    with requests_mock.Mocker() as m:
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        session = requests.Session()
+        LogfireCredentials.from_token(
+            'pylf_v1_us_xxx', session, 'https://logfire-us.pydantic.dev', telemetry_header='{"sdk_version":"1.2.3"}'
+        )
+        [history] = m.request_history
+        assert history.headers[TELEMETRY_HEADER_NAME] == '{"sdk_version":"1.2.3"}'


### PR DESCRIPTION
## Summary

Adds an `X-Logfire-Telemetry: {...}` header (compact JSON) to every Logfire SDK request (OTLP exports, token validation, CRUD client, variable provider, CLI, query client). The value is deliberately small; every field has a concrete product question it answers.

Linear: [PYD-3579](https://linear.app/pydantic/issue/PYD-3579/add-logfire-sdk-version-telemetry-to-all-clients)

> The response-side counterpart (`X-Logfire-Warning` / `X-Logfire-Error` handling) was originally part of this PR; per review it has been split out into #1906.

### What we send and why

**Always sent (`_base_telemetry_pairs`):**
| Field | Why |
|---|---|
| `sdk_version` | Primary signal for deprecation planning — which versions are still in active use, so we know when it is safe to drop one. |
| `sdk_language` | Lets backend ingestion distinguish python from future SDKs (JS, Rust) without parsing User-Agent. |
| `python_version` | Tells us when we can drop support for an older Python. |
| `implementation` | Spots non-CPython users (pypy, graalpy) before we change anything that depends on CPython-specific behaviour. Mirrors `sys.implementation.name`. |
| `os` | Confirms Windows / Linux / macOS coverage before touching platform-sensitive code. |

**Sent when a `LogfireConfig` is available (`_config_telemetry_pairs`):**
| Field | Why |
|---|---|
| `code_source_set` | Adoption signal for the `code_source=` option (newer feature) — informs whether the source-link UI is worth investing in. |
| `variables_set` | Adoption signal for the variables / feature-flag feature (newer feature) — informs whether to keep building on it. |
| `token_count` | How many users configure multiple write tokens in one SDK instance — drives auth/routing roadmap decisions. |
| `service_instance_id` | Mirrors the [`service.instance.id`](https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/#service-instance-id) OTLP resource attribute (same UUID), letting the backend correlate header-only requests (token validation, variables fetch, CRUD) with the spans this SDK instance exports. |

**Explicitly excluded:** `token`, `api_key`, `service_name`, `environment`, `service_version`, `data_dir`, `code_source.repository|revision|root_path`, and any other free-form string the user supplies. There is also no `min_level`, `console_enabled`, etc.: nothing was added that didn't have a clear product use, and adding new fields is gated by the inline comment in `_config_telemetry_pairs`.

The value is encoded as compact JSON (`json.dumps(..., separators=(',', ':'))`) so future fields with arbitrary string values can't silently break parsing.

### Query client

#1875 added a custom User-Agent on the experimental query client to surface SDK version / Python version / OS to the backend. With this header in place that became duplicate plumbing, so it has been reverted as its own commit and the same `X-Logfire-Telemetry` header is now attached on query client construction instead.

### Test plan
- [x] New `tests/test_telemetry_header.py` covers header construction (with/without config), secret exclusion, OTLP export carrying the same `service.instance.id` as the resource attribute, `LogfireCredentials.from_token`, and `LogfireClient`.
- [x] `make format lint typecheck` clean.
- [x] `uv run pytest tests/test_telemetry_header.py tests/test_query_client.py tests/test_configure.py tests/test_client.py tests/test_variables.py tests/test_cli.py` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)