### PR TITLE
Handle malformed exception tracebacks in core

### DIFF
--- a/logfire/_internal/integrations/pytest.py
+++ b/logfire/_internal/integrations/pytest.py
@@ -39,21 +39,6 @@ class LogfirePluginConfig:
         self.trace_phases = trace_phases
 
 
-def _record_exception_with_placeholder_stacktrace(span: Any, exception: BaseException) -> None:
-    """Record exception details when traceback formatting fails."""
-    module = type(exception).__module__
-    qualname = type(exception).__qualname__
-    exception_type = f'{module}.{qualname}' if module and module != 'builtins' else qualname
-    span.add_event(
-        'exception',
-        attributes={
-            'exception.type': exception_type,
-            'exception.message': str(exception),
-            'exception.stacktrace': 'Traceback unavailable: traceback formatting raised RuntimeError("generator raised StopIteration")',
-        },
-    )
-
-
 def _is_enabled(config: pytest.Config) -> bool:
     """Check if the Logfire plugin is enabled."""
     # Explicit --no-logfire always disables
@@ -470,14 +455,7 @@ def pytest_runtest_makereport(
         # Record exception details
         if call.excinfo and call.excinfo.value:  # pragma: no branch
             # Branch coverage: excinfo.value is always present for failed tests in normal pytest execution
-            try:
-                span.record_exception(call.excinfo.value)
-            except RuntimeError as e:
-                # CPython 3.11+ can raise "generator raised StopIteration" from
-                # traceback.extract_tb when processing certain bytecode positions.
-                if str(e) != 'generator raised StopIteration':
-                    raise
-                _record_exception_with_placeholder_stacktrace(span, call.excinfo.value)
+            span.record_exception(call.excinfo.value)
     elif report.skipped:  # pragma: no cover
         # TODO: this needs improvement in processing skip reasons
         skip_reason = ''

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import json
 import traceback
 from collections import defaultdict
@@ -480,44 +481,21 @@ def record_exception(
         else:
             span.set_attribute(ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY, fingerprint)
 
+    span.record_exception(exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
+
+
+original_format_exception = traceback.format_exception
+
+
+@functools.wraps(original_format_exception)
+def _patched_format_exception(*args: Any, **kwargs: Any):
     try:
-        span.record_exception(exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
-    except Exception:
-        _otel_record_exception_patch(span, exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
+        return original_format_exception(*args, **kwargs)
+    except Exception as exc:
+        return [f'Formatting stacktrace failed: {type(exc).__name__}: {exc}\n']
 
 
-def _otel_record_exception_patch(
-    span: trace_api.Span,
-    exception: BaseException,
-    attributes: otel_types.Attributes = None,
-    timestamp: int | None = None,
-    escaped: bool = False,
-) -> None:
-    """A copy of the OTel SDK's record_exception that handles errors in traceback.format_exception."""
-    from opentelemetry.semconv.attributes.exception_attributes import (
-        EXCEPTION_ESCAPED,
-        EXCEPTION_MESSAGE,
-        EXCEPTION_STACKTRACE,
-        EXCEPTION_TYPE,
-    )
-
-    try:
-        stacktrace = ''.join(traceback.format_exception(type(exception), value=exception, tb=exception.__traceback__))
-    except Exception as tb_exc:
-        stacktrace = f'Formatting stacktrace failed: {type(tb_exc).__name__}: {tb_exc}'
-
-    module = type(exception).__module__
-    qualname = type(exception).__qualname__
-    exception_type = f'{module}.{qualname}' if module and module != 'builtins' else qualname
-    _attributes: dict[str, otel_types.AttributeValue] = {
-        EXCEPTION_TYPE: exception_type,
-        EXCEPTION_MESSAGE: str(exception),
-        EXCEPTION_STACKTRACE: stacktrace,
-        EXCEPTION_ESCAPED: str(escaped),
-    }
-    if attributes:
-        _attributes.update(attributes)
-    span.add_event(name='exception', attributes=_attributes, timestamp=timestamp)
+traceback.format_exception = _patched_format_exception
 
 
 def set_exception_status(span: trace_api.Span, exception: BaseException):

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import traceback
 from collections import defaultdict
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -479,7 +480,44 @@ def record_exception(
         else:
             span.set_attribute(ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY, fingerprint)
 
-    span.record_exception(exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
+    try:
+        span.record_exception(exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
+    except Exception:
+        _otel_record_exception_patch(span, exception, attributes=attributes, timestamp=timestamp, escaped=escaped)
+
+
+def _otel_record_exception_patch(
+    span: trace_api.Span,
+    exception: BaseException,
+    attributes: otel_types.Attributes = None,
+    timestamp: int | None = None,
+    escaped: bool = False,
+) -> None:
+    """A copy of the OTel SDK's record_exception that handles errors in traceback.format_exception."""
+    from opentelemetry.semconv.attributes.exception_attributes import (
+        EXCEPTION_ESCAPED,
+        EXCEPTION_MESSAGE,
+        EXCEPTION_STACKTRACE,
+        EXCEPTION_TYPE,
+    )
+
+    try:
+        stacktrace = ''.join(traceback.format_exception(type(exception), value=exception, tb=exception.__traceback__))
+    except Exception as tb_exc:
+        stacktrace = f'Formatting stacktrace failed: {type(tb_exc).__name__}: {tb_exc}'
+
+    module = type(exception).__module__
+    qualname = type(exception).__qualname__
+    exception_type = f'{module}.{qualname}' if module and module != 'builtins' else qualname
+    _attributes: dict[str, otel_types.AttributeValue] = {
+        EXCEPTION_TYPE: exception_type,
+        EXCEPTION_MESSAGE: str(exception),
+        EXCEPTION_STACKTRACE: stacktrace,
+        EXCEPTION_ESCAPED: str(escaped),
+    }
+    if attributes:
+        _attributes.update(attributes)
+    span.add_event(name='exception', attributes=_attributes, timestamp=timestamp)
 
 
 def set_exception_status(span: trace_api.Span, exception: BaseException):

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -301,7 +301,7 @@ def log_internal_error():
                 'This is just logging the internal error.',
                 exc_info=_internal_error_exc_info(),
             )
-        except Exception:
+        except Exception:  # pragma: no cover
             pass
 
 

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -294,12 +294,15 @@ def log_internal_error():
         raise
 
     with suppress_instrumentation():  # prevent infinite recursion from the logging integration
-        logger.exception(
-            'Caught an internal error in Logfire. '
-            'Your code should still be running fine, just with less telemetry. '
-            'This is just logging the internal error.',
-            exc_info=_internal_error_exc_info(),
-        )
+        try:
+            logger.exception(
+                'Caught an internal error in Logfire. '
+                'Your code should still be running fine, just with less telemetry. '
+                'This is just logging the internal error.',
+                exc_info=_internal_error_exc_info(),
+            )
+        except Exception:
+            pass
 
 
 def _internal_error_exc_info() -> SysExcInfo:
@@ -454,7 +457,12 @@ def canonicalize_exception_traceback(exc: BaseException, seen: set[int] | None =
             visited: set[str] = set()
             for frame, lineno in traceback.walk_tb(exc.__traceback__):
                 filename = frame.f_code.co_filename
-                source_line = linecache.getline(filename, lineno, frame.f_globals).strip()
+                line_number = cast(int | None, lineno)
+                source_line = (
+                    linecache.getline(filename, line_number, frame.f_globals).strip()
+                    if line_number is not None
+                    else '<line unavailable>'
+                )
                 module = frame.f_globals.get('__name__', filename)
                 frame_summary = f'{module}.{frame.f_code.co_name}\n   {source_line}'
                 if frame_summary in visited:

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -457,12 +457,10 @@ def canonicalize_exception_traceback(exc: BaseException, seen: set[int] | None =
             visited: set[str] = set()
             for frame, lineno in traceback.walk_tb(exc.__traceback__):
                 filename = frame.f_code.co_filename
-                line_number = cast(int | None, lineno)
-                source_line = (
-                    linecache.getline(filename, line_number, frame.f_globals).strip()
-                    if line_number is not None
-                    else '<line unavailable>'
-                )
+                try:
+                    source_line = linecache.getline(filename, lineno, frame.f_globals).strip()
+                except Exception:
+                    source_line = '<error getting source line>'
                 module = frame.f_globals.get('__name__', filename)
                 frame_summary = f'{module}.{frame.f_code.co_name}\n   {source_line}'
                 if frame_summary in visited:

--- a/tests/otel_integrations/test_pytest_plugin.py
+++ b/tests/otel_integrations/test_pytest_plugin.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import sys
 from typing import Any
 from unittest import mock
 
@@ -429,85 +428,6 @@ def test_failed_test_records_exception(logfire_pytester: pytest.Pytester):
     assert exc_attrs['exception.type'] == 'AssertionError'
     assert 'intentional failure' in exc_attrs['exception.message']
     assert 'exception.stacktrace' in exc_attrs
-
-
-@pytest.mark.skipif(sys.version_info < (3, 11), reason='co_positions traceback formatting was added in Python 3.11')
-def test_failed_test_tolerates_traceback_runtime_error_from_truncated_positions(
-    logfire_pytester: pytest.Pytester,
-) -> None:
-    """Failed test reporting tolerates CPython traceback failures from bad code position metadata."""
-    logfire_pytester.makepyfile("""
-        import traceback
-        import types
-
-        import pytest
-
-
-        def _raise_from_code_with_truncated_positions():
-            detail = "bytecode position metadata is deliberately truncated"
-            raise ValueError(detail)
-
-
-        _code = _raise_from_code_with_truncated_positions.__code__.replace(co_linetable=b"")
-        _bad_function = types.FunctionType(_code, globals())
-
-
-        def test_failure_with_truncated_positions():
-            try:
-                _bad_function()
-            except ValueError as exc:
-                bad_frame_tb = exc.__traceback__.tb_next
-                synthetic_tb = types.TracebackType(
-                    None,
-                    bad_frame_tb.tb_frame,
-                    bad_frame_tb.tb_lasti,
-                    bad_frame_tb.tb_frame.f_code.co_firstlineno,
-                )
-                synthetic_exc = ValueError("failure with truncated bytecode positions").with_traceback(synthetic_tb)
-                with pytest.raises(RuntimeError, match="^generator raised StopIteration$") as traceback_error:
-                    traceback.extract_tb(synthetic_exc.__traceback__)
-                assert isinstance(traceback_error.value.__cause__, StopIteration)
-                raise synthetic_exc from None
-
-            raise AssertionError("Expected _bad_function to raise ValueError")
-    """)
-    # Pytest also calls traceback.extract_tb() while rendering failures, so keep its traceback output disabled.
-    result = logfire_pytester.runpytest_subprocess('-p', 'no:django', '-p', 'no:pretty', '--tb=no', '--logfire')
-    result.assert_outcomes(failed=1)
-
-    spans = load_spans(logfire_pytester)
-    test_span = find_span_by_pattern(spans, 'test_failure_with_truncated_positions')
-    assert test_span is not None, 'Test span not found'
-    assert test_span['attributes']['test.outcome'] == 'failed'
-
-    exception_events = [e for e in test_span.get('events', []) if e.get('name') == 'exception']
-    assert len(exception_events) == 1
-    exc_attrs = exception_events[0]['attributes']
-    assert exc_attrs['exception.type'] == 'ValueError'
-    assert exc_attrs['exception.message'] == 'failure with truncated bytecode positions'
-    assert exc_attrs['exception.stacktrace'] == (
-        'Traceback unavailable: traceback formatting raised RuntimeError("generator raised StopIteration")'
-    )
-    assert 'exception.escaped' not in exc_attrs
-
-
-def test_failed_test_reraises_unexpected_record_exception_runtime_error(logfire_pytester: pytest.Pytester) -> None:
-    """Failed test reporting should only suppress the known CPython traceback bug."""
-    logfire_pytester.makepyfile("""
-        from opentelemetry.sdk.trace import Span
-
-
-        def _unexpected_record_exception_failure(self, exception, *args, **kwargs):
-            raise RuntimeError("unexpected recording failure")
-
-
-        def test_failure(monkeypatch):
-            monkeypatch.setattr(Span, "record_exception", _unexpected_record_exception_failure)
-            raise ValueError("bad value")
-    """)
-    result = logfire_pytester.runpytest_subprocess('-p', 'no:django', '-p', 'no:pretty', '--tb=no', '--logfire')
-    assert result.ret != 0
-    result.stdout.fnmatch_lines(['*RuntimeError: unexpected recording failure*'])
 
 
 def test_skipped_test_with_reason(logfire_pytester: pytest.Pytester):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,6 @@
+import sys
+import traceback
+import types
 from typing import Any
 
 import pytest
@@ -343,6 +346,95 @@ def test_record_exception_directly(exporter: TestExporter, config_kwargs: dict[s
                             'exception.message': 'test',
                             'exception.stacktrace': 'ValueError: test',
                             'exception.escaped': 'False',
+                        },
+                    }
+                ],
+            }
+        ]
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason='co_positions traceback formatting was added in Python 3.11')
+def test_span_records_exception_when_traceback_formatting_fails(exporter: TestExporter) -> None:
+    """Regression test for CPython traceback failures from malformed bytecode position metadata."""
+
+    def clear_exception_context(exc: BaseException) -> None:
+        exc.__traceback__ = None
+        exc.__context__ = None
+        exc.__cause__ = None
+
+    def raise_from_code_with_truncated_positions() -> None:
+        detail = 'bytecode position metadata is deliberately truncated'
+        raise ValueError(detail)
+
+    bad_code = raise_from_code_with_truncated_positions.__code__.replace(co_linetable=b'')
+    bad_function = types.FunctionType(bad_code, globals())
+
+    traceback_error_message = None
+    traceback_error_cause_type = None
+    try:
+        bad_function()
+    except ValueError as exc:
+        try:
+            traceback.format_exception(type(exc), value=exc, tb=exc.__traceback__)
+        except RuntimeError as traceback_error:
+            traceback_error_message = str(traceback_error)
+            traceback_error_cause_type = type(traceback_error.__cause__)
+            clear_exception_context(traceback_error)
+        finally:
+            clear_exception_context(exc)
+    else:  # pragma: no cover
+        raise AssertionError('Expected bad_function to raise ValueError')
+
+    if traceback_error_message is None:  # pragma: no cover
+        pytest.skip('Malformed bytecode position metadata no longer breaks traceback formatting')
+    assert traceback_error_message == 'generator raised StopIteration'
+    assert traceback_error_cause_type is StopIteration
+
+    span_exception_type = None
+    span_exception_message = None
+    try:
+        with logfire.span('span with malformed exception traceback'):
+            bad_function()
+    except BaseException as exc:
+        span_exception_type = type(exc)
+        span_exception_message = str(exc)
+        clear_exception_context(exc)
+    else:  # pragma: no cover
+        raise AssertionError('Expected bad_function to raise ValueError')
+
+    assert span_exception_type is ValueError, span_exception_message
+    assert span_exception_message == 'bytecode position metadata is deliberately truncated'
+
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'span with malformed exception traceback',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 3000000000,
+                'attributes': {
+                    'code.filepath': 'test_exceptions.py',
+                    'code.function': 'test_span_records_exception_when_traceback_formatting_fails',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'span with malformed exception traceback',
+                    'logfire.msg': 'span with malformed exception traceback',
+                    'logfire.span_type': 'span',
+                    'logfire.level_num': 17,
+                    'logfire.exception.fingerprint': '0000000000000000000000000000000000000000000000000000000000000000',
+                },
+                'events': [
+                    {
+                        'name': 'exception',
+                        'timestamp': 2000000000,
+                        'attributes': {
+                            'exception.type': 'ValueError',
+                            'exception.message': 'bytecode position metadata is deliberately truncated',
+                            'exception.stacktrace': (
+                                'Formatting stacktrace failed: RuntimeError: generator raised StopIteration'
+                            ),
+                            'exception.escaped': 'True',
                         },
                     }
                 ],

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,5 +1,4 @@
 import sys
-import traceback
 import types
 from typing import Any
 
@@ -358,53 +357,14 @@ def test_record_exception_directly(exporter: TestExporter, config_kwargs: dict[s
 def test_span_records_exception_when_traceback_formatting_fails(exporter: TestExporter) -> None:
     """Regression test for CPython traceback failures from malformed bytecode position metadata."""
 
-    def clear_exception_context(exc: BaseException) -> None:
-        exc.__traceback__ = None
-        exc.__context__ = None
-        exc.__cause__ = None
-
     def raise_from_code_with_truncated_positions() -> None:
-        detail = 'bytecode position metadata is deliberately truncated'
-        raise ValueError(detail)
+        raise ValueError('test error')
 
     bad_code = raise_from_code_with_truncated_positions.__code__.replace(co_linetable=b'')
     bad_function = types.FunctionType(bad_code, globals())
 
-    traceback_error_message = None
-    traceback_error_cause_type = None
-    try:
+    with pytest.raises(ValueError, match='test error'), logfire.span('span with malformed exception traceback'):
         bad_function()
-    except ValueError as exc:
-        try:
-            traceback.format_exception(type(exc), value=exc, tb=exc.__traceback__)
-        except RuntimeError as traceback_error:
-            traceback_error_message = str(traceback_error)
-            traceback_error_cause_type = type(traceback_error.__cause__)
-            clear_exception_context(traceback_error)
-        finally:
-            clear_exception_context(exc)
-    else:  # pragma: no cover
-        raise AssertionError('Expected bad_function to raise ValueError')
-
-    if traceback_error_message is None:  # pragma: no cover
-        pytest.skip('Malformed bytecode position metadata no longer breaks traceback formatting')
-    assert traceback_error_message == 'generator raised StopIteration'
-    assert traceback_error_cause_type is StopIteration
-
-    span_exception_type = None
-    span_exception_message = None
-    try:
-        with logfire.span('span with malformed exception traceback'):
-            bad_function()
-    except BaseException as exc:
-        span_exception_type = type(exc)
-        span_exception_message = str(exc)
-        clear_exception_context(exc)
-    else:  # pragma: no cover
-        raise AssertionError('Expected bad_function to raise ValueError')
-
-    assert span_exception_type is ValueError, span_exception_message
-    assert span_exception_message == 'bytecode position metadata is deliberately truncated'
 
     assert exporter.exported_spans_as_dict() == snapshot(
         [
@@ -430,7 +390,7 @@ def test_span_records_exception_when_traceback_formatting_fails(exporter: TestEx
                         'timestamp': 2000000000,
                         'attributes': {
                             'exception.type': 'ValueError',
-                            'exception.message': 'bytecode position metadata is deliberately truncated',
+                            'exception.message': 'test error',
                             'exception.stacktrace': (
                                 'Formatting stacktrace failed: RuntimeError: generator raised StopIteration'
                             ),


### PR DESCRIPTION
## Summary
- move malformed traceback handling from the pytest plugin into core exception recording
- preserve exception events when OTel traceback formatting fails
- tolerate missing traceback line numbers while canonicalizing exception fingerprints
- replace the pytest-plugin-specific regression with a core logfire.span regression built from a malformed code object

## Tests
- uv run pytest tests/test_exceptions.py -q
- uv run pytest tests/otel_integrations/test_pytest_plugin.py -q
- uv run ruff check logfire/_internal/tracer.py logfire/_internal/utils.py logfire/_internal/integrations/pytest.py tests/test_exceptions.py tests/otel_integrations/test_pytest_plugin.py
- uv run pyright logfire/_internal/tracer.py logfire/_internal/utils.py tests/test_exceptions.py