### PR TITLE
Drop support for Python < 3.9.2

### DIFF
--- a/logfire/_internal/auto_trace/__init__.py
+++ b/logfire/_internal/auto_trace/__init__.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import sys
 import warnings
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable, Literal
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Literal
 
 from ..constants import ONE_SECOND_IN_NANOSECONDS
 from .import_hook import LogfireFinder

--- a/logfire/_internal/auto_trace/import_hook.py
+++ b/logfire/_internal/auto_trace/import_hook.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import ast
 import sys
-from collections.abc import Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass
 from importlib.abc import Loader, MetaPathFinder
 from importlib.machinery import ModuleSpec
 from importlib.util import spec_from_loader
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..utils import log_internal_error
 from .rewrite_ast import compile_source

--- a/logfire/_internal/auto_trace/rewrite_ast.py
+++ b/logfire/_internal/auto_trace/rewrite_ast.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import ast
 import uuid
 from collections import deque
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from functools import partial
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import logfire
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -10,13 +10,13 @@ import sys
 import time
 import warnings
 import weakref
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 from threading import RLock, Thread
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 from urllib.parse import urljoin
 from uuid import uuid4
 

--- a/logfire/_internal/config_params.py
+++ b/logfire/_internal/config_params.py
@@ -2,11 +2,11 @@ from __future__ import annotations as _annotations
 
 import os
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Callable, Literal, TypeVar, Union
+from typing import Any, Literal, TypeVar, Union
 
 from opentelemetry.sdk.environment_variables import OTEL_SERVICE_NAME
 from typing_extensions import get_args, get_origin

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -4,9 +4,9 @@ import contextlib
 import functools
 import inspect
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import AbstractContextManager, asynccontextmanager, contextmanager
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from opentelemetry import trace
 from opentelemetry.util import types as otel_types

--- a/logfire/_internal/integrations/aiohttp_client.py
+++ b/logfire/_internal/integrations/aiohttp_client.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import functools
 import inspect
+from collections.abc import Callable
 from email.headerregistry import ContentTypeHeader
 from email.policy import EmailPolicy
 from functools import cache
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import attr
 from aiohttp.client import ClientSession

--- a/logfire/_internal/integrations/asgi.py
+++ b/logfire/_internal/integrations/asgi.py
@@ -14,8 +14,8 @@ from logfire._internal.constants import log_level_attributes
 from logfire._internal.utils import is_asgi_send_receive_span_name, maybe_capture_server_headers
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-    from typing import Any, Callable, Protocol, TypedDict
+    from collections.abc import Awaitable, Callable
+    from typing import Any, Protocol, TypedDict
 
     from opentelemetry.trace import Span
     from typing_extensions import Unpack

--- a/logfire/_internal/integrations/aws_lambda.py
+++ b/logfire/_internal/integrations/aws_lambda.py
@@ -12,7 +12,8 @@ except ImportError:
         "    pip install 'logfire[aws-lambda]'"
     )
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 LambdaEvent = Any
 LambdaHandler = Callable[[LambdaEvent, Any], Any]

--- a/logfire/_internal/integrations/django.py
+++ b/logfire/_internal/integrations/django.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from django.http import HttpRequest, HttpResponse
 from opentelemetry.trace import Span

--- a/logfire/_internal/integrations/executors.py
+++ b/logfire/_internal/integrations/executors.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import pickle
+from collections.abc import Callable
 from dataclasses import asdict
 from functools import partial, wraps
-from typing import Any, Callable
+from typing import Any
 
 from logfire.propagate import ContextCarrier, attach_context, get_context
 

--- a/logfire/_internal/integrations/fastapi.py
+++ b/logfire/_internal/integrations/fastapi.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-from collections.abc import Awaitable, Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timezone
 from functools import lru_cache, wraps
-from typing import Any, Callable
+from typing import Any
 from weakref import WeakKeyDictionary
 
 import fastapi.routing

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import contextlib
 import functools
 import inspect
-from collections.abc import Awaitable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from email.headerregistry import ContentTypeHeader
 from email.policy import EmailPolicy
 from functools import cached_property, lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import httpx
 from opentelemetry.trace import NonRecordingSpan, Span, use_span

--- a/logfire/_internal/integrations/llm_providers/llm_provider.py
+++ b/logfire/_internal/integrations/llm_providers/llm_provider.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Generator, Iterable, Iterator
+from collections.abc import AsyncIterator, Callable, Generator, Iterable, Iterator
 from contextlib import AbstractContextManager, ExitStack, contextmanager, nullcontext
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from opentelemetry.trace import SpanKind
 

