### PR TITLE
Own Logfire OTLP HTTP token exporters

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -25,9 +25,11 @@ from opentelemetry import trace
 from opentelemetry._logs import NoOpLoggerProvider, set_logger_provider
 from opentelemetry.environment_variables import OTEL_LOGS_EXPORTER, OTEL_METRICS_EXPORTER, OTEL_TRACES_EXPORTER
 from opentelemetry.exporter.otlp.proto.http import Compression
-from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter as OpenTelemetryOTLPLogExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
+    OTLPMetricExporter as OpenTelemetryOTLPMetricExporter,
+)
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as OpenTelemetryOTLPSpanExporter
 from opentelemetry.metrics import NoOpMeterProvider, set_meter_provider
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
 from opentelemetry.sdk._logs import LoggerProvider as SDKLoggerProvider, LogRecordProcessor
@@ -102,6 +104,7 @@ from .exporters.otlp import (
     RetryFewerSpansSpanExporter,
     cleanup_disk_retryers,
 )
+from .exporters.otlp_proto_http import LogfireOTLPLogExporter, LogfireOTLPMetricExporter
 from .exporters.processor_wrapper import CheckSuppressInstrumentationProcessorWrapper, MainSpanProcessorWrapper
 from .exporters.quiet_metrics import QuietMetricExporter
 from .exporters.remove_pending import RemovePendingSpansExporter
