### PR TITLE
Document Codex Logfire plugins

### DIFF
--- a/docs/how-to-guides/codex-logfire-exporter.md
+++ b/docs/how-to-guides/codex-logfire-exporter.md
@@ -1,0 +1,137 @@
+---
+title: Export Codex Activity to Logfire
+description: Install the Codex Logfire Exporter plugin to send completed Codex turns and tool calls to Logfire as OpenTelemetry traces.
+---
+
+# Export Codex Activity to Logfire
+
+The **Codex Logfire Exporter** plugin sends Codex's own activity telemetry to Logfire. It is separate from the
+main [Logfire plugin](skills.md#codex), which gives Codex skills and MCP access for instrumenting applications
+and querying existing telemetry.
+
+| Plugin | Purpose |
+| --- | --- |
+| **Logfire** | Helps Codex instrument your code, query Logfire data, and open Logfire UI views. |
+| **Codex Logfire Exporter** | Exports Codex turns and tool calls to Logfire. |
+
+The two plugins solve different problems and can be installed together.
+
+## Install
+
+Add the Pydantic marketplace and enable the exporter plugin:
+
+```bash
+codex plugin marketplace add pydantic/skills --ref main
+codex plugin add codex-logfire-exporter@pydantic-skills
+```
+
+You can also enable **Codex Logfire Exporter** from the **Pydantic** marketplace in the Codex plugin UI.
+
+After enabling the plugin:
+
+1. Restart Codex so hook configuration is loaded.
+2. Run `/hooks` if Codex asks you to review or trust the plugin hooks.
+3. Complete a new Codex turn — the exporter sends telemetry when the turn finishes.
+
+## Configure
+
+Create a config file at:
+
+```text
+${XDG_CONFIG_HOME:-~/.config}/codex-logfire-exporter/config.env
+```
+
+Example for Logfire Cloud:
+
+```dotenv
+LOGFIRE_TOKEN=<your Logfire write token>
+LOGFIRE_URL=https://logfire-api.pydantic.dev
+```
+
+For a local Logfire instance:
+
+```dotenv
+LOGFIRE_TOKEN=test-e2e-write-token
+LOGFIRE_URL=http://localhost:3000
+CODEX_LOGFIRE_DEBUG=true
+```
+
+The exporter sends `Authorization: <LOGFIRE_TOKEN>`, matching Logfire's direct OTLP client configuration. If you
+need a scheme-prefixed header, set `CODEX_LOGFIRE_AUTH_SCHEME=Bearer`.
+
+!!! note
+    Do not put tokens in URLs, command examples, or query strings. Keep credentials in `config.env` only.
+
+## How It Works
+
+The exporter registers Codex lifecycle hooks:
+
+| Hook | Purpose |
+| --- | --- |
+| `SessionStart` | Initialize local telemetry state |
+| `UserPromptSubmit` | Store the submitted prompt and turn metadata |
+| `PostToolUse` | Store tool-call results for export as child spans |
+| `Stop` | Export the completed turn and its tool spans to Logfire |
+
+### Export boundary
+
+Only completed turns are exported. The exporter sends telemetry on the `Stop` hook — it does not live-stream every
+Codex action. Interrupted turns that never reach `Stop` are not exported.
+
+### Trace model
+
+There is no long-lived session root span. Codex hooks do not provide a reliable session-end event, so the exporter
+deliberately avoids a session-level trace.
+
+Instead, each completed turn becomes a root-level span in a deterministic conversation trace. Tool calls appear as
+child spans of that turn span. Spans for the same Codex conversation share a stable trace ID derived from Codex
+conversation metadata.
+
+## Content Capture
+
+Content capture controls whether prompt text, assistant text, tool inputs, tool outputs, and tool errors are
+included in exported span attributes. By default, the exporter uses `CODEX_LOGFIRE_CONTENT_CAPTURE_MODE=full`,
+which includes redacted content for all of those fields.
+
+For sensitive projects, set a narrower mode in `config.env`:
+
+```dotenv
+CODEX_LOGFIRE_CONTENT_CAPTURE_MODE=metadata_only
+```
+
+Available modes:
+
+| Mode | Captures |
+| --- | --- |
+| `full` | Redacted user prompt, final assistant message, tool input/output, and tool errors (default). |
+| `no_tool_content` | Redacted user prompt and final assistant message, but not tool input/output. |
+| `metadata_only` | No prompt, assistant, tool input, or tool output content. |
+
+When content capture is enabled, spans include `pydantic_ai.all_messages`, the Pydantic AI message-schema attribute
+that lets Logfire show Codex turns in the generic LLM conversation details panel.
+
+## Troubleshooting
+
+Debug logs are written to:
+
+```text
+${XDG_STATE_HOME:-~/.local/state}/codex-logfire-exporter/logs/
+```
+
+If no spans appear after a completed Codex turn, check the Codex TUI log:
+
+```bash
+rg -n "codex-logfire|failed to load plugin" ~/.codex/log/codex-tui.log
+```
+
+Common issues:
+
+- **No spans after a turn** — confirm `LOGFIRE_TOKEN` is set in `config.env` and the turn completed normally (reached `Stop`).
+- **Hooks not trusted** — run `/hooks` in Codex and approve the exporter hooks.
+- **Stale plugin state** — restart Codex or start a new conversation after changing plugin configuration.
+
+## See also
+
+- [Coding Agent Skills](skills.md) — install the Logfire plugin and other Pydantic skills.
+- [Connect to MCP Server](mcp-server.md) — configure Logfire MCP access through the Logfire plugin.
+- Source repository: [github.com/pydantic/skills](https://github.com/pydantic/skills)

--- a/docs/how-to-guides/codex-logfire-exporter.md
+++ b/docs/how-to-guides/codex-logfire-exporter.md
@@ -1,18 +1,18 @@
 ---
 title: Export Codex Activity to Logfire
-description: Install the Codex Logfire Exporter plugin to send completed Codex turns and tool calls to Logfire as OpenTelemetry traces.
+description: Install the Logfire Exporter plugin to send completed Codex turns and tool calls to Logfire as OpenTelemetry traces.
 ---
 
 # Export Codex Activity to Logfire
 
-The **Codex Logfire Exporter** plugin sends Codex's own activity telemetry to Logfire. It is separate from the
+The **Logfire Exporter** plugin sends Codex's own activity telemetry to Logfire. It is separate from the
 main [Logfire plugin](skills.md#codex), which gives Codex skills and MCP access for instrumenting applications
 and querying existing telemetry.
 
 | Plugin | Purpose |
 | --- | --- |
 | **Logfire** | Helps Codex instrument your code, query Logfire data, and open Logfire UI views. |
-| **Codex Logfire Exporter** | Exports Codex turns and tool calls to Logfire. |
+| **Logfire Exporter** | Exports Codex turns and tool calls to Logfire. |
 
 The two plugins solve different problems and can be installed together.
 
@@ -22,10 +22,10 @@ Add the Pydantic marketplace and enable the exporter plugin:
 
 ```bash
 codex plugin marketplace add pydantic/skills --ref main
-codex plugin add codex-logfire-exporter@pydantic-skills
+codex plugin add logfire-exporter@pydantic-skills
 ```
 
-You can also enable **Codex Logfire Exporter** from the **Pydantic** marketplace in the Codex plugin UI.
+You can also enable **Logfire Exporter** from the **Pydantic** marketplace in the Codex plugin UI.
 
 After enabling the plugin:
 
@@ -38,23 +38,25 @@ After enabling the plugin:
 Create a config file at:
 
 ```text
-${XDG_CONFIG_HOME:-~/.config}/codex-logfire-exporter/config.env
+${XDG_CONFIG_HOME:-~/.config}/logfire-exporter/config.env
 ```
 
 Example for Logfire Cloud:
 
 ```dotenv
 LOGFIRE_TOKEN=<your Logfire write token>
-LOGFIRE_URL=https://logfire-api.pydantic.dev
+LOGFIRE_BASE_URL=https://logfire-api.pydantic.dev
 ```
 
 For a local Logfire instance:
 
 ```dotenv
 LOGFIRE_TOKEN=test-e2e-write-token
-LOGFIRE_URL=http://localhost:3000
+LOGFIRE_BASE_URL=http://localhost:3000
 CODEX_LOGFIRE_DEBUG=true
 ```
+
+`LOGFIRE_URL` is still accepted as a compatibility alias, but `LOGFIRE_BASE_URL` takes precedence.
 
 The exporter sends `Authorization: <LOGFIRE_TOKEN>`, matching Logfire's direct OTLP client configuration. If you
 need a scheme-prefixed header, set `CODEX_LOGFIRE_AUTH_SCHEME=Bearer`.
@@ -115,13 +117,13 @@ that lets Logfire show Codex turns in the generic LLM conversation details panel
 Debug logs are written to:
 
 ```text
-${XDG_STATE_HOME:-~/.local/state}/codex-logfire-exporter/logs/
+${XDG_STATE_HOME:-~/.local/state}/logfire-exporter/logs/
 ```
 
 If no spans appear after a completed Codex turn, check the Codex TUI log:
 
 ```bash
-rg -n "codex-logfire|failed to load plugin" ~/.codex/log/codex-tui.log
+rg -n "logfire-exporter|failed to load plugin" ~/.codex/log/codex-tui.log
 ```
 
 Common issues:

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -82,6 +82,15 @@ Add to your Claude settings:
 Check out the [MCP quickstart](https://modelcontextprotocol.io/quickstart/user)
 for more information.
 
+### Codex
+
+Install the [Logfire plugin](skills.md#codex) from the Pydantic marketplace. The plugin configures the hosted
+Logfire MCP server automatically — no separate MCP JSON configuration is required.
+
+The Codex plugin currently configures the US endpoint. For EU projects, use a local `pydantic/skills` checkout
+and update `plugins/logfire/mcp.json` to `https://logfire-eu.pydantic.dev/mcp` before installing or reloading
+the plugin. Edits made inside an installed plugin cache may be overwritten by plugin updates.
+
 ### Cline
 
 Add to your Cline settings in `cline_mcp_settings.json`:

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -87,9 +87,15 @@ for more information.
 Install the [Logfire plugin](skills.md#codex) from the Pydantic marketplace. The plugin configures the hosted
 Logfire MCP server automatically — no separate MCP JSON configuration is required.
 
-The Codex plugin currently configures the US endpoint. For EU projects, use a local `pydantic/skills` checkout
-and update `plugins/logfire/mcp.json` to `https://logfire-eu.pydantic.dev/mcp` before installing or reloading
-the plugin. Edits made inside an installed plugin cache may be overwritten by plugin updates.
+The Codex plugin currently configures the US endpoint. For EU projects, replace the MCP entry and re-authenticate:
+
+```bash
+codex mcp remove logfire
+codex mcp add logfire --url https://logfire-eu.pydantic.dev/mcp
+codex mcp login logfire
+```
+
+Start a new Codex conversation after switching so the MCP tools reload.
 
 ### Cline
 

--- a/docs/how-to-guides/skills.md
+++ b/docs/how-to-guides/skills.md
@@ -29,7 +29,7 @@ The plugin bundles skills, commands, and an MCP server. Claude will use the rele
 automatically, or you can invoke a command directly:
 
 ```
-/instrumentation
+/instrument
 ```
 
 As an alternative, you can install from the [`pydantic/skills`](https://github.com/pydantic/skills)
@@ -39,6 +39,36 @@ marketplace, which bundles the Logfire skill alongside other Pydantic-maintained
 claude plugin marketplace add pydantic/skills
 claude plugin install logfire@pydantic-skills
 ```
+
+### Codex
+
+Install the Pydantic marketplace in Codex:
+
+```bash
+codex plugin marketplace add pydantic/skills --ref main
+```
+
+Then enable plugins from the **Pydantic** marketplace. Either enable them in the Codex plugin UI, or run:
+
+```bash
+codex plugin add logfire@pydantic-skills
+codex plugin add codex-logfire-exporter@pydantic-skills
+```
+
+Two plugins are available:
+
+| Plugin | Purpose |
+| --- | --- |
+| **Logfire** | Gives Codex Logfire skills and the hosted Logfire MCP server for instrumentation, querying, and opening UI views. |
+| **Codex Logfire Exporter** | Exports completed Codex turns and tool calls to Logfire as OpenTelemetry traces. |
+
+These plugins solve different problems and can be installed together. After enabling **Codex Logfire Exporter**,
+restart Codex and run `/hooks` if Codex asks you to review or trust the new hooks.
+
+See also:
+
+- [Connect to MCP Server](mcp-server.md) for how the Logfire plugin configures MCP access.
+- [Export Codex Activity to Logfire](codex-logfire-exporter.md) for exporter setup, configuration, and troubleshooting.
 
 ### Cross-Agent
 

--- a/docs/how-to-guides/skills.md
+++ b/docs/how-to-guides/skills.md
@@ -52,7 +52,7 @@ Then enable plugins from the **Pydantic** marketplace. Either enable them in the
 
 ```bash
 codex plugin add logfire@pydantic-skills
-codex plugin add codex-logfire-exporter@pydantic-skills
+codex plugin add logfire-exporter@pydantic-skills
 ```
 
 Two plugins are available:
@@ -60,9 +60,9 @@ Two plugins are available:
 | Plugin | Purpose |
 | --- | --- |
 | **Logfire** | Gives Codex Logfire skills and the hosted Logfire MCP server for instrumentation, querying, and opening UI views. |
-| **Codex Logfire Exporter** | Exports completed Codex turns and tool calls to Logfire as OpenTelemetry traces. |
+| **Logfire Exporter** | Exports completed Codex turns and tool calls to Logfire as OpenTelemetry traces. |
 
-These plugins solve different problems and can be installed together. After enabling **Codex Logfire Exporter**,
+These plugins solve different problems and can be installed together. After enabling **Logfire Exporter**,
 restart Codex and run `/hooks` if Codex asks you to review or trust the new hooks.
 
 See also:

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -249,7 +249,8 @@
       { "label": "Use Alternative Clients", "slug": "how-to-guides/alternative-clients" },
       { "label": "Collect Cloud Provider Metrics", "slug": "how-to-guides/cloud-metrics" },
       { "label": "Connect to MCP Server", "slug": "how-to-guides/mcp-server" },
-      { "label": "Coding Agent Skills", "slug": "how-to-guides/skills" }
+      { "label": "Coding Agent Skills", "slug": "how-to-guides/skills" },
+      { "label": "Export Codex Activity", "slug": "how-to-guides/codex-logfire-exporter" }
     ]
   },
   {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -261,6 +261,7 @@ nav:
           - Collect Cloud Provider Metrics: how-to-guides/cloud-metrics.md
           - Connect to MCP Server: how-to-guides/mcp-server.md
           - Coding Agent Skills: how-to-guides/skills.md
+          - Export Codex Activity: how-to-guides/codex-logfire-exporter.md
       - Reference:
           - SQL: reference/sql.md
       - Deploy & Scale:


### PR DESCRIPTION
## Summary

- add Codex installation guidance for the Pydantic skills marketplace
- document the Logfire Exporter plugin, configuration, trace model, content capture, and troubleshooting
- add Codex MCP guidance and wire the new exporter guide into docs navigation
- align plugin names, config paths, and MCP endpoint override instructions with the merged pydantic/skills content

## Validation

- `git diff --check`
- `uv run mkdocs build --no-strict`