### PR TITLE
Include project URL in configuration span message

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -860,7 +860,7 @@ class _LogfireConfigData:
 
         self.additional_span_processors = additional_span_processors
         self._project_url: str | None = None
-        self._instant_project_url: str | None = None
+        self._configuration_span_project_url: str | None = None
 
         if metrics is None:
             metrics = MetricsOptions()
@@ -1156,7 +1156,7 @@ class LogfireConfig(_LogfireConfigData):
                     # printing separately. Otherwise, print it now.
                     if credentials and show_project_link and credentials.token in token_list:
                         if self.advanced.emit_configuration_span:
-                            self._instant_project_url = credentials.project_url
+                            self._configuration_span_project_url = credentials.project_url
                         else:
                             credentials.print_token_summary()
                         printed_tokens.add(credentials.token)
@@ -1562,6 +1562,11 @@ class LogfireConfig(_LogfireConfigData):
                 category=LogfireNotConfiguredWarning,
             )
 
+    @property
+    def configuration_span_project_url(self) -> str | None:
+        """Project URL to include in the configuration span message, if available."""
+        return self._configuration_span_project_url
+
     def _initialize_credentials_from_token(self, token: str) -> LogfireCredentials | None:
         session = requests.Session()
         install_logfire_response_hook(session, self.advanced.server_response_hook)