--- a/logfire/_internal/integrations/pymongo.py
+++ b/logfire/_internal/integrations/pymongo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from opentelemetry.sdk.trace import Span
 from pymongo.monitoring import CommandFailedEvent, CommandStartedEvent, CommandSucceededEvent

--- a/logfire/_internal/integrations/requests.py
+++ b/logfire/_internal/integrations/requests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import requests
 from opentelemetry.sdk.trace import Span

--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -4,7 +4,7 @@ import contextlib
 import dataclasses
 import datetime
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from decimal import Decimal
 from enum import Enum
 from functools import cache, lru_cache
@@ -13,7 +13,7 @@ from itertools import chain
 from pathlib import PosixPath
 from re import Pattern
 from types import GeneratorType
-from typing import Any, Callable
+from typing import Any
 from uuid import UUID
 
 from .utils import JsonValue, safe_repr

--- a/logfire/_internal/json_formatter.py
+++ b/logfire/_internal/json_formatter.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import io
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta
 from functools import partial
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 from .json_types import ArraySchema, DataType, JSONSchema
 from .utils import safe_repr

--- a/logfire/_internal/json_schema.py
+++ b/logfire/_internal/json_schema.py
@@ -20,7 +20,7 @@ import datetime
 import re
 import uuid
 from collections import deque
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import suppress
 from decimal import Decimal
 from enum import Enum
@@ -28,7 +28,7 @@ from functools import lru_cache
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from pathlib import PosixPath
 from types import GeneratorType
-from typing import Any, Callable, NewType, cast
+from typing import Any, NewType, cast
 
 from .constants import ATTRIBUTES_SCRUBBED_KEY
 from .json_encoder import is_attrs, is_sqlalchemy, to_json_value

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -4,9 +4,9 @@ import copy
 import json
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 import typing_extensions
 from opentelemetry._logs import LogRecord

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
 import opentelemetry.trace as trace_api

--- a/logfire/_internal/ulid.py
+++ b/logfire/_internal/ulid.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from random import Random
-from typing import Callable
 
 
 def ulid(random: Random, ms_timestamp_generator: Callable[[], int]) -> int:

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -11,7 +11,7 @@ import platform
 import random
 import sys
 import traceback
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,7 +20,6 @@ from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     TypedDict,
     TypeVar,
     Union,

--- a/logfire/integrations/flask.py
+++ b/logfire/integrations/flask.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, TypedDict
+from collections.abc import Callable
+from typing import TYPE_CHECKING, TypedDict
 
 from opentelemetry.trace import Span
 

--- a/logfire/integrations/httpx.py
+++ b/logfire/integrations/httpx.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from typing import Any, Callable, NamedTuple
+from collections.abc import Awaitable, Callable
+from typing import Any, NamedTuple
 
 import httpx
 from opentelemetry.trace import Span

--- a/logfire/integrations/loguru.py
+++ b/logfire/integrations/loguru.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import inspect
+from collections.abc import Callable
 from logging import LogRecord
 from pathlib import Path
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import loguru
 

--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -6,9 +6,10 @@ import functools
 import inspect
 import os
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, Callable, Literal, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
 
 import pydantic
 from typing_extensions import ParamSpec

--- a/logfire/integrations/wsgi.py
+++ b/logfire/integrations/wsgi.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 
 from opentelemetry.trace import Span
 

--- a/logfire/sampling/_tail_sampling.py
+++ b/logfire/sampling/_tail_sampling.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from threading import Lock
-from typing import Callable, Literal
+from typing import Literal
 
 from opentelemetry import context
 from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor

--- a/logfire/types.py
+++ b/logfire/types.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from logfire._internal.constants import (
     ATTRIBUTES_LOG_LEVEL_NUM_KEY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "logfire"
 version = "4.32.1"
 description = "The best Python observability tool! 🪵🔥"
-requires-python = ">=3.9"
+requires-python = ">=3.9.2"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },
     { name = "Samuel Colvin", email = "samuel@pydantic.dev" },

--- a/tests/otel_integrations/test_claude_sdk.py
+++ b/tests/otel_integrations/test_claude_sdk.py
@@ -10,6 +10,29 @@ from inline_snapshot import snapshot
 from logfire._internal.exporters.processor_wrapper import _transform_langsmith_span_attributes  # type: ignore
 
 