@@ -1198,7 +1201,7 @@ class LogfireConfig(_LogfireConfigData):
                             metric_readers.append(
                                 PeriodicExportingMetricReader(
                                     QuietMetricExporter(
-                                        OTLPMetricExporter(
+                                        LogfireOTLPMetricExporter(
                                             endpoint=urljoin(base_url, '/v1/metrics'),
                                             headers=headers,
                                             session=session,
@@ -1213,7 +1216,7 @@ class LogfireConfig(_LogfireConfigData):
                                 )
                             )
 
-                        log_exporter = OTLPLogExporter(
+                        log_exporter = LogfireOTLPLogExporter(
                             endpoint=urljoin(base_url, '/v1/logs'),
                             session=session,
                             headers=headers,
@@ -1276,21 +1279,21 @@ class LogfireConfig(_LogfireConfigData):
             otlp_logs_exporter = os.getenv(OTEL_LOGS_EXPORTER, '').lower()
 
             if (otlp_endpoint or otlp_traces_endpoint) and otlp_traces_exporter in ('otlp', ''):
-                add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+                add_span_processor(BatchSpanProcessor(OpenTelemetryOTLPSpanExporter()))
 
             if (
                 (otlp_endpoint or otlp_metrics_endpoint)
                 and otlp_metrics_exporter in ('otlp', '')
                 and metric_readers is not None
             ):
-                metric_readers += [PeriodicExportingMetricReader(OTLPMetricExporter())]
+                metric_readers += [PeriodicExportingMetricReader(OpenTelemetryOTLPMetricExporter())]
 
             if (otlp_endpoint or otlp_logs_endpoint) and otlp_logs_exporter in ('otlp', ''):
                 if emscripten:  # pragma: no cover
                     # BatchLogRecordProcessor uses threads which fail in Pyodide / Emscripten
-                    logfire_log_processor = SimpleLogRecordProcessor(OTLPLogExporter())
+                    logfire_log_processor = SimpleLogRecordProcessor(OpenTelemetryOTLPLogExporter())
                 else:
-                    logfire_log_processor = BatchLogRecordProcessor(OTLPLogExporter())
+                    logfire_log_processor = BatchLogRecordProcessor(OpenTelemetryOTLPLogExporter())
                 log_record_processors.append(logfire_log_processor)
 
             if metric_readers is not None:

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -15,7 +15,6 @@ from threading import Lock, Thread
 from typing import Any
 
 import requests.exceptions
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk._logs._internal.export import LogRecordExportResult
 from opentelemetry.sdk.trace import ReadableSpan
@@ -25,6 +24,7 @@ from requests import Session
 import logfire
 
 from ..utils import logger, platform_is_emscripten
+from .otlp_proto_http.trace_exporter import LogfireOTLPSpanExporter
 from .wrapper import WrapperLogExporter, WrapperSpanExporter
 
 _DISK_RETRYERS: list[weakref.ref[DiskRetryer]] = []
@@ -38,7 +38,7 @@ def cleanup_disk_retryers() -> None:
             retryer.close()
 
 
-class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
+class BodySizeCheckingOTLPSpanExporter(LogfireOTLPSpanExporter):
     # 5MB is significantly less than what our backend currently accepts,
     # but smaller requests are faster and more reliable.
     # This won't prevent bigger spans/payloads from being exported,
@@ -60,7 +60,7 @@ class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
             # Tell outer RetryFewerSpansSpanExporter to split in half
             raise BodyTooLargeError(len(serialized_data), self.max_body_size)
 
-        return super()._export(serialized_data, *args, **kwargs)
+        return super()._export(serialized_data)
 
 
 class OTLPExporterHttpSession(Session):

--- a/logfire/_internal/exporters/otlp_proto_http/__init__.py
+++ b/logfire/_internal/exporters/otlp_proto_http/__init__.py
@@ -1,1 +1,7 @@
 """Logfire-owned OTLP/HTTP exporters for the internal send-to-Logfire path."""
+
+from ._log_exporter import LogfireOTLPLogExporter
+from .metric_exporter import LogfireOTLPMetricExporter
+from .trace_exporter import LogfireOTLPSpanExporter
+
+__all__ = 'LogfireOTLPLogExporter', 'LogfireOTLPMetricExporter', 'LogfireOTLPSpanExporter'

--- a/logfire/_internal/exporters/otlp_proto_http/__init__.py
+++ b/logfire/_internal/exporters/otlp_proto_http/__init__.py
@@ -1,0 +1,1 @@
+"""Logfire-owned OTLP/HTTP exporters for the internal send-to-Logfire path."""

--- a/logfire/_internal/exporters/otlp_proto_http/_common.py
+++ b/logfire/_internal/exporters/otlp_proto_http/_common.py
@@ -6,7 +6,7 @@ import zlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Literal
+from typing import Literal, Union
 
 import requests
 from opentelemetry.exporter.otlp.proto.http import Compression
@@ -30,7 +30,7 @@ from opentelemetry.sdk.environment_variables import (
 )
 
 SignalName = Literal['traces', 'metrics', 'logs']
-ClientCert = str | tuple[str, str] | None
+ClientCert = Union[str, tuple[str, str], None]
 
 DEFAULT_TIMEOUT = 10.0
 OTLP_HTTP_HEADERS: Mapping[str, str] = {'Content-Type': 'application/x-protobuf'}

--- a/logfire/_internal/exporters/otlp_proto_http/_common.py
+++ b/logfire/_internal/exporters/otlp_proto_http/_common.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import gzip
+import os
+import zlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Literal
+
+import requests
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.environment_variables import (
+    OTEL_EXPORTER_OTLP_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+    OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+    OTEL_EXPORTER_OTLP_TIMEOUT,
+    OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
+    OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
+    OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+)
+
+SignalName = Literal['traces', 'metrics', 'logs']
+ClientCert = str | tuple[str, str] | None
+
+DEFAULT_TIMEOUT = 10.0
+OTLP_HTTP_HEADERS: Mapping[str, str] = {'Content-Type': 'application/x-protobuf'}
+
+
+@dataclass(frozen=True)
+class SignalEnvironmentVariables:
+    timeout: str
+    certificate: str
+    client_certificate: str
+    client_key: str
+
+
+SIGNAL_ENVIRONMENT_VARIABLES: Mapping[SignalName, SignalEnvironmentVariables] = {
+    'traces': SignalEnvironmentVariables(
+        timeout=OTEL_EXPORTER_OTLP_TRACES_TIMEOUT,
+        certificate=OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE,
+        client_certificate=OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE,
+        client_key=OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY,
+    ),
+    'metrics': SignalEnvironmentVariables(
+        timeout=OTEL_EXPORTER_OTLP_METRICS_TIMEOUT,
+        certificate=OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE,
+        client_certificate=OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE,
+        client_key=OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY,
+    ),
+    'logs': SignalEnvironmentVariables(
+        timeout=OTEL_EXPORTER_OTLP_LOGS_TIMEOUT,
+        certificate=OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE,
+        client_certificate=OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE,
+        client_key=OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY,
+    ),
+}
+
+
+def resolve_timeout(signal: SignalName, explicit_timeout: float | None) -> float:
+    if explicit_timeout is not None:
+        return explicit_timeout
+
+    signal_env = SIGNAL_ENVIRONMENT_VARIABLES[signal].timeout
+    return float(os.environ.get(signal_env, os.environ.get(OTEL_EXPORTER_OTLP_TIMEOUT, DEFAULT_TIMEOUT)))
+
+
+def resolve_certificate_file(signal: SignalName, explicit_certificate_file: str | None) -> str | bool:
+    if explicit_certificate_file:
+        return explicit_certificate_file
+
+    signal_env = SIGNAL_ENVIRONMENT_VARIABLES[signal].certificate
+    if signal_env in os.environ:
+        return os.environ[signal_env]
+    return os.environ.get(OTEL_EXPORTER_OTLP_CERTIFICATE, True)
+
+
+def resolve_client_cert(
+    signal: SignalName,
+    explicit_client_certificate_file: str | None,
+    explicit_client_key_file: str | None,
+) -> ClientCert:
+    env_vars = SIGNAL_ENVIRONMENT_VARIABLES[signal]
+    client_certificate_file = explicit_client_certificate_file or os.environ.get(
+        env_vars.client_certificate,
+        os.environ.get(OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE),
+    )
+    client_key_file = explicit_client_key_file or os.environ.get(
+        env_vars.client_key,
+        os.environ.get(OTEL_EXPORTER_OTLP_CLIENT_KEY),
+    )
+    if client_certificate_file and client_key_file:
+        return client_certificate_file, client_key_file
+    return client_certificate_file
+
+
+def apply_session_headers(
+    session: requests.Session,
+    headers: Mapping[str, str] | None,
+    compression: Compression,
+) -> None:
+    if headers:
+        session.headers.update(headers)
+    session.headers.update(OTLP_HTTP_HEADERS)
+    if headers:
+        session.headers.update(headers)
+    if compression is not Compression.NoCompression:
+        session.headers.update({'Content-Encoding': compression.value})
+
+
+def compress_serialized_data(serialized_data: bytes, compression: Compression) -> bytes:
+    if compression == Compression.Gzip:
+        gzip_data = BytesIO()
+        with gzip.GzipFile(fileobj=gzip_data, mode='w') as gzip_stream:
+            gzip_stream.write(serialized_data)
+        return gzip_data.getvalue()
+    if compression == Compression.Deflate:
+        return zlib.compress(serialized_data)
+    return serialized_data
+
+
+def post_serialized_data(
+    session: requests.Session,
+    endpoint: str,
+    serialized_data: bytes,
+    *,
+    compression: Compression,
+    certificate_file: str | bool,
+    timeout: float,
+    client_cert: ClientCert,
+) -> requests.Response:
+    return session.post(
+        url=endpoint,
+        data=compress_serialized_data(serialized_data, compression),
+        verify=certificate_file,
+        timeout=timeout,
+        cert=client_cert,
+    )

--- a/logfire/_internal/exporters/otlp_proto_http/_log_exporter.py
+++ b/logfire/_internal/exporters/otlp_proto_http/_log_exporter.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import requests
+from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+
+from ._common import (
+    ClientCert,
+    apply_session_headers,
+    post_serialized_data,
+    resolve_certificate_file,
+    resolve_client_cert,
+    resolve_timeout,
+)
+
+UPSTREAM_OTEL_MODULE = 'opentelemetry.exporter.otlp.proto.http._log_exporter'
+UPSTREAM_OTEL_VERSION = '1.41.1'
+OWNED_OTEL_ENCODING_DEPENDENCIES = ('opentelemetry.exporter.otlp.proto.common._log_encoder.encode_logs',)
+INTENTIONAL_OTEL_DEVIATIONS = (
+    'No OpenTelemetry HTTP retry loop; Logfire request retry remains in OTLPExporterHttpSession/DiskRetryer.',
+    'No OpenTelemetry private credential-provider or session loading.',
+    'No generic OTLP endpoint, header, or compression environment handling in the Logfire token path.',
+    'Exporter shutdown is state-only and does not close the supplied shared session.',
+)
+
+DEFAULT_ENDPOINT = 'http://localhost:4318/v1/logs'
+
+
+class LogfireOTLPLogExporter(LogRecordExporter):
+    def __init__(
+        self,
+        endpoint: str = DEFAULT_ENDPOINT,
+        *,
+        certificate_file: str | None = None,
+        client_key_file: str | None = None,
+        client_certificate_file: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        compression: Compression = Compression.Gzip,
+        session: requests.Session,
+    ) -> None:
+        self._endpoint = endpoint
+        self._headers = dict(headers or {})
+        self._timeout = resolve_timeout('logs', timeout)
+        self._certificate_file = resolve_certificate_file('logs', certificate_file)
+        self._client_cert: ClientCert = resolve_client_cert('logs', client_certificate_file, client_key_file)
+        self._compression = compression
+        self._session = session
+        self._shutdown = False
+
+        apply_session_headers(self._session, self._headers, self._compression)
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        if self._shutdown:
+            return LogRecordExportResult.FAILURE
+
+        response = self._export(self._serialize_logs(batch))
+        if response.ok:
+            return LogRecordExportResult.SUCCESS
+        return LogRecordExportResult.FAILURE
+
+    def _serialize_logs(self, batch: Sequence[ReadableLogRecord]) -> bytes:
+        try:
+            return encode_logs(batch).SerializeToString()
+        except Exception as exc:
+            raise RuntimeError(
+                'OpenTelemetry log encoder API is incompatible with LogfireOTLPLogExporter. '
+                'Expected encode_logs(...) to return a protobuf message with SerializeToString().'
+            ) from exc
+
+    def _export(self, serialized_data: bytes) -> requests.Response:
+        return post_serialized_data(
+            self._session,
+            self._endpoint,
+            serialized_data,
+            compression=self._compression,
+            certificate_file=self._certificate_file,
+            timeout=self._timeout,
+            client_cert=self._client_cert,
+        )
+
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        return True

--- a/logfire/_internal/exporters/otlp_proto_http/metric_exporter.py
+++ b/logfire/_internal/exporters/otlp_proto_http/metric_exporter.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    MetricExporter,
+    MetricExportResult,
+    MetricsData,
+)
+from opentelemetry.sdk.metrics.view import Aggregation
+
+from ._common import (
+    ClientCert,
+    apply_session_headers,
+    post_serialized_data,
+    resolve_certificate_file,
+    resolve_client_cert,
+    resolve_timeout,
+)
+
+UPSTREAM_OTEL_MODULE = 'opentelemetry.exporter.otlp.proto.http.metric_exporter'
+UPSTREAM_OTEL_VERSION = '1.41.1'
+OWNED_OTEL_ENCODING_DEPENDENCIES = ('opentelemetry.exporter.otlp.proto.common.metrics_encoder.encode_metrics',)
+INTENTIONAL_OTEL_DEVIATIONS = (
+    'No OpenTelemetry HTTP retry loop; Logfire request retry remains in OTLPExporterHttpSession/DiskRetryer.',
+    'No OpenTelemetry private credential-provider or session loading.',
+    'No generic OTLP endpoint, header, or compression environment handling in the Logfire token path.',
+    'Exporter shutdown is state-only and does not close the supplied shared session.',
+    'No OpenTelemetry max_export_batch_size split behavior; it is outside the Logfire token-path preservation target.',
+)
+
+DEFAULT_ENDPOINT = 'http://localhost:4318/v1/metrics'
+
+
+class LogfireOTLPMetricExporter(MetricExporter):
+    def __init__(
+        self,
+        endpoint: str = DEFAULT_ENDPOINT,
+        *,
+        certificate_file: str | None = None,
+        client_key_file: str | None = None,
+        client_certificate_file: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        compression: Compression = Compression.Gzip,
+        session: requests.Session,
+        preferred_temporality: dict[type, AggregationTemporality] | None = None,
+        preferred_aggregation: dict[type, Aggregation] | None = None,
+    ) -> None:
+        super().__init__(
+            preferred_temporality=preferred_temporality,
+            preferred_aggregation=preferred_aggregation,
+        )
+        self._endpoint = endpoint
+        self._headers = dict(headers or {})
+        self._timeout = resolve_timeout('metrics', timeout)
+        self._certificate_file = resolve_certificate_file('metrics', certificate_file)
+        self._client_cert: ClientCert = resolve_client_cert('metrics', client_certificate_file, client_key_file)
+        self._compression = compression
+        self._session = session
+        self._shutdown = False
+
+        apply_session_headers(self._session, self._headers, self._compression)
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10_000,
+        **kwargs: Any,
+    ) -> MetricExportResult:
+        if self._shutdown:
+            return MetricExportResult.FAILURE
+
+        response = self._export(self._serialize_metrics(metrics_data))
+        if response.ok:
+            return MetricExportResult.SUCCESS
+        return MetricExportResult.FAILURE
+
+    def _serialize_metrics(self, metrics_data: MetricsData) -> bytes:
+        try:
+            return encode_metrics(metrics_data).SerializeToString()
+        except Exception as exc:
+            raise RuntimeError(
+                'OpenTelemetry metrics encoder API is incompatible with LogfireOTLPMetricExporter. '
+                'Expected encode_metrics(...) to return a protobuf message with SerializeToString().'
+            ) from exc
+
+    def _export(self, serialized_data: bytes) -> requests.Response:
+        return post_serialized_data(
+            self._session,
+            self._endpoint,
+            serialized_data,
+            compression=self._compression,
+            certificate_file=self._certificate_file,
+            timeout=self._timeout,
+            client_cert=self._client_cert,
+        )
+
+    def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: float = 10_000) -> bool:
+        return True

--- a/logfire/_internal/exporters/otlp_proto_http/trace_exporter.py
+++ b/logfire/_internal/exporters/otlp_proto_http/trace_exporter.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import requests
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from ._common import (
+    ClientCert,
+    apply_session_headers,
+    post_serialized_data,
+    resolve_certificate_file,
+    resolve_client_cert,
+    resolve_timeout,
+)
+
+UPSTREAM_OTEL_MODULE = 'opentelemetry.exporter.otlp.proto.http.trace_exporter'
+UPSTREAM_OTEL_VERSION = '1.41.1'
+OWNED_OTEL_ENCODING_DEPENDENCIES = ('opentelemetry.exporter.otlp.proto.common.trace_encoder.encode_spans',)
+INTENTIONAL_OTEL_DEVIATIONS = (
+    'No OpenTelemetry HTTP retry loop; Logfire request retry remains in OTLPExporterHttpSession/DiskRetryer.',
+    'No OpenTelemetry private credential-provider or session loading.',
+    'No generic OTLP endpoint, header, or compression environment handling in the Logfire token path.',
+    'Exporter shutdown is state-only and does not close the supplied shared session.',
+)
+
+DEFAULT_ENDPOINT = 'http://localhost:4318/v1/traces'
+
+
+class LogfireOTLPSpanExporter(SpanExporter):
+    def __init__(
+        self,
+        endpoint: str = DEFAULT_ENDPOINT,
+        *,
+        certificate_file: str | None = None,
+        client_key_file: str | None = None,
+        client_certificate_file: str | None = None,
+        headers: dict[str, str] | None = None,
+        timeout: float | None = None,
+        compression: Compression = Compression.Gzip,
+        session: requests.Session,
+    ) -> None:
+        self._endpoint = endpoint
+        self._headers = dict(headers or {})
+        self._timeout = resolve_timeout('traces', timeout)
+        self._certificate_file = resolve_certificate_file('traces', certificate_file)
+        self._client_cert: ClientCert = resolve_client_cert('traces', client_certificate_file, client_key_file)
+        self._compression = compression
+        self._session = session
+        self._shutdown = False
+
+        apply_session_headers(self._session, self._headers, self._compression)
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if self._shutdown:
+            return SpanExportResult.FAILURE
+
+        response = self._export(self._serialize_spans(spans))
+        if response.ok:
+            return SpanExportResult.SUCCESS
+        return SpanExportResult.FAILURE
+
+    def _serialize_spans(self, spans: Sequence[ReadableSpan]) -> bytes:
+        try:
+            return encode_spans(spans).SerializePartialToString()
+        except Exception as exc:
+            raise RuntimeError(
+                'OpenTelemetry trace encoder API is incompatible with LogfireOTLPSpanExporter. '
+                'Expected encode_spans(...) to return a protobuf message with SerializePartialToString().'
+            ) from exc
+
+    def _export(self, serialized_data: bytes) -> requests.Response:
+        return post_serialized_data(
+            self._session,
+            self._endpoint,
+            serialized_data,
+            compression=self._compression,
+            certificate_file=self._certificate_file,
+            timeout=self._timeout,
+            client_cert=self._client_cert,
+        )
+
+    def shutdown(self) -> None:
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True

--- a/tests/exporters/otlp_proto_http/test_common.py
+++ b/tests/exporters/otlp_proto_http/test_common.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import gzip
+import zlib
+from unittest.mock import Mock
+
+import pytest
+import requests
+from opentelemetry.exporter.otlp.proto.http import Compression
+
+from logfire._internal.exporters.otlp_proto_http._common import (
+    DEFAULT_TIMEOUT,
+    OTLP_HTTP_HEADERS,
+    SIGNAL_ENVIRONMENT_VARIABLES,
+    SignalName,
+    apply_session_headers,
+    compress_serialized_data,
+    post_serialized_data,
+    resolve_certificate_file,
+    resolve_client_cert,
+    resolve_timeout,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_effective_otlp_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    env_var_names = {
+        'OTEL_EXPORTER_OTLP_TIMEOUT',
+        'OTEL_EXPORTER_OTLP_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_CLIENT_KEY',
+    }
+    for env_vars in SIGNAL_ENVIRONMENT_VARIABLES.values():
+        env_var_names.update(
+            {
+                env_vars.timeout,
+                env_vars.certificate,
+                env_vars.client_certificate,
+                env_vars.client_key,
+            }
+        )
+    for env_var_name in env_var_names:
+        monkeypatch.delenv(env_var_name, raising=False)
+
+
+def test_apply_session_headers_preserves_logfire_headers_over_otlp_defaults() -> None:
+    session = requests.Session()
+
+    apply_session_headers(
+        session,
+        {'User-Agent': 'logfire/test', 'Authorization': 'pylf_v1_test'},
+        Compression.Gzip,
+    )
+
+    assert session.headers['User-Agent'] == 'logfire/test'
+    assert session.headers['Authorization'] == 'pylf_v1_test'
+    assert session.headers['Content-Type'] == OTLP_HTTP_HEADERS['Content-Type']
+    assert session.headers['Content-Encoding'] == 'gzip'
+
+
+def test_apply_session_headers_omits_content_encoding_without_compression() -> None:
+    session = requests.Session()
+
+    apply_session_headers(session, None, Compression.NoCompression)
+
+    assert session.headers['Content-Type'] == 'application/x-protobuf'
+    assert 'Content-Encoding' not in session.headers
+
+
+def test_compress_serialized_data() -> None:
+    payload = b'payload'
+
+    assert gzip.decompress(compress_serialized_data(payload, Compression.Gzip)) == payload
+    assert zlib.decompress(compress_serialized_data(payload, Compression.Deflate)) == payload
+    assert compress_serialized_data(payload, Compression.NoCompression) == payload
+
+
+@pytest.mark.parametrize('signal', ['traces', 'metrics', 'logs'])
+def test_timeout_resolution_uses_exact_effective_env_vars(signal: SignalName, monkeypatch: pytest.MonkeyPatch) -> None:
+    signal_timeout = SIGNAL_ENVIRONMENT_VARIABLES[signal].timeout
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_TIMEOUT', '11')
+
+    assert resolve_timeout(signal, None) == 11
+
+    monkeypatch.setenv(signal_timeout, '12')
+    assert resolve_timeout(signal, None) == 12
+    assert resolve_timeout(signal, 13) == 13
+
+
+@pytest.mark.parametrize('signal', ['traces', 'metrics', 'logs'])
+def test_timeout_defaults_to_ten_seconds(signal: SignalName) -> None:
+    assert resolve_timeout(signal, None) == DEFAULT_TIMEOUT
+
+
+@pytest.mark.parametrize('signal', ['traces', 'metrics', 'logs'])
+def test_certificate_resolution_uses_exact_effective_env_vars(
+    signal: SignalName, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    signal_certificate = SIGNAL_ENVIRONMENT_VARIABLES[signal].certificate
+    assert resolve_certificate_file(signal, None) is True
+
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_CERTIFICATE', 'generic.pem')
+    assert resolve_certificate_file(signal, None) == 'generic.pem'
+
+    monkeypatch.setenv(signal_certificate, 'signal.pem')
+    assert resolve_certificate_file(signal, None) == 'signal.pem'
+    assert resolve_certificate_file(signal, 'explicit.pem') == 'explicit.pem'
+
+
+@pytest.mark.parametrize('signal', ['traces', 'metrics', 'logs'])
+def test_client_cert_resolution_uses_exact_effective_env_vars(
+    signal: SignalName, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    env_vars = SIGNAL_ENVIRONMENT_VARIABLES[signal]
+    assert resolve_client_cert(signal, None, None) is None
+
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE', 'generic-cert.pem')
+    assert resolve_client_cert(signal, None, None) == 'generic-cert.pem'
+
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_CLIENT_KEY', 'generic-key.pem')
+    assert resolve_client_cert(signal, None, None) == ('generic-cert.pem', 'generic-key.pem')
+
+    monkeypatch.setenv(env_vars.client_certificate, 'signal-cert.pem')
+    monkeypatch.setenv(env_vars.client_key, 'signal-key.pem')
+    assert resolve_client_cert(signal, None, None) == ('signal-cert.pem', 'signal-key.pem')
+    assert resolve_client_cert(signal, 'explicit-cert.pem', 'explicit-key.pem') == (
+        'explicit-cert.pem',
+        'explicit-key.pem',
+    )
+
+
+def test_generic_endpoint_header_and_compression_env_vars_do_not_affect_common_helpers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_ENDPOINT', 'https://otel.example')
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_HEADERS', 'Authorization=otel')
+    monkeypatch.setenv('OTEL_EXPORTER_OTLP_COMPRESSION', 'deflate')
+
+    session = requests.Session()
+    apply_session_headers(session, {'Authorization': 'logfire'}, Compression.Gzip)
+
+    assert session.headers['Authorization'] == 'logfire'
+    assert session.headers['Content-Encoding'] == 'gzip'
+
+
+def test_post_serialized_data_uses_supplied_request_metadata() -> None:
+    session = Mock(spec=requests.Session)
+    response = requests.Response()
+    session.post.return_value = response
+
+    assert (
+        post_serialized_data(
+            session,
+            'https://example.com/v1/traces',
+            b'payload',
+            compression=Compression.Deflate,
+            certificate_file='cert.pem',
+            timeout=12.5,
+            client_cert=('client.pem', 'key.pem'),
+        )
+        is response
+    )
+
+    session.post.assert_called_once()
+    _, kwargs = session.post.call_args
+    assert kwargs == {
+        'url': 'https://example.com/v1/traces',
+        'data': zlib.compress(b'payload'),
+        'verify': 'cert.pem',
+        'timeout': 12.5,
+        'cert': ('client.pem', 'key.pem'),
+    }
+
+
+def test_common_environment_mapping_is_exact() -> None:
+    mapped_env_vars: set[str] = set()
+    for env_vars in SIGNAL_ENVIRONMENT_VARIABLES.values():
+        mapped_env_vars.update(
+            {
+                env_vars.timeout,
+                env_vars.certificate,
+                env_vars.client_certificate,
+                env_vars.client_key,
+            }
+        )
+
+    assert mapped_env_vars == {
+        'OTEL_EXPORTER_OTLP_TRACES_TIMEOUT',
+        'OTEL_EXPORTER_OTLP_TRACES_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_TRACES_CLIENT_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_TRACES_CLIENT_KEY',
+        'OTEL_EXPORTER_OTLP_METRICS_TIMEOUT',
+        'OTEL_EXPORTER_OTLP_METRICS_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_METRICS_CLIENT_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_METRICS_CLIENT_KEY',
+        'OTEL_EXPORTER_OTLP_LOGS_TIMEOUT',
+        'OTEL_EXPORTER_OTLP_LOGS_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_LOGS_CLIENT_CERTIFICATE',
+        'OTEL_EXPORTER_OTLP_LOGS_CLIENT_KEY',
+    }

--- a/tests/exporters/otlp_proto_http/test_log_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_log_exporter.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import gzip
+import importlib
+import inspect
+from collections.abc import Sequence
+from typing import Any
+
+import pytest
+import requests
+from opentelemetry._logs import LogRecord, SeverityNumber
+from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExportResult
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+from requests import Response
+
+from logfire._internal.exporters.otlp_proto_http import (
+    LogfireOTLPLogExporter,
+    LogfireOTLPMetricExporter,
+    LogfireOTLPSpanExporter,
+)
+from logfire._internal.exporters.otlp_proto_http._log_exporter import (
+    INTENTIONAL_OTEL_DEVIATIONS,
+    OWNED_OTEL_ENCODING_DEPENDENCIES,
+    UPSTREAM_OTEL_MODULE,
+    UPSTREAM_OTEL_VERSION,
+)
+
+
+class RecordingSession(requests.Session):
+    def __init__(self, response: Response | None = None) -> None:
+        super().__init__()
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+        self.response = response if response is not None else Response()
+        if response is None:
+            self.response.status_code = 200
+
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        self.requests.append(kwargs)
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+        super().close()
+
+
+class FailingSession(requests.Session):
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        raise requests.exceptions.ConnectionError('no connection')
+
+
+@pytest.fixture
+def log_batch() -> list[ReadableLogRecord]:
+    return [
+        ReadableLogRecord(
+            LogRecord(
+                body='hello from owned log exporter',
+                severity_number=SeverityNumber.INFO,
+                severity_text='INFO',
+                attributes={'route': '/export'},
+            ),
+            Resource.create({'service.name': 'test-service'}),
+            InstrumentationScope(__name__, '1.0.0'),
+        )
+    ]
+
+
+def test_log_exporter_serializes_logs_with_owned_encoder_dependency(log_batch: Sequence[ReadableLogRecord]) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPLogExporter(
+        endpoint='https://logfire.example/v1/logs',
+        session=session,
+        headers={'Authorization': 'pylf_v1_test'},
+        compression=Compression.NoCompression,
+    )
+
+    assert exporter.export(log_batch) is LogRecordExportResult.SUCCESS
+
+    assert session.requests[0]['data'] == encode_logs(log_batch).SerializeToString()
+
+
+def test_log_exporter_posts_expected_request_metadata(log_batch: Sequence[ReadableLogRecord]) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPLogExporter(
+        endpoint='https://logfire.example/v1/logs',
+        session=session,
+        headers={'User-Agent': 'logfire/test', 'Authorization': 'pylf_v1_test'},
+        compression=Compression.Gzip,
+        certificate_file='server.pem',
+        client_certificate_file='client.pem',
+        client_key_file='client-key.pem',
+        timeout=12.5,
+    )
+
+    assert exporter.export(log_batch) is LogRecordExportResult.SUCCESS
+
+    request = session.requests[0]
+    assert request['url'] == 'https://logfire.example/v1/logs'
+    assert gzip.decompress(request['data']) == encode_logs(log_batch).SerializeToString()
+    assert request['verify'] == 'server.pem'
+    assert request['timeout'] == 12.5
+    assert request['cert'] == ('client.pem', 'client-key.pem')
+    assert session.headers['User-Agent'] == 'logfire/test'
+    assert session.headers['Authorization'] == 'pylf_v1_test'
+    assert session.headers['Content-Type'] == 'application/x-protobuf'
+    assert session.headers['Content-Encoding'] == 'gzip'
+
+
+def test_log_exporter_maps_non_ok_response_to_failure(log_batch: Sequence[ReadableLogRecord]) -> None:
+    response = Response()
+    response.status_code = 400
+    exporter = LogfireOTLPLogExporter(session=RecordingSession(response), compression=Compression.NoCompression)
+
+    assert exporter.export(log_batch) is LogRecordExportResult.FAILURE
+
+
+def test_log_exporter_leaves_request_exceptions_to_quiet_wrapper(log_batch: Sequence[ReadableLogRecord]) -> None:
+    exporter = LogfireOTLPLogExporter(session=FailingSession(), compression=Compression.NoCompression)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match='no connection'):
+        exporter.export(log_batch)
+
+
+def test_log_exporter_shutdown_is_state_only_and_force_flush_is_noop(log_batch: Sequence[ReadableLogRecord]) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPLogExporter(session=session)
+
+    exporter.shutdown()
+
+    assert session.closed is False
+    assert exporter.export(log_batch) is LogRecordExportResult.FAILURE
+    assert session.requests == []
+    assert exporter.force_flush() is True
+
+
+def test_log_exporter_declares_owned_compatibility_surface() -> None:
+    assert UPSTREAM_OTEL_MODULE == 'opentelemetry.exporter.otlp.proto.http._log_exporter'
+    assert UPSTREAM_OTEL_VERSION == '1.41.1'
+    assert OWNED_OTEL_ENCODING_DEPENDENCIES == ('opentelemetry.exporter.otlp.proto.common._log_encoder.encode_logs',)
+    assert 'No OpenTelemetry HTTP retry loop' in INTENTIONAL_OTEL_DEVIATIONS[0]
+
+
+def test_log_exporter_does_not_copy_opentelemetry_retry_logic() -> None:
+    source = inspect.getsource(LogfireOTLPLogExporter)
+
+    assert '_MAX_RETRYS' not in source
+    assert '_is_retryable' not in source
+    assert 'ConnectionError' not in source
+
+
+def test_log_exporter_encoder_incompatibility_fails_loudly(
+    log_batch: Sequence[ReadableLogRecord], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def incompatible_encode_logs(batch: object) -> object:
+        return object()
+
+    log_exporter_module = importlib.import_module('logfire._internal.exporters.otlp_proto_http._log_exporter')
+    monkeypatch.setattr(log_exporter_module, 'encode_logs', incompatible_encode_logs)
+    exporter = LogfireOTLPLogExporter(session=RecordingSession())
+
+    with pytest.raises(RuntimeError, match='log encoder API is incompatible'):
+        exporter.export(log_batch)
+
+
+def test_package_reexports_owned_exporters() -> None:
+    assert LogfireOTLPSpanExporter.__name__ == 'LogfireOTLPSpanExporter'
+    assert LogfireOTLPMetricExporter.__name__ == 'LogfireOTLPMetricExporter'
+    assert LogfireOTLPLogExporter.__name__ == 'LogfireOTLPLogExporter'

--- a/tests/exporters/otlp_proto_http/test_log_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_log_exporter.py
@@ -49,6 +49,9 @@ class RecordingSession(requests.Session):
 
 
 class FailingSession(requests.Session):
+    def __init__(self) -> None:
+        super().__init__()
+
     def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
         raise requests.exceptions.ConnectionError('no connection')
 

--- a/tests/exporters/otlp_proto_http/test_metric_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_metric_exporter.py
@@ -47,6 +47,9 @@ class RecordingSession(requests.Session):
 
 
 class FailingSession(requests.Session):
+    def __init__(self) -> None:
+        super().__init__()
+
     def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
         raise requests.exceptions.ConnectionError('no connection')
 

--- a/tests/exporters/otlp_proto_http/test_metric_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_metric_exporter.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import gzip
+import inspect
+from typing import Any
+
+import pytest
+import requests
+from opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.metrics import Counter, MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    InMemoryMetricReader,
+    MetricExportResult,
+    MetricsData,
+)
+from opentelemetry.sdk.metrics.view import Aggregation, DropAggregation
+from requests import Response
+
+from logfire._internal.exporters.otlp_proto_http import metric_exporter
+from logfire._internal.exporters.otlp_proto_http.metric_exporter import (
+    INTENTIONAL_OTEL_DEVIATIONS,
+    OWNED_OTEL_ENCODING_DEPENDENCIES,
+    UPSTREAM_OTEL_MODULE,
+    UPSTREAM_OTEL_VERSION,
+    LogfireOTLPMetricExporter,
+)
+
+
+class RecordingSession(requests.Session):
+    def __init__(self, response: Response | None = None) -> None:
+        super().__init__()
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+        self.response = response if response is not None else Response()
+        if response is None:
+            self.response.status_code = 200
+
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        self.requests.append(kwargs)
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+        super().close()
+
+
+class FailingSession(requests.Session):
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        raise requests.exceptions.ConnectionError('no connection')
+
+
+@pytest.fixture
+def metrics_data() -> MetricsData:
+    reader = InMemoryMetricReader(preferred_temporality={Counter: AggregationTemporality.DELTA})
+    provider = MeterProvider(metric_readers=[reader])
+    counter = provider.get_meter(__name__).create_counter('owned_metric_exporter_counter')
+    counter.add(123, {'route': '/export'})
+    collected = reader.get_metrics_data()
+    assert collected is not None
+    return collected
+
+
+def test_metric_exporter_serializes_metrics_with_owned_encoder_dependency(metrics_data: MetricsData) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPMetricExporter(
+        endpoint='https://logfire.example/v1/metrics',
+        session=session,
+        headers={'Authorization': 'pylf_v1_test'},
+        compression=Compression.NoCompression,
+    )
+
+    assert exporter.export(metrics_data) is MetricExportResult.SUCCESS
+
+    assert session.requests[0]['data'] == encode_metrics(metrics_data).SerializeToString()
+
+
+def test_metric_exporter_preserves_preferred_reader_configuration() -> None:
+    preferred_temporality = {Counter: AggregationTemporality.DELTA}
+    preferred_aggregation: dict[type, Aggregation] = {Counter: DropAggregation()}
+
+    exporter = LogfireOTLPMetricExporter(
+        session=RecordingSession(),
+        preferred_temporality=preferred_temporality,
+        preferred_aggregation=preferred_aggregation,
+    )
+
+    assert exporter._preferred_temporality == preferred_temporality  # pyright: ignore[reportPrivateUsage]
+    assert exporter._preferred_aggregation == preferred_aggregation  # pyright: ignore[reportPrivateUsage]
+
+
+def test_metric_exporter_posts_expected_request_metadata(metrics_data: MetricsData) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPMetricExporter(
+        endpoint='https://logfire.example/v1/metrics',
+        session=session,
+        headers={'User-Agent': 'logfire/test', 'Authorization': 'pylf_v1_test'},
+        compression=Compression.Gzip,
+        certificate_file='server.pem',
+        client_certificate_file='client.pem',
+        client_key_file='client-key.pem',
+        timeout=12.5,
+    )
+
+    assert exporter.export(metrics_data) is MetricExportResult.SUCCESS
+
+    request = session.requests[0]
+    assert request['url'] == 'https://logfire.example/v1/metrics'
+    assert gzip.decompress(request['data']) == encode_metrics(metrics_data).SerializeToString()
+    assert request['verify'] == 'server.pem'
+    assert request['timeout'] == 12.5
+    assert request['cert'] == ('client.pem', 'client-key.pem')
+    assert session.headers['User-Agent'] == 'logfire/test'
+    assert session.headers['Authorization'] == 'pylf_v1_test'
+    assert session.headers['Content-Type'] == 'application/x-protobuf'
+    assert session.headers['Content-Encoding'] == 'gzip'
+
+
+def test_metric_exporter_maps_non_ok_response_to_failure(metrics_data: MetricsData) -> None:
+    response = Response()
+    response.status_code = 400
+    exporter = LogfireOTLPMetricExporter(session=RecordingSession(response), compression=Compression.NoCompression)
+
+    assert exporter.export(metrics_data) is MetricExportResult.FAILURE
+
+
+def test_metric_exporter_leaves_request_exceptions_to_quiet_wrapper(metrics_data: MetricsData) -> None:
+    exporter = LogfireOTLPMetricExporter(session=FailingSession(), compression=Compression.NoCompression)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match='no connection'):
+        exporter.export(metrics_data)
+
+
+def test_metric_exporter_shutdown_is_state_only_and_force_flush_is_noop(metrics_data: MetricsData) -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPMetricExporter(session=session)
+
+    exporter.shutdown()
+
+    assert session.closed is False
+    assert exporter.export(metrics_data) is MetricExportResult.FAILURE
+    assert session.requests == []
+    assert exporter.force_flush() is True
+
+
+def test_metric_exporter_declares_owned_compatibility_surface() -> None:
+    assert UPSTREAM_OTEL_MODULE == 'opentelemetry.exporter.otlp.proto.http.metric_exporter'
+    assert UPSTREAM_OTEL_VERSION == '1.41.1'
+    assert OWNED_OTEL_ENCODING_DEPENDENCIES == (
+        'opentelemetry.exporter.otlp.proto.common.metrics_encoder.encode_metrics',
+    )
+    assert 'No OpenTelemetry HTTP retry loop' in INTENTIONAL_OTEL_DEVIATIONS[0]
+
+
+def test_metric_exporter_does_not_copy_opentelemetry_retry_logic() -> None:
+    source = inspect.getsource(LogfireOTLPMetricExporter)
+
+    assert '_MAX_RETRYS' not in source
+    assert '_is_retryable' not in source
+    assert 'ConnectionError' not in source
+
+
+def test_metric_exporter_encoder_incompatibility_fails_loudly(
+    metrics_data: MetricsData, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def incompatible_encode_metrics(metrics_data: object) -> object:
+        return object()
+
+    monkeypatch.setattr(metric_exporter, 'encode_metrics', incompatible_encode_metrics)
+    exporter = LogfireOTLPMetricExporter(session=RecordingSession())
+
+    with pytest.raises(RuntimeError, match='metrics encoder API is incompatible'):
+        exporter.export(metrics_data)

--- a/tests/exporters/otlp_proto_http/test_trace_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_trace_exporter.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import gzip
+import inspect
+from typing import Any
+
+import pytest
+import requests
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.trace.export import SpanExportResult
+from requests import Response
+
+from logfire._internal.exporters.otlp_proto_http import trace_exporter
+from logfire._internal.exporters.otlp_proto_http.trace_exporter import (
+    INTENTIONAL_OTEL_DEVIATIONS,
+    OWNED_OTEL_ENCODING_DEPENDENCIES,
+    UPSTREAM_OTEL_MODULE,
+    UPSTREAM_OTEL_VERSION,
+    LogfireOTLPSpanExporter,
+)
+from tests.exporters.test_retry_fewer_spans import TEST_SPANS
+
+
+class RecordingSession(requests.Session):
+    def __init__(self, response: Response | None = None) -> None:
+        super().__init__()
+        self.requests: list[dict[str, Any]] = []
+        self.closed = False
+        self.response = response if response is not None else Response()
+        if response is None:
+            self.response.status_code = 200
+
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        self.requests.append(kwargs)
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+        super().close()
+
+
+class FailingSession(requests.Session):
+    def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
+        raise requests.exceptions.ConnectionError('no connection')
+
+
+def test_trace_exporter_serializes_spans_with_owned_encoder_dependency() -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPSpanExporter(
+        endpoint='https://logfire.example/v1/traces',
+        session=session,
+        headers={'Authorization': 'pylf_v1_test'},
+        compression=Compression.NoCompression,
+    )
+
+    assert exporter.export(TEST_SPANS) is SpanExportResult.SUCCESS
+
+    assert session.requests[0]['data'] == encode_spans(TEST_SPANS).SerializePartialToString()
+
+
+def test_trace_exporter_posts_expected_request_metadata() -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPSpanExporter(
+        endpoint='https://logfire.example/v1/traces',
+        session=session,
+        headers={'User-Agent': 'logfire/test', 'Authorization': 'pylf_v1_test'},
+        compression=Compression.Gzip,
+        certificate_file='server.pem',
+        client_certificate_file='client.pem',
+        client_key_file='client-key.pem',
+        timeout=12.5,
+    )
+
+    assert exporter.export(TEST_SPANS) is SpanExportResult.SUCCESS
+
+    request = session.requests[0]
+    assert request['url'] == 'https://logfire.example/v1/traces'
+    assert gzip.decompress(request['data']) == encode_spans(TEST_SPANS).SerializePartialToString()
+    assert request['verify'] == 'server.pem'
+    assert request['timeout'] == 12.5
+    assert request['cert'] == ('client.pem', 'client-key.pem')
+    assert session.headers['User-Agent'] == 'logfire/test'
+    assert session.headers['Authorization'] == 'pylf_v1_test'
+    assert session.headers['Content-Type'] == 'application/x-protobuf'
+    assert session.headers['Content-Encoding'] == 'gzip'
+
+
+def test_trace_exporter_maps_non_ok_response_to_failure() -> None:
+    response = Response()
+    response.status_code = 400
+    exporter = LogfireOTLPSpanExporter(session=RecordingSession(response), compression=Compression.NoCompression)
+
+    assert exporter.export(TEST_SPANS) is SpanExportResult.FAILURE
+
+
+def test_trace_exporter_leaves_request_exceptions_to_quiet_wrapper() -> None:
+    exporter = LogfireOTLPSpanExporter(session=FailingSession(), compression=Compression.NoCompression)
+
+    with pytest.raises(requests.exceptions.ConnectionError, match='no connection'):
+        exporter.export(TEST_SPANS)
+
+
+def test_trace_exporter_shutdown_is_state_only_and_force_flush_is_noop() -> None:
+    session = RecordingSession()
+    exporter = LogfireOTLPSpanExporter(session=session)
+
+    exporter.shutdown()
+
+    assert session.closed is False
+    assert exporter.export(TEST_SPANS) is SpanExportResult.FAILURE
+    assert session.requests == []
+    assert exporter.force_flush() is True
+
+
+def test_trace_exporter_declares_owned_compatibility_surface() -> None:
+    assert UPSTREAM_OTEL_MODULE == 'opentelemetry.exporter.otlp.proto.http.trace_exporter'
+    assert UPSTREAM_OTEL_VERSION == '1.41.1'
+    assert OWNED_OTEL_ENCODING_DEPENDENCIES == ('opentelemetry.exporter.otlp.proto.common.trace_encoder.encode_spans',)
+    assert 'No OpenTelemetry HTTP retry loop' in INTENTIONAL_OTEL_DEVIATIONS[0]
+
+
+def test_trace_exporter_does_not_copy_opentelemetry_retry_logic() -> None:
+    source = inspect.getsource(LogfireOTLPSpanExporter)
+
+    assert '_MAX_RETRYS' not in source
+    assert '_is_retryable' not in source
+    assert 'ConnectionError' not in source
+
+
+def test_trace_exporter_encoder_incompatibility_fails_loudly(monkeypatch: pytest.MonkeyPatch) -> None:
+    def incompatible_encode_spans(spans: object) -> object:
+        return object()
+
+    monkeypatch.setattr(trace_exporter, 'encode_spans', incompatible_encode_spans)
+    exporter = LogfireOTLPSpanExporter(session=RecordingSession())
+
+    with pytest.raises(RuntimeError, match='trace encoder API is incompatible'):
+        exporter.export(TEST_SPANS)

--- a/tests/exporters/otlp_proto_http/test_trace_exporter.py
+++ b/tests/exporters/otlp_proto_http/test_trace_exporter.py
@@ -41,6 +41,9 @@ class RecordingSession(requests.Session):
 
 
 class FailingSession(requests.Session):
+    def __init__(self) -> None:
+        super().__init__()
+
     def post(self, **kwargs: Any) -> Response:  # pyright: ignore[reportIncompatibleMethodOverride]
         raise requests.exceptions.ConnectionError('no connection')
 

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -154,6 +154,14 @@ def test_session_close_closes_lazy_retryer() -> None:
     assert not retryer_dir.exists()
 
 
+def test_session_close_without_retryer() -> None:
+    session = OTLPExporterHttpSession()
+
+    session.close()
+
+    assert 'retryer' not in session.__dict__
+
+
 def test_disk_retryer_cleanup_after_logfire_shutdown(tmp_path: Path) -> None:
     retryer_dir = tmp_path / 'retryer-dir'
     marker_file = tmp_path / 'retryer-marker.txt'

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -23,6 +23,7 @@ from logfire._internal.exporters.otlp import (
     OTLPExporterHttpSession,
     cleanup_disk_retryers,
 )
+from logfire._internal.exporters.otlp_proto_http.trace_exporter import LogfireOTLPSpanExporter
 from tests.exporters.test_retry_fewer_spans import TEST_SPANS
 
 
@@ -40,6 +41,7 @@ def test_max_body_size_bytes() -> None:
     session.mount('http://', SinkHTTPAdapter())
     exporter = BodySizeCheckingOTLPSpanExporter(session=session)
 
+    assert isinstance(exporter, LogfireOTLPSpanExporter)
     assert exporter.export(TEST_SPANS) == SpanExportResult.SUCCESS
 
     exporter.max_body_size = 10

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -143,6 +143,17 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
     assert caplog.messages[0] == snapshot('Currently retrying 1 failed export(s) (3 bytes)')
 
 
+def test_session_close_closes_lazy_retryer() -> None:
+    session = OTLPExporterHttpSession()
+    retryer = session.retryer
+    retryer_dir = retryer.dir
+
+    session.close()
+
+    assert retryer.closed
+    assert not retryer_dir.exists()
+
+
 def test_disk_retryer_cleanup_after_logfire_shutdown(tmp_path: Path) -> None:
     retryer_dir = tmp_path / 'retryer-dir'
     marker_file = tmp_path / 'retryer-marker.txt'

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -66,7 +66,12 @@ from logfire._internal.exporters.console import (
 )
 from logfire._internal.exporters.dynamic_batch import DynamicBatchSpanProcessor
 from logfire._internal.exporters.logs import CheckSuppressInstrumentationLogProcessorWrapper, MainLogProcessorWrapper
-from logfire._internal.exporters.otlp import QuietLogExporter, QuietSpanExporter
+from logfire._internal.exporters.otlp import BodySizeCheckingOTLPSpanExporter, QuietLogExporter, QuietSpanExporter
+from logfire._internal.exporters.otlp_proto_http import (
+    LogfireOTLPLogExporter,
+    LogfireOTLPMetricExporter,
+    LogfireOTLPSpanExporter,
+)
 from logfire._internal.exporters.processor_wrapper import (
     CheckSuppressInstrumentationProcessorWrapper,
     MainSpanProcessorWrapper,
@@ -1702,6 +1707,11 @@ def test_default_exporters(monkeypatch: pytest.MonkeyPatch):
 
     assert isinstance(send_to_logfire_processor, DynamicBatchSpanProcessor)
     assert isinstance(send_to_logfire_processor.span_exporter, RemovePendingSpansExporter)
+    span_exporter = send_to_logfire_processor.span_exporter
+    while hasattr(span_exporter, 'wrapped_exporter'):
+        span_exporter = span_exporter.wrapped_exporter  # type: ignore
+    assert isinstance(span_exporter, BodySizeCheckingOTLPSpanExporter)
+    assert isinstance(span_exporter, LogfireOTLPSpanExporter)
 
     assert isinstance(pending_span_processor, PendingSpanProcessor)
     assert isinstance(pending_span_processor.processor, MainSpanProcessorWrapper)
@@ -1714,6 +1724,7 @@ def test_default_exporters(monkeypatch: pytest.MonkeyPatch):
     [logfire_metric_reader] = get_metric_readers()
     assert isinstance(logfire_metric_reader, PeriodicExportingMetricReader)
     assert isinstance(logfire_metric_reader._exporter, QuietMetricExporter)  # type: ignore
+    assert isinstance(logfire_metric_reader._exporter.wrapped_exporter, LogfireOTLPMetricExporter)  # type: ignore
 
     [console_log_processor, logfire_log_processor] = get_log_record_processors()
 
@@ -1723,7 +1734,7 @@ def test_default_exporters(monkeypatch: pytest.MonkeyPatch):
 
     exporter = get_batch_log_exporter(logfire_log_processor)
     assert isinstance(exporter, QuietLogExporter)
-    assert isinstance(exporter.exporter, OTLPLogExporter)
+    assert isinstance(exporter.exporter, LogfireOTLPLogExporter)
 
 
 def test_custom_exporters():
@@ -2482,6 +2493,8 @@ def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:
         token2_exporter = token2_exporter.wrapped_exporter  # type: ignore
     assert token1_exporter._session.headers['Authorization'] == 'pylf_v1_us_token1'  # type: ignore
     assert token2_exporter._session.headers['Authorization'] == 'pylf_v1_us_token2'  # type: ignore
+    assert isinstance(token1_exporter, LogfireOTLPSpanExporter)
+    assert isinstance(token2_exporter, LogfireOTLPSpanExporter)
 
     # Check that TWO metric readers are created (one per token)
     metric_readers = list(get_metric_readers())
@@ -2489,6 +2502,7 @@ def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:
     for reader in metric_readers:
         assert isinstance(reader, PeriodicExportingMetricReader)
         assert isinstance(reader._exporter, QuietMetricExporter)  # type: ignore
+        assert isinstance(reader._exporter.wrapped_exporter, LogfireOTLPMetricExporter)  # type: ignore
 
     # Check that TWO log processors are created (one per token)
     log_processors = list(get_log_record_processors())
@@ -2496,7 +2510,7 @@ def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:
     for processor in log_processors:
         exporter = get_batch_log_exporter(processor)
         assert isinstance(exporter, QuietLogExporter)
-        assert isinstance(exporter.exporter, OTLPLogExporter)
+        assert isinstance(exporter.exporter, LogfireOTLPLogExporter)
 
 
 def test_multiple_tokens_env_var(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add Logfire-owned OTLP/HTTP helpers and span, metric, and log exporters for the explicit token path
- move body-size checking onto the owned span exporter while keeping OTLPExporterHttpSession and DiskRetryer behavior unchanged
- wire send_to_logfire token exports to owned exporters while preserving generic OpenTelemetry env-driven exporters

## Tests
- uv run pytest tests/exporters/otlp_proto_http tests/exporters/test_otlp_session.py tests/test_configure.py