### PR TITLE
Harden forwarding lifecycle

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -934,6 +934,7 @@ class LogfireConfig(_LogfireConfigData):
         self._variable_provider: VariableProvider = NoOpVariableProvider()
         self._logger_provider = ProxyLoggerProvider(NoOpLoggerProvider())
         self._otlp_forwarding = OTLPForwardingManager(self)
+        self._retired_otlp_forwarding: list[OTLPForwardingManager] = []
         # This ensures that we only call OTEL's global set_tracer_provider once to avoid warnings.
         self._has_set_providers = False
         self._initialized = False
@@ -1388,7 +1389,9 @@ class LogfireConfig(_LogfireConfigData):
 
             previous_otlp_forwarding = self._otlp_forwarding
             self._otlp_forwarding = otlp_forwarding
-            previous_otlp_forwarding.shutdown(0, drain_queued=False)
+            self._prune_retired_otlp_forwarding()
+            if previous_otlp_forwarding.retire():
+                self._retired_otlp_forwarding.append(previous_otlp_forwarding)
             self._initialized = True
 
             # set up context propagation for ThreadPoolExecutor and ProcessPoolExecutor
@@ -1407,6 +1410,19 @@ class LogfireConfig(_LogfireConfigData):
 
             self._ensure_flush_after_aws_lambda()
 
+    def _forget_retired_otlp_forwarding(self, manager: OTLPForwardingManager) -> None:
+        with self._lock:
+            with suppress(ValueError):
+                self._retired_otlp_forwarding.remove(manager)
+
+    def _prune_retired_otlp_forwarding(self) -> None:
+        self._retired_otlp_forwarding = [manager for manager in self._retired_otlp_forwarding if not manager.is_idle()]
+
+    def _otlp_forwarding_managers(self) -> tuple[OTLPForwardingManager, ...]:
+        with self._lock:
+            self._prune_retired_otlp_forwarding()
+            return (self._otlp_forwarding, *self._retired_otlp_forwarding)
+
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
         """Force flush all spans and metrics.
 
@@ -1418,8 +1434,22 @@ class LogfireConfig(_LogfireConfigData):
         """
         self._meter_provider.force_flush(timeout_millis)
         self._logger_provider.force_flush(timeout_millis)
-        self._otlp_forwarding.force_flush(timeout_millis)
+        deadline = time.monotonic() + timeout_millis / 1000
+        for manager in self._otlp_forwarding_managers():
+            remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
+            manager.force_flush(remaining_millis)
         return self._tracer_provider.force_flush(timeout_millis)
