### PR TITLE
Make browser telemetry forwarding fail open with disk retry

### DIFF
--- a/docs/integrations/javascript/browser.md
+++ b/docs/integrations/javascript/browser.md
@@ -49,11 +49,14 @@ Note that if you're using an SSR/SSG framework, you should ensure that the code 
 
 ## Proxying Browser Telemetry
 
-If you use a Python backend, logfire provide experimental tools in the `logfire.experimental.forwarding` module to easily create this proxy.
+If you use a Python backend, logfire provides experimental tools in the `logfire.experimental.forwarding` module to easily create this proxy.
+The proxy stores accepted telemetry in a local disk-backed retry queue, returns an OTLP success response to the browser,
+and forwards to Logfire from a background thread with exponential backoff.
+This keeps temporary Logfire network failures out of your frontend and backend request paths.
 
 ### FastAPI
 
-For FastAPI, logfire provide a built-in `logfire_proxy` handler that limits request body size (default 50MB) by reading in chunks to avoid loading oversized payloads into memory.
+For FastAPI, logfire provides a built-in `logfire_proxy` handler that limits request body size (default 50MB) and queues accepted telemetry for background forwarding.
 
 ```py title="main.py" skip-run="true" skip-reason="server-start"
 from fastapi import FastAPI, Request
@@ -72,7 +75,8 @@ async def proxy_browser_telemetry(request: Request):
     return await logfire_proxy(request)
 ```
 
-By default, this endpoint is unauthenticated and accepts payloads up to 50MB. In production, you should protect it using FastAPI dependencies to prevent abuse:
+By default, this endpoint is unauthenticated, accepts payloads up to 50MB, and uses a 5 second timeout for each background forwarding attempt.
+In production, you should protect it using FastAPI dependencies to prevent abuse:
 
 ```py skip-run="true" skip-reason="server-start"
 from fastapi import Depends, FastAPI, Request
@@ -123,6 +127,7 @@ app = Starlette(
 If you are using another web framework (such as Django, Flask, Litestar, or a custom HTTP server), you can use the underlying `forward_export_request` function directly.
 
 You simply extract the path, headers, and body from your framework's request object, pass them to `forward_export_request` as keyword arguments, and return the resulting status code, headers, and content.
+The function queues accepted telemetry locally and does not wait for Logfire to accept the payload.
 
 ```py title="main.py" skip-run="true" skip-reason="server-start"
 import logfire

--- a/docs/integrations/web-frameworks/fastapi.md
+++ b/docs/integrations/web-frameworks/fastapi.md
@@ -114,7 +114,7 @@ It can also be useful for grouping together child logs and spans produced by the
 
 If your frontend application sends telemetry from the browser, you should never expose your Logfire Write Token in the frontend code.
 
