### PR TITLE
Remove Python 3.9 handlebars test skips

### DIFF
--- a/docs/reference/advanced/managed-variables/index.md
+++ b/docs/reference/advanced/managed-variables/index.md
@@ -118,7 +118,7 @@ With managed variables, you can iterate safely in production:
 For AI applications, variables often contain prompt templates with placeholders that get filled in at runtime. **Template variables** support this natively with Handlebars `{{placeholder}}` syntax:
 
 !!! note "Install the variables extra for templates"
-    Template rendering requires the `pydantic-handlebars` package, which is installed by the `logfire[variables]` extra on Python 3.10 and later.
+    Template rendering requires the `pydantic-handlebars` package, which is installed by the `logfire[variables]` extra.
 
     ```bash
     pip install 'logfire[variables]'

--- a/docs/reference/advanced/managed-variables/templates-and-composition.md
+++ b/docs/reference/advanced/managed-variables/templates-and-composition.md
@@ -5,7 +5,7 @@ Managed variables can contain **Handlebars templates** (`{{placeholder}}`) and *
 This is especially useful for AI applications where prompts are built from reusable fragments and personalized with request-specific data.
 
 !!! note "Install the variables extra"
-    Template rendering requires the `pydantic-handlebars` package, which is installed by the `logfire[variables]` extra on Python 3.10 and later:
+    Template rendering requires the `pydantic-handlebars` package, which is installed by the `logfire[variables]` extra:
 
     ```bash
     pip install 'logfire[variables]'
@@ -214,7 +214,3 @@ with chat_prompt.get(ChatInputs(user_name='Alice', language='French')) as resolv
 ### Cycle Detection
 
 The system detects circular references during validation. If variable A references `@{B}@` and variable B references `@{A}@`, `logfire.variables_validate()` reports the cycle, and `logfire.variables_push(strict=True)` fails instead of applying the invalid configuration. This prevents infinite loops during resolution.
-
-## Requirements
-
-`pydantic-handlebars` requires Python 3.10 or later. On Python 3.9, basic variable features (`logfire.var()` without templates or composition) still work, but template rendering is not available.

--- a/logfire/variables/_handlebars.py
+++ b/logfire/variables/_handlebars.py
@@ -24,7 +24,7 @@ class HandlebarsDependencyError(ImportError):
 def _dependency_error() -> HandlebarsDependencyError:
     return HandlebarsDependencyError(
         'Handlebars template rendering requires the `pydantic-handlebars` package, '
-        'which is only installed by the `logfire[variables]` extra on Python 3.10 and later.'
+        'which is installed by the `logfire[variables]` extra.'
     )
 
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,15 +2,12 @@
 
 import gc
 import os
-from importlib.util import find_spec
 
 import pydantic
 import pytest
 from pytest_examples import CodeExample, EvalExample, find_examples
 
 from logfire._internal.utils import get_version
-
-HAS_PYDANTIC_HANDLEBARS = find_spec('pydantic_handlebars') is not None
 
 # Prevent accidental live API calls during testing
 os.environ.setdefault('LOGFIRE_SEND_TO_LOGFIRE', 'false')
@@ -90,9 +87,6 @@ def test_runnable(example: CodeExample, eval_example: EvalExample):
     """Ensure examples in documentation are runnable."""
     if 'from fastapi' in example.source and get_version(pydantic.__version__) < get_version('2.7.0'):
         pytest.skip('FastAPI requires pydantic>=2.7')
-
-    if not HAS_PYDANTIC_HANDLEBARS and ('logfire.template_var' in example.source or '@{' in example.source):
-        pytest.skip('Variable templates and composition require pydantic-handlebars (Python 3.10+)')
 
     set_eval_config(eval_example)
 

--- a/tests/test_template_validation.py
+++ b/tests/test_template_validation.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-from importlib.util import find_spec
 from types import SimpleNamespace
 
 import pytest
@@ -16,12 +15,6 @@ from logfire.variables.template_validation import (
     detect_composition_cycles,
     find_template_fields,
     validate_template_composition,
-)
-
-HAS_PYDANTIC_HANDLEBARS = find_spec('pydantic_handlebars') is not None
-requires_handlebars = pytest.mark.skipif(
-    not HAS_PYDANTIC_HANDLEBARS,
-    reason='pydantic-handlebars requires Python 3.10+',
 )
 
 # =============================================================================
