### PR TITLE
Add `logfire.forward_export_request` and `forward_export_request_starlette` methods

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import importlib
 import sys
-from contextlib import contextmanager, nullcontext
-from typing import Any, ContextManager, Literal, TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from contextlib import AbstractContextManager, contextmanager, nullcontext
+from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import MagicMock
-
 
 try:
     logfire_module = importlib.import_module('logfire')
@@ -143,7 +143,7 @@ except ImportError:
             def instrument_wsgi(self, app, *args, **kwargs):
                 return app
 
-            def instrument_fastapi(self, *args, **kwargs) -> ContextManager[None]:
+            def instrument_fastapi(self, *args, **kwargs) -> AbstractContextManager[None]:
                 return nullcontext()
 
             def instrument_pydantic(self, *args, **kwargs) -> None: ...
@@ -176,13 +176,13 @@ except ImportError:
 
             def instrument_asyncpg(self, *args, **kwargs) -> None: ...
 
-            def instrument_anthropic(self, *args, **kwargs) -> ContextManager[None]:
+            def instrument_anthropic(self, *args, **kwargs) -> AbstractContextManager[None]:
                 return nullcontext()
 
-            def instrument_openai(self, *args, **kwargs) -> ContextManager[None]:
+            def instrument_openai(self, *args, **kwargs) -> AbstractContextManager[None]:
                 return nullcontext()
 
-            def instrument_print(self, *args, **kwargs) -> ContextManager[None]:
+            def instrument_print(self, *args, **kwargs) -> AbstractContextManager[None]:
                 return nullcontext()
 
             def instrument_openai_agents(self, *args, **kwargs) -> None: ...
@@ -201,10 +201,16 @@ except ImportError:
 
             def instrument_mcp(self, *args, **kwargs) -> None: ...
 
-            def instrument_claude_agent_sdk(self, *args, **kwargs) -> ContextManager[None]:
+            def instrument_claude_agent_sdk(self, *args, **kwargs) -> AbstractContextManager[None]:
                 return nullcontext()
 
             def url_from_eval(self, *args, **kwargs) -> str | None: ...
+
+            def forward_export_request(self, *args, **kwargs) -> MagicMock:
+                return MagicMock()
+
+            async def forward_export_request_starlette(self, *args, **kwargs) -> MagicMock:
+                return MagicMock()
 
             def shutdown(self, *args, **kwargs) -> None: ...
 
@@ -262,6 +268,8 @@ except ImportError:
         shutdown = DEFAULT_LOGFIRE_INSTANCE.shutdown
         suppress_scopes = DEFAULT_LOGFIRE_INSTANCE.suppress_scopes
         url_from_eval = DEFAULT_LOGFIRE_INSTANCE.url_from_eval
+        forward_export_request = DEFAULT_LOGFIRE_INSTANCE.forward_export_request
+        forward_export_request_starlette = DEFAULT_LOGFIRE_INSTANCE.forward_export_request_starlette
 
         def loguru_handler() -> dict[str, Any]:
             return {}
@@ -316,11 +324,11 @@ except ImportError:
         def get_baggage(*args, **kwargs) -> dict[str, str]:
             return {}
 
-        def set_baggage(*args, **kwargs) -> ContextManager[None]:
+        def set_baggage(*args, **kwargs) -> AbstractContextManager[None]:
             return nullcontext()
 
         def get_context(*args, **kwargs) -> dict[str, Any]:
             return {}
 
-        def attach_context(*args, **kwargs) -> ContextManager[None]:
+        def attach_context(*args, **kwargs) -> AbstractContextManager[None]:
             return nullcontext()

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -75,6 +75,8 @@ with_tags = DEFAULT_LOGFIRE_INSTANCE.with_tags
 # with_trace_sample_rate = DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate
 with_settings = DEFAULT_LOGFIRE_INSTANCE.with_settings
 url_from_eval = DEFAULT_LOGFIRE_INSTANCE.url_from_eval
+forward_export_request = DEFAULT_LOGFIRE_INSTANCE.forward_export_request
+forward_export_request_starlette = DEFAULT_LOGFIRE_INSTANCE.forward_export_request_starlette
 
 # Logging
 log = DEFAULT_LOGFIRE_INSTANCE.log
@@ -213,4 +215,6 @@ __all__ = (
     'get_context',
     'attach_context',
     'url_from_eval',
+    'forward_export_request',
+    'forward_export_request_starlette',
 )

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -92,11 +92,13 @@ if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
     from starlette.applications import Starlette
     from starlette.requests import Request
+    from starlette.responses import Response
     from starlette.websockets import WebSocket
     from surrealdb.connections.async_template import AsyncTemplate
     from surrealdb.connections.sync_template import SyncTemplate
     from typing_extensions import Unpack
 
