### PR TITLE
Update links to Pydantic documentation to use new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is a very brief overview of how to use Logfire, the [documentation](https:/
 pip install logfire
 ```
 
-[_(learn more)_](https://pydantic.dev/docs/logfire/guides/first_steps/#install)
+[_(learn more)_](https://pydantic.dev/docs/logfire/get-started/#sdk)
 
 ## Authenticate
 
@@ -43,7 +43,7 @@ pip install logfire
 logfire auth
 ```
 
-[_(learn more)_](https://pydantic.dev/docs/logfire/guides/first_steps/#authentication)
+[_(learn more)_](https://pydantic.dev/docs/logfire/get-started/#instrument)
 
 ### Manual tracing
 
@@ -63,7 +63,7 @@ with logfire.span('Asking the user their {question}', question='age'):
     logfire.debug('{dob=} {age=!r}', dob=dob, age=date.today() - dob)
 ```
 
-[_(learn more)_](https://pydantic.dev/docs/logfire/guides/onboarding-checklist/add-manual-tracing/)
+[_(learn more)_](https://pydantic.dev/docs/logfire/instrument/add-manual-tracing/)
 
 ### Integration
 
@@ -93,7 +93,7 @@ async def add_user(user: User):
     return {'message': f'{user.name} added'}
 ```
 
-[_(learn more)_](https://pydantic.dev/docs/logfire/integrations/fastapi/)
+[_(learn more)_](https://pydantic.dev/docs/logfire/integrations/web-frameworks/fastapi/)
 
 Logfire gives you a view into how your code is running like this:
 
@@ -109,6 +109,6 @@ See our [security policy](https://github.com/pydantic/logfire/security).
 
 ## Logfire Open-Source and Closed-Source Boundaries
 
-The Logfire SDKs (we also have them for [TypeScript](https://github.com/pydantic/logfire-js) and [Rust](https://github.com/pydantic/logfire-rust)) are open source, and you can use them to export data to [any OTel-compatible backend](https://pydantic.dev/docs/logfire/how-to-guides/alternative-backends/).
+The Logfire SDKs (we also have them for [TypeScript](https://github.com/pydantic/logfire-js) and [Rust](https://github.com/pydantic/logfire-rust)) are open source, and you can use them to export data to [any OTel-compatible backend](https://pydantic.dev/docs/logfire/guides/alternative-backends/).
 
-The Logfire platform (the UI and backend) is closed source. You can self-host it by purchasing an [enterprise license](https://pydantic.dev/docs/logfire/enterprise/).
+The Logfire platform (the UI and backend) is closed source. You can self-host it by purchasing an [enterprise license](https://pydantic.dev/docs/logfire/deploy/enterprise/).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ What sets Logfire apart:
 - **OpenTelemetry:** Logfire is an opinionated wrapper around OpenTelemetry, allowing you to leverage existing tooling, infrastructure, and instrumentation for many common Python packages, and enabling support for virtually any language. We offer full support for all OpenTelemetry signals (traces, metrics and logs).
 - **Pydantic Integration:** Understand the data flowing through your Pydantic Validation models and get built-in analytics on validations.
 
-See the [documentation](https://logfire.pydantic.dev/docs/) for more information.
+See the [documentation](https://pydantic.dev/docs/logfire/) for more information.
 
 **Feel free to report issues and ask any questions about Logfire in this repository!**
 
@@ -27,7 +27,7 @@ This repo contains the Python SDK for `logfire` and documentation; the server ap
 
 ## Using Logfire
 
-This is a very brief overview of how to use Logfire, the [documentation](https://logfire.pydantic.dev/docs/) has much more detail.
+This is a very brief overview of how to use Logfire, the [documentation](https://pydantic.dev/docs/logfire/) has much more detail.
 
 ### Install
 
@@ -35,7 +35,7 @@ This is a very brief overview of how to use Logfire, the [documentation](https:/
 pip install logfire
 ```
 
-[_(learn more)_](https://logfire.pydantic.dev/docs/guides/first_steps/#install)
+[_(learn more)_](https://pydantic.dev/docs/logfire/guides/first_steps/#install)
 
 ## Authenticate
 
@@ -43,7 +43,7 @@ pip install logfire
 logfire auth
 ```
 
-[_(learn more)_](https://logfire.pydantic.dev/docs/guides/first_steps/#authentication)
+[_(learn more)_](https://pydantic.dev/docs/logfire/guides/first_steps/#authentication)
 
 ### Manual tracing
 
@@ -63,11 +63,11 @@ with logfire.span('Asking the user their {question}', question='age'):
     logfire.debug('{dob=} {age=!r}', dob=dob, age=date.today() - dob)
 ```
 
-[_(learn more)_](https://logfire.pydantic.dev/docs/guides/onboarding-checklist/add-manual-tracing/)
+[_(learn more)_](https://pydantic.dev/docs/logfire/guides/onboarding-checklist/add-manual-tracing/)
 
 ### Integration
 
-Or you can also avoid manual instrumentation and instead integrate with [lots of popular packages](https://logfire.pydantic.dev/docs/integrations/), here's an example of integrating with FastAPI:
+Or you can also avoid manual instrumentation and instead integrate with [lots of popular packages](https://pydantic.dev/docs/logfire/integrations/), here's an example of integrating with FastAPI:
 
 ```py skip-run="true" skip-reason="global-instrumentation"
 from fastapi import FastAPI
@@ -93,11 +93,11 @@ async def add_user(user: User):
     return {'message': f'{user.name} added'}
 ```
 
-[_(learn more)_](https://logfire.pydantic.dev/docs/integrations/fastapi/)
+[_(learn more)_](https://pydantic.dev/docs/logfire/integrations/fastapi/)
 
 Logfire gives you a view into how your code is running like this:
 
-![Logfire screenshot](https://logfire.pydantic.dev/docs/images/index/logfire-screenshot-fastapi-200.png)
+![Logfire screenshot](https://pydantic.dev/docs/logfire/images/index/logfire-screenshot-fastapi-200.png)
 
 ## Contributing
 
@@ -109,6 +109,6 @@ See our [security policy](https://github.com/pydantic/logfire/security).
 
 ## Logfire Open-Source and Closed-Source Boundaries
 
-The Logfire SDKs (we also have them for [TypeScript](https://github.com/pydantic/logfire-js) and [Rust](https://github.com/pydantic/logfire-rust)) are open source, and you can use them to export data to [any OTel-compatible backend](https://logfire.pydantic.dev/docs/how-to-guides/alternative-backends/).
+The Logfire SDKs (we also have them for [TypeScript](https://github.com/pydantic/logfire-js) and [Rust](https://github.com/pydantic/logfire-rust)) are open source, and you can use them to export data to [any OTel-compatible backend](https://pydantic.dev/docs/logfire/how-to-guides/alternative-backends/).
 
-The Logfire platform (the UI and backend) is closed source. You can self-host it by purchasing an [enterprise license](https://logfire.pydantic.dev/docs/enterprise/).
+The Logfire platform (the UI and backend) is closed source. You can self-host it by purchasing an [enterprise license](https://pydantic.dev/docs/logfire/enterprise/).

--- a/docs/audit-logs-api.md
+++ b/docs/audit-logs-api.md
@@ -5,7 +5,7 @@ description: "Retrieve organization activity logs for security monitoring, compl
 
 # Logfire audit logs API
 
-The Audit Logs API lets you retrieve activity logs for your organization. This feature is available on the [Enterprise plan](https://logfire.pydantic.dev/docs/enterprise/) only.
+The Audit Logs API lets you retrieve activity logs for your organization. This feature is available on the [Enterprise plan](https://pydantic.dev/docs/logfire/enterprise/) only.
 
 Each log entry records user actions: logins, project updates, token changes, and more. Use it for security monitoring, compliance reporting, and usage auditing.
 
@@ -20,7 +20,7 @@ Each log entry records user actions: logins, project updates, token changes, and
 
 ## Authentication
 
-Requests are authenticated with a Bearer token scoped to `organizations:auditlog`. See [API Keys docs](https://logfire.pydantic.dev/docs/reference/advanced/use-api-keys/#API%20Keys) for instructions on how to generate one.
+Requests are authenticated with a Bearer token scoped to `organizations:auditlog`. See [API Keys docs](https://pydantic.dev/docs/logfire/reference/advanced/use-api-keys/#API%20Keys) for instructions on how to generate one.
 
 **Type:** Bearer token
 

--- a/docs/audit-logs-api.md
+++ b/docs/audit-logs-api.md
@@ -5,7 +5,7 @@ description: "Retrieve organization activity logs for security monitoring, compl
 
 # Logfire audit logs API
 
-The Audit Logs API lets you retrieve activity logs for your organization. This feature is available on the [Enterprise plan](https://pydantic.dev/docs/logfire/enterprise/) only.
+The Audit Logs API lets you retrieve activity logs for your organization. This feature is available on the [Enterprise plan](./enterprise.md) only.
 
 Each log entry records user actions: logins, project updates, token changes, and more. Use it for security monitoring, compliance reporting, and usage auditing.
 
@@ -20,7 +20,7 @@ Each log entry records user actions: logins, project updates, token changes, and
 
 ## Authentication
 
-Requests are authenticated with a Bearer token scoped to `organizations:auditlog`. See [API Keys docs](https://pydantic.dev/docs/logfire/reference/advanced/use-api-keys/#API%20Keys) for instructions on how to generate one.
+Requests are authenticated with a Bearer token scoped to `organizations:auditlog`. See [API Keys docs](./reference/advanced//use-api-keys.md) for instructions on how to generate one.
 
 **Type:** Bearer token
 

--- a/docs/comparisons/braintrust.md
+++ b/docs/comparisons/braintrust.md
@@ -69,7 +69,7 @@ Different philosophies: Choose based on your team's workflow.
 
 **Braintrust** focuses purely on AI. To instrument non-LLM parts of your application, you need to set up raw OpenTelemetry and send to their OTLP endpoint.
 
-**Logfire** makes all instrumentation easy with first-class [integrations](https://logfire.pydantic.dev/docs/integrations/?utm_source=braintrust_compare_docs):
+**Logfire** makes all instrumentation easy with first-class [integrations](https://pydantic.dev/docs/logfire/integrations/?utm_source=braintrust_compare_docs):
 
 ```python skip="true" skip-reason="incomplete"
 import logfire

--- a/docs/comparisons/datadog.md
+++ b/docs/comparisons/datadog.md
@@ -57,7 +57,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 
 **Datadog** added LLM observability as a separate product. It works, but AI isn't central to the platform's design.
 
-**Logfire** was built for the AI era. [One function call](https://logfire.pydantic.dev/docs/integrations/?utm_source=datadog_comparison_docs) (`logfire.instrument_openai()`) gives you:
+**Logfire** was built for the AI era. [One function call](https://pydantic.dev/docs/logfire/integrations/?utm_source=datadog_comparison_docs) (`logfire.instrument_openai()`) gives you:
 
 - Token tracking and cost monitoring
 - LLM-specific panels for conversations
@@ -69,7 +69,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 
 **Datadog** uses proprietary agents. While they support OTel export, it's not the native path.
 
-**Logfire** is OpenTelemetry-native with [first-class integrations for most technologies](https://logfire.pydantic.dev/docs/integrations/?utm_source=datadog_comparison_docs). Any OTel instrumentation works automatically. Your instrumentation is portable: if you ever want to switch, your code doesn't change.
+**Logfire** is OpenTelemetry-native with [first-class integrations for most technologies](https://pydantic.dev/docs/logfire/integrations/?utm_source=datadog_comparison_docs). Any OTel instrumentation works automatically. Your instrumentation is portable: if you ever want to switch, your code doesn't change.
 
 ### Query Language — Essential for Agentic Coding
 

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -48,10 +48,10 @@ We provide first-party SDKs for Python, JavaScript/TypeScript, and Rust that off
 Logfire is a great fit when you:
 
 - **Want one stack, not two** - AI + infrastructure observability unified, not an agent framework plus a separate APM tool
-- **AI enabled workflows** - Use the [Logfire MCP server](https://pydantic.dev/docs/logfire/how-to-guides/mcp-server/?utm_source=comparison_docs) to query your app's telemetry data, analyze distributed traces, and fix errors with AI using Logfire's OTel-native API
+- **AI enabled workflows** - Use the [Logfire MCP server](https://pydantic.dev/docs/logfire/guides/mcp-server/?utm_source=comparison_docs) to query your app's telemetry data, analyze distributed traces, and fix errors with AI using Logfire's OTel-native API
 - **Have polyglot architectures** - Python backend + TypeScript frontend, microservices in different languages
 - **Want exceptional Python, TS/JS, Rust support** - While also supporting other languages via OTel
-- **Need code-first evals** - [pydantic-evals](https://pydantic.dev/docs/logfire/guides/web-ui/evals/?utm_source=comparison_docs) tests any Python function, not just LLM calls
+- **Need code-first evals** - [pydantic-evals](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=comparison_docs) tests any Python function, not just LLM calls
 - **Prefer SQL-based querying** - Familiar PostgreSQL syntax over proprietary query languages
 - **Value simple, predictable pricing** - $2/million spans, scales to billions of spans per month
 - **Need enterprise features** - [SOC2, HIPAA, self-hosting](https://pydantic.dev/pricing#enterprise?utm_source=comparison_docs options

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -48,10 +48,10 @@ We provide first-party SDKs for Python, JavaScript/TypeScript, and Rust that off
 Logfire is a great fit when you:
 
 - **Want one stack, not two** - AI + infrastructure observability unified, not an agent framework plus a separate APM tool
-- **AI enabled workflows** - Use the [Logfire MCP server](https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/?utm_source=comparison_docs) to query your app's telemetry data, analyze distributed traces, and fix errors with AI using Logfire's OTel-native API
+- **AI enabled workflows** - Use the [Logfire MCP server](https://pydantic.dev/docs/logfire/how-to-guides/mcp-server/?utm_source=comparison_docs) to query your app's telemetry data, analyze distributed traces, and fix errors with AI using Logfire's OTel-native API
 - **Have polyglot architectures** - Python backend + TypeScript frontend, microservices in different languages
 - **Want exceptional Python, TS/JS, Rust support** - While also supporting other languages via OTel
-- **Need code-first evals** - [pydantic-evals](https://logfire.pydantic.dev/docs/guides/web-ui/evals/?utm_source=comparison_docs) tests any Python function, not just LLM calls
+- **Need code-first evals** - [pydantic-evals](https://pydantic.dev/docs/logfire/guides/web-ui/evals/?utm_source=comparison_docs) tests any Python function, not just LLM calls
 - **Prefer SQL-based querying** - Familiar PostgreSQL syntax over proprietary query languages
 - **Value simple, predictable pricing** - $2/million spans, scales to billions of spans per month
 - **Need enterprise features** - [SOC2, HIPAA, self-hosting](https://pydantic.dev/pricing#enterprise?utm_source=comparison_docs options

--- a/docs/comparisons/sentry.md
+++ b/docs/comparisons/sentry.md
@@ -41,7 +41,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 **Logfire** provides full observability:
 
 - **Structured logs:** Every log/span/trace with full context, not just errors
-- **[Issue alerts](https://pydantic.dev/docs/logfire/guides/web-ui/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
+- **[Issue alerts](https://pydantic.dev/docs/logfire/observe/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
 - **Distributed traces:** See requests flow through your entire system
 - **Real-time monitoring:** Watch your application in real-time with "pending spans"
 - **AI visibility:** Automatic instrumentation for LLM calls, tool invocations, and more

--- a/docs/comparisons/sentry.md
+++ b/docs/comparisons/sentry.md
@@ -20,7 +20,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 - **Full observability:** You want logs, traces, AND error tracking in one tool
 - **AI/LLM applications:** You need to observe prompts, responses, token usage
 - **Real-time debugging:** You want to see what's happening right now, not just errors
-- **Frontend + backend debugging:** Use Logfire's  [JavaScript SDK](https://logfire.pydantic.dev/docs/integrations/javascript/?utm_source=sentry_comparison_docs) to trace and debug your entire application
+- **Frontend + backend debugging:** Use Logfire's  [JavaScript SDK](https://pydantic.dev/docs/logfire/integrations/javascript/?utm_source=sentry_comparison_docs) to trace and debug your entire application
 - **SQL analysis:** You want to query your data with familiar SQL
 - **Unified tooling:** You don't want to juggle Sentry + logging service + APM tool
 - **One-click AI-assisted debugging via MCP**
@@ -41,7 +41,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 **Logfire** provides full observability:
 
 - **Structured logs:** Every log/span/trace with full context, not just errors
-- **[Issue alerts](https://logfire.pydantic.dev/docs/guides/web-ui/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
+- **[Issue alerts](https://pydantic.dev/docs/logfire/guides/web-ui/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
 - **Distributed traces:** See requests flow through your entire system
 - **Real-time monitoring:** Watch your application in real-time with "pending spans"
 - **AI visibility:** Automatic instrumentation for LLM calls, tool invocations, and more

--- a/docs/evaluate/datasets/index.md
+++ b/docs/evaluate/datasets/index.md
@@ -5,11 +5,11 @@ description: "Create, manage, and fetch typed evaluation datasets in Pydantic Lo
 
 # Datasets
 
-Datasets let you build and maintain collections of test cases for evaluating your AI systems. You can create datasets through the Logfire web UI or programmatically via the SDK, then fetch them as [pydantic-evals](https://ai.pydantic.dev/evals/) `Dataset` objects to run evaluations.
+Datasets let you build and maintain collections of test cases for evaluating your AI systems. You can create datasets through the Logfire web UI or programmatically via the SDK, then fetch them as [pydantic-evals](https://pydantic.dev/docs/ai/evals/evals/) `Dataset` objects to run evaluations.
 
 !!! note "Relationship with Pydantic Evals"
 
-    Datasets in Logfire are the server-side complement to [pydantic-evals](https://ai.pydantic.dev/evals/) file-based datasets. While pydantic-evals stores datasets as local YAML files, Logfire datasets are stored on the server and can be created from production traces, edited collaboratively in the UI, and fetched for evaluation. The SDK is designed so you can move seamlessly between the two.
+    Datasets in Logfire are the server-side complement to [pydantic-evals](https://pydantic.dev/docs/ai/evals/evals/) file-based datasets. While pydantic-evals stores datasets as local YAML files, Logfire datasets are stored on the server and can be created from production traces, edited collaboratively in the UI, and fetched for evaluation. The SDK is designed so you can move seamlessly between the two.
 
 ## Hosted vs Local Datasets
 

--- a/docs/guides/web-ui/evals.md
+++ b/docs/guides/web-ui/evals.md
@@ -8,7 +8,7 @@ This is the reference for the **Evals: Datasets & Experiments** page in the Logf
 
 **Where to go next:**
 
-- To get started with creating and running evals in code, see the [Pydantic Evals docs](https://ai.pydantic.dev/evals/).
+- To get started with creating and running evals in code, see the [Pydantic Evals docs](https://pydantic.dev/docs/ai/evals/evals/).
 - To create or edit datasets through the Logfire UI, see the [Datasets Web UI Guide](../../evaluate/datasets/ui.md). This page covers what you see on the Evals page itself; the Web UI Guide covers dataset/case lifecycle tasks (create, edit, manage cases, export).
 - For programmatic dataset access, see the [SDK Guide](../../evaluate/datasets/sdk.md).
 

--- a/docs/guides/web-ui/issues.md
+++ b/docs/guides/web-ui/issues.md
@@ -100,7 +100,7 @@ The Fix with AI button uses Logfire's MCP server to give your AI assistant acces
 
 Run the command provided to retrieve the exception information from the Logfire MCP server so your AI assistant can analyze that specific exception and provide debugging suggestions based on your application context.
 
-Want us to integrate more AI Code assistants? [Let us know](https://pydantic.dev/docs/logfire/help/)
+Want us to integrate more AI Code assistants? [Let us know](../../help.md).
 
 ## Sorting and Searching
 

--- a/docs/guides/web-ui/issues.md
+++ b/docs/guides/web-ui/issues.md
@@ -100,7 +100,7 @@ The Fix with AI button uses Logfire's MCP server to give your AI assistant acces
 
 Run the command provided to retrieve the exception information from the Logfire MCP server so your AI assistant can analyze that specific exception and provide debugging suggestions based on your application context.
 
-Want us to integrate more AI Code assistants? [Let us know](https://logfire.pydantic.dev/docs/help/)
+Want us to integrate more AI Code assistants? [Let us know](https://pydantic.dev/docs/logfire/help/)
 
 ## Sorting and Searching
 

--- a/docs/guides/web-ui/live-evals.md
+++ b/docs/guides/web-ui/live-evals.md
@@ -4,9 +4,9 @@ description: "View real-time online-evaluation activity for your agents and func
 ---
 # Live Evaluations
 
-The **Evals: Live Monitoring** page streams evaluator results from live application traffic (e.g., from a production deployment) into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window. This is the Logfire view of what Pydantic AI calls [online evaluation](https://ai.pydantic.dev/evals/online-evaluation/).
+The **Evals: Live Monitoring** page streams evaluator results from live application traffic (e.g., from a production deployment) into the Pydantic Logfire web UI. Every target that emits evaluation events appears here as a single row, with a sparkline for each attached evaluator and a summary of activity over the selected time window. This is the Logfire view of what Pydantic AI calls [online evaluation](https://pydantic.dev/docs/ai/evals/online-evaluation/).
 
-To wire up evaluators on the Python side, see the [Online Evaluation guide](https://ai.pydantic.dev/evals/online-evaluation/) in the Pydantic AI docs. The page renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the [GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult) — the [`@evaluate`](https://ai.pydantic.dev/evals/online-evaluation/#quick-start) decorator and the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
+To wire up evaluators on the Python side, see the [Online Evaluation guide](https://pydantic.dev/docs/ai/evals/online-evaluation/) in the Pydantic AI docs. The page renders any ingested `gen_ai.evaluation.result` OpenTelemetry events that follow the [GenAI evaluation semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-events/#event-gen_aievaluationresult) — the [`@evaluate`](https://pydantic.dev/docs/ai/evals/online-evaluation/#quick-start) decorator and the [`OnlineEvaluation`](https://pydantic.dev/docs/ai/evals/online-evaluation/#agent-integration) agent capability from `pydantic-evals` are the supported entry points today.
 
 ## The Directory
 
@@ -15,7 +15,7 @@ Click **Evals: Live Monitoring** in the sidebar to open the directory. Each row 
 Each row shows:
 
 - **Target** — the target name, with an agent or function icon
-- **Type** — `agent` or `function`. Evaluations dispatched by the [`OnlineEvaluation`](https://ai.pydantic.dev/evals/online-evaluation/#agent-integration) capability on a Pydantic AI agent appear as `agent`; `@evaluate`-decorated functions appear as `function`, even when the decorated function runs inside an agent
+- **Type** — `agent` or `function`. Evaluations dispatched by the [`OnlineEvaluation`](https://pydantic.dev/docs/ai/evals/online-evaluation/#agent-integration) capability on a Pydantic AI agent appear as `agent`; `@evaluate`-decorated functions appear as `function`, even when the decorated function runs inside an agent
 - **Evaluations** — one compact cell per evaluator with a pass rate, numeric average, or categorical label summary plus a sparkline
 - **Events** — total number of evaluation events in the window
 - **Last activity** — when the most recent event arrived
@@ -37,7 +37,7 @@ The **Evaluator** filter dropdown narrows the recent-events table to a single ev
 
 Each recent-events row includes an **Open trace in live view** link that jumps to the live trace view for the span the evaluation was attached to — useful for seeing the full context of a low-scoring call.
 
-Each evaluator row also shows the distinct `evaluator_version` values seen in the window as small version badges. During a deploy rollout where two versions of the same evaluator are live at once, both versions appear side-by-side. See [Evaluator Versioning](https://ai.pydantic.dev/evals/online-evaluation/#evaluator-versioning) in the Pydantic AI docs for how to set the version tag.
+Each evaluator row also shows the distinct `evaluator_version` values seen in the window as small version badges. During a deploy rollout where two versions of the same evaluator are live at once, both versions appear side-by-side. See [Evaluator Versioning](https://pydantic.dev/docs/ai/evals/online-evaluation/#evaluator-versioning) in the Pydantic AI docs for how to set the version tag.
 
 ## Evaluator Shapes
 

--- a/docs/guides/web-ui/live.md
+++ b/docs/guides/web-ui/live.md
@@ -17,7 +17,7 @@ To search the live view, click `Search your spans` (keyboard shortcut `/`), this
 ### SQL Search
 
 For confident SQL users, write your queries directly here. For devs who want a bit of help,
-try the new [Pydantic AI](https://ai.pydantic.dev/) feature which generates a SQL query based on your prompt.
+try the new [Pydantic AI](https://pydantic.dev/docs/ai/overview/) feature which generates a SQL query based on your prompt.
 You can also review the fields available and populate your SQL automatically using the `Reference` list, see more on this below.
 
 **WHERE clause**

--- a/docs/guides/web-ui/prompt-playground.md
+++ b/docs/guides/web-ui/prompt-playground.md
@@ -17,7 +17,7 @@ Clicking **Open in Playground** will redirect you to the Agent Playground, prefi
 
 You can then modify parts of the captured run, such as the system prompt, user requests, tool calls, available tools, or model settings, and trigger another run to see the results.
 
-You can also configure which tools are available as well as the [model settings](https://ai.pydantic.dev/api/settings/) (for example, temperature).
+You can also configure which tools are available as well as the [model settings](https://pydantic.dev/docs/ai/api/pydantic-ai/settings/) (for example, temperature).
 
 ## Compared with Prompt Management
 

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -120,5 +120,5 @@ logfire.info('Hello, Logfire!')
 
 All the **Logfire** API methods are available in `logfire-api`.
 
-[slack]: https://logfire.pydantic.dev/docs/join-slack/
+[slack]: https://pydantic.dev/docs/logfire/join-slack/
 [opentelemetry]: https://opentelemetry.io/

--- a/docs/integrations/javascript/cloudflare.md
+++ b/docs/integrations/javascript/cloudflare.md
@@ -16,7 +16,7 @@ Next, add the Node.js compatibility flag to your Wrangler configuration:
 - For `wrangler.toml`: `compatibility_flags = [ "nodejs_compat" ]`
 - For `wrangler.jsonc`: `"compatibility_flags": ["nodejs_compat"]`
 
-Add your [Logfire write token](https://pydantic.dev/docs/logfire/how-to-guides/create-write-tokens/) to your `.dev.vars` file:
+Add your [Logfire write token](../../how-to-guides/create-write-tokens.md) to your `.dev.vars` file:
 
 ```sh
 LOGFIRE_TOKEN=your-write-token

--- a/docs/integrations/javascript/cloudflare.md
+++ b/docs/integrations/javascript/cloudflare.md
@@ -16,7 +16,7 @@ Next, add the Node.js compatibility flag to your Wrangler configuration:
 - For `wrangler.toml`: `compatibility_flags = [ "nodejs_compat" ]`
 - For `wrangler.jsonc`: `"compatibility_flags": ["nodejs_compat"]`
 
-Add your [Logfire write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/) to your `.dev.vars` file:
+Add your [Logfire write token](https://pydantic.dev/docs/logfire/how-to-guides/create-write-tokens/) to your `.dev.vars` file:
 
 ```sh
 LOGFIRE_TOKEN=your-write-token

--- a/docs/integrations/javascript/node.md
+++ b/docs/integrations/javascript/node.md
@@ -5,7 +5,7 @@ integration: logfire
 ---
 # Node.js
 
-Using Logfire in your Node.js script is straightforward. You need to [get a write token](https://pydantic.dev/docs/logfire/how-to-guides/create-write-tokens/), install the package, configure it, and use the provided API.
+Using Logfire in your Node.js script is straightforward. You need to [get a write token](../../how-to-guides/create-write-tokens.md), install the package, configure it, and use the provided API.
 
 Let's create an empty project:
 

--- a/docs/integrations/javascript/node.md
+++ b/docs/integrations/javascript/node.md
@@ -5,7 +5,7 @@ integration: logfire
 ---
 # Node.js
 
-Using Logfire in your Node.js script is straightforward. You need to [get a write token](https://logfire.pydantic.dev/docs/how-to-guides/create-write-tokens/), install the package, configure it, and use the provided API.
+Using Logfire in your Node.js script is straightforward. You need to [get a write token](https://pydantic.dev/docs/logfire/how-to-guides/create-write-tokens/), install the package, configure it, and use the provided API.
 
 Let's create an empty project:
 

--- a/docs/integrations/llms/llamaindex.md
+++ b/docs/integrations/llms/llamaindex.md
@@ -32,7 +32,7 @@ logfire.configure()
 LlamaIndexInstrumentor().instrument()
 
 # URL for Pydantic's main concepts page
-url = 'https://docs.pydantic.dev/latest/concepts/models/'
+url = 'https://pydantic.dev/docs/validation/latest/concepts/models/'
 
 # Load the webpage
 documents = SimpleWebPageReader(html_to_text=True).load_data([url])

--- a/docs/integrations/llms/mcp.md
+++ b/docs/integrations/llms/mcp.md
@@ -8,7 +8,7 @@ integration: logfire
 
 **Logfire** supports instrumenting the [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk) with the [`logfire.instrument_mcp()`][logfire.Logfire.instrument_mcp] method. This works on both the client and server side. If possible, calling this in both the client and server processes is recommended for nice distributed traces.
 
-Below is a simple example. For the client, we use [Pydantic AI](https://ai.pydantic.dev/mcp/client/) (though any MCP client will work) and OpenAI. To use a different LLM provider instead of OpenAI, replace `openai:gpt-4o` in the client script with a different model name supported by Pydantic AI.
+Below is a simple example. For the client, we use [Pydantic AI](https://pydantic.dev/docs/ai/mcp/client/) (though any MCP client will work) and OpenAI. To use a different LLM provider instead of OpenAI, replace `openai:gpt-4o` in the client script with a different model name supported by Pydantic AI.
 
 First, install the required dependencies:
 

--- a/docs/integrations/llms/mirascope.md
+++ b/docs/integrations/llms/mirascope.md
@@ -93,5 +93,4 @@ For more information on Mirascope and what you can do with it, check out their [
 [mirascope-logfire]: https://mirascope.io/docs/latest/integrations/logfire/
 [mirascope-supported-providers]: https://mirascope.io/docs/latest/learn/calls/#supported-providers
 [mirascope-extracting-structured-information]: https://mirascope.io/docs/latest/learn/response_models/
-[pydantic]: https://docs.pydantic.dev/latest/
-[pydantic-plugin]: https://docs.pydantic.dev/latest/concepts/plugins/
+[pydantic]: https://pydantic.dev/docs/validation/latest/get-started/

--- a/docs/integrations/llms/pydanticai.md
+++ b/docs/integrations/llms/pydanticai.md
@@ -3,7 +3,7 @@ title: Logfire Pydantic AI Integration
 description: "Get deep visibility into your Pydantic AI agents. Logfire tracing captures every tool call, retry, and complex agent step for reliable, structured debugging."
 integration: logfire
 ---
-**Pydantic Logfire** supports instrumenting [Pydantic AI](https://ai.pydantic.dev/) with the
+**Pydantic Logfire** supports instrumenting [Pydantic AI](https://pydantic.dev/docs/ai/overview/) with the
 [`logfire.instrument_pydantic_ai()`][logfire.Logfire.instrument_pydantic_ai] method:
 
 ```python hl_lines="7-8" skip-run="true" skip-reason="external-connection"

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -103,4 +103,4 @@ from pydantic import BaseModel
 class Foo(BaseModel, plugin_settings={'logfire': {'record': 'all', 'tags': ('tag1', 'tag2')}}): ...
 ```
 
-[pydantic]: https://docs.pydantic.dev/latest/
+[pydantic]: https://pydantic.dev/docs/validation/latest/get-started/

--- a/docs/reference/advanced/managed-variables/configuration-reference.md
+++ b/docs/reference/advanced/managed-variables/configuration-reference.md
@@ -231,4 +231,4 @@ config = VariablesConfig(
 )
 ```
 
-[slack]: https://logfire.pydantic.dev/docs/join-slack/
+[slack]: https://pydantic.dev/docs/logfire/join-slack/

--- a/docs/reference/advanced/metrics-in-spans.md
+++ b/docs/reference/advanced/metrics-in-spans.md
@@ -15,7 +15,7 @@ This guide will walk you through how to enable this feature and use it with both
 
 ## Enabling Metric Aggregation
 
-This feature is _always_ enabled for any metric named `operation.cost`, which in particular is recorded by [Pydantic AI](https://ai.pydantic.dev/) (since [v1.0.11](https://github.com/pydantic/pydantic-ai/releases/tag/v1.0.11)) when [instrumented](../../integrations/llms/pydanticai.md) for LLM costs.
+This feature is _always_ enabled for any metric named `operation.cost`, which in particular is recorded by [Pydantic AI](https://pydantic.dev/docs/ai/overview/) (since [v1.0.11](https://github.com/pydantic/pydantic-ai/releases/tag/v1.0.11)) when [instrumented](../../integrations/llms/pydanticai.md) for LLM costs.
 
 To enable this feature for all metrics, you need to configure Logfire with the `collect_in_spans` option in [`MetricsOptions`][logfire.MetricsOptions]. This should be done once when your application starts.
 

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -177,7 +177,7 @@ with logfire.span('parent'):
 
 with the above query will return a single row with `parent_message` set to `'parent'` and `child_message` set to `'child'`.
 
-If you find yourself needing to do this, consider using [Baggage](https://logfire.pydantic.dev/docs/reference/advanced/baggage/) instead.
+If you find yourself needing to do this, consider using [Baggage](https://pydantic.dev/docs/logfire/reference/advanced/baggage/) instead.
 
 ### Timestamps
 

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -177,7 +177,7 @@ with logfire.span('parent'):
 
 with the above query will return a single row with `parent_message` set to `'parent'` and `child_message` set to `'child'`.
 
-If you find yourself needing to do this, consider using [Baggage](https://pydantic.dev/docs/logfire/reference/advanced/baggage/) instead.
+If you find yourself needing to do this, consider using [Baggage](./advanced/baggage.md) instead.
 
 ### Timestamps
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,5 +7,5 @@ best place to check for updates to the Pydantic Logfire roadmap.
 
 If you have any questions, or a feature request, **please join our [Slack][slack]**.
 
-[slack]: https://logfire.pydantic.dev/docs/join-slack/
+[slack]: https://pydantic.dev/docs/logfire/join-slack/
 [roadmap]: https://github.com/pydantic/logfire/issues/1004

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1148,7 +1148,7 @@ class Logfire:
                 If `'attributes'`, events are attached to the span as attributes.
                 If `'logs'`, events are emitted as OpenTelemetry log-based events.
             kwargs: Additional keyword arguments to pass to
-                [`InstrumentationSettings`](https://ai.pydantic.dev/api/models/instrumented/#pydantic_ai.models.instrumented.InstrumentationSettings)
+                [`InstrumentationSettings`](https://pydantic.dev/docs/ai/api/models/instrumented/#pydantic_ai.models.instrumented.InstrumentationSettings)
                 for future compatibility.
         """
         from .integrations.pydantic_ai import instrument_pydantic_ai

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,8 @@ variables = ["pydantic>=2"]
 [project.urls]
 Homepage = "https://logfire.pydantic.dev/"
 Source = "https://github.com/pydantic/logfire"
-Documentation = "https://logfire.pydantic.dev/docs/"
-Changelog = "https://logfire.pydantic.dev/docs/release-notes/"
+Documentation = "https://pydantic.dev/docs/logfire/"
+Changelog = "https://pydantic.dev/docs/logfire/release-notes/"
 
 [project.scripts]
 logfire = "logfire.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,10 +87,10 @@ datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.0.0; python_versi
 variables = ["pydantic>=2"]
 
 [project.urls]
-Homepage = "https://logfire.pydantic.dev/"
+Homepage = "https://pydantic.dev/logfire"
 Source = "https://github.com/pydantic/logfire"
 Documentation = "https://pydantic.dev/docs/logfire/"
-Changelog = "https://pydantic.dev/docs/logfire/release-notes/"
+Changelog = "https://github.com/pydantic/logfire/blob/main/CHANGELOG.md"
 
 [project.scripts]
 logfire = "logfire.cli:main"


### PR DESCRIPTION
## Summary

Mechanical link hygiene: rewrite `https://logfire.pydantic.dev/docs/...` cross-links to the canonical `https://pydantic.dev/docs/logfire/...` location across `README.md`, `pyproject.toml` (`Documentation`, `Changelog`), and 13 files under `docs/` (30 occurrences total).

This is independent of the apex-redirect cutover work — these links would keep working through the existing `/docs/*` redirect — but canonicalising them is good hygiene and avoids the apex appearing in places where the canonical domain is more appropriate.

The narrative changes related to the apex redirect cutover live in a separate PR.

## Out of scope

- Root `https://logfire.pydantic.dev`, `pyproject.toml` `Homepage`, `/login`, `/login/{org-name}`, `/settings/...`, `/-/redirect/...` — left untouched
- `CHANGELOG.md` historical entries
- Source code and test fixtures

## Test plan

- [ ] Spot-check that rewritten `pydantic.dev/docs/logfire/...` URLs resolve

https://claude.ai/code/session_016QT2g2gvpVHYxLcLfifDXq

---
_Generated by [Claude Code](https://claude.ai/code/session_016QT2g2gvpVHYxLcLfifDXq)_