@@ -219,7 +212,6 @@ def _make_get_all_serialized(
     return get_all_serialized_values
 
 
-@requires_handlebars
 class TestValidateTemplateComposition:
     def test_all_fields_valid(self):
         """All {{field}} references match schema properties — no issues."""

--- a/tests/test_variable_composition.py
+++ b/tests/test_variable_composition.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import json
-from importlib.util import find_spec
 from typing import Any
 
 import pytest
@@ -29,12 +28,6 @@ from logfire.variables.config import (
     VariablesConfig,
 )
 
-HAS_PYDANTIC_HANDLEBARS = find_spec('pydantic_handlebars') is not None
-requires_handlebars = pytest.mark.skipif(
-    not HAS_PYDANTIC_HANDLEBARS,
-    reason='pydantic-handlebars requires Python 3.10+',
-)
-
 # =============================================================================
 # Tests for the pure composition functions (expand_references, find_references)
 # =============================================================================
@@ -56,7 +49,6 @@ def _make_resolve_fn(
     return resolve_fn
 
 
-@requires_handlebars
 class TestExpandReferences:
     def test_invalid_serialized_value_is_returned_unchanged(self):
         """Non-JSON values cannot be composed and are returned as-is."""
@@ -415,7 +407,6 @@ class TestFindReferences:
 # =============================================================================
 
 
-@requires_handlebars
 class TestBlockHelpers:
     def test_block_if_true(self):
         """@{#if flag}@yes@{else}@no@{/if}@ with truthy flag."""
@@ -531,7 +522,6 @@ def _make_variables_config(**variables: str | None) -> VariablesConfig:
     return VariablesConfig(variables=configs)
 
 
-@requires_handlebars
 class TestCompositionIntegration:
     def test_simple_reference(self, config_kwargs: dict[str, Any]):
         """End-to-end: variable with @{ref}@ is resolved with composition."""
@@ -970,7 +960,6 @@ class TestCodeDefaultSerializationFailures:
         assert result.value is sentinel
         assert result.reason == 'code_default'
 
-    @requires_handlebars
     def test_unserializable_default_with_references_falls_back(self, config_kwargs: dict[str, Any]):
         """A code default that references missing variables still falls back to the plain default."""
         config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))

--- a/tests/test_variable_templates.py
+++ b/tests/test_variable_templates.py
@@ -10,7 +10,6 @@ import os
 import subprocess
 import sys
 import textwrap
-from importlib.util import find_spec
 from pathlib import Path
 from typing import Any
 
@@ -25,12 +24,6 @@ from logfire.variables.config import (
     Rollout,
     VariableConfig,
     VariablesConfig,
-)
-
-HAS_PYDANTIC_HANDLEBARS = find_spec('pydantic_handlebars') is not None
-requires_handlebars = pytest.mark.skipif(
-    not HAS_PYDANTIC_HANDLEBARS,
-    reason='pydantic-handlebars requires Python 3.10+',
 )
 
 
@@ -104,7 +97,6 @@ def test_import_logfire_without_pydantic_handlebars():
     assert result.returncode == 0, result.stderr
 
 
-@requires_handlebars
 def test_handlebars_import_helpers_are_memoized(monkeypatch: pytest.MonkeyPatch):
     """Successful pydantic-handlebars imports are cached after the first lookup."""
     renderer = _handlebars.get_handlebars_renderer()
@@ -162,7 +154,6 @@ class TestVariableConfigTemplateInputs:
 # =============================================================================
 
 
-@requires_handlebars
 class TestTemplateVariable:
     """Test TemplateVariable[T, InputsT] — single-step get(inputs) rendering."""
 
@@ -390,7 +381,6 @@ class TestTemplateVariable:
         assert 'count' in config.template_inputs_schema['properties']
 
 
-@requires_handlebars
 class TestRenderSerializedString:
     """Cover the input-shape branches of `render_serialized_string`."""
 
@@ -446,7 +436,6 @@ class TestRenderSerializedString:
         assert json.loads(result) == {'tags': ['Hello Alice', 'static']}
 
 
-@requires_handlebars
 class TestTemplateVariableOverrideRender:
     """Cover render failures on `TemplateVariable.override(...)`."""
 


### PR DESCRIPTION
## Summary

- remove Python 3.9-era `pydantic-handlebars` skip wrappers from the managed variable tests
- remove Python-version-specific docs and optional dependency error wording for template variables
- keep the optional-extra error path because `pydantic-handlebars` is still provided by `logfire[variables]`, not the core install

## Tests

- `uv run pytest tests/test_variable_templates.py tests/test_template_validation.py tests/test_variable_composition.py tests/test_docs.py -q`
- `uv run ruff check logfire/variables/_handlebars.py tests/test_docs.py tests/test_template_validation.py tests/test_variable_composition.py tests/test_variable_templates.py`
- `uv run pyright logfire/variables/_handlebars.py tests/test_docs.py tests/test_template_validation.py tests/test_variable_composition.py tests/test_variable_templates.py`
