### PR TITLE
Fix Logfire docs chevron separator

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ logfire auth
 
     1. Generate a new write token in the **Logfire** platform
 
-        - Go to Project :material-chevron-right: Settings :material-chevron-right: Write Tokens
+        - Go to Project > Settings > Write Tokens
         - Follow the prompts to create a new token
 
 


### PR DESCRIPTION
## Summary
- Replace the Material chevron icon shortcode in the Logfire get-started production path with a plain text separator.
- Avoid the generated inline SVG baseline issue on the unified docs page.

## Testing
- `uv run pytest tests/test_docs.py::test_formatting -q`