-You can use experimental proxy handler to securely forward OTLP telemetry through your FastAPI backend. See the [Browser Telemetry Proxying guide](../javascript/browser.md#proxying-browser-telemetry) for detailed instructions.
+You can use the experimental proxy handler to securely queue OTLP telemetry through your FastAPI backend and forward it to Logfire from a background retry thread. See the [Browser Telemetry Proxying guide](../javascript/browser.md#proxying-browser-telemetry) for detailed instructions.
 
 [fastapi]: https://fastapi.tiangolo.com/
 [opentelemetry-asgi]: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html

--- a/docs/integrations/web-frameworks/starlette.md
+++ b/docs/integrations/web-frameworks/starlette.md
@@ -60,7 +60,7 @@ The keyword arguments of `logfire.instrument_starlette()` are passed to the `Sta
 
 If your frontend application sends telemetry from the browser, you should never expose your Logfire Write Token in the frontend code.
 
-You can use experimental proxy handler to securely forward OTLP telemetry through your Starlette backend. See the [Browser Telemetry Proxying guide](../javascript/browser.md#proxying-browser-telemetry) for detailed instructions.
+You can use the experimental proxy handler to securely queue OTLP telemetry through your Starlette backend and forward it to Logfire from a background retry thread. See the [Browser Telemetry Proxying guide](../javascript/browser.md#proxying-browser-telemetry) for detailed instructions.
 
 [starlette]: https://www.starlette.io/
 [opentelemetry-asgi]: https://opentelemetry-python-contrib.readthedocs.io/en/latest/instrumentation/asgi/asgi.html

--- a/logfire-api/logfire_api/experimental/forwarding.pyi
+++ b/logfire-api/logfire_api/experimental/forwarding.pyi
@@ -3,7 +3,9 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
 
-__all__ = ['ForwardExportRequestResponse', 'forward_export_request', 'logfire_proxy']
+__all__ = ['DEFAULT_FORWARD_TIMEOUT', 'ForwardExportRequestResponse', 'forward_export_request', 'logfire_proxy']
+
+DEFAULT_FORWARD_TIMEOUT: float
 
 @dataclass
 class ForwardExportRequestResponse:
@@ -12,13 +14,16 @@ class ForwardExportRequestResponse:
     headers: Mapping[str, str]
     content: bytes
 
-def forward_export_request(*, path: str, headers: Mapping[str, str], body: bytes | None, logfire_instance: logfire.Logfire | None = None) -> ForwardExportRequestResponse:
-    """Forward an export request to the Logfire API.
+def forward_export_request(*, path: str, headers: Mapping[str, str], body: bytes | None, logfire_instance: logfire.Logfire | None = None, timeout: float = ...) -> ForwardExportRequestResponse:
+    """Queue an export request to be forwarded to the Logfire API.
+
+    The request body is written to a local disk retry queue and forwarded by a background thread.
+    This keeps Logfire network failures out of the caller's request path.
 
     Note: If the provided logfire instance is configured with multiple tokens,
     only the first token will be used for the proxy request.
     """
-async def logfire_proxy(request: Any, *, logfire_instance: logfire.Logfire | None = None, max_body_size: int = ...) -> Any:
+async def logfire_proxy(request: Any, *, logfire_instance: logfire.Logfire | None = None, max_body_size: int = ..., timeout: float = ...) -> Any:
     """A Starlette/FastAPI handler to proxy requests to Logfire.
 
     This is useful for proxying requests from a browser to Logfire,
@@ -36,6 +41,7 @@ async def logfire_proxy(request: Any, *, logfire_instance: logfire.Logfire | Non
         request: The Starlette/FastAPI Request object.
         logfire_instance: The Logfire instance to use. If not provided, the default instance is used.
         max_body_size: The maximum allowed request body size in bytes. Defaults to 50MB.
+        timeout: The timeout in seconds for each background forwarding attempt. Defaults to 5 seconds.
 
     Returns:
         A Starlette/FastAPI Response object.

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -168,19 +168,19 @@ class DiskRetryer:
         self.session.close()
         self._cleanup_dir(self.dir)
 
-    def add_task(self, data: bytes, kwargs: dict[str, Any]):
+    def add_task(self, data: bytes, kwargs: dict[str, Any]) -> bool:
         try:
             with self.lock:
                 if self.closed:
-                    return
-                if self.total_size >= self.MAX_TASK_SIZE:  # pragma: no cover
+                    return False
+                if self.total_size + len(data) > self.MAX_TASK_SIZE:  # pragma: no cover
                     if self._should_log():
                         logger.error(
                             'Already retrying %s failed exports (%s bytes), dropping an export',
                             len(self.tasks),
                             self.total_size,
                         )
-                    return
+                    return False
                 self.total_size += len(data)
 
             # TODO consider keeping the first few tasks in memory to avoid disk I/O and possible errors.
@@ -204,9 +204,11 @@ class DiskRetryer:
 
             if self._should_log():
                 logger.warning('Currently retrying %s failed export(s) (%s bytes)', num_tasks, num_bytes)
+            return True
         except Exception as e:  # pragma: no cover
             if self._should_log():
                 logger.error('Export and retry failed: %s', e)
+            return False
 
     def _should_log(self) -> bool:
         result = time.monotonic() - self.last_log_time >= self.LOG_INTERVAL

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -173,7 +173,7 @@ class DiskRetryer:
             with self.lock:
                 if self.closed:
                     return False
-                if self.total_size + len(data) > self.MAX_TASK_SIZE:  # pragma: no cover
+                if self.total_size >= self.MAX_TASK_SIZE:  # pragma: no cover
                     if self._should_log():
                         logger.error(
                             'Already retrying %s failed exports (%s bytes), dropping an export',

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -134,13 +134,21 @@ class DiskRetryer:
     # Log about problems at most once a minute.
     LOG_INTERVAL = 60
 
-    def __init__(self, headers: Mapping[str, str | bytes]):
+    def __init__(
+        self,
+        headers: Mapping[str, str | bytes],
+        *,
+        initial_delay: float = 1,
+        success_delay: float = 0.2,
+    ):
         # Reading/writing `thread`, `tasks`, and `total_size` should generally be protected by `lock`.
         self.lock = Lock()
         self.thread: Thread | None = None
         self.tasks: deque[tuple[Path, dict[str, Any]]] = deque()
         self.total_size = 0
         self.closed = False
+        self.initial_delay = initial_delay
+        self.success_delay = success_delay
 
         # Make a new session rather than using the OTLPExporterHttpSession directly
         # because thread safety of Session is questionable.
@@ -217,7 +225,7 @@ class DiskRetryer:
         return result
 
     def _run(self):
-        delay = 1
+        delay = self.initial_delay
         while True:
             with self.lock:
                 if not self.tasks:
@@ -238,7 +246,8 @@ class DiskRetryer:
                     # Exponential backoff with jitter.
                     # The jitter is proportional to the delay, in particular so that if we go down for a while
                     # and then come back up then retry requests will be spread out over a time of MAX_DELAY.
-                    time.sleep(delay * (1 + random.random()))
+                    if delay:
+                        time.sleep(delay * (1 + random.random()))
                     try:
                         with logfire.suppress_instrumentation():
                             response = self.session.post(**kwargs, data=data)
@@ -251,7 +260,7 @@ class DiskRetryer:
                     else:
                         # Success, set the delay to a small value (so that remaining tasks can be done quickly),
                         # remove the file, and move on to the next task.
-                        delay = 0.2
+                        delay = self.success_delay
                         path.unlink(missing_ok=True)
                         with self.lock:
                             self.total_size -= len(data)

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import atexit
 import posixpath
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -21,6 +22,7 @@ DEFAULT_FORWARD_TIMEOUT = 5.0
 OTLP_PROTOBUF_HEADERS = {'Content-Type': 'application/x-protobuf'}
 
 _forwarding_retryer: DiskRetryer | None = None
+_forwarding_retryer_shutdown = False
 _FORWARDING_RETRYER_LOCK = Lock()
 
 
@@ -115,7 +117,8 @@ def forward_export_request(
     if not data:
         return _otlp_success_response(path)
 
-    accepted = _get_forwarding_retryer().add_task(
+    retryer = _get_forwarding_retryer()
+    accepted = retryer is not None and retryer.add_task(
         data,
         {
             'url': url,
@@ -201,13 +204,25 @@ async def logfire_proxy(
     return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
 
 
-def _get_forwarding_retryer() -> DiskRetryer:
+def _get_forwarding_retryer() -> DiskRetryer | None:
     global _forwarding_retryer
     with _FORWARDING_RETRYER_LOCK:
+        if _forwarding_retryer_shutdown:
+            return None
         if _forwarding_retryer is None or _forwarding_retryer.closed:
-            # DiskRetryer instances are also closed by the shared atexit cleanup hook.
             _forwarding_retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
     return _forwarding_retryer
+
+
+def _close_forwarding_retryer() -> None:
+    global _forwarding_retryer_shutdown
+    with _FORWARDING_RETRYER_LOCK:
+        _forwarding_retryer_shutdown = True
+        if _forwarding_retryer is not None:
+            _forwarding_retryer.close()
+
+
+atexit.register(_close_forwarding_retryer)
 
 
 def _otlp_success_response(path: str) -> ForwardExportRequestResponse:

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -3,15 +3,25 @@ from __future__ import annotations
 import posixpath
 from collections.abc import Mapping
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any
 from urllib.parse import unquote, urljoin
 
-import requests
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceResponse
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
 
 import logfire
+from logfire._internal.exporters.otlp import DiskRetryer
 from logfire.version import VERSION
 
-__all__ = ('ForwardExportRequestResponse', 'forward_export_request', 'logfire_proxy')
+__all__ = ('DEFAULT_FORWARD_TIMEOUT', 'ForwardExportRequestResponse', 'forward_export_request', 'logfire_proxy')
+
+DEFAULT_FORWARD_TIMEOUT = 5.0
+OTLP_PROTOBUF_HEADERS = {'Content-Type': 'application/x-protobuf'}
+
+_forwarding_retryer: DiskRetryer | None = None
+_FORWARDING_RETRYER_LOCK = Lock()
 
 
 @dataclass
@@ -29,8 +39,12 @@ def forward_export_request(
     headers: Mapping[str, str],
     body: bytes | None,
     logfire_instance: logfire.Logfire | None = None,
+    timeout: float = DEFAULT_FORWARD_TIMEOUT,
 ) -> ForwardExportRequestResponse:
-    """Forward an export request to the Logfire API.
+    """Queue an export request to be forwarded to the Logfire API.
+
+    The request body is written to a local disk retry queue and forwarded by a background thread.
+    This keeps Logfire network failures out of the caller's request path.
 
     Note: If the provided logfire instance is configured with multiple tokens,
     only the first token will be used for the proxy request.
@@ -61,7 +75,7 @@ def forward_export_request(
 
     if not token:
         return ForwardExportRequestResponse(
-            status_code=500,
+            status_code=403,
             headers={'Content-Type': 'text/plain'},
             content=b'Logfire is not configured with a token',
         )
@@ -97,35 +111,26 @@ def forward_export_request(
 
     new_headers['Authorization'] = token
 
-    try:
-        # Wrap with suppress_instrumentation so we don't infinitely trace proxy telemetry
-        with logfire.suppress_instrumentation():
-            response = requests.post(
-                url=url,
-                headers=new_headers,
-                data=body,
-                stream=False,
-                timeout=30,
-            )
-    except requests.RequestException:
-        # Security: Return a generic error to avoid leaking internal URL/configuration details
-        return ForwardExportRequestResponse(
-            status_code=502,
-            headers={'Content-Type': 'text/plain'},
-            content=b'Upstream service error',
+    data = body or b''
+    if not data:
+        return _otlp_success_response()
+
+    accepted = _get_forwarding_retryer().add_task(
+        data,
+        {
+            'url': url,
+            'headers': new_headers,
+            'stream': False,
+            'timeout': timeout,
+        },
+    )
+    if not accepted:
+        return _otlp_partial_success_response(
+            path,
+            'Logfire proxy retry queue is full or unavailable; telemetry was dropped.',
         )
 
-    response_headers = {
-        k: v
-        for k, v in response.headers.items()
-        if k.lower() not in ('content-encoding', 'content-length', 'transfer-encoding', 'connection', 'set-cookie')
-    }
-
-    return ForwardExportRequestResponse(
-        status_code=response.status_code,
-        headers=response_headers,
-        content=response.content,
-    )
+    return _otlp_success_response()
 
 
 async def logfire_proxy(
@@ -133,6 +138,7 @@ async def logfire_proxy(
     *,
     logfire_instance: logfire.Logfire | None = None,
     max_body_size: int = 50 * 1024 * 1024,
+    timeout: float = DEFAULT_FORWARD_TIMEOUT,
 ) -> Any:
     """A Starlette/FastAPI handler to proxy requests to Logfire.
 
@@ -151,6 +157,7 @@ async def logfire_proxy(
         request: The Starlette/FastAPI Request object.
         logfire_instance: The Logfire instance to use. If not provided, the default instance is used.
         max_body_size: The maximum allowed request body size in bytes. Defaults to 50MB.
+        timeout: The timeout in seconds for each background forwarding attempt. Defaults to 5 seconds.
 
     Returns:
         A Starlette/FastAPI Response object.
@@ -170,7 +177,7 @@ async def logfire_proxy(
         except ValueError:
             return Response(status_code=400, content='Invalid Content-Length header')
 
-    # Security: Read the body in chunks to prevent memory exhaustion DoS attacks
+    # Security: Read the body in chunks so a single oversized request can be rejected
     # in cases where the Content-Length header is omitted or spoofed.
     body = bytearray()
     async for chunk in request.stream():
@@ -182,12 +189,45 @@ async def logfire_proxy(
     if not path:
         return Response(status_code=400, content='Missing path parameter. Use {path:path} in the route definition.')
 
-    # Performance: Run synchronous requests call in a thread pool to avoid blocking the event loop
+    # The request path only does local queue I/O. Network forwarding happens in the retryer's background thread.
     response = await run_in_threadpool(
         forward_export_request,
         path=path,
         headers=request.headers,
         body=bytes(body),
         logfire_instance=logfire_instance,
+        timeout=timeout,
     )
     return Response(content=response.content, status_code=response.status_code, headers=dict(response.headers))
+
+
+def _get_forwarding_retryer() -> DiskRetryer:
+    global _forwarding_retryer
+    if _forwarding_retryer is None or _forwarding_retryer.closed:
+        with _FORWARDING_RETRYER_LOCK:
+            if _forwarding_retryer is None or _forwarding_retryer.closed:
+                _forwarding_retryer = DiskRetryer({})
+    return _forwarding_retryer
+
+
+def _otlp_success_response() -> ForwardExportRequestResponse:
+    return ForwardExportRequestResponse(
+        status_code=200,
+        headers=OTLP_PROTOBUF_HEADERS,
+        content=b'',
+    )
+
+
+def _otlp_partial_success_response(path: str, error_message: str) -> ForwardExportRequestResponse:
+    if path == '/v1/traces':
+        response = ExportTraceServiceResponse()
+    elif path == '/v1/logs':
+        response = ExportLogsServiceResponse()
+    else:
+        response = ExportMetricsServiceResponse()
+    response.partial_success.error_message = error_message
+    return ForwardExportRequestResponse(
+        status_code=200,
+        headers=OTLP_PROTOBUF_HEADERS,
+        content=response.SerializeToString(),
+    )

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -206,6 +206,7 @@ def _get_forwarding_retryer() -> DiskRetryer:
     if _forwarding_retryer is None or _forwarding_retryer.closed:
         with _FORWARDING_RETRYER_LOCK:
             if _forwarding_retryer is None or _forwarding_retryer.closed:
+                # DiskRetryer instances are also closed by the shared atexit cleanup hook.
                 _forwarding_retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
     return _forwarding_retryer
 

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -203,11 +203,10 @@ async def logfire_proxy(
 
 def _get_forwarding_retryer() -> DiskRetryer:
     global _forwarding_retryer
-    if _forwarding_retryer is None or _forwarding_retryer.closed:
-        with _FORWARDING_RETRYER_LOCK:
-            if _forwarding_retryer is None or _forwarding_retryer.closed:
-                # DiskRetryer instances are also closed by the shared atexit cleanup hook.
-                _forwarding_retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
+    with _FORWARDING_RETRYER_LOCK:
+        if _forwarding_retryer is None or _forwarding_retryer.closed:
+            # DiskRetryer instances are also closed by the shared atexit cleanup hook.
+            _forwarding_retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
     return _forwarding_retryer
 
 

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -206,7 +206,7 @@ def _get_forwarding_retryer() -> DiskRetryer:
     if _forwarding_retryer is None or _forwarding_retryer.closed:
         with _FORWARDING_RETRYER_LOCK:
             if _forwarding_retryer is None or _forwarding_retryer.closed:
-                _forwarding_retryer = DiskRetryer({})
+                _forwarding_retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
     return _forwarding_retryer
 
 

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -113,7 +113,7 @@ def forward_export_request(
 
     data = body or b''
     if not data:
-        return _otlp_success_response()
+        return _otlp_success_response(path)
 
     accepted = _get_forwarding_retryer().add_task(
         data,
@@ -130,7 +130,7 @@ def forward_export_request(
             'Logfire proxy retry queue is full or unavailable; telemetry was dropped.',
         )
 
-    return _otlp_success_response()
+    return _otlp_success_response(path)
 
 
 async def logfire_proxy(
@@ -210,11 +210,18 @@ def _get_forwarding_retryer() -> DiskRetryer:
     return _forwarding_retryer
 
 
-def _otlp_success_response() -> ForwardExportRequestResponse:
+def _otlp_success_response(path: str) -> ForwardExportRequestResponse:
+    if path == '/v1/traces':
+        content = ExportTraceServiceResponse().SerializeToString()
+    elif path == '/v1/logs':
+        content = ExportLogsServiceResponse().SerializeToString()
+    else:
+        content = ExportMetricsServiceResponse().SerializeToString()
+
     return ForwardExportRequestResponse(
         status_code=200,
         headers=OTLP_PROTOBUF_HEADERS,
-        content=b'',
+        content=content,
     )
 
 

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -247,7 +247,18 @@ def test_disk_retryer_add_task_after_close_does_nothing() -> None:
     retryer = DiskRetryer({})
     retryer.close()
 
-    retryer.add_task(b'123', {'url': 'http://example.com/'})
+    assert not retryer.add_task(b'123', {'url': 'http://example.com/'})
+
+    assert retryer.total_size == 0
+    assert not retryer.tasks
+    assert retryer.thread is None
+
+
+def test_disk_retryer_add_task_returns_false_when_full(monkeypatch: pytest.MonkeyPatch) -> None:
+    retryer = DiskRetryer({})
+    monkeypatch.setattr(retryer, 'MAX_TASK_SIZE', 2)
+
+    assert not retryer.add_task(b'123', {'url': 'http://example.com/'})
 
     assert retryer.total_size == 0
     assert not retryer.tasks

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -252,14 +252,3 @@ def test_disk_retryer_add_task_after_close_does_nothing() -> None:
     assert retryer.total_size == 0
     assert not retryer.tasks
     assert retryer.thread is None
-
-
-def test_disk_retryer_add_task_returns_false_when_full(monkeypatch: pytest.MonkeyPatch) -> None:
-    retryer = DiskRetryer({})
-    monkeypatch.setattr(retryer, 'MAX_TASK_SIZE', 2)
-
-    assert not retryer.add_task(b'123', {'url': 'http://example.com/'})
-
-    assert retryer.total_size == 0
-    assert not retryer.tasks
-    assert retryer.thread is None

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -252,3 +252,22 @@ def test_disk_retryer_add_task_after_close_does_nothing() -> None:
     assert retryer.total_size == 0
     assert not retryer.tasks
     assert retryer.thread is None
+
+
+def test_disk_retryer_can_send_queued_tasks_without_sleeping(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_mock = Mock()
+    monkeypatch.setattr('time.sleep', sleep_mock)
+
+    retryer = DiskRetryer({}, initial_delay=0, success_delay=0)
+    retryer.session.mount('http://', SinkHTTPAdapter())
+
+    assert retryer.add_task(b'123', {'url': 'http://example.com/'})
+    assert retryer.add_task(b'456', {'url': 'http://example.com/'})
+
+    assert retryer.thread
+    retryer.thread.join()
+
+    assert not retryer.tasks
+    assert not retryer.thread
+    assert not list(retryer.dir.iterdir())
+    sleep_mock.assert_not_called()

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -6,9 +6,12 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceResponse
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
 
 import logfire
+import logfire.experimental.forwarding as forwarding
 from logfire.experimental.forwarding import ForwardExportRequestResponse, forward_export_request, logfire_proxy
 from logfire.version import VERSION
 
@@ -85,6 +88,74 @@ def test_forward_export_request_queue_full_returns_partial_success(monkeypatch: 
     assert otlp_response.partial_success.error_message == (
         'Logfire proxy retry queue is full or unavailable; telemetry was dropped.'
     )
+
+
+@pytest.mark.parametrize(
+    ('path', 'response_type'),
+    [
+        ('/v1/logs', ExportLogsServiceResponse),
+        ('/v1/metrics', ExportMetricsServiceResponse),
+    ],
+)
+def test_forward_export_request_empty_body_returns_signal_success(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    response_type: type[ExportLogsServiceResponse] | type[ExportMetricsServiceResponse],
+) -> None:
+    logfire.configure(token='test_token', send_to_logfire=False)
+
+    retryer = FakeRetryer()
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
+
+    response = forward_export_request(path=path, headers={}, body=None)
+
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/x-protobuf'
+    assert response.content == response_type().SerializeToString()
+    assert not retryer.tasks
+
+
+@pytest.mark.parametrize(
+    ('path', 'response_type'),
+    [
+        ('/v1/logs', ExportLogsServiceResponse),
+        ('/v1/metrics', ExportMetricsServiceResponse),
+    ],
+)
+def test_forward_export_request_queue_full_returns_signal_partial_success(
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    response_type: type[ExportLogsServiceResponse] | type[ExportMetricsServiceResponse],
+) -> None:
+    logfire.configure(token='test_token', send_to_logfire=False)
+
+    retryer = FakeRetryer(accepted=False)
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
+
+    response = forward_export_request(path=path, headers={}, body=b'data')
+
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/x-protobuf'
+    otlp_response = response_type.FromString(response.content)
+    assert otlp_response.partial_success.error_message == (
+        'Logfire proxy retry queue is full or unavailable; telemetry was dropped.'
+    )
+
+
+def test_get_forwarding_retryer_recreates_closed_retryer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(forwarding, '_forwarding_retryer', None)
+    get_forwarding_retryer = getattr(forwarding, '_get_forwarding_retryer')
+
+    retryer = get_forwarding_retryer()
+    assert retryer.initial_delay == 0
+    assert retryer.success_delay == 0
+
+    retryer.close()
+    new_retryer = get_forwarding_retryer()
+    assert new_retryer is not retryer
+    assert new_retryer.initial_delay == 0
+    assert new_retryer.success_delay == 0
+    new_retryer.close()
 
 
 def test_fastapi_proxy_handler(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -149,6 +149,7 @@ def test_get_forwarding_retryer_recreates_closed_retryer(monkeypatch: pytest.Mon
     retryer = get_forwarding_retryer()
     assert retryer.initial_delay == 0
     assert retryer.success_delay == 0
+    assert get_forwarding_retryer() is retryer
 
     retryer.close()
     new_retryer = get_forwarding_retryer()

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -144,19 +144,45 @@ def test_forward_export_request_queue_full_returns_signal_partial_success(
 
 def test_get_forwarding_retryer_recreates_closed_retryer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(forwarding, '_forwarding_retryer', None)
+    monkeypatch.setattr(forwarding, '_forwarding_retryer_shutdown', False)
     get_forwarding_retryer = getattr(forwarding, '_get_forwarding_retryer')
 
     retryer = get_forwarding_retryer()
+    assert retryer is not None
     assert retryer.initial_delay == 0
     assert retryer.success_delay == 0
     assert get_forwarding_retryer() is retryer
 
     retryer.close()
     new_retryer = get_forwarding_retryer()
+    assert new_retryer is not None
     assert new_retryer is not retryer
     assert new_retryer.initial_delay == 0
     assert new_retryer.success_delay == 0
     new_retryer.close()
+
+
+def test_forwarding_retryer_does_not_recreate_after_shutdown(monkeypatch: pytest.MonkeyPatch) -> None:
+    logfire.configure(token='test_token', send_to_logfire=False)
+    monkeypatch.setattr(forwarding, '_forwarding_retryer', None)
+    monkeypatch.setattr(forwarding, '_forwarding_retryer_shutdown', False)
+    get_forwarding_retryer = getattr(forwarding, '_get_forwarding_retryer')
+    close_forwarding_retryer = getattr(forwarding, '_close_forwarding_retryer')
+
+    retryer = get_forwarding_retryer()
+    assert retryer is not None
+
+    close_forwarding_retryer()
+
+    assert retryer.closed
+    assert get_forwarding_retryer() is None
+
+    response = forward_export_request(path='/v1/traces', headers={}, body=b'data')
+    assert response.status_code == 200
+    otlp_response = ExportTraceServiceResponse.FromString(response.content)
+    assert otlp_response.partial_success.error_message == (
+        'Logfire proxy retry queue is full or unavailable; telemetry was dropped.'
+    )
 
 
 def test_fastapi_proxy_handler(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -185,6 +185,16 @@ def test_forwarding_retryer_does_not_recreate_after_shutdown(monkeypatch: pytest
     )
 
 
+def test_close_forwarding_retryer_without_retryer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(forwarding, '_forwarding_retryer', None)
+    monkeypatch.setattr(forwarding, '_forwarding_retryer_shutdown', False)
+    close_forwarding_retryer = getattr(forwarding, '_close_forwarding_retryer')
+
+    close_forwarding_retryer()
+
+    assert getattr(forwarding, '_forwarding_retryer_shutdown')
+
+
 def test_fastapi_proxy_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
     TestClient = pytest.importorskip('starlette.testclient').TestClient

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -6,44 +6,55 @@ from typing import Any
 from unittest import mock
 
 import pytest
-import requests
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
 
 import logfire
 from logfire.experimental.forwarding import ForwardExportRequestResponse, forward_export_request, logfire_proxy
+from logfire.version import VERSION
 
 
-def test_forward_export_request_logic() -> None:
+class FakeRetryer:
+    def __init__(self, accepted: bool = True) -> None:
+        self.accepted = accepted
+        self.tasks: list[tuple[bytes, dict[str, Any]]] = []
+
+    def add_task(self, data: bytes, kwargs: dict[str, Any]) -> bool:
+        self.tasks.append((data, kwargs))
+        return self.accepted
+
+
+def test_forward_export_request_logic(monkeypatch: pytest.MonkeyPatch) -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    with mock.patch('requests.post') as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.headers = {
-            'Content-Type': 'application/json',
-            'Content-Length': '123',
-            'Set-Cookie': 'secret=value',
-        }
-        mock_post.return_value.content = b'{"status": "ok"}'
+    retryer = FakeRetryer()
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
 
-        response = forward_export_request(
-            path='/v1/traces',
-            headers={'Content-Type': 'application/x-protobuf', 'Host': 'example.com'},
-            body=b'data',
+    response = forward_export_request(
+        path='/v1/traces',
+        headers={'Content-Type': 'application/x-protobuf', 'Host': 'example.com'},
+        body=b'data',
+    )
+
+    assert isinstance(response, ForwardExportRequestResponse)
+    assert response.status_code == 200
+    assert response.content == b''
+    assert response.headers['Content-Type'] == 'application/x-protobuf'
+
+    assert retryer.tasks == [
+        (
+            b'data',
+            {
+                'url': 'https://logfire-us.pydantic.dev/v1/traces',
+                'headers': {
+                    'Content-Type': 'application/x-protobuf',
+                    'User-Agent': f'logfire-proxy/{VERSION}',
+                    'Authorization': 'test_token',
+                },
+                'stream': False,
+                'timeout': 5.0,
+            },
         )
-
-        assert isinstance(response, ForwardExportRequestResponse)
-        assert response.status_code == 200
-        assert response.content == b'{"status": "ok"}'
-        assert response.headers['Content-Type'] == 'application/json'
-        assert 'Content-Length' not in response.headers
-        assert 'Set-Cookie' not in response.headers
-
-        mock_post.assert_called_once()
-        _, kwargs = mock_post.call_args
-        assert kwargs['url'] == 'https://logfire-us.pydantic.dev/v1/traces'
-        assert kwargs['headers']['Authorization'] == 'test_token'
-        assert kwargs['headers']['Content-Type'] == 'application/x-protobuf'
-        assert 'Host' not in kwargs['headers']
-        assert kwargs['data'] == b'data'
+    ]
 
 
 def test_forward_export_request_invalid_path() -> None:
@@ -60,42 +71,47 @@ def test_forward_export_request_path_traversal() -> None:
     assert b'Invalid path' in response.content
 
 
-def test_forward_export_request_exception_handling() -> None:
+def test_forward_export_request_queue_full_returns_partial_success(monkeypatch: pytest.MonkeyPatch) -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    with mock.patch('requests.post', side_effect=requests.RequestException('connection failure')):
-        response = forward_export_request(path='/v1/traces', headers={}, body=b'')
-        assert response.status_code == 502
-        assert response.content == b'Upstream service error'
+    retryer = FakeRetryer(accepted=False)
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
+
+    response = forward_export_request(path='/v1/traces', headers={}, body=b'data')
+
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/x-protobuf'
+    otlp_response = ExportTraceServiceResponse.FromString(response.content)
+    assert otlp_response.partial_success.error_message == (
+        'Logfire proxy retry queue is full or unavailable; telemetry was dropped.'
+    )
 
 
-def test_fastapi_proxy_handler() -> None:
+def test_fastapi_proxy_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
     TestClient = pytest.importorskip('starlette.testclient').TestClient
     FastAPI = fastapi.FastAPI
 
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
+    retryer = FakeRetryer()
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
 
     app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST'])
 
     client = TestClient(app)
 
-    with mock.patch('requests.post') as mock_post:
-        mock_post.return_value.status_code = 202
-        mock_post.return_value.headers = {}
-        mock_post.return_value.content = b''
+    response = client.post(
+        '/logfire-proxy/v1/traces', content=b'trace_data', headers={'Content-Type': 'application/x-protobuf'}
+    )
 
-        response = client.post(
-            '/logfire-proxy/v1/traces', content=b'trace_data', headers={'Content-Type': 'application/x-protobuf'}
-        )
+    assert response.status_code == 200
+    assert response.content == b''
 
-        assert response.status_code == 202
-
-        mock_post.assert_called_once()
-        _, kwargs = mock_post.call_args
-        assert kwargs['url'].endswith('/v1/traces')
-        assert kwargs['data'] == b'trace_data'
+    assert len(retryer.tasks) == 1
+    data, kwargs = retryer.tasks[0]
+    assert data == b'trace_data'
+    assert kwargs['url'].endswith('/v1/traces')
 
 
 def test_fastapi_proxy_size_limit() -> None:
@@ -161,17 +177,15 @@ def test_forward_export_request_percent_encoded_traversal() -> None:
     assert response.status_code == 400
 
 
-def test_forward_export_request_multi_token() -> None:
+def test_forward_export_request_multi_token(monkeypatch: pytest.MonkeyPatch) -> None:
     logfire.configure(token=['tok1', 'tok2'], send_to_logfire=False)
 
-    with mock.patch('requests.post') as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.headers = {}
-        mock_post.return_value.content = b''
+    retryer = FakeRetryer()
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
 
-        forward_export_request(path='/v1/traces', headers={}, body=b'')
-        headers = mock_post.call_args[1]['headers']
-        assert headers['Authorization'] == 'tok1'
+    forward_export_request(path='/v1/traces', headers={}, body=b'data')
+    headers = retryer.tasks[0][1]['headers']
+    assert headers['Authorization'] == 'tok1'
 
 
 def test_forward_export_request_missing_token() -> None:
@@ -180,27 +194,24 @@ def test_forward_export_request_missing_token() -> None:
 
     with mock.patch.object(logfire_instance.config, 'token', None):
         response = forward_export_request(path='/v1/traces', headers={}, body=b'', logfire_instance=logfire_instance)
-        assert response.status_code == 500
+        assert response.status_code == 403
         assert b'not configured' in response.content
 
 
-def test_forward_export_request_explicit_instance() -> None:
+def test_forward_export_request_explicit_instance(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that an explicit instance can be passed to forward_export_request."""
     logfire.configure(token='explicit_token', send_to_logfire=False)
+    retryer = FakeRetryer()
+    monkeypatch.setattr('logfire.experimental.forwarding._get_forwarding_retryer', lambda: retryer)
 
     explicit_instance = logfire.DEFAULT_LOGFIRE_INSTANCE
 
-    with mock.patch('requests.post') as mock_post:
-        mock_post.return_value.status_code = 200
-        mock_post.return_value.headers = {}
-        mock_post.return_value.content = b'ok'
+    response = forward_export_request(path='/v1/traces', headers={}, body=b'data', logfire_instance=explicit_instance)
 
-        response = forward_export_request(path='/v1/traces', headers={}, body=b'', logfire_instance=explicit_instance)
+    assert response.status_code == 200
 
-        assert response.status_code == 200
-
-        headers = mock_post.call_args[1]['headers']
-        assert headers['Authorization'] == 'explicit_token'
+    headers = retryer.tasks[0][1]['headers']
+    assert headers['Authorization'] == 'explicit_token'
 
 
 def test_fastapi_proxy_invalid_method() -> None:


### PR DESCRIPTION
## Summary
- queue accepted browser OTLP payloads into the existing disk-backed retryer instead of forwarding to Logfire on the request path
- return OTLP HTTP 200 after local acceptance, and OTLP partial-success 200 when the retry queue cannot accept the payload
- return non-retryable 403 for missing Logfire token and use a 5s per-attempt background forwarding timeout
- document the new queue/background retry semantics for browser telemetry proxying

## Rationale
Browser telemetry forwarding should not let Logfire latency or outages occupy application request workers. This changes the proxy semantics to acknowledge the browser once the proxy has accepted local custody of the payload, then forward best-effort from a bounded disk retry queue with exponential backoff.

## Tests
- uv run pytest tests/test_experimental_forwarding.py tests/exporters/test_otlp_session.py
- uv run ruff check logfire/experimental/forwarding.py logfire/_internal/exporters/otlp.py tests/test_experimental_forwarding.py tests/exporters/test_otlp_session.py
- uv run pyright logfire/experimental/forwarding.py logfire/_internal/exporters/otlp.py tests/test_experimental_forwarding.py tests/exporters/test_otlp_session.py