### PR TITLE
Avoid raising error on `prompt` command without `--project`

### DIFF
--- a/logfire/_internal/cli/prompt.py
+++ b/logfire/_internal/cli/prompt.py
@@ -49,7 +49,10 @@ def parse_prompt(args: argparse.Namespace) -> None:
         configure_opencode(client, console, update=update)
 
     if not getattr(args, 'project', None):
-        return
+        if args.claude or args.codex or args.opencode:
+            return
+        console.print('The --project option is required unless configuring an agent integration.')
+        sys.exit(1)
 
     response = client.get_prompt(args.organization, args.project, args.issue)
     sys.stdout.write(response['prompt'])

--- a/logfire/_internal/cli/prompt.py
+++ b/logfire/_internal/cli/prompt.py
@@ -48,6 +48,9 @@ def parse_prompt(args: argparse.Namespace) -> None:
     elif args.opencode:
         configure_opencode(client, console, update=update)
 
+    if not getattr(args, 'project', None):
+        return
+
     response = client.get_prompt(args.organization, args.project, args.issue)
     sys.stdout.write(response['prompt'])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1835,6 +1835,31 @@ Logfire MCP server added to Codex.
 """)
 
 
+def test_parse_prompt_codex_without_project(
+    prompt_http_calls: None, capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(shutil, 'which', lambda x: True)  # type: ignore
+
+    codex_path = tmp_path / 'codex'
+    codex_path.mkdir()
+    codex_config_path = codex_path / 'config.toml'
+    codex_config_path.write_text('')
+
+    with patch.dict(os.environ, {'CODEX_HOME': str(codex_path)}):
+        main(['prompt', '--codex'])
+
+    assert codex_config_path.read_text() == snapshot("""\
+
+[mcp_servers.logfire]
+url = "https://logfire-us.pydantic.dev/mcp"
+""")
+    out, err = capsys.readouterr()
+    assert out == ''
+    assert err == snapshot("""\
+Logfire MCP server added to Codex.
+""")
+
+
 def test_parse_prompt_codex_not_installed(
     prompt_http_calls: None, capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1810,6 +1810,15 @@ def test_parse_prompt(prompt_http_calls: None, capsys: pytest.CaptureFixture[str
     assert capsys.readouterr().out == snapshot('This is the prompt\n')
 
 
+def test_parse_prompt_without_project_errors(prompt_http_calls: None, capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit):
+        main(['prompt'])
+
+    assert capsys.readouterr().err == snapshot(
+        'The --project option is required unless configuring an agent integration.\n'
+    )
+
+
 def test_parse_prompt_codex(
     prompt_http_calls: None, capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Fix `logfire prompt --codex` when it is used as a setup verification command without `--project`.

Previously the command configured the Codex MCP entry, then continued into prompt fetching and crashed because `args.organization` is only populated by `--project <org>/<project>`. The setup-only path now returns after configuring the selected agent integration when no project is provided.

## Validation

- `uv run pytest tests/test_cli.py -k "parse_prompt_codex"`
- commit hooks: Ruff, Ruff Format, pyright