### PR TITLE
docs: restore JavaScript integration pages

### DIFF
--- a/docs/integrations/javascript/browser.md
+++ b/docs/integrations/javascript/browser.md
@@ -1,0 +1,159 @@
+---
+title: Pydantic Logfire Browser Integration
+description: "Guide for tracing browser activity: Learn how to set up getwebautoinstrumentations and configure a proxy to send frontend traces securely to Logfire."
+integration: logfire
+---
+# Browser
+
+The `@pydantic/logfire-browser` NPM package wraps [OpenTelemetry browser tracing](https://opentelemetry.io/docs/languages/js/getting-started/browser/) with sensible defaults and provides a simple API for creating spans and reporting exceptions.
+
+!!! info "Securely Sending Traces"
+    Logfire does not directly expose an endpoint suitable for sending traces from the browser, as this would make your write token publicly accessible.
+
+    To safely send traces, you must create a proxy in your app that **forwards requests from your browser instrumentation to Logfire** while attaching the `Authorization` header server-side.
+    - **Python:** See [Proxying Browser Telemetry](#proxying-browser-telemetry) below for FastAPI, Starlette, and generic framework examples.
+    - **Next.js:** Check out the [Next.js proxy example implementation](https://github.com/pydantic/logfire-js/blob/main/examples/nextjs-client-side-instrumentation/proxy.ts)
+
+## Simple Usage
+
+```ts
+import { getWebAutoInstrumentations } from "@opentelemetry/auto-instrumentations-web";
+import * as logfire from '@pydantic/logfire-browser';
+
+// Set the path to your backend proxy endpoint
+// For example, if using the Python `logfire_proxy` handler hosted on the same domain:
+const url = new URL(window.location.href);
+url.pathname = "/logfire-proxy/v1/traces";
+
+logfire.configure({
+  traceUrl: url.toString(),
+  serviceName: 'my-service',
+  serviceVersion: '0.1.0',
+  // The instrumentations to use
+  // https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-web - for more options and configuration
+  instrumentations:[
+    getWebAutoInstrumentations()
+  ],
+  // This outputs details about the generated spans in the browser console, use only in development and for troubleshooting.
+  diagLogLevel: logfire.DiagLogLevel.ALL
+})
+
+```
+
+!!! info
+    the `@pydantic/logfire-browser` package is bundled as an ESM module, that's supported by all modern frameworks and browsers.
+
+Note that if you're using an SSR/SSG framework, you should ensure that the code above runs only in the browser runtime.
+[A dedicated example for Next.js](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs-client-side-instrumentation) is available.
+
+
+## Proxying Browser Telemetry
+
+If you use a Python backend, logfire provide experimental tools in the `logfire.experimental.forwarding` module to easily create this proxy.
+
+### FastAPI
+
+For FastAPI, logfire provide a built-in `logfire_proxy` handler that limits request body size (default 50MB) by reading in chunks to avoid loading oversized payloads into memory.
+
+```py title="main.py" skip-run="true" skip-reason="server-start"
+from fastapi import FastAPI, Request
+
+import logfire
+from logfire.experimental.forwarding import logfire_proxy
+
+logfire.configure()
+app = FastAPI()
+
+
+# Mount the proxy handler
+# Note: {path:path} is strictly required to capture the OTLP route (e.g., /v1/traces)
+@app.post('/logfire-proxy/{path:path}')
+async def proxy_browser_telemetry(request: Request):
+    return await logfire_proxy(request)
+```
+
+By default, this endpoint is unauthenticated and accepts payloads up to 50MB. In production, you should protect it using FastAPI dependencies to prevent abuse:
+
+```py skip-run="true" skip-reason="server-start"
+from fastapi import Depends, FastAPI, Request
+
+import logfire
+from logfire.experimental.forwarding import logfire_proxy
+
+logfire.configure()
+app = FastAPI()
+
+
+async def verify_user_session():
+    # Implement your authentication/rate-limiting logic here
+    pass
+
+
+@app.post('/logfire-proxy/{path:path}', dependencies=[Depends(verify_user_session)])
+async def proxy_browser_telemetry_secure(request: Request):
+    return await logfire_proxy(request)
+```
+
+### Starlette
+
+For Starlette, you can mount the `logfire_proxy` handler directly as a route.
+
+```py title="main.py" skip-run="true" skip-reason="server-start"
+from starlette.applications import Starlette
+from starlette.routing import Route
+
+import logfire
+from logfire.experimental.forwarding import logfire_proxy
+
+logfire.configure()
+
+app = Starlette(
+    routes=[
+        # Note: {path:path} is strictly required to capture the OTLP route (e.g., /v1/traces)
+        Route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST'])
+    ]
+)
+```
+
+!!! warning "Security Note"
+    By default, this endpoint is unauthenticated. In production, ensure you wrap your route with appropriate authentication middleware or rate-limiting to prevent unauthorized clients from sending arbitrary telemetry to your Logfire project.
+
+### Generic Python Frameworks
+
+If you are using another web framework (such as Django, Flask, Litestar, or a custom HTTP server), you can use the underlying `forward_export_request` function directly.
+
+You simply extract the path, headers, and body from your framework's request object, pass them to `forward_export_request` as keyword arguments, and return the resulting status code, headers, and content.
+
+```py title="main.py" skip-run="true" skip-reason="server-start"
+import logfire
+from logfire.experimental.forwarding import forward_export_request
+
+logfire.configure()
+
+class CustomFrameworkResponse:
+    """Replace this with your framework's actual Response class."""
+    def __init__(self, content: bytes, status_code: int, headers: dict[str, str]):
+        pass
+
+# Example generic route handler:
+def my_custom_proxy_route(request):
+
+    # 1. Extract data from your framework's request object
+    path = request.path      # e.g. "/v1/traces"
+    headers = request.headers
+    body = request.read()
+
+    # 2. Forward the request to Logfire
+    response = forward_export_request(
+        path=path,
+        headers=headers,
+        body=body
+    )
+
+    # 3. Return the Logfire response to the browser
+    return CustomFrameworkResponse(
+        content=response.content,
+        status_code=response.status_code,
+        headers=response.headers
+    )
+```

--- a/docs/integrations/javascript/cloudflare.md
+++ b/docs/integrations/javascript/cloudflare.md
@@ -1,0 +1,79 @@
+---
+title: Pydantic Logfire Cloudflare Integration
+description: Instrument Cloudflare Workers for distributed tracing. Use npx wrangler dev for local testing and wrangler secret put to secure your Logfire token.
+integration: logfire
+---
+# Cloudflare
+
+To instrument your Cloudflare Workers and send spans to Logfire, install the `@pydantic/logfire-cf-workers` and `logfire` NPM packages:
+
+```sh
+npm install @pydantic/logfire-cf-workers logfire
+```
+
+Next, add the Node.js compatibility flag to your Wrangler configuration:
+
+- For `wrangler.toml`: `compatibility_flags = [ "nodejs_compat" ]`
+- For `wrangler.jsonc`: `"compatibility_flags": ["nodejs_compat"]`
+
+Add your [Logfire write token](../../how-to-guides/create-write-tokens.md) to your `.dev.vars` file:
+
+```sh
+LOGFIRE_TOKEN=your-write-token
+LOGFIRE_ENVIRONMENT=development
+```
+
+The `LOGFIRE_ENVIRONMENT` variable is optional and specifies the environment name for your service.
+
+For production deployment, refer to the [Cloudflare documentation on managing and deploying secrets](https://developers.cloudflare.com/workers/configuration/secrets/). You can set secrets using the Wrangler CLI:
+
+```sh
+npx wrangler secret put LOGFIRE_TOKEN
+```
+
+Finally, wrap your handler with the instrumentation. The `instrument` function will automatically configure Logfire using your environment variables:
+
+```ts
+import * as logfire from "logfire";
+import { instrument } from "@pydantic/logfire-cf-workers";
+
+const handler = {
+  async fetch(): Promise<Response> {
+    logfire.info("info span from inside the worker body");
+    return new Response("hello world!");
+  },
+} satisfies ExportedHandler;
+
+export default instrument(handler, {
+  service: {
+    name: "my-cloudflare-worker",
+    namespace: "",
+    version: "1.0.0",
+  },
+});
+```
+
+A complete working example is available in the [examples/cf-worker](https://github.com/pydantic/logfire-js/tree/main/examples/cf-worker) directory.
+
+!!! info
+    If you're testing your Worker with Vitest, add the following configuration to your `vitest.config.mts` to ensure proper module loading:
+
+        ```ts
+        export default defineWorkersConfig({
+          test: {
+            deps: {
+              optimizer: {
+                ssr: {
+                  enabled: true,
+                  include: ['@pydantic/logfire-cf-workers'],
+                },
+              },
+            },
+            poolOptions: {
+              workers: {
+                // ...
+              },
+            },
+          },
+        });
+      ```

--- a/docs/integrations/javascript/deno.md
+++ b/docs/integrations/javascript/deno.md
@@ -1,0 +1,15 @@
+---
+title: Pydantic Logfire Deno Integration
+description: Learn how to configure Deno to export OpenTelemetry data to Logfire through environment variables.
+integration: "third-party"
+---
+# Deno
+
+Since v2.2, Deno has
+[built-in support for OpenTelemetry](https://docs.deno.com/runtime/fundamentals/open_telemetry/).
+The [logfire-js examples directory includes a `Hello World` example](https://github.com/pydantic/logfire-js/tree/main/examples/deno-project) that shows how to configure Deno
+to export OpenTelemetry data to Logfire through environment variables.
+
+You can also use the Logfire API package to create manual spans.
+Install the `logfire` NPM package and call the appropriate methods
+in your code.

--- a/docs/integrations/javascript/express.md
+++ b/docs/integrations/javascript/express.md
@@ -1,0 +1,62 @@
+---
+title: Logfire Express Application Integration
+description: Guide for instrumenting an Express application with Logfire. Learn how to use the logfire package to set up logging and monitoring for Express routes.
+integration: logfire
+---
+# Express
+
+Instrumenting an Express application with Logfire is straightforward. You can use the `logfire` package to set up logging and monitoring for your Express routes.
+
+!!!info
+    The [@opentelemetry/instrumentation-express](https://www.npmjs.com/package/@opentelemetry/instrumentation-express) NPM package lists the following Express version requirements:
+    > `express` version >=4.0.0 <5
+
+```ts title="app.ts"
+import express, type { Express } from 'express';
+
+const PORT: number = parseInt(process.env.PORT || '8080');
+const app: Express = express();
+
+function getRandomNumber(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+app.get('/rolldice', (req, res) => {
+  res.send(getRandomNumber(1, 6).toString());
+});
+
+app.listen(PORT, () => {
+  console.log(`Listening for requests on http://localhost:${PORT}`);
+});
+```
+
+To get started, install the `logfire` and `dotenv` NPM packages. This will allow you to keep your Logfire write token in a `.env` file:
+
+```sh
+npm install logfire dotenv
+```
+
+Add your token to the `.env` file:
+
+```sh title=".env"
+LOGFIRE_TOKEN=your-write-token
+```
+
+Then, create an `instrumentation.ts` file to set up the instrumentation. The
+`logfire` package includes a `configure` function that simplifies the setup:
+
+```ts title="instrumentation.ts"
+import * as logfire from "logfire";
+import "dotenv/config";
+
+logfire.configure();
+```
+
+The `logfire.configure` call should happen before importing the actual Express module, so your NPM start script should look like this in `package.json`. Note that we use `npx ts-node` to run the TypeScript code directly:
+
+```json title="package.json"
+"scripts": {
+  "start": "npx ts-node --require ./instrumentation.ts app.ts"
+```
+
+A working example can be found in the [examples/express](https://github.com/pydantic/logfire-js/tree/main/examples/express) directory of the `pydantic/logfire-js` repository.

--- a/docs/integrations/javascript/index.md
+++ b/docs/integrations/javascript/index.md
@@ -1,0 +1,40 @@
+---
+title: Logfire JavaScript Integrations
+description: "Overview of JavaScript integrations with Pydantic Logfire: Browser, Next.js, Cloudflare, Express, Node.js and Deno."
+---
+# JavaScript
+
+Logfire offers first-class integration for the most popular JavaScript frameworks
+and runtimes. Where appropriate (like Deno or Next.js), integration happens through the framework/runtime's built-in OTel mechanism.
+
+In addition to the instrumentation itself, we ship an `logfire` package that mirrors the Python `logfire` package API for creating spans and reporting exceptions.
+
+## Browser
+
+The `@pydantic/logfire-browser` package wraps [the OpenTelemetry browser tracing](https://opentelemetry.io/docs/languages/js/getting-started/browser/) with some sensible defaults and provides a simple API for creating spans and reporting exceptions.
+
+Refer to the [browser documentation section](./browser.md) for more details.
+
+## Next.js
+
+Next.js is a popular React framework for building server-rendered applications. It offers a first-party OTel integration through `@vercel/otel`, which is fully compatible with Logfire. In addition to that, the client-side can be instrumented with the `@pydantic/logfire-browser` package.
+
+Refer to the [Next.js documentation section](./nextjs.md) for more details.
+
+## Cloudflare
+
+Instrumenting Cloudflare Workers is straightforward with Logfire. You can use the `@pydantic/logfire-cf-workers` package to instrument your worker handlers, and the `logfire` package to send logs and spans.
+
+Refer to the [Cloudflare Workers documentation section](./cloudflare.md) for more details.
+
+## Express
+
+To instrument an Express app, use the `logfire` package, optionally using `dotenv` for reading environment variables from a file. Refer to the [Express documentation section](./express.md) for more details.
+
+## Node.js
+
+Generic Node.js scripts can be instrumented using the `@pydantic/logfire-node` package. Refer to the [Node.js documentation section](./node.md) for more details.
+
+## Deno
+
+Deno has built-in support for OpenTelemetry. You can configure OTel export to Logfire using environment variables. Refer to the [Deno documentation section](./deno.md) for more details.

--- a/docs/integrations/javascript/nextjs.md
+++ b/docs/integrations/javascript/nextjs.md
@@ -1,0 +1,61 @@
+---
+title: Pydantic Logfire Next.js Integration
+description: "Trace your Next.js application end-to-end. Implement both Server-Side & Client-Side instrumentation for full visibility into SSR & API routes with Logfire."
+integration: logfire
+---
+# Next.js
+
+## Server-side Instrumentation
+
+Vercel provides a comprehensive OpenTelemetry integration through the
+`@vercel/otel` package. After following
+[Vercel's integration instructions](https://vercel.com/docs/otel), add the
+following environment variables to your project:
+
+```sh
+OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-api.pydantic.dev
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+```
+
+This configuration directs the OpenTelemetry instrumentation to send data to Logfire.
+
+!!! note
+    Vercel production deployments use a caching mechanism that may prevent
+    configuration changes from taking effect immediately or prevent spans from being reported. If you
+    don't see spans appearing in Logfire, you can
+    [clear the data cache for your project](https://vercel.com/docs/data-cache/manage-data-cache).
+
+    Optionally, you can use the Logfire API package to create manual spans.
+    Install the `logfire` NPM package and call the appropriate methods
+    from your server-side code:
+
+    ```tsx
+    import * as logfire from "logfire";
+
+    export default async function Home() {
+      return logfire.span(
+        "A warning span",
+        {},
+        {
+          level: logfire.Level.Warning,
+        },
+        async (span) => {
+          logfire.info("Nested info span");
+          // Call span.end() to ensure the span is properly reported
+          span.end();
+          return <div>Hello</div>;
+        },
+      );
+    }
+    ```
+
+A working example can be found in the [examples/nextjs](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs) directory.
+
+## Client-side Instrumentation
+
+Client-side instrumentation can be implemented using the `@pydantic/logfire-browser` package. To set it up, you need to complete the following steps:
+
+- Add a [proxy to the Logfire traces endpoint in `proxy.ts`](https://github.com/pydantic/logfire-js/blob/main/examples/nextjs-client-side-instrumentation/proxy.ts) to prevent exposing your Logfire write token.
+- Wrap the browser instrumentation in [a client-only React component](https://github.com/pydantic/logfire-js/blob/main/examples/nextjs-client-side-instrumentation/app/components/ClientInstrumentationProvider.tsx). Use `next/dynamic` to ensure the component renders only in the browser ([see example](https://github.com/pydantic/logfire-js/blob/main/examples/nextjs-client-side-instrumentation/app/page.tsx#L5-L8)).
+
+A complete working example can be found in the [examples/nextjs-client-side-instrumentation](https://github.com/pydantic/logfire-js/tree/main/examples/nextjs-client-side-instrumentation) directory.

--- a/docs/integrations/javascript/node.md
+++ b/docs/integrations/javascript/node.md
@@ -1,0 +1,44 @@
+---
+title: Pydantic Logfire Node.js Integration
+description: "Get structured logging for Node.js with Logfire. Learn how to install and configure the @pydantic/logfire-node package for Node.js applications."
+integration: logfire
+---
+# Node.js
+
+Using Logfire in your Node.js script is straightforward. You need to [get a write token](../../how-to-guides/create-write-tokens.md), install the package, configure it, and use the provided API.
+
+Let's create an empty project:
+
+```sh
+mkdir test-logfire-js
+cd test-logfire-js
+npm init -y es6 # This creates a package.json with `type: module` for ES6 support
+npm install @pydantic/logfire-node
+```
+
+Then, create the following `hello.js` script in the directory:
+
+```js
+import * as logfire from "@pydantic/logfire-node";
+
+logfire.configure({
+  token: "your-write-token",
+  serviceName: "example-node-script",
+  serviceVersion: "1.0.0",
+});
+
+logfire.info(
+  "Hello from Node.js",
+  {
+    "attribute-key": "attribute-value",
+  },
+  {
+    tags: ["example", "example2"],
+  },
+);
+```
+
+Run the script with `node hello.js`, and you should see the span appear in
+the live view of your Logfire project.
+
+A working example can be found in the [examples/node](https://github.com/pydantic/logfire-js/tree/main/examples/node) directory of the logfire-js repository.

--- a/docs/integrations/javascript/vercel-ai.md
+++ b/docs/integrations/javascript/vercel-ai.md
@@ -1,0 +1,173 @@
+---
+title: Pydantic Logfire Vercel AI SDK Integration
+description: "Track LLM calls, token usage, tool invocations, and response times in AI applications built with the Vercel AI SDK using Logfire."
+integration: logfire
+---
+# Vercel AI SDK
+
+Logfire works well with AI applications built with the [Vercel AI SDK](https://ai-sdk.dev/). Track LLM calls, token usage, tool invocations, and response times across any supported model provider.
+
+## Node.js Scripts
+
+For standalone Node.js scripts, use the `@pydantic/logfire-node` package combined with the Vercel AI SDK.
+
+### Installation
+
+```bash
+npm install @pydantic/logfire-node ai @ai-sdk/your-provider
+```
+
+Replace `@ai-sdk/your-provider` with the provider package you're using (e.g., `@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`).
+
+### Setup
+
+**1. Create an instrumentation file**
+
+Create an `instrumentation.ts` file that configures Logfire:
+
+```typescript
+import logfire from "@pydantic/logfire-node";
+
+logfire.configure({
+  token: "your-write-token",
+  serviceName: "my-ai-app",
+  serviceVersion: "1.0.0",
+});
+```
+
+You can also use the `LOGFIRE_TOKEN` environment variable instead of passing the token directly.
+
+**2. Import instrumentation first**
+
+In your main script, import the instrumentation file before other imports:
+
+```typescript
+import "./instrumentation.ts";
+import { generateText } from "ai";
+import { yourProvider } from "@ai-sdk/your-provider";
+
+// Your AI code here
+```
+
+## Next.js
+
+For Next.js applications, use [Vercel's built-in OpenTelemetry support](https://nextjs.org/docs/app/guides/open-telemetry) with environment variables pointing to Logfire.
+
+### Installation
+
+```bash
+npm install @vercel/otel @opentelemetry/api ai @ai-sdk/your-provider
+```
+
+### Setup
+
+**1. Add environment variables**
+
+Add these to your `.env.local` file (or your deployment environment):
+
+```
+OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-api.pydantic.dev
+OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+```
+
+**2. Create the instrumentation file**
+
+Create `instrumentation.ts` in your project root (or `src` directory if using that structure):
+
+```typescript
+import { registerOTel } from "@vercel/otel";
+
+export function register() {
+  registerOTel({ serviceName: "my-nextjs-app" });
+}
+```
+
+This file must be in the root directory, not inside `app` or `pages`. See the [Vercel instrumentation docs](https://vercel.com/docs/tracing/instrumentation) for more configuration options.
+
+**3. Enable telemetry on AI SDK calls**
+
+See the [Enabling Telemetry](#enabling-telemetry) section below.
+
+## Enabling Telemetry
+
+The Vercel AI SDK uses [OpenTelemetry for telemetry](https://ai-sdk.dev/docs/ai-sdk-core/telemetry). To capture traces, add the `experimental_telemetry` option to your AI SDK function calls:
+
+```typescript
+const result = await generateText({
+  model: yourModel("model-name"),
+  prompt: "Your prompt here",
+  experimental_telemetry: { isEnabled: true },
+});
+```
+
+This option works with all AI SDK core functions:
+
+- `generateText` / `streamText`
+- `generateObject` / `streamObject`
+- `embed` / `embedMany`
+
+## Example: Text Generation with Tools
+
+Here's a complete example showing text generation with a tool and telemetry enabled:
+
+```typescript
+import { generateText, tool } from "ai";
+import { yourProvider } from "@ai-sdk/your-provider";
+import { z } from "zod";
+
+const result = await generateText({
+  model: yourProvider("model-name"),
+  experimental_telemetry: { isEnabled: true },
+  tools: {
+    weather: tool({
+      description: "Get the weather in a location",
+      inputSchema: z.object({
+        location: z.string().describe("The location to get the weather for"),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+  prompt: "What is the weather in San Francisco?",
+});
+
+console.log(result.text);
+```
+
+For Node.js scripts, remember to import your instrumentation file at the top of your entry point.
+
+## What You'll See in Logfire
+
+When telemetry is enabled, Logfire captures a hierarchical trace of your AI operations:
+
+- **Parent span** for the AI operation (e.g., `ai.generateText`)
+  - **Provider call spans** showing the actual LLM API calls
+  - **Tool call spans** for each tool invocation
+
+The captured data includes:
+
+- Prompts and responses
+- Model information and provider details
+- Token usage (input and output tokens)
+- Timing information
+- Tool call arguments and results
+
+## Advanced Options
+
+The `experimental_telemetry` option accepts additional configuration:
+
+```typescript
+experimental_telemetry: {
+  isEnabled: true,
+  functionId: "weather-lookup",
+  metadata: {
+    userId: "user-123",
+    environment: "production",
+  },
+}
+```
+
+- `functionId` - A custom identifier that appears in span names, useful for distinguishing different use cases
+- `metadata` - Custom key-value pairs attached to the telemetry spans


### PR DESCRIPTION
- restore the JavaScript integration docs that are still referenced from mkdocs nav and public docs pages
- fixes the Cloudflare Pages strict MkDocs build failing with missing integrations/javascript targets