### PR TITLE
Clean up compliance page and route requests to Pylon form

### DIFF
--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -20,7 +20,9 @@ Logfire is SOC2 Type II certified. We did not receive any exceptions in our repo
 ![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=true#only-dark){ width="150" }
 ![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=false#only-light){ width="150" }
 
-Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant. We offer Business Associate Agreements (BAAs) to customers on our enterprise plans — request one via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
+Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant.
+
+If your use of Logfire involves Protected Health Information (PHI), HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us. We offer BAAs to customers on our enterprise plans — to put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
 
 ## GDPR
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -2,30 +2,33 @@
 title: "Logfire Compliance Standards & Security Protocols"
 description: "Overview of Logfire compliance standards. We are SOC2 Type II certified and HIPAA compliant, offer BAAs, and provide an EU Data Region for GDPR compliance."
 ---
-If you have any questions about compliance, feel free to [get in touch](help.md)
+For more about our security posture, see the [Pydantic security page](https://pydantic.dev/security) and our [trust page](https://trust.oneleet.com/pydantic).
 
-An overview of our security controls and processes can be found on our <a href="https://trust.oneleet.com/pydantic" target="_blank">trust page</a>.
+To request our SOC2 report, BAA, or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
 
+If you have any other questions about compliance, feel free to [get in touch](help.md).
 
-## SOC2 💡
-![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=true#only-dark){: style="width:150px"}
-![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=false#only-light){: style="width:150px"}
+## SOC2
 
-Logfire is SOC2 Type II certified. We did not receive any exceptions in our report. You can request a copy of our SOC2
-report by emailing: [legal@pydantic.dev](mailto:legal@pydantic.dev)
+![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=true#only-dark){ width="150" }
+![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=false#only-light){ width="150" }
+
+Logfire is SOC2 Type II certified. We did not receive any exceptions in our report. Request a copy of our SOC2 report via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
 
 ## HIPAA
-![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=true#only-dark){: style="width:150px"}
-![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=false#only-light){: style="width:150px"}
 
-Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html) compliant. We are able to offer Business Associate Agreements (BAAs) to customers
-on our enterprise plans. For details, please email: [sales@pydantic.dev](mailto:sales@pydantic.dev)
+![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=true#only-dark){ width="150" }
+![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=false#only-light){ width="150" }
+
+Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html) compliant. We offer Business Associate Agreements (BAAs) to customers on our enterprise plans — request one via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
 
 ## GDPR
-![Pydantic Logfire GDPR Badge](https://badges.oneleet.com/badge/fd18577a-ed97-40a9-afb2-d32a8c755d2a?dark=true#only-dark){: style="width:150px"}
-![Pydantic Logfire GDPR Badge](https://badges.oneleet.com/badge/fd18577a-ed97-40a9-afb2-d32a8c755d2a?dark=false#only-light){: style="width:150px"}
+
+![Pydantic Logfire GDPR Badge](https://badges.oneleet.com/badge/fd18577a-ed97-40a9-afb2-d32a8c755d2a?dark=true#only-dark){ width="150" }
+![Pydantic Logfire GDPR Badge](https://badges.oneleet.com/badge/fd18577a-ed97-40a9-afb2-d32a8c755d2a?dark=false#only-light){ width="150" }
 
 Pydantic is GDPR compliant.
 
 ## EU Region
+
 For customers who need data to be kept in the EU, we offer an [EU Data Region](reference/data-regions.md).

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -2,9 +2,9 @@
 title: "Logfire Compliance Standards & Security Protocols"
 description: "Overview of Logfire compliance standards. We are SOC2 Type II certified and HIPAA compliant, offer BAAs, and provide an EU Data Region for GDPR compliance."
 ---
-For more about our security posture, see the [Pydantic security page](https://pydantic.dev/security) and our [trust page](https://trust.oneleet.com/pydantic).
+For more about our security posture, see the [Pydantic security page](https://pydantic.dev/security){ target="_blank" rel="noopener" } and our [trust page](https://trust.oneleet.com/pydantic){ target="_blank" rel="noopener" }.
 
-To request our SOC2 report, BAA, or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
+To request our SOC2 report, BAA, or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
 
 If you have any other questions about compliance, feel free to [get in touch](help.md).
 
@@ -13,14 +13,14 @@ If you have any other questions about compliance, feel free to [get in touch](he
 ![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=true#only-dark){ width="150" }
 ![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=false#only-light){ width="150" }
 
-Logfire is SOC2 Type II certified. We did not receive any exceptions in our report. Request a copy of our SOC2 report via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
+Logfire is SOC2 Type II certified. We did not receive any exceptions in our report. Request a copy of our SOC2 report via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
 
 ## HIPAA
 
 ![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=true#only-dark){ width="150" }
 ![Pydantic Logfire HIPAA Badge](https://badges.oneleet.com/badge/0192577e-6462-4160-b19b-59e6e6af422e?dark=false#only-light){ width="150" }
 
-Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html) compliant. We offer Business Associate Agreements (BAAs) to customers on our enterprise plans — request one via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
+Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant. We offer Business Associate Agreements (BAAs) to customers on our enterprise plans — request one via our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
 
 ## GDPR
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -8,7 +8,7 @@ To request our SOC2 report, BAA, or any other compliance documentation, use our 
 
 If you have any other questions about compliance, feel free to [get in touch](help.md).
 
-## SOC2
+## SOC2 💡
 
 ![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=true#only-dark){ width="150" }
 ![Pydantic Logfire SOC2 Badge](https://badges.oneleet.com/badge/59e88e9f-ed29-49bc-a91d-0c9d1b8b5c2e?dark=false#only-light){ width="150" }

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -4,9 +4,7 @@ description: "Overview of Logfire compliance standards. We are SOC2 Type II cert
 ---
 For more about our security posture, see the [Pydantic security page](https://pydantic.dev/security){ target="_blank" rel="noopener" } and our [trust page](https://trust.oneleet.com/pydantic){ target="_blank" rel="noopener" }.
 
-To request our SOC2 report or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
-
-If you have any other questions about compliance, feel free to [get in touch](help.md).
+To request our SOC2 report or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }. For anything else, feel free to [get in touch](help.md).
 
 ## SOC2 💡
 
@@ -22,7 +20,7 @@ Logfire is SOC2 Type II certified. We did not receive any exceptions in our repo
 
 Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant.
 
-HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us if your use of Logfire involves Protected Health Information (PHI). We offer BAAs to customers on our enterprise plans. To put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
+HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us if your use of Logfire involves Protected Health Information (PHI). We offer a boilerplate BAA on our Growth plan and a custom BAA on our Enterprise plan (see [pricing](https://pydantic.dev/pricing){ target="_blank" rel="noopener" }). To put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
 
 ## GDPR
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -4,7 +4,7 @@ description: "Overview of Logfire compliance standards. We are SOC2 Type II cert
 ---
 For more about our security posture, see the [Pydantic security page](https://pydantic.dev/security){ target="_blank" rel="noopener" } and our [trust page](https://trust.oneleet.com/pydantic){ target="_blank" rel="noopener" }.
 
-To request our SOC2 report, BAA, or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
+To request our SOC2 report or any other compliance documentation, use our [compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request){ target="_blank" rel="noopener" }.
 
 If you have any other questions about compliance, feel free to [get in touch](help.md).
 
@@ -22,7 +22,7 @@ Logfire is SOC2 Type II certified. We did not receive any exceptions in our repo
 
 Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant.
 
-If your use of Logfire involves Protected Health Information (PHI), HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us. We offer BAAs to customers on our enterprise plans — to put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
+HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us if your use of Logfire involves Protected Health Information (PHI). We offer BAAs to customers on our enterprise plans. To put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
 
 ## GDPR
 

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -20,7 +20,7 @@ Logfire is SOC2 Type II certified. We did not receive any exceptions in our repo
 
 Logfire is [HIPAA](https://www.hhs.gov/hipaa/for-professionals/privacy/laws-regulations/index.html){ target="_blank" rel="noopener" } compliant.
 
-HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us if your use of Logfire involves Protected Health Information (PHI). We offer a boilerplate BAA on our Growth plan and a custom BAA on our Enterprise plan (see [pricing](https://pydantic.dev/pricing){ target="_blank" rel="noopener" }). To put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
+HIPAA requires a [Business Associate Agreement (BAA)](https://www.hhs.gov/hipaa/for-professionals/privacy/guidance/business-associates/index.html){ target="_blank" rel="noopener" } between you and us if your use of Logfire involves Protected Health Information (PHI). We offer a boilerplate BAA on our Growth plan and a custom BAA on any Enterprise plan (see [pricing](https://pydantic.dev/pricing){ target="_blank" rel="noopener" }). To put one in place, email [sales@pydantic.dev](mailto:sales@pydantic.dev).
 
 ## GDPR
 


### PR DESCRIPTION
## Summary

Tidies up `docs/compliance.md`:

- Fixes visible `{: style="width:150px"}` artefacts under each badge by swapping to the supported `{ width="150" }` attr_list syntax.
- Adds blank lines between headings and badge images so attr_list parses cleanly.
- Routes SOC2 report and other compliance documentation requests to the new [Pylon compliance request form](https://portal.usepylon.com/pydantic/forms/compliance-request).
- Keeps BAA requests routed to `sales@pydantic.dev` (BAA is a sales document, not a compliance doc), and clarifies that we offer a boilerplate BAA on the Growth plan and a custom BAA on the Enterprise plan, with a link to the [pricing page](https://pydantic.dev/pricing).
- Links the term "Business Associate Agreement (BAA)" to the HHS Office for Civil Rights guidance page on Business Associates.
- Links out to the new [pydantic.dev/security](https://pydantic.dev/security) marketing page as the primary "read more" destination, alongside the existing Oneleet trust page.
- Tightens intro copy into two short paragraphs.
- Opens external links in a new tab via `{ target="_blank" rel="noopener" }`.

## Test plan

- [ ] Visual check on the rendered docs page that the badges no longer show stray `{: style=...}` text.
- [ ] SOC2 / compliance doc links go to the Pylon form.
- [ ] BAA route goes to `sales@pydantic.dev` and the BAA term links to the HHS guidance page.
- [ ] External links open in a new tab.
