### PR TITLE
Open external docs links in a new tab via theme override (prototype)

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -97,5 +97,24 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 </script>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    // Open external links in a new tab.
+    const here = window.location.hostname;
+    document.querySelectorAll('a[href]').forEach(function(a) {
+        let url;
+        try { url = new URL(a.href, window.location.href); } catch (e) { return; }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+        if (url.hostname === here) return;
+        if (a.hasAttribute('target')) return;
+        a.setAttribute('target', '_blank');
+        const existingRel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean);
+        for (const token of ['noopener', 'noreferrer']) {
+            if (!existingRel.includes(token)) existingRel.push(token);
+        }
+        a.setAttribute('rel', existingRel.join(' '));
+    });
+});
+</script>
 {% include 'mkdocs_run_deps.html' ignore missing %}
 {% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -100,12 +100,19 @@ document.addEventListener('DOMContentLoaded', function() {
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // Open external links in a new tab.
-    const here = window.location.hostname;
+    // Hosts in this set are treated as "internal" regardless of which one is
+    // currently serving the page, so cross-links between the old and new docs
+    // subdomains stay in-tab during the migration.
+    const internalHosts = new Set([
+        window.location.hostname,
+        'logfire.pydantic.dev',
+        // TODO: add the new docs subdomain here once the migration host is finalised
+    ]);
     document.querySelectorAll('a[href]').forEach(function(a) {
         let url;
         try { url = new URL(a.href, window.location.href); } catch (e) { return; }
         if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
-        if (url.hostname === here) return;
+        if (internalHosts.has(url.hostname)) return;
         if (a.hasAttribute('target')) return;
         a.setAttribute('target', '_blank');
         const existingRel = (a.getAttribute('rel') || '').split(/\s+/).filter(Boolean);


### PR DESCRIPTION
## Summary

Prototype for option 4 from the "make external links open in a new tab" discussion. Adds a small DOMContentLoaded script to `docs/overrides/main.html` that walks every `<a>` on the page and, for links pointing to a host different from `window.location.hostname`, sets `target="_blank"` with `rel="noopener noreferrer"`.

Why this approach instead of per-link markup:

- The inline attr_list syntax (`{:target="_blank"}` or `{ target="_blank" rel="noopener" }`) does not work on the production docs pipeline for inline links (confirmed against the live site). Raw `<a target="_blank">` tags work but require hand-maintaining ~300 external links across the docs, and any new external link added in plain markdown by default opens in the same tab.
- The script applies once per page load, leaves same-origin links alone, and leaves any link with an explicit `target` already set alone, so authors retain the escape hatch.

Open as a draft for discussion with @ docs owners. If preferred we can scope this differently — e.g. only force new-tab for a small allowlist of marketing domains (`pydantic.dev`, `trust.oneleet.com`, `portal.usepylon.com`), or do the opposite and leave behaviour as-is for the long tail of GitHub / OTel / vendor links.

## Test plan

- [ ] Build the docs locally; click an external link (e.g. any GitHub link) and confirm it opens in a new tab.
- [ ] Click an internal link (e.g. anything under the same docs host) and confirm it still opens in the same tab.
- [ ] Inspect a link in DevTools and confirm `rel` contains both `noopener` and `noreferrer`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSUFcWv4asGbRPPuUfCLWS)_