### PR TITLE
Fix new-tab behaviour on examples page GitHub link

### DIFF
--- a/docs/reference/examples.md
+++ b/docs/reference/examples.md
@@ -24,7 +24,7 @@ automatically generated:
 
 ![Flask and SQLAlchemy example](../images/logfire-screenshot-examples-flask-sqlalchemy.png)
 
-[View on GitHub :material-open-in-new:](https://github.com/pydantic/logfire/tree/main/examples/python/flask-sqlalchemy/){:target="_blank"}
+<a href="https://github.com/pydantic/logfire/tree/main/examples/python/flask-sqlalchemy/" target="_blank" rel="noopener">View on GitHub :material-open-in-new:</a>
 
 ## JavaScript/TypeScript
 


### PR DESCRIPTION
## Summary

Small follow-up to #1936. The "View on GitHub" link in `docs/reference/examples.md` uses the `{:target="_blank"}` attr_list syntax, which (as confirmed by manual testing on the live docs) doesn't actually produce a new-tab link in production — same pipeline issue as the compliance page. Switching it to a raw `<a target="_blank" rel="noopener">` tag, which works reliably.

## Test plan

- [ ] Once deployed, clicking the "View on GitHub" link on `/docs/logfire/reference/examples/` opens in a new tab.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSUFcWv4asGbRPPuUfCLWS)_