+
+    def shutdown_otlp_forwarding(self, timeout_millis: int, *, drain_queued: bool = True) -> bool:
+        deadline = time.monotonic() + timeout_millis / 1000
+        complete = True
+        for manager in self._otlp_forwarding_managers():
+            remaining_millis = max(0, int((deadline - time.monotonic()) * 1000))
+            if not manager.shutdown(remaining_millis, drain_queued=drain_queued):
+                complete = False
+            if manager is not self._otlp_forwarding:
+                self._forget_retired_otlp_forwarding(manager)
+        return complete
 
     def get_tracer_provider(self) -> ProxyTracerProvider:
         """Get a tracer provider from this `LogfireConfig`.

--- a/logfire/_internal/forwarding.py
+++ b/logfire/_internal/forwarding.py
@@ -193,6 +193,19 @@ class OTLPForwardingPipeline:
             self.session.close()
             self.session_closed = True
 
+    def is_idle(self) -> bool:
+        with self.condition:
+            return not self.queue and self.active_send_count == 0 and not self._has_live_worker_locked()
+
+    def retire(self) -> bool:
+        with self.condition:
+            self.closed = True
+            pending = bool(self.queue or self.active_send_count or self._has_live_worker_locked())
+            if not pending:
+                self._close_session_once()
+            self.condition.notify_all()
+            return pending
+
     def shutdown(self, timeout_millis: int, *, drain_queued: bool = True) -> bool:
         deadline = monotonic() + timeout_millis / 1000
         complete = True
@@ -290,6 +303,23 @@ class OTLPForwardingManager:
             if not pipeline.force_flush(remaining_millis):
                 complete = False
         return complete
+
+    def is_idle(self) -> bool:
+        with self.lock:
+            pipelines = tuple(self.pipelines.values())
+
+        return all(pipeline.is_idle() for pipeline in pipelines)
+
+    def retire(self) -> bool:
+        with self.lock:
+            self.closed = True
+            pipelines = tuple(self.pipelines.values())
+
+        pending = False
+        for pipeline in pipelines:
+            if pipeline.retire():
+                pending = True
+        return pending
 
     def shutdown(self, timeout_millis: int, *, drain_queued: bool = True) -> bool:
         deadline = monotonic() + timeout_millis / 1000

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2491,9 +2491,7 @@ class Logfire:
         if not remaining:  # pragma: no cover
             complete = False
 
-        forwarding_shutdown_result = self.config._otlp_forwarding.shutdown(  # pyright: ignore[reportPrivateUsage]
-            remaining, drain_queued=flush
-        )
+        forwarding_shutdown_result = self.config.shutdown_otlp_forwarding(remaining, drain_queued=flush)
         complete = complete and forwarding_shutdown_result
         remaining = remaining_ms()
         if not remaining:  # pragma: no cover

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -595,6 +595,7 @@ def test_logfire_config_has_empty_forwarding_manager() -> None:
 def test_logfire_config_reconfigure_replaces_forwarding_manager() -> None:
     config = LogfireConfig(send_to_logfire=False)
     previous_manager = mock.Mock()
+    previous_manager.retire.return_value = False
     config._otlp_forwarding = previous_manager  # pyright: ignore[reportPrivateUsage]
 
     config.configure(
@@ -620,7 +621,8 @@ def test_logfire_config_reconfigure_replaces_forwarding_manager() -> None:
         advanced=None,
     )
 
-    previous_manager.shutdown.assert_called_once_with(0, drain_queued=False)
+    previous_manager.retire.assert_called_once_with()
+    previous_manager.shutdown.assert_not_called()
     manager = config._otlp_forwarding  # pyright: ignore[reportPrivateUsage]
     assert isinstance(manager, OTLPForwardingManager)
     assert manager is not previous_manager
@@ -661,6 +663,75 @@ def test_logfire_config_reconfigure_keeps_forwarding_manager_when_configuration_
     assert config._otlp_forwarding is previous_manager  # pyright: ignore[reportPrivateUsage]
 
 
+def test_logfire_config_reconfigure_prunes_idle_retired_forwarding_managers() -> None:
+    config = LogfireConfig(send_to_logfire=False)
+    idle_retired = mock.Mock()
+    idle_retired.is_idle.return_value = True
+    active_retired = mock.Mock()
+    active_retired.is_idle.return_value = False
+    previous_manager = mock.Mock()
+    previous_manager.retire.return_value = False
+    config._retired_otlp_forwarding = [idle_retired, active_retired]  # pyright: ignore[reportPrivateUsage]
+    config._otlp_forwarding = previous_manager  # pyright: ignore[reportPrivateUsage]
+
+    config.configure(
+        send_to_logfire=False,
+        token=None,
+        api_key=None,
+        service_name=None,
+        service_version=None,
+        environment=None,
+        console=False,
+        config_dir=None,
+        data_dir=None,
+        additional_span_processors=None,
+        metrics=False,
+        scrubbing=None,
+        inspect_arguments=None,
+        sampling=None,
+        min_level=None,
+        add_baggage_to_attributes=True,
+        code_source=None,
+        variables=None,
+        distributed_tracing=None,
+        advanced=None,
+    )
+
+    assert config._retired_otlp_forwarding == [active_retired]  # pyright: ignore[reportPrivateUsage]
+
+
+def test_logfire_config_reconfigure_tracks_pending_forwarding_manager() -> None:
+    config = LogfireConfig(send_to_logfire=False)
+    previous_manager = mock.Mock()
+    previous_manager.retire.return_value = True
+    config._otlp_forwarding = previous_manager  # pyright: ignore[reportPrivateUsage]
+
+    config.configure(
+        send_to_logfire=False,
+        token=None,
+        api_key=None,
+        service_name=None,
+        service_version=None,
+        environment=None,
+        console=False,
+        config_dir=None,
+        data_dir=None,
+        additional_span_processors=None,
+        metrics=False,
+        scrubbing=None,
+        inspect_arguments=None,
+        sampling=None,
+        min_level=None,
+        add_baggage_to_attributes=True,
+        code_source=None,
+        variables=None,
+        distributed_tracing=None,
+        advanced=None,
+    )
+
+    assert config._retired_otlp_forwarding == [previous_manager]  # pyright: ignore[reportPrivateUsage]
+
+
 def test_logfire_config_reconfigure_does_not_start_forwarding_shutdown_thread_for_idle_manager() -> None:
     config = LogfireConfig(send_to_logfire=False)
     previous_manager = OTLPForwardingManager(config)
@@ -693,6 +764,7 @@ def test_logfire_config_reconfigure_does_not_start_forwarding_shutdown_thread_fo
     thread.assert_not_called()
     assert previous_manager.closed is True
     assert config._otlp_forwarding is not previous_manager  # pyright: ignore[reportPrivateUsage]
+    assert config._retired_otlp_forwarding == []  # pyright: ignore[reportPrivateUsage]
 
 
 def test_forwarding_destinations_registered_from_active_logfire_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -723,17 +795,21 @@ def test_forwarding_destinations_not_registered_when_send_to_logfire_false() -> 
 
 def test_logfire_config_force_flush_includes_forwarding_manager() -> None:
     config = LogfireConfig(send_to_logfire=False)
+    retired_forwarding = mock.Mock()
+    retired_forwarding.is_idle.return_value = False
     config._meter_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
     config._logger_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
     config._tracer_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
     config._otlp_forwarding = mock.Mock()  # pyright: ignore[reportPrivateUsage]
+    config._retired_otlp_forwarding = [retired_forwarding]  # pyright: ignore[reportPrivateUsage]
     config._tracer_provider.force_flush.return_value = False  # pyright: ignore[reportPrivateUsage]
 
     assert config.force_flush(1234) is False
 
     config._meter_provider.force_flush.assert_called_once_with(1234)  # pyright: ignore[reportPrivateUsage]
     config._logger_provider.force_flush.assert_called_once_with(1234)  # pyright: ignore[reportPrivateUsage]
-    config._otlp_forwarding.force_flush.assert_called_once_with(1234)  # pyright: ignore[reportPrivateUsage]
+    config._otlp_forwarding.force_flush.assert_called_once()  # pyright: ignore[reportPrivateUsage]
+    retired_forwarding.force_flush.assert_called_once()
     config._tracer_provider.force_flush.assert_called_once_with(1234)  # pyright: ignore[reportPrivateUsage]
 
 
@@ -799,6 +875,26 @@ def test_logfire_shutdown_returns_false_when_forwarding_shutdown_incomplete() ->
 
     config._tracer_provider.shutdown.assert_called_once()  # pyright: ignore[reportPrivateUsage]
     config._meter_provider.shutdown.assert_called_once()  # pyright: ignore[reportPrivateUsage]
+
+
+def test_logfire_shutdown_includes_retired_forwarding_managers() -> None:
+    config = LogfireConfig(send_to_logfire=False)
+    retired_forwarding = mock.Mock()
+    retired_forwarding.is_idle.return_value = False
+    config._initialized = True  # pyright: ignore[reportPrivateUsage]
+    config._variable_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
+    config._otlp_forwarding = mock.Mock()  # pyright: ignore[reportPrivateUsage]
+    config._otlp_forwarding.shutdown.return_value = True  # pyright: ignore[reportPrivateUsage]
+    config._retired_otlp_forwarding = [retired_forwarding]  # pyright: ignore[reportPrivateUsage]
+    retired_forwarding.shutdown.return_value = True
+    config._tracer_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
+    config._meter_provider = mock.Mock()  # pyright: ignore[reportPrivateUsage]
+
+    assert logfire.Logfire(config=config).shutdown(timeout_millis=1000, flush=False) is True
+
+    config._otlp_forwarding.shutdown.assert_called_once()  # pyright: ignore[reportPrivateUsage]
+    retired_forwarding.shutdown.assert_called_once()
+    assert config._retired_otlp_forwarding == []  # pyright: ignore[reportPrivateUsage]
 
 
 def test_logfire_shutdown_still_shuts_down_providers_when_forwarding_uses_timeout(

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -25,6 +25,12 @@ class FakeForwardingManager:
     def has_destinations(self) -> bool:
         return True
 
+    def is_idle(self) -> bool:
+        return True
+
+    def retire(self) -> bool:
+        return False
+
     def submit(self, request: ForwardingRequest) -> ForwardingAdmissionResult:
         self.submissions.append(request)
         return self.result

--- a/tests/test_internal_forwarding.py
+++ b/tests/test_internal_forwarding.py
@@ -802,6 +802,44 @@ class BlockingShutdownForwardingPipeline(OTLPForwardingPipeline):
         self.release.wait(timeout=5)
 
 
+def test_forwarding_pipeline_retire_closes_idle_session_without_worker() -> None:
+    session = FakeForwardingSession()
+    pipeline = OTLPForwardingPipeline(
+        base_url='https://example.com',
+        session=session,  # type: ignore[arg-type]
+        max_queued_body_bytes=100,
+    )
+
+    assert pipeline.is_idle() is True
+    assert pipeline.retire() is False
+
+    assert pipeline.closed is True
+    assert pipeline.worker is None
+    assert session.close_count == 1
+    assert pipeline.enqueue(_make_queued_forwarding_request(b'one')) is False
+
+
+def test_forwarding_pipeline_retire_lets_existing_worker_drain() -> None:
+    pipeline = BlockingShutdownForwardingPipeline()
+    assert pipeline.enqueue(_make_queued_forwarding_request(b'one')) is True
+    assert pipeline.started.wait(timeout=5) is True
+    worker = pipeline.worker
+
+    assert pipeline.retire() is True
+
+    assert pipeline.closed is True
+    assert pipeline.is_idle() is False
+    assert pipeline.worker is worker
+    assert pipeline.enqueue(_make_queued_forwarding_request(b'two')) is False
+    assert pipeline.fake_session.close_count == 0
+
+    pipeline.release.set()
+    _wait_for_no_live_worker(pipeline)
+
+    assert pipeline.is_idle() is True
+    assert pipeline.fake_session.close_count == 1
+
+
 def test_forwarding_pipeline_run_clears_current_worker_reference_after_unexpected_exit() -> None:
     class FatalForwardingPipeline(RecordingForwardingPipeline):
         def _send(self, queued_request: QueuedForwardingRequest) -> None:
@@ -1300,6 +1338,42 @@ class FakeShutdownPipeline:
     def shutdown(self, timeout_millis: int, *, drain_queued: bool = True) -> bool:
         self.shutdown_calls.append((timeout_millis, drain_queued))
         return self.result
+
+
+class FakeRetirePipeline:
+    def __init__(self, *, pending: bool) -> None:
+        self.pending = pending
+        self.retire_calls = 0
+
+    def is_idle(self) -> bool:
+        return not self.pending
+
+    def retire(self) -> bool:
+        self.retire_calls += 1
+        return self.pending
+
+
+def test_forwarding_manager_retire_closes_all_pipelines_and_reports_pending() -> None:
+    pipeline_1 = FakeRetirePipeline(pending=False)
+    pipeline_2 = FakeRetirePipeline(pending=True)
+    manager = OTLPForwardingManager(object())  # type: ignore[arg-type]
+    manager.pipelines = {'one': pipeline_1, 'two': pipeline_2}  # type: ignore[assignment]
+
+    assert manager.retire() is True
+
+    assert manager.closed is True
+    assert pipeline_1.retire_calls == 1
+    assert pipeline_2.retire_calls == 1
+
+
+def test_forwarding_manager_is_idle_requires_all_pipelines_idle() -> None:
+    manager = OTLPForwardingManager(object())  # type: ignore[arg-type]
+    manager.pipelines = {  # type: ignore[assignment]
+        'one': FakeRetirePipeline(pending=False),
+        'two': FakeRetirePipeline(pending=True),
+    }
+
+    assert manager.is_idle() is False
 
 
 def test_forwarding_manager_shutdown_basic() -> None:


### PR DESCRIPTION
Stacked on #1967.\n\nAdds the lifecycle-hardening layer from #1940: retired forwarding manager tracking, pruning, shared timeout handling, race coverage, and stabilization tests.\n\nThe top of this stack has been verified to match 977b07833611842ffc205b8dc2343522abb60583 exactly.