@@ -1643,9 +1648,9 @@ def emit_configuration_span(config: LogfireConfig, logfire_instance: Logfire, *,
     else:  # pragma: no cover
         token_count = len(config.token)
 
-    # Build message with optional project URL
-    if config._instant_project_url:
-        message = f'Logfire configured | {config._instant_project_url}'
+    project_url = config.configuration_span_project_url
+    if project_url:
+        message = f'Logfire configured | {project_url}'
     else:
         message = 'Logfire configured'
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -5,6 +5,7 @@ import dataclasses
 import functools
 import json
 import os
+import platform
 import re
 import sys
 import time
@@ -860,6 +861,7 @@ class _LogfireConfigData:
 
         self.additional_span_processors = additional_span_processors
         self._project_url: str | None = None
+        self._instant_project_url: str | None = None
 
         if metrics is None:
             metrics = MetricsOptions()
@@ -1151,8 +1153,13 @@ class LogfireConfig(_LogfireConfigData):
                     # The creds file contains the project link, so we can display it immediately.
                     # We do this if the token comes from the creds file or if it was explicitly configured
                     # and happens to match the creds file anyway.
+                    # If emit_configuration_span is enabled, include the URL in the span instead of
+                    # printing separately. Otherwise, print it now.
                     if credentials and show_project_link and credentials.token in token_list:
-                        credentials.print_token_summary()
+                        if self.advanced.emit_configuration_span:
+                            self._instant_project_url = credentials.project_url
+                        else:
+                            credentials.print_token_summary()
                         printed_tokens.add(credentials.token)
 
                     # Regardless of where the token comes from, check that it's valid.
@@ -1637,8 +1644,16 @@ def emit_configuration_span(config: LogfireConfig, logfire_instance: Logfire, *,
     else:  # pragma: no cover
         token_count = len(config.token)
 
+    # Build message with system info and optional project URL
+    python_version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
+    os_name = platform.system()
+    msg_parts = [f'Logfire configured | Python {python_version} | {os_name}']
+    if config._instant_project_url:
+        msg_parts.append(config._instant_project_url)
+    message = ' | '.join(msg_parts)
+
     logfire_instance.info(
-        'Logfire configured',
+        message,
         **{  # type: ignore
             ATTRIBUTES_CONFIG: {
                 'local': local,

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -860,7 +860,6 @@ class _LogfireConfigData:
 
         self.additional_span_processors = additional_span_processors
         self._project_url: str | None = None
-        self._configuration_span_project_url: str | None = None
 
         if metrics is None:
             metrics = MetricsOptions()
@@ -1148,6 +1147,9 @@ class LogfireConfig(_LogfireConfigData):
 
                     # Track tokens we've already printed info for (to avoid duplicates)
                     printed_tokens: set[str] = set()
+                    project_url_emitted_in_configuration_span = bool(
+                        self.advanced.emit_configuration_span and self._project_url
+                    )
 
                     # The creds file contains the project link, so we can display it immediately.
                     # We do this if the token comes from the creds file or if it was explicitly configured
@@ -1155,9 +1157,7 @@ class LogfireConfig(_LogfireConfigData):
                     # If emit_configuration_span is enabled, include the URL in the span instead of
                     # printing separately. Otherwise, print it now.
                     if credentials and show_project_link and credentials.token in token_list:
-                        if self.advanced.emit_configuration_span:
-                            self._configuration_span_project_url = credentials.project_url
-                        else:
+                        if not self.advanced.emit_configuration_span:
                             credentials.print_token_summary()
                         printed_tokens.add(credentials.token)
 
@@ -1174,7 +1174,11 @@ class LogfireConfig(_LogfireConfigData):
                                 if validated_credentials is not None:
                                     self._project_url = self._project_url or validated_credentials.project_url
                                     if show_project_link and token not in printed_tokens:
-                                        validated_credentials.print_token_summary()
+                                        if not (
+                                            project_url_emitted_in_configuration_span
+                                            and validated_credentials.project_url == self._project_url
+                                        ):
+                                            validated_credentials.print_token_summary()
 
                     if emscripten:  # pragma: no cover
                         check_tokens()
@@ -1563,9 +1567,9 @@ class LogfireConfig(_LogfireConfigData):
             )
 
     @property
-    def configuration_span_project_url(self) -> str | None:
-        """Project URL to include in the configuration span message, if available."""
-        return self._configuration_span_project_url
+    def project_url(self) -> str | None:
+        """Best known Logfire project URL for this configuration."""
+        return self._project_url
 
     def _initialize_credentials_from_token(self, token: str) -> LogfireCredentials | None:
         session = requests.Session()
@@ -1648,7 +1652,7 @@ def emit_configuration_span(config: LogfireConfig, logfire_instance: Logfire, *,
     else:  # pragma: no cover
         token_count = len(config.token)
 
-    project_url = config.configuration_span_project_url
+    project_url = config.project_url
     if project_url:
         message = f'Logfire configured | {project_url}'
     else:

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -5,7 +5,6 @@ import dataclasses
 import functools
 import json
 import os
-import platform
 import re
 import sys
 import time
@@ -1644,13 +1643,11 @@ def emit_configuration_span(config: LogfireConfig, logfire_instance: Logfire, *,
     else:  # pragma: no cover
         token_count = len(config.token)
 
-    # Build message with system info and optional project URL
-    python_version = f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}'
-    os_name = platform.system()
-    msg_parts = [f'Logfire configured | Python {python_version} | {os_name}']
+    # Build message with optional project URL
     if config._instant_project_url:
-        msg_parts.append(config._instant_project_url)
-    message = ' | '.join(msg_parts)
+        message = f'Logfire configured | {config._instant_project_url}'
+    else:
+        message = 'Logfire configured'
 
     logfire_instance.info(
         message,

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -920,7 +920,7 @@ class Logfire:
         Returns:
             The URL string, or `None` if the project URL or trace/span IDs are not available.
         """
-        project_url = self._config._project_url  # type: ignore[reportPrivateUsage]
+        project_url = self._config.project_url
         trace_id = report.trace_id
         span_id = report.span_id
         if not project_url or not trace_id or not span_id:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1788,12 +1788,16 @@ def test_configuration_span_includes_project_url(
             'https://logfire.test/v1/info',
             json={'project_name': 'myproject', 'project_url': 'https://logfire.test/myproject'},
         )
-        configure(
+        request_mocker.post('https://logfire.test/v1/traces', content=b'', status_code=200)
+        logfire_instance = configure(
             send_to_logfire='if-token-present',
             data_dir=tmp_path,
-            console=False,
+            console=logfire.ConsoleOptions(output=StringIO()),
+            metrics=False,
+            additional_span_processors=[SimpleSpanProcessor(exporter)],
             advanced=logfire.AdvancedOptions(emit_configuration_span=True),
         )
+        assert logfire_instance.force_flush()
         wait_for_check_token_thread()
 
     # The URL should NOT be printed separately to stderr

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1797,7 +1797,7 @@ def test_configuration_span_includes_project_url(
             additional_span_processors=[SimpleSpanProcessor(exporter)],
             advanced=logfire.AdvancedOptions(emit_configuration_span=True),
         )
-        assert logfire_instance.force_flush()
+        logfire_instance.force_flush()
         wait_for_check_token_thread()
 
     # The URL should NOT be printed separately to stderr
@@ -1806,6 +1806,8 @@ def test_configuration_span_includes_project_url(
     # Instead, it should be included in the configuration span message
     spans = exporter.exported_spans_as_dict()
     assert len(spans) == 1
+    assert spans[0]['name'] == 'Logfire configured | https://logfire.test/myproject'
+    assert spans[0]['attributes']['logfire.msg_template'] == 'Logfire configured | https://logfire.test/myproject'
     msg = spans[0]['attributes']['logfire.msg']
     assert msg == 'Logfire configured | https://logfire.test/myproject'
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1767,8 +1767,9 @@ def test_configuration_span_enabled_via_env_var(monkeypatch: pytest.MonkeyPatch)
     assert GLOBAL_CONFIG.advanced.emit_configuration_span is True
 
 
+@pytest.mark.parametrize('token', [None, 'explicit-token'])
 def test_configuration_span_includes_project_url(
-    tmp_path: Path, exporter: TestExporter, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, exporter: TestExporter, capsys: pytest.CaptureFixture[str], token: str | None
 ) -> None:
     """When emit_configuration_span is True and the project URL is known from credentials,
     the URL should be included in the span message instead of printed separately."""
@@ -1791,7 +1792,7 @@ def test_configuration_span_includes_project_url(
         request_mocker.post('https://logfire.test/v1/traces', content=b'', status_code=200)
         logfire_instance = configure(
             send_to_logfire='if-token-present',
-            token='explicit-token',
+            token=token,
             data_dir=tmp_path,
             console=logfire.ConsoleOptions(output=StringIO()),
             metrics=False,

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1711,10 +1711,12 @@ def test_configuration_span_emitted_when_opted_in(config_kwargs: dict[str, Any],
     config_kwargs['advanced'].emit_configuration_span = True
     configure(**config_kwargs)
 
+    # Message format: "Logfire configured | Python X.Y.Z | OS"
+    config_msg_pattern = r'Logfire configured \| Python \d+\.\d+\.\d+ \| \w+'
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
-                'name': 'Logfire configured',
+                'name': IsStr(regex=config_msg_pattern),
                 'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
                 'parent': None,
                 'start_time': 1000000000,
@@ -1722,8 +1724,8 @@ def test_configuration_span_emitted_when_opted_in(config_kwargs: dict[str, Any],
                 'attributes': {
                     'logfire.span_type': 'log',
                     'logfire.level_num': 9,
-                    'logfire.msg_template': 'Logfire configured',
-                    'logfire.msg': 'Logfire configured',
+                    'logfire.msg_template': IsStr(regex=config_msg_pattern),
+                    'logfire.msg': IsStr(regex=config_msg_pattern),
                     'code.filepath': 'test_configure.py',
                     'code.function': 'test_configuration_span_emitted_when_opted_in',
                     'code.lineno': 123,
@@ -1765,6 +1767,47 @@ def test_configuration_span_enabled_via_env_var(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setenv('LOGFIRE_EMIT_CONFIGURATION_SPAN', '1')
     configure(send_to_logfire=False, console=False, inspect_arguments=False)
     assert GLOBAL_CONFIG.advanced.emit_configuration_span is True
+
+
+def test_configuration_span_includes_project_url(
+    tmp_path: Path, exporter: TestExporter, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When emit_configuration_span is True and credentials are available from file,
+    the project URL should be included in the span message instead of printed separately."""
+    creds_file = tmp_path / 'logfire_credentials.json'
+    creds_file.write_text(
+        """
+        {
+            "token": "foobar",
+            "project_name": "myproject",
+            "project_url": "https://logfire.test/myproject",
+            "logfire_api_url": "https://logfire.test"
+        }
+        """
+    )
+    with requests_mock.Mocker() as request_mocker:
+        request_mocker.get(
+            'https://logfire.test/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'https://logfire.test/myproject'},
+        )
+        configure(
+            send_to_logfire='if-token-present',
+            data_dir=tmp_path,
+            console=False,
+            advanced=logfire.AdvancedOptions(emit_configuration_span=True),
+        )
+        wait_for_check_token_thread()
+
+    # The URL should NOT be printed separately to stderr
+    assert capsys.readouterr().err == ''
+
+    # Instead, it should be included in the configuration span message
+    spans = exporter.exported_spans_as_dict()
+    assert len(spans) == 1
+    msg = spans[0]['attributes']['logfire.msg']
+    assert 'Logfire configured' in msg
+    assert 'Python' in msg
+    assert 'https://logfire.test/myproject' in msg
 
 
 def test_exit_open_spans_exports_suspended_generator_span_before_shutdown() -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1711,12 +1711,10 @@ def test_configuration_span_emitted_when_opted_in(config_kwargs: dict[str, Any],
     config_kwargs['advanced'].emit_configuration_span = True
     configure(**config_kwargs)
 
-    # Message format: "Logfire configured | Python X.Y.Z | OS"
-    config_msg_pattern = r'Logfire configured \| Python \d+\.\d+\.\d+ \| \w+'
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
-                'name': IsStr(regex=config_msg_pattern),
+                'name': 'Logfire configured',
                 'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
                 'parent': None,
                 'start_time': 1000000000,
@@ -1724,8 +1722,8 @@ def test_configuration_span_emitted_when_opted_in(config_kwargs: dict[str, Any],
                 'attributes': {
                     'logfire.span_type': 'log',
                     'logfire.level_num': 9,
-                    'logfire.msg_template': IsStr(regex=config_msg_pattern),
-                    'logfire.msg': IsStr(regex=config_msg_pattern),
+                    'logfire.msg_template': 'Logfire configured',
+                    'logfire.msg': 'Logfire configured',
                     'code.filepath': 'test_configure.py',
                     'code.function': 'test_configuration_span_emitted_when_opted_in',
                     'code.lineno': 123,
@@ -1805,9 +1803,7 @@ def test_configuration_span_includes_project_url(
     spans = exporter.exported_spans_as_dict()
     assert len(spans) == 1
     msg = spans[0]['attributes']['logfire.msg']
-    assert 'Logfire configured' in msg
-    assert 'Python' in msg
-    assert 'https://logfire.test/myproject' in msg
+    assert msg == 'Logfire configured | https://logfire.test/myproject'
 
 
 def test_exit_open_spans_exports_suspended_generator_span_before_shutdown() -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1770,8 +1770,8 @@ def test_configuration_span_enabled_via_env_var(monkeypatch: pytest.MonkeyPatch)
 def test_configuration_span_includes_project_url(
     tmp_path: Path, exporter: TestExporter, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """When emit_configuration_span is True and credentials are available from file,
-    the project URL should be included in the span message instead of printed separately."""
+    """When emit_configuration_span is True and the project URL is known from credentials,
+    the URL should be included in the span message instead of printed separately."""
     creds_file = tmp_path / 'logfire_credentials.json'
     creds_file.write_text(
         """
@@ -1791,6 +1791,7 @@ def test_configuration_span_includes_project_url(
         request_mocker.post('https://logfire.test/v1/traces', content=b'', status_code=200)
         logfire_instance = configure(
             send_to_logfire='if-token-present',
+            token='explicit-token',
             data_dir=tmp_path,
             console=logfire.ConsoleOptions(output=StringIO()),
             metrics=False,


### PR DESCRIPTION
When `emit_configuration_span` is enabled and Logfire already knows the project URL during configuration, include that URL in the `Logfire configured` span message instead of printing a separate project URL line.

This uses the existing `_project_url` state as the source of truth, so credentials-file URLs are available eagerly even when a token is supplied by another source. If async token validation later confirms the same URL, Logfire now avoids printing a duplicate `Logfire project URL` line.

Validation covered in this PR:

- configuration span URL message with credentials-file token
- configuration span URL message with an explicit token override
- no real OTLP export leakage from the regression test
- pyright-safe project URL access via a typed `project_url` property

https://claude.ai/code/session_01BaJtdKyNpFQhjPmBLofWty
