### PR TITLE
Expose ResolvedVariable reason

### DIFF
--- a/logfire/variables/__init__.py
+++ b/logfire/variables/__init__.py
@@ -6,6 +6,7 @@ from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 from logfire.variables.abstract import (
+    ResolutionReason,
     ResolvedVariable,
     SyncMode,
     ValidationReport,
@@ -71,6 +72,7 @@ __all__ = [
     # Context managers and utilities
     'targeting_context',
     # Types
+    'ResolutionReason',
     'SyncMode',
     'ValidationReport',
     # Exceptions

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -30,6 +30,7 @@ ANSI_GRAY = '\033[90m'
 
 __all__ = (
     'ResolvedVariable',
+    'ResolutionReason',
     'SyncMode',
     'ValidationReport',
     'VariableProvider',
@@ -41,6 +42,28 @@ __all__ = (
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
+
+ResolutionReason = Literal[
+    'resolved',
+    'context_override',
+    'missing_config',
+    'unrecognized_variable',
+    'validation_error',
+    'other_error',
+    'no_provider',
+    'code_default',
+]
+"""Why a variable (or a composed reference) resolved to its final value.
+
+- `resolved`: provider returned a value that was used as-is.
+- `context_override`: a value set via `Variable.override(...)` was used.
+- `missing_config`: the variable exists on the provider but the targeting/rollout produced no value.
+- `unrecognized_variable`: the provider has no entry for the variable.
+- `validation_error`: the serialized value failed deserialization.
+- `other_error`: composition, rendering or other error during resolution.
+- `no_provider`: no provider is configured.
+- `code_default`: the variable's code-default was used because the provider had no value.
+"""
 
 if not TYPE_CHECKING:  # pragma: no branch
     if sys.version_info < (3, 10):  # pragma: no cover
@@ -96,18 +119,10 @@ class ResolvedVariable(Generic[T_co]):
     """The name of the variable."""
     value: T_co
     """The resolved value of the variable."""
-    _reason: Literal[
-        'resolved',
-        'context_override',
-        'missing_config',
-        'unrecognized_variable',
-        'validation_error',
-        'other_error',
-        'no_provider',
-    ]  # we might eventually make this public, but I didn't want to yet
-    """Internal field indicating how the value was resolved."""
-    # Note: I had to put _reason before fields with defaults due to lack of kw_only
-    # Note: When we drop support for python 3.9, move _reason to the end
+    reason: ResolutionReason
+    """How the variable was resolved (see `ResolutionReason` for possible values)."""
+    # Note: `reason` is declared before fields with defaults because we don't use kw_only=True
+    # on Python<3.10; move it to the end when 3.9 support is dropped.
     label: str | None = None
     """The name of the selected label, if any."""
     version: int | None = None
@@ -680,11 +695,11 @@ class VariableProvider(ABC):
         """
         config = self.get_variable_config(variable_name)
         if config is None:
-            return ResolvedVariable(name=variable_name, value=None, _reason='unrecognized_variable')
+            return ResolvedVariable(name=variable_name, value=None, reason='unrecognized_variable')
 
         labeled_value = config.labels.get(label)
         if labeled_value is None:
-            return ResolvedVariable(name=variable_name, value=None, _reason='resolved')
+            return ResolvedVariable(name=variable_name, value=None, reason='resolved')
 
         serialized, version = config.follow_ref(labeled_value)
         return ResolvedVariable(
@@ -692,7 +707,7 @@ class VariableProvider(ABC):
             value=serialized,
             label=label,
             version=version,
-            _reason='resolved',
+            reason='resolved',
         )
 
     def refresh(self, force: bool = False):
@@ -1422,7 +1437,7 @@ class NoOpVariableProvider(VariableProvider):
         Returns:
             A ResolvedVariable with value=None.
         """
-        return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')
+        return ResolvedVariable(name=variable_name, value=None, reason='no_provider')
 
     def get_variable_config(self, name: str) -> VariableConfig | None:
         """Return None for all variable lookups.

--- a/logfire/variables/config.py
+++ b/logfire/variables/config.py
@@ -507,7 +507,7 @@ class VariablesConfig(BaseModel):
         """
         variable_config = self._get_variable_config(name)
         if variable_config is None:
-            return ResolvedVariable(name=name, value=None, _reason='unrecognized_variable')
+            return ResolvedVariable(name=name, value=None, reason='unrecognized_variable')
 
         serialized_value, selected_label, version = variable_config.resolve_value(
             targeting_key, attributes, label=label
@@ -517,7 +517,7 @@ class VariablesConfig(BaseModel):
             value=serialized_value,
             label=selected_label,
             version=version,
-            _reason='resolved',
+            reason='resolved',
         )
 
     def _get_variable_config(self, name: VariableName) -> VariableConfig | None:

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -356,7 +356,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
             self.refresh()
 
         if self._config is None:
-            return ResolvedVariable(name=variable_name, value=None, _reason='missing_config')
+            return ResolvedVariable(name=variable_name, value=None, reason='missing_config')
 
         return self._config.resolve_serialized_value(variable_name, targeting_key, attributes)
 

--- a/logfire/variables/variable.py
+++ b/logfire/variables/variable.py
@@ -4,7 +4,7 @@ import inspect
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
 
@@ -248,7 +248,7 @@ class Variable(Generic[T_co]):
                         'value': serialized_value,
                         'label': result.label,
                         'version': result.version,
-                        'reason': result._reason,  # pyright: ignore[reportPrivateUsage]
+                        'reason': result.reason,
                     }
                 )
                 if result.exception:
@@ -270,7 +270,7 @@ class Variable(Generic[T_co]):
                 context_value = context_overrides[self.name]
                 if is_resolve_function(context_value):
                     context_value = context_value(targeting_key, attributes)
-                return ResolvedVariable(name=self.name, value=context_value, _reason='context_override')
+                return ResolvedVariable(name=self.name, value=context_value, reason='context_override')
 
             provider = self.logfire_instance.config.get_variable_provider()
 
@@ -286,21 +286,35 @@ class Variable(Generic[T_co]):
                             span.set_attribute('invalid_serialized_value', serialized_result.value)
                         default = self._get_default(targeting_key, attributes)
                         reason: str = 'validation_error' if isinstance(value_or_exc, ValidationError) else 'other_error'
-                        return ResolvedVariable(name=self.name, value=default, exception=value_or_exc, _reason=reason)
+                        return ResolvedVariable(
+                            name=self.name,
+                            value=default,
+                            exception=value_or_exc,
+                            reason=reason,
+                            label=serialized_result.label,
+                            version=serialized_result.version,
+                        )
                     return ResolvedVariable(
                         name=self.name,
                         value=value_or_exc,
                         label=serialized_result.label,
                         version=serialized_result.version,
-                        _reason='resolved',
+                        reason='resolved',
                     )
                 # Label not found - fall through to default resolution
 
             serialized_result = provider.get_serialized_value(self.name, targeting_key, attributes)
 
             if serialized_result.value is None:
-                default = self._get_default(targeting_key, attributes)
-                return _with_value(serialized_result, default)
+                # Provider had no value; surface that the code default was used.
+                return ResolvedVariable(
+                    name=self.name,
+                    value=self._get_default(targeting_key, attributes),
+                    exception=serialized_result.exception,
+                    label=serialized_result.label,
+                    version=serialized_result.version,
+                    reason='code_default',
+                )
 
             # Deserialize - returns T | Exception
             value_or_exc = self._deserialize(serialized_result.value)
@@ -310,14 +324,21 @@ class Variable(Generic[T_co]):
                     span.set_attribute('invalid_serialized_value', serialized_result.value)
                 default = self._get_default(targeting_key, attributes)
                 reason: str = 'validation_error' if isinstance(value_or_exc, ValidationError) else 'other_error'
-                return ResolvedVariable(name=self.name, value=default, exception=value_or_exc, _reason=reason)
+                return ResolvedVariable(
+                    name=self.name,
+                    value=default,
+                    exception=value_or_exc,
+                    reason=reason,
+                    label=serialized_result.label,
+                    version=serialized_result.version,
+                )
 
             return ResolvedVariable(
                 name=self.name,
                 value=value_or_exc,
                 label=serialized_result.label,
                 version=serialized_result.version,
-                _reason='resolved',
+                reason='resolved',
             )
 
         except Exception as e:
@@ -325,7 +346,7 @@ class Variable(Generic[T_co]):
                 span.set_attribute('invalid_serialized_label', serialized_result.label)
                 span.set_attribute('invalid_serialized_value', serialized_result.value)
             default = self._get_default(targeting_key, attributes)
-            return ResolvedVariable(name=self.name, value=default, exception=e, _reason='other_error')
+            return ResolvedVariable(name=self.name, value=default, exception=e, reason='other_error')
 
     def _get_default(
         self, targeting_key: str | None = None, merged_attributes: Mapping[str, Any] | None = None
@@ -383,19 +404,6 @@ class Variable(Generic[T_co]):
             json_schema=json_schema,
             example=example,
         )
-
-
-def _with_value(details: ResolvedVariable[Any], new_value: T_co) -> ResolvedVariable[T_co]:
-    """Return a copy of the provided resolution details, just with a different value.
-
-    Args:
-        details: Existing resolution details to modify.
-        new_value: The new value to use.
-
-    Returns:
-        A new ResolvedVariable with the given value.
-    """
-    return replace(details, value=new_value)
 
 
 @contextmanager

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -634,7 +634,7 @@ class TestNoOpVariableProvider:
         provider = NoOpVariableProvider()
         result = provider.get_serialized_value('any_variable')
         assert result.value is None
-        assert result._reason == 'no_provider'
+        assert result.reason == 'no_provider'
 
     def test_with_targeting_key_and_attributes(self):
         provider = NoOpVariableProvider()
@@ -662,19 +662,19 @@ class TestNoOpVariableProvider:
 
 class TestResolvedVariable:
     def test_basic_details(self):
-        details = ResolvedVariable(name='test_var', value='test', _reason='resolved')
+        details = ResolvedVariable(name='test_var', value='test', reason='resolved')
         assert details.name == 'test_var'
         assert details.value == 'test'
         assert details.label is None
         assert details.exception is None
 
     def test_with_label(self):
-        details = ResolvedVariable(name='test_var', value='test', label='v1', _reason='resolved')
+        details = ResolvedVariable(name='test_var', value='test', label='v1', reason='resolved')
         assert details.label == 'v1'
 
     def test_with_exception(self):
         error = ValueError('test error')
-        details = ResolvedVariable(name='test_var', value='default', exception=error, _reason='validation_error')
+        details = ResolvedVariable(name='test_var', value='default', exception=error, reason='validation_error')
         assert details.exception is error
 
     def test_context_manager_sets_baggage(self, config_kwargs: dict[str, Any]):
@@ -837,7 +837,7 @@ class TestLocalVariableProvider:
         result = provider.get_serialized_value('test_var')
         assert result.value == '"default_value"'
         assert result.label == 'default'
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
     def test_get_serialized_value_with_override(self, simple_config: VariablesConfig):
         provider = LocalVariableProvider(simple_config)
@@ -852,7 +852,7 @@ class TestLocalVariableProvider:
         provider = LocalVariableProvider(simple_config)
         result = provider.get_serialized_value('unknown_var')
         assert result.value is None
-        assert result._reason == 'unrecognized_variable'
+        assert result.reason == 'unrecognized_variable'
 
     def test_rollout_returns_none(self):
         config = VariablesConfig(
@@ -868,7 +868,7 @@ class TestLocalVariableProvider:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value('partial_var')
         assert result.value is None
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
 
 # =============================================================================
@@ -939,7 +939,7 @@ class TestLogfireRemoteVariableProvider:
                 # Without blocking, config might not be fetched yet
                 result = provider.get_serialized_value('test_var')
                 # Should return missing_config if not fetched
-                assert result._reason in ('missing_config', 'resolved', 'unrecognized_variable')
+                assert result.reason in ('missing_config', 'resolved', 'unrecognized_variable')
             finally:
                 provider.shutdown()
 
@@ -975,7 +975,7 @@ class TestLogfireRemoteVariableProvider:
             try:
                 result = provider.get_serialized_value('nonexistent_var')
                 assert result.value is None
-                assert result._reason == 'unrecognized_variable'
+                assert result.reason == 'unrecognized_variable'
             finally:
                 provider.shutdown()
 
@@ -1043,7 +1043,7 @@ class TestLogfireRemoteVariableProvider:
             try:
                 provider.refresh(force=True)
                 result = provider.get_serialized_value('test_var')
-                assert result._reason == 'unrecognized_variable'
+                assert result.reason == 'unrecognized_variable'
             finally:
                 provider.shutdown()
 
@@ -1081,7 +1081,7 @@ class TestLogfireRemoteVariableProvider:
             try:
                 result = provider.get_serialized_value('partial_var')
                 assert result.value is None
-                assert result._reason == 'resolved'
+                assert result.reason == 'resolved'
             finally:
                 provider.shutdown()
 
@@ -1160,7 +1160,7 @@ class TestLogfireRemoteVariableProvider:
                 # since no config has been fetched yet
                 result = provider.get_serialized_value_for_label('test_var', 'production')
                 assert result.value is None
-                assert result._reason == 'unrecognized_variable'
+                assert result.reason == 'unrecognized_variable'
             finally:
                 provider.shutdown()
 
@@ -1302,7 +1302,7 @@ class TestLogfireRemoteVariableProviderErrors:
             try:
                 # The mock returns an error, so config should not be set
                 result = provider.get_serialized_value('test_var')
-                assert result._reason == 'missing_config'
+                assert result.reason == 'missing_config'
             finally:
                 provider.shutdown()
 
@@ -1325,7 +1325,7 @@ class TestLogfireRemoteVariableProviderErrors:
             try:
                 # The mock returns invalid data, so validation error happens
                 result = provider.get_serialized_value('test_var')
-                assert result._reason == 'missing_config'
+                assert result.reason == 'missing_config'
             finally:
                 provider.shutdown()
 
@@ -1652,15 +1652,40 @@ class TestVariable:
         # Falls back to default when validation fails
         assert details.value == 999
         assert details.exception is not None
-        assert details._reason == 'validation_error'
+        assert details.reason == 'validation_error'
+        assert details.label == 'default'
+        assert details.version == 1
 
     def test_get_uses_default_when_no_config(self, config_kwargs: dict[str, Any]):
         config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
         lf = logfire.configure(**config_kwargs)
 
         var = lf.var(name='unconfigured', default='my_default', type=str)
-        value = var.get().value
-        assert value == 'my_default'
+        result = var.get()
+        assert result.value == 'my_default'
+        assert result.reason == 'code_default'
+
+    def test_get_preserves_provider_exception_when_using_code_default(
+        self, config_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ):
+        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        provider_error = RuntimeError('missing')
+
+        def missing_get(
+            variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
+        ) -> ResolvedVariable[str | None]:
+            return ResolvedVariable(
+                name=variable_name, value=None, exception=provider_error, reason='unrecognized_variable'
+            )
+
+        monkeypatch.setattr(lf.config._variable_provider, 'get_serialized_value', missing_get)
+
+        var = lf.var(name='unconfigured', default='my_default', type=str)
+        result = var.get()
+        assert result.value == 'my_default'
+        assert result.reason == 'code_default'
+        assert result.exception is provider_error
 
     def test_override_context_manager(self, config_kwargs: dict[str, Any], variables_config: VariablesConfig):
         config_kwargs['variables'] = LocalVariablesOptions(config=variables_config)
@@ -2197,15 +2222,15 @@ class TestLogfireVarIntegration:
         original = lf.config._variable_provider.get_serialized_value
 
         def failing_get(*args: Any, **kwargs: Any) -> ResolvedVariable[str | None]:
-            raise RuntimeError('Provider failed!')
+            raise IndexError('Provider failed!')
 
         lf.config._variable_provider.get_serialized_value = failing_get
 
         var = lf.var(name='failing_var', default='fallback', type=str)
         details = var.get()
         assert details.value == 'fallback'
-        assert details._reason == 'other_error'
-        assert isinstance(details.exception, RuntimeError)
+        assert details.reason == 'other_error'
+        assert isinstance(details.exception, IndexError)
 
         # Restore original
         lf.config._variable_provider.get_serialized_value = original
@@ -2849,7 +2874,7 @@ class TestVariablesConfigAliases:
         # Access via alias
         result = config.resolve_serialized_value('old_name')
         assert result.value == '"value"'
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
     def test_multiple_aliases(self):
         """Test that multiple aliases resolve correctly."""
@@ -2868,7 +2893,7 @@ class TestVariablesConfigAliases:
         for alias in ['alias1', 'alias2', 'alias3']:
             result = config.resolve_serialized_value(alias)
             assert result.value == '"value"'
-            assert result._reason == 'resolved'
+            assert result.reason == 'resolved'
 
     def test_nonexistent_variable_returns_unrecognized(self):
         """Test that nonexistent variable returns unrecognized."""
@@ -2884,7 +2909,7 @@ class TestVariablesConfigAliases:
         )
         result = config.resolve_serialized_value('nonexistent')
         assert result.value is None
-        assert result._reason == 'unrecognized_variable'
+        assert result.reason == 'unrecognized_variable'
 
     def test_direct_name_takes_precedence(self):
         """Test that direct variable name takes precedence over alias lookup."""
@@ -2922,7 +2947,7 @@ class TestBaseVariableProviderWriteMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         result = provider.get_all_variables_config()
@@ -2935,7 +2960,7 @@ class TestBaseVariableProviderWriteMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         config = VariableConfig(
@@ -2955,7 +2980,7 @@ class TestBaseVariableProviderWriteMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         config = VariableConfig(
@@ -2975,7 +3000,7 @@ class TestBaseVariableProviderWriteMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         with pytest.warns(UserWarning, match='does not persist variable writes'):
@@ -2994,7 +3019,7 @@ class TestBaseVariableProviderWriteMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_variable_config(self, name: str) -> VariableConfig | None:
                 return self.configs.get(name)
@@ -3449,7 +3474,7 @@ class TestPushValidateErrorHandling:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def refresh(self, force: bool = False):
                 raise RuntimeError('Refresh failed!')
@@ -3476,7 +3501,7 @@ class TestPushValidateErrorHandling:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_all_variables_config(self) -> VariablesConfig:
                 raise RuntimeError('Config fetch failed!')
@@ -3500,7 +3525,7 @@ class TestPushValidateErrorHandling:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_all_variables_config(self) -> VariablesConfig:
                 return VariablesConfig(variables={})
@@ -3525,7 +3550,7 @@ class TestPushValidateErrorHandling:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def refresh(self, force: bool = False):
                 raise RuntimeError('Refresh failed!')
@@ -3547,7 +3572,7 @@ class TestPushValidateErrorHandling:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_all_variables_config(self) -> VariablesConfig:
                 raise RuntimeError('Config fetch failed!')
@@ -3853,7 +3878,7 @@ class TestGetSerializedValueForVariantUnknown:
         provider = NoOpVariableProvider()
         result = provider.get_serialized_value_for_label('nonexistent', 'v1')
         assert result.value is None
-        assert result._reason == 'unrecognized_variable'
+        assert result.reason == 'unrecognized_variable'
 
 
 class TestBaseVariableProviderTypesMethods:
@@ -3866,7 +3891,7 @@ class TestBaseVariableProviderTypesMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         with pytest.warns(UserWarning, match='does not support variable types'):
@@ -3880,7 +3905,7 @@ class TestBaseVariableProviderTypesMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         with pytest.warns(UserWarning, match='does not support variable types'):
@@ -3895,7 +3920,7 @@ class TestBaseVariableProviderTypesMethods:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
         provider = MinimalProvider()
         config = VariableTypeConfig(name='test_type', json_schema={'type': 'string'})
@@ -4247,7 +4272,7 @@ class TestPushVariableTypes:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def list_variable_types(self) -> dict[str, VariableTypeConfig]:
                 return dict(self._types)
@@ -4351,7 +4376,7 @@ class TestPushVariableTypes:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def refresh(self, force: bool = False):
                 raise RuntimeError('Refresh failed!')
@@ -4375,7 +4400,7 @@ class TestPushVariableTypes:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def list_variable_types(self) -> dict[str, Any]:
                 raise RuntimeError('List failed!')
@@ -4397,7 +4422,7 @@ class TestPushVariableTypes:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def list_variable_types(self) -> dict[str, Any]:
                 return {}
@@ -4483,7 +4508,7 @@ class TestPushVariableTypesWithUnchangedTypes:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def list_variable_types(self) -> dict[str, VariableTypeConfig]:
                 return dict(self._types)
@@ -4521,7 +4546,7 @@ class TestPushVariableTypesWithIncompatibleLabels:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_all_variables_config(self) -> VariablesConfig:
                 return self._variables_config
@@ -4617,7 +4642,7 @@ class TestPushVariableTypesWithIncompatibleLabels:
             def get_serialized_value(
                 self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
             ) -> ResolvedVariable[str | None]:
-                return ResolvedVariable(name=variable_name, value=None, _reason='no_provider')  # pragma: no cover
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
 
             def get_all_variables_config(self) -> VariablesConfig:
                 raise RuntimeError('Config fetch failed!')
@@ -4939,7 +4964,7 @@ class TestVariablesConfigResolveSerializedValueCodeDefault:
         )
         result = config.resolve_serialized_value('test_var')
         assert result.value is None
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
 
 class TestVariablesConfigValidationErrorsWithLatestVersion:
@@ -5024,7 +5049,7 @@ class TestGetSerializedValueForLabelCodeDefault:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'v1')
         assert result.value is None
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
 
 class TestGetSerializedValueForLabelNotFound:
@@ -5044,7 +5069,7 @@ class TestGetSerializedValueForLabelNotFound:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'nonexistent')
         assert result.value is None
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
 
 class TestVariableGetWithExplicitLabel:
@@ -5072,7 +5097,7 @@ class TestVariableGetWithExplicitLabel:
         assert result.value == 'experiment_value'
         assert result.label == 'experiment'
         assert result.version == 2
-        assert result._reason == 'resolved'
+        assert result.reason == 'resolved'
 
     def test_explicit_label_not_found_falls_through(self, config_kwargs: dict[str, Any]):
         variables_config = VariablesConfig(


### PR DESCRIPTION
## Summary
- expose ResolutionReason and make ResolvedVariable.reason public
- include code_default as the final resolution reason when a variable falls back to its code default
- rename internal _reason usage to reason across variable providers and tests

Extracted from #1731 without the unrelated variable composition changes.

## Tests
- uv run pytest tests/test_variables.py
- uv run ruff check logfire/variables/__init__.py logfire/variables/abstract.py logfire/variables/config.py logfire/variables/remote.py logfire/variables/variable.py tests/test_variables.py
- uv run pyright logfire/variables/abstract.py logfire/variables/config.py logfire/variables/remote.py logfire/variables/variable.py tests/test_variables.py