### PR TITLE
Improve error message suggesting logfire auth

### DIFF
--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -167,7 +167,7 @@ class UserTokenCollection:
 
 Hey, looks like you don't have Pydantic Logfire configured yet.
 
-If you're running this locally, we recommend running `logfire auth`.
+If you're running this locally, we recommend running `uv run logfire auth`.
 
 Or you could get a write token for a specific project and set the `LOGFIRE_TOKEN` environment variable.
 

--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -163,7 +163,15 @@ class UserTokenCollection:
             )
             token = tokens_list[int_choice - 1]
         else:  # tokens_list == []
-            raise LogfireConfigError('You are not logged into Logfire. Please run `logfire auth` to authenticate.')
+            raise LogfireConfigError("""
+
+Hey, looks like you don't have Pydantic Logfire configured yet.
+
+If you're running this locally, we recommend running `logfire auth`.
+
+Or you could get a write token for a specific project and set the `LOGFIRE_TOKEN` environment variable.
+
+See https://pydantic.dev/docs/logfire/get-started for more details.""")
 
         if token.is_expired:
             raise LogfireConfigError(f'User token {token} is expired. Please run `logfire auth` to authenticate.')

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -626,28 +626,31 @@ def configure(
         config = LogfireConfig()
     else:
         config = GLOBAL_CONFIG
-    config.configure(
-        send_to_logfire=send_to_logfire,
-        token=token,
-        api_key=api_key,
-        service_name=service_name,
-        service_version=service_version,
-        environment=environment,
-        console=console,
-        metrics=metrics,
-        config_dir=Path(config_dir) if config_dir else None,
-        data_dir=Path(data_dir) if data_dir else None,
-        additional_span_processors=additional_span_processors,
-        scrubbing=scrubbing,
-        inspect_arguments=inspect_arguments,
-        min_level=min_level,
-        sampling=sampling,
-        add_baggage_to_attributes=add_baggage_to_attributes,
-        code_source=code_source,
-        variables=variables,
-        distributed_tracing=distributed_tracing,
-        advanced=advanced,
-    )
+    try:
+        config.configure(
+            send_to_logfire=send_to_logfire,
+            token=token,
+            api_key=api_key,
+            service_name=service_name,
+            service_version=service_version,
+            environment=environment,
+            console=console,
+            metrics=metrics,
+            config_dir=Path(config_dir) if config_dir else None,
+            data_dir=Path(data_dir) if data_dir else None,
+            additional_span_processors=additional_span_processors,
+            scrubbing=scrubbing,
+            inspect_arguments=inspect_arguments,
+            min_level=min_level,
+            sampling=sampling,
+            add_baggage_to_attributes=add_baggage_to_attributes,
+            code_source=code_source,
+            variables=variables,
+            distributed_tracing=distributed_tracing,
+            advanced=advanced,
+        )
+    except LogfireConfigError as e:
+        raise e.with_traceback(None)
 
     if local:
         logfire_instance = Logfire(config=config)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,7 +89,18 @@ def test_get_user_token_empty_credentials(tmp_path: Path) -> None:
 
     token_collection = UserTokenCollection(empty_auth_file)
     with inline_snapshot.extra.raises(
-        snapshot('LogfireConfigError: You are not logged into Logfire. Please run `logfire auth` to authenticate.')
+        snapshot("""\
+LogfireConfigError:
+
+
+Hey, looks like you don't have Pydantic Logfire configured yet.
+
+If you're running this locally, we recommend running `uv run logfire auth`.
+
+Or you could get a write token for a specific project and set the `LOGFIRE_TOKEN` environment variable.
+
+See https://pydantic.dev/docs/logfire/get-started for more details.\
+""")
     ):
         token_collection.get_token()
 


### PR DESCRIPTION
```
$ python -c 'import logfire; logfire.configure()'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/alex/work/logfire/logfire/_internal/config.py", line 653, in configure
    raise e.with_traceback(None)
logfire.exceptions.LogfireConfigError: 

Hey, looks like you don't have Pydantic Logfire configured yet.

If you're running this locally, we recommend running `uv run logfire auth`.

Or you could get a write token for a specific project and set the `LOGFIRE_TOKEN` environment variable.

See https://pydantic.dev/docs/logfire/get-started for more details.
```

https://pydantic.slack.com/archives/C0813FX362E/p1780304417089289