+def test_transform_langsmith_span_uses_completion_model_for_request_model():
+    assert _transform_langsmith_span_attributes(
+        {'logfire.span_type': 'span'},
+        {
+            'gen_ai.completion': {
+                'llm_output': {
+                    'model_name': 'claude-sonnet-4-5-20250929',
+                },
+            },
+        },
+    ) == (
+        {
+            'logfire.span_type': 'span',
+        },
+        {
+            'gen_ai.response.model': 'claude-sonnet-4-5-20250929',
+            'gen_ai.request.model': 'claude-sonnet-4-5-20250929',
+            'gen_ai.system': 'anthropic',
+            'gen_ai.provider.name': 'anthropic',
+        },
+    )
+
+
 # Testing this properly is too much of a pain, we'd need to create a clever mock transport or something.
 # Can't use VCR because the HTTP requests happen in a different claude process.
 # Testing _transform_langsmith_span_attributes covers the actual relevant changes.

--- a/tests/test_auto_trace.py
+++ b/tests/test_auto_trace.py
@@ -3,9 +3,10 @@ import asyncio
 import importlib.resources
 import runpy
 import sys
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from importlib.machinery import SourceFileLoader
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 from inline_snapshot import snapshot

--- a/tests/test_canonicalize_exception.py
+++ b/tests/test_canonicalize_exception.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from inline_snapshot import snapshot

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -5,12 +5,13 @@ import os
 import re
 import sys
 import warnings
+from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from functools import partial
 from logging import getLogger
-from typing import Any, Callable
+from typing import Any
 from unittest.mock import patch
 
 import cloudpickle

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import importlib
 import sys
 import warnings
+from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
-from typing import Callable
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_source_code_extraction.py
+++ b/tests/test_source_code_extraction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import sys
 from typing import Any
 
@@ -7,6 +8,7 @@ import pytest
 from inline_snapshot import snapshot
 
 import logfire
+from logfire._internal import ast_utils
 from logfire._internal.ast_utils import InspectArgumentsFailedWarning
 from logfire.testing import TestExporter
 
@@ -60,7 +62,7 @@ def test_source_code_extraction_function(exporter: TestExporter) -> None:
                 'end_time': 2000000000,
                 'attributes': {
                     'code.filepath': 'tests/test_source_code_extraction.py',
-                    'code.lineno': 15,
+                    'code.lineno': 17,
                     'code.function': 'func',
                     'logfire.msg_template': 'from function',
                     'logfire.span_type': 'span',
@@ -87,7 +89,7 @@ def test_source_code_extraction_method(exporter: TestExporter) -> None:
                 'end_time': 2000000000,
                 'attributes': {
                     'code.filepath': 'tests/test_source_code_extraction.py',
-                    'code.lineno': 21,
+                    'code.lineno': 23,
                     'code.function': code_function,
                     'logfire.msg_template': 'from method',
                     'logfire.span_type': 'span',
@@ -206,7 +208,7 @@ def test_source_code_extraction_nested(exporter: TestExporter) -> None:
                 'end_time': 2000000000,
                 'attributes': {
                     'code.filepath': 'tests/test_source_code_extraction.py',
-                    'code.lineno': 29,
+                    'code.lineno': 31,
                     'code.function': code_function,
                     'logfire.msg_template': 'hi!',
                     'logfire.span_type': 'span',
@@ -218,20 +220,14 @@ def test_source_code_extraction_nested(exporter: TestExporter) -> None:
 
 
 def test_get_node_source_text_falls_back_to_unparse(monkeypatch: pytest.MonkeyPatch) -> None:
-    import ast
-
-    from logfire._internal import ast_utils
-
     node = ast.parse('x', mode='eval').body
 
     class Source:
         text = 'x'
 
-    ast_utils.get_node_source_text.cache_clear()
-
     def get_source_segment(*args: Any) -> str:
         return 'x +'
 
-    monkeypatch.setattr(ast_utils.ast, 'get_source_segment', get_source_segment)
+    monkeypatch.setattr(ast, 'get_source_segment', get_source_segment)
 
     assert ast_utils.get_node_source_text(node, Source()) == 'x'

--- a/tests/test_source_code_extraction.py
+++ b/tests/test_source_code_extraction.py
@@ -215,3 +215,23 @@ def test_source_code_extraction_nested(exporter: TestExporter) -> None:
             }
         ]
     )
+
+
+def test_get_node_source_text_falls_back_to_unparse(monkeypatch: pytest.MonkeyPatch) -> None:
+    import ast
+
+    from logfire._internal import ast_utils
+
+    node = ast.parse('x', mode='eval').body
+
+    class Source:
+        text = 'x'
+
+    ast_utils.get_node_source_text.cache_clear()
+
+    def get_source_segment(*args: Any) -> str:
+        return 'x +'
+
+    monkeypatch.setattr(ast_utils.ast, 'get_source_segment', get_source_segment)
+
+    assert ast_utils.get_node_source_text(node, Source()) == 'x'

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
+requires-python = ">=3.9.2"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",


### PR DESCRIPTION
Moving towards dropping 3.9 entirely in #1919