### PR TITLE
Add `db.query.text` to scrubber SAFE_KEYS

### DIFF
--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -140,6 +140,7 @@ class BaseScrubber(ABC):
         'http.target',
         'http.route',
         'db.statement',
+        'db.query.text',
         'db.plan',
         'fastapi.route.name',
         'fastapi.route.operation_id',


### PR DESCRIPTION
Adds `'db.query.text'` to `BaseScrubber.SAFE_KEYS` alongside the deprecated `'db.statement'`.

Upstream OTel semconv replaced `db.statement` with `db.query.text` Until the scrubber's allow list tracks the new name, anyone emitting `db.query.text` loses SQL text to scrubbing whenever a query contains trigger tokens like `privateKey`, `password`, or `secret`.

`'db.statement'` is kept for backwards compatibility .

See the [OTel SQL semconv](https://opentelemetry.io/docs/specs/semconv/db/sql/) for the current canonical attribute names.