+    from ..experimental.forwarding import ForwardExportRequestResponse
     from ..integrations.aiohttp_client import (
         RequestHook as AiohttpClientRequestHook,
         ResponseHook as AiohttpClientResponseHook,
@@ -2838,6 +2840,80 @@ class Logfire:
         from logfire.variables.config import VariablesConfig
 
         return VariablesConfig.from_variables(variables)
+
+    def forward_export_request(
+        self,
+        *,
+        path: str,
+        headers: Mapping[str, str],
+        body: bytes,
+        max_body_size: int = 50 * 1024 * 1024,
+    ) -> ForwardExportRequestResponse:
+        """Forward an OpenTelemetry export request to the Logfire backend.
+
+        This method is generic and can be used for any web framework.
+        For Starlette/FastAPI, use `forward_export_request_starlette` instead for extra protection and convenience.
+
+        This is for proxying telemetry from a browser to Logfire so that the write token doesn't need to be
+        exposed in the frontend code.
+        See https://pydantic.dev/docs/logfire/typescript-sdk/packages/browser/#python-backend-proxy
+        for more details.
+
+        We recommend protecting the endpoint that uses this method with authentication, rate limiting, and CORS.
+
+        Args:
+            path: one of "/v1/traces", "/v1/metrics", or "/v1/logs"
+            headers: the request headers, as a mapping of header names to values
+            body: the request body, as bytes
+            max_body_size: the maximum allowed body size, in bytes.
+                If the body exceeds this size, the response will be a 413, rejecting the payload.
+
+        Returns:
+            A `ForwardExportRequestResponse` containing the repsonse status code, body, and headers.
+        """
+        from ..experimental.forwarding import forward_export_request
+
+        return forward_export_request(
+            path=path,
+            headers=headers,
+            body=body,
+            max_body_size=max_body_size,
+            logfire_instance=self,
+        )
+
+    async def forward_export_request_starlette(
+        self,
+        request: Request,
+        *,
+        max_body_size: int = 50 * 1024 * 1024,
+    ) -> Response:
+        """Forward an OpenTelemetry export request to the Logfire backend.
+
+        This method is designed for Starlette/FastAPI.
+        For other web frameworks, use `forward_export_request` instead and adapt the request/response handling as needed.
+
+        This is for proxying telemetry from a browser to Logfire so that the write token doesn't need to be
+        exposed in the frontend code.
+        See https://pydantic.dev/docs/logfire/typescript-sdk/packages/browser/#python-backend-proxy
+        for more details.
+
+        We recommend protecting the endpoint that uses this method with authentication, rate limiting, and CORS.
+
+        Args:
+            request: The Starlette/FastAPI `Request` object.
+            max_body_size: the maximum allowed body size, in bytes.
+                If the body exceeds this size, the response will be a 413, rejecting the payload.
+
+        Returns:
+            A Starlette/FastAPI `Response` object.
+        """
+        from ..experimental.forwarding import logfire_proxy
+
+        return await logfire_proxy(
+            request=request,
+            max_body_size=max_body_size,
+            logfire_instance=self,
+        )
 
 
 class FastLogfireSpan:

--- a/logfire/experimental/forwarding.py
+++ b/logfire/experimental/forwarding.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING
 
 import logfire
 from logfire._internal.forwarding import (
@@ -12,6 +12,11 @@ from logfire._internal.forwarding import (
     build_partial_success_response,
     build_success_response,
 )
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+    from starlette.responses import Response
+
 
 __all__ = ('ForwardExportRequestResponse', 'forward_export_request', 'logfire_proxy')
 
@@ -35,8 +40,7 @@ def forward_export_request(
 ) -> ForwardExportRequestResponse:
     """Forward an export request to the Logfire API.
 
-    Note: If the provided logfire instance is configured with multiple Logfire destinations,
-    the request is admitted for forwarding to all of them.
+    See the Logfire.forward_export_request method for more details.
     """
     if logfire_instance is None:
         logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE
@@ -71,31 +75,14 @@ def forward_export_request(
 
 
 async def logfire_proxy(
-    request: Any,
+    request: Request,
     *,
     logfire_instance: logfire.Logfire | None = None,
     max_body_size: int = 50 * 1024 * 1024,
-) -> Any:
+) -> Response:
     """A Starlette/FastAPI handler to proxy requests to Logfire.
 
-    This is useful for proxying requests from a browser to Logfire,
-    to avoid exposing your write token in the browser.
-
-    Note: If the provided logfire instance is configured with multiple Logfire destinations,
-    accepted requests are admitted for forwarding to all of them.
-
-    **Security Note**: This endpoint is unauthenticated unless you protect it.
-    Any client capable of reaching this endpoint can send telemetry data to your Logfire project.
-    In production, ensure you have appropriate protections in place (e.g. CORS policies,
-    rate limiting, or upstream authentication/dependency injection).
-
-    Args:
-        request: The Starlette/FastAPI Request object.
-        logfire_instance: The Logfire instance to use. If not provided, the default instance is used.
-        max_body_size: The maximum allowed request body size in bytes. Defaults to 50MB.
-
-    Returns:
-        A Starlette/FastAPI Response object.
+    See the Logfire.forward_export_request_starlette method for more details.
     """
     from starlette.responses import Response
 

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -15,7 +15,7 @@ from starlette.testclient import TestClient
 import logfire
 from logfire._internal.config import LogfireConfig
 from logfire._internal.forwarding import ForwardingAdmissionResult, ForwardingRequest
-from logfire.experimental.forwarding import ForwardExportRequestResponse, forward_export_request, logfire_proxy
+from logfire.experimental.forwarding import ForwardExportRequestResponse
 
 
 class FakeForwardingManager:
@@ -67,7 +67,7 @@ def test_forward_export_request_logic() -> None:
     manager = _set_successful_forwarding_manager()
 
     with mock.patch('requests.post') as mock_post:
-        response = forward_export_request(
+        response = logfire.forward_export_request(
             path='/v1/traces',
             headers={'Content-Type': 'application/x-protobuf', 'Host': 'example.com'},
             body=b'data',
@@ -84,14 +84,14 @@ def test_forward_export_request_logic() -> None:
 
 def test_forward_export_request_invalid_path() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
-    response = forward_export_request(path='/invalid', headers={}, body=b'')
+    response = logfire.forward_export_request(path='/invalid', headers={}, body=b'')
     assert response.status_code == 400
     assert b'Invalid path' in response.content
 
 
 def test_forward_export_request_path_traversal() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
-    response = forward_export_request(path='/v1/traces/../secret', headers={}, body=b'')
+    response = logfire.forward_export_request(path='/v1/traces/../secret', headers={}, body=b'')
     assert response.status_code == 400
     assert b'Invalid path' in response.content
 
@@ -101,7 +101,7 @@ def test_forward_export_request_exception_handling() -> None:
     _set_successful_forwarding_manager()
 
     with mock.patch('requests.post') as mock_post:
-        response = forward_export_request(
+        response = logfire.forward_export_request(
             path='/v1/traces', headers={'Content-Type': 'application/x-protobuf'}, body=b''
         )
         assert response.status_code == 200
@@ -113,7 +113,7 @@ def test_fastapi_proxy_handler() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
 
-    app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST'])
+    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
     client = TestClient(app)
 
@@ -130,7 +130,7 @@ def test_fastapi_proxy_size_limit() -> None:
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    handler = functools.partial(logfire_proxy, max_body_size=10)
+    handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
     client = TestClient(app)
@@ -145,7 +145,7 @@ def test_fastapi_proxy_size_limit() -> None:
 def test_fastapi_proxy_invalid_content_length() -> None:
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST'])
+    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
     client = TestClient(app)
 
@@ -158,7 +158,7 @@ def test_fastapi_proxy_body_limit_late_check() -> None:
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    handler = functools.partial(logfire_proxy, max_body_size=10)
+    handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
     client = TestClient(app)
@@ -171,7 +171,7 @@ def test_fastapi_proxy_body_limit_late_check() -> None:
 
 def test_forward_export_request_percent_encoded_traversal() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
-    response = forward_export_request(path='/v1/traces/%2e%2e/secret', headers={}, body=b'')
+    response = logfire.forward_export_request(path='/v1/traces/%2e%2e/secret', headers={}, body=b'')
     assert response.status_code == 400
 
 
@@ -180,7 +180,7 @@ def test_forward_export_request_multi_token() -> None:
     _set_successful_forwarding_manager()
 
     with mock.patch('requests.post') as mock_post:
-        response = forward_export_request(
+        response = logfire.forward_export_request(
             path='/v1/traces', headers={'Content-Type': 'application/x-protobuf'}, body=b''
         )
 
@@ -194,11 +194,10 @@ def test_forward_export_request_missing_token() -> None:
     logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE
 
     with mock.patch.object(logfire_instance.config, 'token', None):
-        response = forward_export_request(
+        response = logfire.forward_export_request(
             path='/v1/traces',
             headers={'Content-Type': 'application/x-protobuf'},
             body=b'',
-            logfire_instance=logfire_instance,
         )
         assert response.status_code == 200
 
@@ -211,11 +210,10 @@ def test_forward_export_request_explicit_instance() -> None:
     explicit_instance = logfire.DEFAULT_LOGFIRE_INSTANCE
 
     with mock.patch('requests.post') as mock_post:
-        response = forward_export_request(
+        response = explicit_instance.forward_export_request(
             path='/v1/traces',
             headers={'Content-Type': 'application/x-protobuf'},
             body=b'',
-            logfire_instance=explicit_instance,
         )
 
         assert response.status_code == 200
@@ -225,7 +223,7 @@ def test_forward_export_request_explicit_instance() -> None:
 def test_forward_export_request_missing_content_type() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    response = forward_export_request(path='/v1/traces', headers={}, body=b'')
+    response = logfire.forward_export_request(path='/v1/traces', headers={}, body=b'')
 
     assert response.status_code == 415
     assert response.headers == {'Content-Type': 'text/plain'}
@@ -235,7 +233,7 @@ def test_forward_export_request_missing_content_type() -> None:
 def test_forward_export_request_unsupported_content_type() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    response = forward_export_request(path='/v1/traces', headers={'Content-Type': 'text/plain'}, body=b'')
+    response = logfire.forward_export_request(path='/v1/traces', headers={'Content-Type': 'text/plain'}, body=b'')
 
     assert response.status_code == 415
     assert response.content == b'Unsupported content type, must be application/json or application/x-protobuf'
@@ -244,7 +242,7 @@ def test_forward_export_request_unsupported_content_type() -> None:
 def test_forward_export_request_oversized_body() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/traces',
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'12345',
@@ -258,7 +256,7 @@ def test_forward_export_request_oversized_body() -> None:
 def test_forward_export_request_no_destination_forbidden() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/traces',
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'',
@@ -281,7 +279,7 @@ def test_forward_export_request_submits_to_checked_forwarding_manager() -> None:
     manager = SwappingForwardingManager()
     cast(Any, config)._otlp_forwarding = manager
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/traces',
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'data',
@@ -295,7 +293,7 @@ def test_forward_export_request_submits_to_checked_forwarding_manager() -> None:
 def test_forward_export_request_validation_before_no_destination() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
 
-    response = forward_export_request(path='/invalid', headers={}, body=b'')
+    response = logfire.forward_export_request(path='/invalid', headers={}, body=b'')
 
     assert response.status_code == 400
 
@@ -320,7 +318,7 @@ def test_forward_export_request_configured_token_fanout(monkeypatch: pytest.Monk
         metrics=False,
     )
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/traces',
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'trace-payload',
@@ -374,7 +372,7 @@ def test_forward_export_request_backend_isolation(monkeypatch: pytest.MonkeyPatc
         metrics=False,
     )
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/logs',
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'log-payload',
@@ -432,7 +430,7 @@ def test_forward_export_request_header_sanitization(monkeypatch: pytest.MonkeyPa
         metrics=False,
     )
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/metrics',
         headers={
             'Content-Type': 'application/json; charset=utf-8',
@@ -482,7 +480,7 @@ def test_forward_export_request_partial_success_when_backend_queue_full(
     manager = logfire.DEFAULT_LOGFIRE_INSTANCE.config._otlp_forwarding  # pyright: ignore[reportPrivateUsage]
     manager.pipelines['https://logfire-us.pydantic.dev'].max_queued_body_bytes = 0
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path='/v1/traces',
         headers={'Content-Type': 'application/json'},
         body=b'{}',
@@ -525,7 +523,7 @@ def test_forward_export_request_partial_success_json(path: str, rejected_field: 
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager(ForwardingAdmissionResult(response='partial_success', message='queue full'))
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path=path,
         headers={'Content-Type': 'application/json'},
         body=b'{}',
@@ -550,7 +548,7 @@ def test_forward_export_request_partial_success_protobuf(
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager(ForwardingAdmissionResult(response='partial_success', message='closed'))
 
-    response = forward_export_request(
+    response = logfire.forward_export_request(
         path=path,
         headers={'Content-Type': 'application/x-protobuf'},
         body=b'',
@@ -567,7 +565,7 @@ def test_forward_export_request_partial_success_protobuf(
 def test_fastapi_proxy_invalid_method() -> None:
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST', 'GET'])
+    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
 
     client = TestClient(app)
     response = client.get('/logfire-proxy/v1/traces')
@@ -578,7 +576,7 @@ def test_fastapi_proxy_invalid_method() -> None:
 def test_fastapi_proxy_missing_path() -> None:
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy-missing', logfire_proxy, methods=['POST'])
+    app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
 
     client = TestClient(app)
     response = client.post('/logfire-proxy-missing')
@@ -602,7 +600,7 @@ async def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
     with mock.patch('logfire.experimental.forwarding.forward_export_request') as mock_fwd:
         mock_fwd.return_value = ForwardExportRequestResponse(200, {'Content-Type': 'application/json'}, b'{"ok": true}')
 
-        response = await logfire_proxy(request, max_body_size=10)
+        response = await logfire.forward_export_request_starlette(request, max_body_size=10)
 
         assert response.status_code == 200
         assert response.body == b'{"ok": true}'
@@ -610,14 +608,14 @@ async def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
             'path': 'v1/traces',
             'headers': {},
             'body': b'1234567890',
-            'logfire_instance': None,
+            'logfire_instance': logfire.DEFAULT_LOGFIRE_INSTANCE,
             'max_body_size': 10,
         }
 
         mock_fwd.reset_mock()
 
         request.headers = {'content-length': '10'}
-        response2 = await logfire_proxy(request, max_body_size=10)
+        response2 = await logfire.forward_export_request_starlette(request, max_body_size=10)
 
         assert response2.status_code == 200
         assert response2.body == b'{"ok": true}'
@@ -625,6 +623,6 @@ async def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
             'path': 'v1/traces',
             'headers': {'content-length': '10'},
             'body': b'1234567890',
-            'logfire_instance': None,
+            'logfire_instance': logfire.DEFAULT_LOGFIRE_INSTANCE,
             'max_body_size': 10,
         }

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -123,11 +123,10 @@ def test_forward_export_request_exception_handling() -> None:
 
 
 def test_fastapi_proxy_handler(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
 
-    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
+    fastapi_app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
     with mock.patch('requests.post') as mock_post:
         response = fastapi_client.post(
@@ -139,11 +138,10 @@ def test_fastapi_proxy_handler(fastapi_app: FastAPI, fastapi_client: TestClient)
 
 
 def test_fastapi_proxy_size_limit(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
-    app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
+    fastapi_app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
     response = fastapi_client.post(
         '/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Type': 'application/json'}
@@ -153,9 +151,8 @@ def test_fastapi_proxy_size_limit(fastapi_app: FastAPI, fastapi_client: TestClie
 
 
 def test_fastapi_proxy_invalid_content_length(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
+    fastapi_app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
     response = fastapi_client.post('/logfire-proxy/v1/traces', content=b'', headers={'Content-Length': 'invalid'})
     assert response.status_code == 400
@@ -163,11 +160,10 @@ def test_fastapi_proxy_invalid_content_length(fastapi_app: FastAPI, fastapi_clie
 
 
 def test_fastapi_proxy_body_limit_late_check(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
-    app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
+    fastapi_app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
     # Lying about Content-Length bypasses early check, so we catch it while chunking
     response = fastapi_client.post('/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Length': '5'})
@@ -569,9 +565,10 @@ def test_forward_export_request_partial_success_protobuf(
 
 
 def test_fastapi_proxy_invalid_method(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
+    fastapi_app.add_route(
+        '/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET']
+    )
 
     response = fastapi_client.get('/logfire-proxy/v1/traces')
     assert response.status_code == 405
@@ -579,9 +576,8 @@ def test_fastapi_proxy_invalid_method(fastapi_app: FastAPI, fastapi_client: Test
 
 
 def test_fastapi_proxy_missing_path(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
-    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
-    app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
+    fastapi_app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
 
     response = fastapi_client.post('/logfire-proxy-missing')
     assert response.status_code == 400

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+import functools
 import json
 from typing import Any, cast
 from unittest import mock
 
 import pytest
+from fastapi import FastAPI
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceResponse
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
+from starlette.testclient import TestClient
 
 import logfire
 from logfire._internal.config import LogfireConfig
@@ -106,10 +109,6 @@ def test_forward_export_request_exception_handling() -> None:
 
 
 def test_fastapi_proxy_handler() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
@@ -128,11 +127,6 @@ def test_fastapi_proxy_handler() -> None:
 
 
 def test_fastapi_proxy_size_limit() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-    import functools
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
 
@@ -149,10 +143,6 @@ def test_fastapi_proxy_size_limit() -> None:
 
 
 def test_fastapi_proxy_invalid_content_length() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST'])
@@ -165,11 +155,6 @@ def test_fastapi_proxy_invalid_content_length() -> None:
 
 
 def test_fastapi_proxy_body_limit_late_check() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-    import functools
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
 
@@ -580,10 +565,6 @@ def test_forward_export_request_partial_success_protobuf(
 
 
 def test_fastapi_proxy_invalid_method() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire_proxy, methods=['POST', 'GET'])
@@ -595,10 +576,6 @@ def test_fastapi_proxy_invalid_method() -> None:
 
 
 def test_fastapi_proxy_missing_path() -> None:
-    fastapi = pytest.importorskip('fastapi', exc_type=ImportError)
-    TestClient = pytest.importorskip('starlette.testclient').TestClient
-    FastAPI = fastapi.FastAPI
-
     app = FastAPI()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy-missing', logfire_proxy, methods=['POST'])

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -60,10 +60,15 @@ def _set_successful_forwarding_manager(
     return manager
 
 
-def _make_fastapi_app() -> tuple[Any, type[Any]]:
+@pytest.fixture
+def fastapi_app() -> Any:
     fastapi = pytest.importorskip('fastapi', reason='FastAPI requires pydantic>=2.7', exc_type=ImportError)
-    test_client = pytest.importorskip('starlette.testclient').TestClient
-    return fastapi.FastAPI(), test_client
+    return fastapi.FastAPI()
+
+
+@pytest.fixture
+def test_client_cls(fastapi_app: Any) -> type[Any]:
+    return pytest.importorskip('starlette.testclient').TestClient
 
 
 def test_forward_export_request_logic() -> None:
@@ -112,14 +117,14 @@ def test_forward_export_request_exception_handling() -> None:
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_handler() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_handler(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
 
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
 
     with mock.patch('requests.post') as mock_post:
         response = client.post(
@@ -130,14 +135,14 @@ def test_fastapi_proxy_handler() -> None:
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_size_limit() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_size_limit(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
 
     response = client.post(
         '/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Type': 'application/json'}
@@ -146,26 +151,26 @@ def test_fastapi_proxy_size_limit() -> None:
     assert response.content == b'Payload too large'
 
 
-def test_fastapi_proxy_invalid_content_length() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_invalid_content_length(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
 
     response = client.post('/logfire-proxy/v1/traces', content=b'', headers={'Content-Length': 'invalid'})
     assert response.status_code == 400
     assert response.content == b'Invalid Content-Length header'
 
 
-def test_fastapi_proxy_body_limit_late_check() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_body_limit_late_check(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
 
     # Lying about Content-Length bypasses early check, so we catch it while chunking
     response = client.post('/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Length': '5'})
@@ -566,23 +571,23 @@ def test_forward_export_request_partial_success_protobuf(
     assert getattr(message.partial_success, rejected_attr) == 0  # type: ignore[attr-defined]
 
 
-def test_fastapi_proxy_invalid_method() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_invalid_method(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
     response = client.get('/logfire-proxy/v1/traces')
     assert response.status_code == 405
     assert response.content == b'Method Not Allowed'
 
 
-def test_fastapi_proxy_missing_path() -> None:
-    app, TestClient = _make_fastapi_app()
+def test_fastapi_proxy_missing_path(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+    app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = TestClient(app)
+    client = test_client_cls(app)
     response = client.post('/logfire-proxy-missing')
     assert response.status_code == 400
     assert response.content == b'Missing path parameter. Use {path:path} in the route definition.'

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import sys
 from typing import Any, cast
 from unittest import mock
 
@@ -610,62 +609,45 @@ def test_fastapi_proxy_missing_path() -> None:
     assert response.content == b'Missing path parameter. Use {path:path} in the route definition.'
 
 
-def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
-    mock_responses = mock.Mock()
+@pytest.mark.anyio
+async def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
+    request = mock.Mock()
+    request.headers = {}
 
-    class MockResponse:
-        def __init__(self, content: Any, status_code: int, headers: dict[str, str] | None = None) -> None:
-            self.body = content
-            self.status_code = status_code
-            self.headers = headers or {}
+    async def mock_stream():
+        yield b'12345'
+        yield b'67890'
 
-    mock_responses.Response = MockResponse
+    request.stream = mock_stream
+    request.path_params = {'path': 'v1/traces'}
+    request.method = 'POST'
 
-    with mock.patch.dict(
-        sys.modules,
-        {'starlette': mock.Mock(), 'starlette.responses': mock_responses},
-    ):
-        request = mock.Mock()
-        request.headers = {}
+    with mock.patch('logfire.experimental.forwarding.forward_export_request') as mock_fwd:
+        mock_fwd.return_value = ForwardExportRequestResponse(200, {'Content-Type': 'application/json'}, b'{"ok": true}')
 
-        async def mock_stream():
-            yield b'12345'
-            yield b'67890'
+        response = await logfire_proxy(request, max_body_size=10)
 
-        request.stream = mock_stream
-        request.path_params = {'path': 'v1/traces'}
-        request.method = 'POST'
+        assert response.status_code == 200
+        assert response.body == b'{"ok": true}'
+        assert mock_fwd.call_args.kwargs == {
+            'path': 'v1/traces',
+            'headers': {},
+            'body': b'1234567890',
+            'logfire_instance': None,
+            'max_body_size': 10,
+        }
 
-        with mock.patch('logfire.experimental.forwarding.forward_export_request') as mock_fwd:
-            mock_fwd.return_value = ForwardExportRequestResponse(
-                200, {'Content-Type': 'application/json'}, b'{"ok": true}'
-            )
+        mock_fwd.reset_mock()
 
-            import asyncio
+        request.headers = {'content-length': '10'}
+        response2 = await logfire_proxy(request, max_body_size=10)
 
-            response = asyncio.run(logfire_proxy(request, max_body_size=10))
-
-            assert response.status_code == 200
-            assert response.body == b'{"ok": true}'
-            assert mock_fwd.call_args.kwargs == {
-                'path': 'v1/traces',
-                'headers': {},
-                'body': b'1234567890',
-                'logfire_instance': None,
-                'max_body_size': 10,
-            }
-
-            mock_fwd.reset_mock()
-
-            request.headers = {'content-length': '10'}
-            response2 = asyncio.run(logfire_proxy(request, max_body_size=10))
-
-            assert response2.status_code == 200
-            assert response2.body == b'{"ok": true}'
-            assert mock_fwd.call_args.kwargs == {
-                'path': 'v1/traces',
-                'headers': {'content-length': '10'},
-                'body': b'1234567890',
-                'logfire_instance': None,
-                'max_body_size': 10,
-            }
+        assert response2.status_code == 200
+        assert response2.body == b'{"ok": true}'
+        assert mock_fwd.call_args.kwargs == {
+            'path': 'v1/traces',
+            'headers': {'content-length': '10'},
+            'body': b'1234567890',
+            'logfire_instance': None,
+            'max_body_size': 10,
+        }

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -71,8 +71,9 @@ def fastapi_app() -> FastAPI:
 
 
 @pytest.fixture
-def test_client_cls(fastapi_app: FastAPI) -> type[TestClient]:
-    return cast('type[TestClient]', pytest.importorskip('starlette.testclient').TestClient)
+def fastapi_client(fastapi_app: FastAPI) -> TestClient:
+    test_client_cls = pytest.importorskip('starlette.testclient').TestClient
+    return cast('TestClient', test_client_cls(fastapi_app))
 
 
 def test_forward_export_request_logic() -> None:
@@ -121,17 +122,15 @@ def test_forward_export_request_exception_handling() -> None:
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_handler(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_handler(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
 
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = test_client_cls(app)
-
     with mock.patch('requests.post') as mock_post:
-        response = client.post(
+        response = fastapi_client.post(
             '/logfire-proxy/v1/traces', content=b'trace_data', headers={'Content-Type': 'application/x-protobuf'}
         )
 
@@ -139,45 +138,39 @@ def test_fastapi_proxy_handler(fastapi_app: FastAPI, test_client_cls: type[TestC
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_size_limit(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_size_limit(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
-    client = test_client_cls(app)
-
-    response = client.post(
+    response = fastapi_client.post(
         '/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Type': 'application/json'}
     )
     assert response.status_code == 413
     assert response.content == b'Payload too large'
 
 
-def test_fastapi_proxy_invalid_content_length(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_invalid_content_length(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = test_client_cls(app)
-
-    response = client.post('/logfire-proxy/v1/traces', content=b'', headers={'Content-Length': 'invalid'})
+    response = fastapi_client.post('/logfire-proxy/v1/traces', content=b'', headers={'Content-Length': 'invalid'})
     assert response.status_code == 400
     assert response.content == b'Invalid Content-Length header'
 
 
-def test_fastapi_proxy_body_limit_late_check(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_body_limit_late_check(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
     app.add_route('/logfire-proxy/{path:path}', handler, methods=['POST'])
 
-    client = test_client_cls(app)
-
     # Lying about Content-Length bypasses early check, so we catch it while chunking
-    response = client.post('/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Length': '5'})
+    response = fastapi_client.post('/logfire-proxy/v1/traces', content=b'12345678901', headers={'Content-Length': '5'})
     assert response.status_code == 413
     assert response.content == b'Payload too large'
 
@@ -575,24 +568,22 @@ def test_forward_export_request_partial_success_protobuf(
     assert getattr(message.partial_success, rejected_attr) == 0  # type: ignore[attr-defined]
 
 
-def test_fastapi_proxy_invalid_method(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_invalid_method(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
 
-    client = test_client_cls(app)
-    response = client.get('/logfire-proxy/v1/traces')
+    response = fastapi_client.get('/logfire-proxy/v1/traces')
     assert response.status_code == 405
     assert response.content == b'Method Not Allowed'
 
 
-def test_fastapi_proxy_missing_path(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
+def test_fastapi_proxy_missing_path(fastapi_app: FastAPI, fastapi_client: TestClient) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
 
-    client = test_client_cls(app)
-    response = client.post('/logfire-proxy-missing')
+    response = fastapi_client.post('/logfire-proxy-missing')
     assert response.status_code == 400
     assert response.content == b'Missing path parameter. Use {path:path} in the route definition.'
 

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -13,6 +13,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTrace
 import logfire
 from logfire._internal.config import LogfireConfig
 from logfire._internal.forwarding import ForwardingAdmissionResult, ForwardingRequest
+from logfire.experimental import forwarding
 from logfire.experimental.forwarding import ForwardExportRequestResponse
 
 if TYPE_CHECKING:
@@ -94,6 +95,20 @@ def test_forward_export_request_logic() -> None:
         mock_post.assert_not_called()
         assert manager.submissions[0].path == '/v1/traces'
         assert manager.submissions[0].body == b'data'
+
+
+def test_forward_export_request_function_defaults_to_default_instance() -> None:
+    logfire.configure(token='test_token', send_to_logfire=False)
+    manager = _set_successful_forwarding_manager()
+
+    response = forwarding.forward_export_request(
+        path='/v1/traces',
+        headers={'Content-Type': 'application/x-protobuf'},
+        body=b'data',
+    )
+
+    assert response.status_code == 200
+    assert manager.submissions[0].body == b'data'
 
 
 def test_forward_export_request_invalid_path() -> None:

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -6,11 +6,9 @@ from typing import Any, cast
 from unittest import mock
 
 import pytest
-from fastapi import FastAPI
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceResponse
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceResponse
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceResponse
-from starlette.testclient import TestClient
 
 import logfire
 from logfire._internal.config import LogfireConfig
@@ -62,6 +60,12 @@ def _set_successful_forwarding_manager(
     return manager
 
 
+def _make_fastapi_app() -> tuple[Any, type[Any]]:
+    fastapi = pytest.importorskip('fastapi', reason='FastAPI requires pydantic>=2.7', exc_type=ImportError)
+    test_client = pytest.importorskip('starlette.testclient').TestClient
+    return fastapi.FastAPI(), test_client
+
+
 def test_forward_export_request_logic() -> None:
     logfire.configure(token='test_token', send_to_logfire=False)
     manager = _set_successful_forwarding_manager()
@@ -109,7 +113,7 @@ def test_forward_export_request_exception_handling() -> None:
 
 
 def test_fastapi_proxy_handler() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
 
@@ -127,7 +131,7 @@ def test_fastapi_proxy_handler() -> None:
 
 
 def test_fastapi_proxy_size_limit() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
@@ -143,7 +147,7 @@ def test_fastapi_proxy_size_limit() -> None:
 
 
 def test_fastapi_proxy_invalid_content_length() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
 
@@ -155,7 +159,7 @@ def test_fastapi_proxy_invalid_content_length() -> None:
 
 
 def test_fastapi_proxy_body_limit_late_check() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
 
     handler = functools.partial(logfire.forward_export_request_starlette, max_body_size=10)
@@ -563,7 +567,7 @@ def test_forward_export_request_partial_success_protobuf(
 
 
 def test_fastapi_proxy_invalid_method() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
 
@@ -574,7 +578,7 @@ def test_fastapi_proxy_invalid_method() -> None:
 
 
 def test_fastapi_proxy_missing_path() -> None:
-    app = FastAPI()
+    app, TestClient = _make_fastapi_app()
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])
 

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import functools
 import json
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest import mock
 
 import pytest
@@ -14,6 +14,10 @@ import logfire
 from logfire._internal.config import LogfireConfig
 from logfire._internal.forwarding import ForwardingAdmissionResult, ForwardingRequest
 from logfire.experimental.forwarding import ForwardExportRequestResponse
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from starlette.testclient import TestClient
 
 
 class FakeForwardingManager:
@@ -61,14 +65,14 @@ def _set_successful_forwarding_manager(
 
 
 @pytest.fixture
-def fastapi_app() -> Any:
+def fastapi_app() -> FastAPI:
     fastapi = pytest.importorskip('fastapi', reason='FastAPI requires pydantic>=2.7', exc_type=ImportError)
-    return fastapi.FastAPI()
+    return cast('FastAPI', fastapi.FastAPI())
 
 
 @pytest.fixture
-def test_client_cls(fastapi_app: Any) -> type[Any]:
-    return pytest.importorskip('starlette.testclient').TestClient
+def test_client_cls(fastapi_app: FastAPI) -> type[TestClient]:
+    return cast('type[TestClient]', pytest.importorskip('starlette.testclient').TestClient)
 
 
 def test_forward_export_request_logic() -> None:
@@ -117,7 +121,7 @@ def test_forward_export_request_exception_handling() -> None:
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_handler(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_handler(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     _set_successful_forwarding_manager()
@@ -135,7 +139,7 @@ def test_fastapi_proxy_handler(fastapi_app: Any, test_client_cls: type[Any]) -> 
         mock_post.assert_not_called()
 
 
-def test_fastapi_proxy_size_limit(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_size_limit(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
@@ -151,7 +155,7 @@ def test_fastapi_proxy_size_limit(fastapi_app: Any, test_client_cls: type[Any]) 
     assert response.content == b'Payload too large'
 
 
-def test_fastapi_proxy_invalid_content_length(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_invalid_content_length(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST'])
@@ -163,7 +167,7 @@ def test_fastapi_proxy_invalid_content_length(fastapi_app: Any, test_client_cls:
     assert response.content == b'Invalid Content-Length header'
 
 
-def test_fastapi_proxy_body_limit_late_check(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_body_limit_late_check(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
 
@@ -571,7 +575,7 @@ def test_forward_export_request_partial_success_protobuf(
     assert getattr(message.partial_success, rejected_attr) == 0  # type: ignore[attr-defined]
 
 
-def test_fastapi_proxy_invalid_method(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_invalid_method(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy/{path:path}', logfire.forward_export_request_starlette, methods=['POST', 'GET'])
@@ -582,7 +586,7 @@ def test_fastapi_proxy_invalid_method(fastapi_app: Any, test_client_cls: type[An
     assert response.content == b'Method Not Allowed'
 
 
-def test_fastapi_proxy_missing_path(fastapi_app: Any, test_client_cls: type[Any]) -> None:
+def test_fastapi_proxy_missing_path(fastapi_app: FastAPI, test_client_cls: type[TestClient]) -> None:
     app = fastapi_app
     logfire.configure(token='test_token', send_to_logfire=False)
     app.add_route('/logfire-proxy-missing', logfire.forward_export_request_starlette, methods=['POST'])

--- a/tests/test_experimental_forwarding.py
+++ b/tests/test_experimental_forwarding.py
@@ -615,7 +615,7 @@ def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
 
     class MockResponse:
         def __init__(self, content: Any, status_code: int, headers: dict[str, str] | None = None) -> None:
-            self.content = content
+            self.body = content
             self.status_code = status_code
             self.headers = headers or {}
 
@@ -646,7 +646,7 @@ def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
             response = asyncio.run(logfire_proxy(request, max_body_size=10))
 
             assert response.status_code == 200
-            assert response.content == b'{"ok": true}'
+            assert response.body == b'{"ok": true}'
             assert mock_fwd.call_args.kwargs == {
                 'path': 'v1/traces',
                 'headers': {},
@@ -661,7 +661,7 @@ def test_fastapi_proxy_instrumentation_coverage_mock() -> None:
             response2 = asyncio.run(logfire_proxy(request, max_body_size=10))
 
             assert response2.status_code == 200
-            assert response2.content == b'{"ok": true}'
+            assert response2.body == b'{"ok": true}'
             assert mock_fwd.call_args.kwargs == {
                 'path': 'v1/traces',
                 'headers': {'content-length': '10'},

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 import sys
 import warnings
@@ -323,6 +324,15 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     assert hasattr(logfire_api, 'url_from_eval')
     logfire_api.url_from_eval(MagicMock(trace_id='abc', span_id='def'))
     logfire__all__.remove('url_from_eval')
+
+    assert hasattr(logfire_api, 'forward_export_request')
+    logfire_api.forward_export_request(path='/invalid', headers={}, body=b'')
+    logfire__all__.remove('forward_export_request')
+
+    assert hasattr(logfire_api, 'forward_export_request_starlette')
+    request = MagicMock(method='GET', headers={})
+    asyncio.run(logfire_api.forward_export_request_starlette(request))
+    logfire__all__.remove('forward_export_request_starlette')
 
     # If it's not empty, it means that some of the __all__ members are not tested.
     assert logfire__all__ == set(), logfire__all__


### PR DESCRIPTION
This exposes the functions previously only under `logfire.experimental.forwarding`