### PR TITLE
Add test to assert DEFAULT_PATTERNS with docs update reminder

### DIFF
--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -51,6 +51,8 @@ Here are the default scrubbing patterns:
     'cookie',
     'social[._ -]?security',
     'credit[._ -]?card',
+    'logfire[._ -]?token',
+    'pylf_v\\d+_',
     '(?:\\b|_)csrf(?:\\b|_)',
     '(?:\\b|_)xsrf(?:\\b|_)',
     '(?:\\b|_)jwt(?:\\b|_)',

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -556,6 +556,31 @@ def test_word_boundaries(exporter: TestExporter):
     )
 
 
+def test_default_patterns():
+    from logfire._internal.scrubbing import DEFAULT_PATTERNS
+
+    assert DEFAULT_PATTERNS == [
+        'password',
+        'passwd',
+        'mysql_pwd',
+        'secret',
+        r'auth(?!ors?\b)',
+        'credential',
+        'private[._ -]?key',
+        'api[._ -]?key',
+        'session',
+        'cookie',
+        'social[._ -]?security',
+        'credit[._ -]?card',
+        'logfire[._ -]?token',
+        r'pylf_v\d+_',
+        r'(?:\b|_)csrf(?:\b|_)',
+        r'(?:\b|_)xsrf(?:\b|_)',
+        r'(?:\b|_)jwt(?:\b|_)',
+        r'(?:\b|_)ssn(?:\b|_)',
+    ], 'Docs need to be updated if this test fails: docs/how-to-guides/scrubbing.md'
+
+
 def test_logfire_token_prefix_scrubbing(exporter: TestExporter):
     logfire.info(
         'hi',

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import os
 import re
 from pathlib import Path
@@ -562,25 +561,31 @@ def test_word_boundaries(exporter: TestExporter):
 def test_default_patterns_match_docs():
     """The default scrubbing patterns are documented, so the docs must be kept in sync with the code.
 
-    This parses the list out of the docs and compares it to `DEFAULT_PATTERNS` directly,
-    so it fails (rather than silently drifting) whenever the two get out of sync.
+    The docs list is generated from `DEFAULT_PATTERNS`. If it has drifted, this test rewrites
+    the docs to match (so a local re-run passes) and then fails, like inline-snapshot's fix mode.
     """
     from logfire._internal.scrubbing import DEFAULT_PATTERNS
 
     docs = Path(__file__).parent.parent / 'docs' / 'how-to-guides' / 'scrubbing.md'
-    # Extract the ```python [...] ``` block that follows the "default scrubbing patterns" sentence.
+    content = docs.read_text()
+
+    # `repr` of each pattern reproduces exactly how it's written in the docs code block.
+    expected_block = '[\n' + ''.join(f'    {pattern!r},\n' for pattern in DEFAULT_PATTERNS) + ']'
+
+    # Match the ```python [...] ``` block that follows the "default scrubbing patterns" sentence.
     match = re.search(
-        r'Here are the default scrubbing patterns:\n+```python\n(\[.*?\])\n```',
-        docs.read_text(),
+        r'(Here are the default scrubbing patterns:\n+```python\n)(\[.*?\])(\n```)',
+        content,
         re.DOTALL,
     )
     assert match, 'Could not find the default scrubbing patterns code block in the docs'
-    documented_patterns = ast.literal_eval(match.group(1))
 
-    assert documented_patterns == DEFAULT_PATTERNS, (
-        f'The scrubbing patterns documented in {docs} are out of sync with '
-        '`DEFAULT_PATTERNS` in logfire/_internal/scrubbing.py. Update the docs.'
-    )
+    if match.group(2) != expected_block:
+        docs.write_text(content[: match.start(2)] + expected_block + content[match.end(2) :])
+        pytest.fail(
+            f'The scrubbing patterns documented in {docs} were out of sync with `DEFAULT_PATTERNS` '
+            'in logfire/_internal/scrubbing.py. The docs have been updated to match; re-run to confirm.'
+        )
 
 
 def test_logfire_token_prefix_scrubbing(exporter: TestExporter):

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import ast
 import os
+import re
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -556,29 +559,28 @@ def test_word_boundaries(exporter: TestExporter):
     )
 
 
-def test_default_patterns():
+def test_default_patterns_match_docs():
+    """The default scrubbing patterns are documented, so the docs must be kept in sync with the code.
+
+    This parses the list out of the docs and compares it to `DEFAULT_PATTERNS` directly,
+    so it fails (rather than silently drifting) whenever the two get out of sync.
+    """
     from logfire._internal.scrubbing import DEFAULT_PATTERNS
 
-    assert DEFAULT_PATTERNS == [
-        'password',
-        'passwd',
-        'mysql_pwd',
-        'secret',
-        r'auth(?!ors?\b)',
-        'credential',
-        'private[._ -]?key',
-        'api[._ -]?key',
-        'session',
-        'cookie',
-        'social[._ -]?security',
-        'credit[._ -]?card',
-        'logfire[._ -]?token',
-        r'pylf_v\d+_',
-        r'(?:\b|_)csrf(?:\b|_)',
-        r'(?:\b|_)xsrf(?:\b|_)',
-        r'(?:\b|_)jwt(?:\b|_)',
-        r'(?:\b|_)ssn(?:\b|_)',
-    ], 'Docs need to be updated if this test fails: docs/how-to-guides/scrubbing.md'
+    docs = Path(__file__).parent.parent / 'docs' / 'how-to-guides' / 'scrubbing.md'
+    # Extract the ```python [...] ``` block that follows the "default scrubbing patterns" sentence.
+    match = re.search(
+        r'Here are the default scrubbing patterns:\n+```python\n(\[.*?\])\n```',
+        docs.read_text(),
+        re.DOTALL,
+    )
+    assert match, 'Could not find the default scrubbing patterns code block in the docs'
+    documented_patterns = ast.literal_eval(match.group(1))
+
+    assert documented_patterns == DEFAULT_PATTERNS, (
+        f'The scrubbing patterns documented in {docs} are out of sync with '
+        '`DEFAULT_PATTERNS` in logfire/_internal/scrubbing.py. Update the docs.'
+    )
 
 
 def test_logfire_token_prefix_scrubbing(exporter: TestExporter):


### PR DESCRIPTION
Similar to test_basic_base and test_full_base for system metrics, this test will fail if DEFAULT_PATTERNS changes, reminding developers to update docs/how-to-guides/scrubbing.md.

https://claude.ai/code/session_01AmFFk16jwbQRqGz9AVBq5Y