### PR TITLE
docs: Add /mcp authentication step for Claude Code MCP setup

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -58,11 +58,16 @@ For more detailed information, you can check the
 
 ### Claude Code
 
-Run the following command:
+Run the following command to add the Logfire MCP server:
 
 ```bash
 claude mcp add logfire --transport http https://logfire-us.pydantic.dev/mcp
 ```
+
+Then use the `/mcp` slash command within Claude Code to authenticate with your Logfire account.
+This will open a browser window where you can complete the login process.
+
+For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#authenticate-with-remote-mcp-servers).
 
 ### Claude Desktop
 


### PR DESCRIPTION
## Summary

- Adds instructions to use the `/mcp` slash command within Claude Code to complete authentication after adding the MCP server
- Links to the official Claude Code MCP documentation for more details

The existing instructions only showed how to add the MCP server but didn't explain how to complete the authentication flow, which caused confusion for users.

## Test plan

- [ ] Verify the documentation renders correctly
- [ ] Confirm the link to the Claude Code docs is working

Slack thread: https://pydantic.slack.com/archives/C05AF4A4WRM/p1779870871255599?thread_ts=1779861796.772129&cid=C05AF4A4WRM

https://claude.ai/code/session_01SRwSYgvKcuRyrR7qAddkP5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRwSYgvKcuRyrR7qAddkP5)_