### PR TITLE
Document prompt management parity workflows

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -238,7 +238,10 @@
     "items": [
       { "label": "Overview", "slug": "reference/advanced/prompt-management/index" },
       { "label": "Core Concepts", "slug": "reference/advanced/prompt-management/concepts" },
+      { "label": "UI Guide", "slug": "reference/advanced/prompt-management/ui" },
       { "label": "Writing Templates", "slug": "reference/advanced/prompt-management/templates" },
+      { "label": "Prompt Composition Walkthrough", "slug": "reference/advanced/prompt-management/composition-walkthrough" },
+      { "label": "Promote and Roll Out Prompts", "slug": "reference/advanced/prompt-management/promotion-and-rollouts" },
       { "label": "Test Prompts", "slug": "reference/advanced/prompt-management/scenarios" },
       { "label": "Use Prompts in Your Application", "slug": "reference/advanced/prompt-management/application" },
       { "label": "Template Reference", "slug": "reference/advanced/prompt-management/template-reference" },

--- a/docs/reference/advanced/prompt-management/application.md
+++ b/docs/reference/advanced/prompt-management/application.md
@@ -10,7 +10,8 @@ Once a prompt looks good in the editor, the production workflow is:
 1. Save a version on the Prompts page.
 2. Promote the version by moving a label such as `production`.
 3. Fetch that labeled prompt from your application.
-4. Render the template with runtime variables before sending it to your model.
+4. Render the template with runtime variables before sending it to your model,
+   preferably with `logfire.template_var()`.
 
 ## Promote a version
 
@@ -21,59 +22,103 @@ Saving a version and promoting a version are separate steps.
 
 This lets you iterate on drafts without changing what production imports.
 
-## Fetch the prompt from the SDK
+## Fetch and render the prompt from the SDK
 
-Today, application code fetches prompts with `logfire.var(...)`.
+Each prompt is exposed to application code through its backing managed variable:
 
-```python skip="true"
-import logfire
-
-prompt_var = logfire.var(name='prompt__welcome_email', default='')
-with prompt_var.get(label='production') as resolved:
-    template = resolved.value
+```text
+prompt__<slug_with_underscores>
 ```
 
-The `name` currently follows the pattern `prompt__<slug_with_underscores>`.
+If your prompt slug is `welcome-email`, the SDK name is
+`prompt__welcome_email`.
 
-If your prompt slug is `welcome-email`, the SDK name is `prompt__welcome_email`.
+Install the variables extra in applications that fetch prompt variables:
 
-## Render the template in your application
-
-The SDK returns the template string. Your application renders it with runtime variables before passing the result to your model client.
-
-If you keep your templates to flat variables such as `{{customer_name}}`, simple substitution is often enough.
-
-If you want to use dotted paths or Handlebars block helpers, use a renderer that supports the same Handlebars features documented in [Template Reference](./template-reference.md).
-
-## Example
-
-```python skip="true"
-import logfire
-
-customer_name = 'Taylor'
-prompt_var = logfire.var(name='prompt__welcome_email', default='')
-with prompt_var.get(label='production') as resolved:
-    rendered_prompt = resolved.value.replace('{{customer_name}}', customer_name)
+```bash
+pip install 'logfire[variables]'
 ```
 
-Here is a slightly more complete example:
+For prompts with runtime `{{...}}` inputs, prefer `logfire.template_var(...)`.
+It resolves the prompt variable, expands `@{...}@` composition references,
+renders the remaining Handlebars template with your typed inputs, and returns
+the final prompt text.
 
 ```python skip="true"
+from pydantic import BaseModel
+
 import logfire
 
-customer_name = 'Taylor'
+logfire.configure()
 
 
-def render_prompt(template: str, variables: dict[str, str]) -> str:
-    rendered = template
-    for key, value in variables.items():
-        rendered = rendered.replace(f'{{{{{key}}}}}', value)
-    return rendered
+class WelcomeEmailInputs(BaseModel):
+    customer_name: str
+    topic: str
 
 
-prompt_var = logfire.var(name='prompt__welcome_email', default='')
-with prompt_var.get(label='production') as resolved:
-    prompt = render_prompt(resolved.value, {'customer_name': customer_name})
+prompt_var = logfire.template_var(
+    name='prompt__welcome_email',
+    type=str,
+    default='',
+    inputs_type=WelcomeEmailInputs,
+)
+
+with prompt_var.get(
+    WelcomeEmailInputs(customer_name='Taylor', topic='your recent order'),
+    label='production',
+) as resolved:
+    prompt = resolved.value
 
 # Pass `prompt` to your model client here.
 ```
+
+If your prompt composes shared fragments, keep those fragments as managed variables
+and reference them from the prompt with `@{variable_name}@`. The SDK resolves
+those references during `.get()`. See the
+[Prompt composition walkthrough](./composition-walkthrough.md) for the full
+workflow.
+
+## Manual rendering
+
+If you need to control rendering yourself, fetch the prompt with
+`logfire.var(...)`. In that mode, `.get()` still expands `@{...}@` composition
+references, but your application renders the remaining `{{...}}` placeholders.
+
+```python skip="true"
+import logfire
+from pydantic_handlebars import render
+
+logfire.configure()
+
+prompt_var = logfire.var(name='prompt__welcome_email', type=str, default='')
+
+with prompt_var.get(label='production', targeting_key='customer-123') as resolved:
+    template = resolved.value
+
+prompt = render(
+    template,
+    {
+        'customer': {
+            'name': 'Taylor',
+            'tier': 'enterprise',
+        },
+        'topic': 'your recent order',
+        'is_urgent': False,
+    },
+)
+
+# Pass `prompt` to your model client here.
+```
+
+When rendering manually, keep simple templates to flat variables such as
+`{{customer_name}}`. For dotted paths, conditionals, loops, or composed
+fragments, use a renderer that supports the same Handlebars features documented
+in [Template Reference](./template-reference.md).
+
+## Labels and rollouts
+
+When you want rollout percentages or targeting rules to select the prompt
+version, omit `label` and pass a stable `targeting_key` instead. Use
+`label='production'` only when you want to bypass rollout and request that label
+explicitly.

--- a/docs/reference/advanced/prompt-management/composition-walkthrough.md
+++ b/docs/reference/advanced/prompt-management/composition-walkthrough.md
@@ -1,0 +1,217 @@
+---
+title: "Prompt Composition Walkthrough"
+description: "Build a Prompt Management prompt from reusable managed-variable and prompt fragments."
+---
+
+# Prompt composition walkthrough
+
+Prompt composition lets one prompt reuse text or structured values from managed
+variables and other prompts. Use `@{variable_name}@` references for shared
+fragments, and keep `{{runtime_input}}` placeholders for the values supplied by a
+scenario or by your application at request time.
+
+This walkthrough builds a support-agent prompt from:
+
+- `support_brand_profile`: a JSON managed variable with product and escalation
+  facts.
+- `support_safety_rules`: a text managed variable with reusable safety guidance.
+- `support_agent`: the prompt that composes those fragments and renders
+  per-request values such as `{{customer_name}}`.
+
+## 1. Create reusable fragments
+
+Open **Managed Variables** and create a JSON variable named
+`support_brand_profile`. Save a version with this value:
+
+```json
+{
+  "company": "Acme Support",
+  "product": "OrderDesk",
+  "escalation_email": "tier2@example.com"
+}
+```
+
+Create a second managed variable named `support_safety_rules` with type **Text**.
+Save a version with this value:
+
+```text
+Never reveal private account data. Acknowledge uncertainty. Ask for missing
+operational details before taking any irreversible action.
+```
+
+Route the label you will use for testing and production, such as `production`, to
+the saved versions. The prompt will resolve references through the
+same managed-variable targeting and label rules used by application code.
+
+## 2. Create the composed prompt
+
+Open **Prompt Management**, create a prompt named `Support Agent`, and use this
+template:
+
+```handlebars
+You are the support assistant for @{support_brand_profile.product}@, made by @{support_brand_profile.company}@.
+
+You are helping {{customer_name}} (on the {{tier}} plan).
+
+@{support_safety_rules}@
+
+{{#if is_urgent}}
+This issue is urgent. Escalate to @{support_brand_profile.escalation_email}@ after your first reply.
+{{else}}
+This issue is not marked urgent. Keep your reply concise and action-oriented.
+{{/if}}
+```
+
+There are two kinds of placeholders here:
+
+- `@{support_brand_profile.product}@`, `@{support_safety_rules}@`, and
+  `@{support_brand_profile.escalation_email}@` are composition references. They
+  are expanded from managed variables before the prompt is rendered.
+- `{{customer_name}}`, `{{tier}}`, and `{{#if is_urgent}}` are Handlebars
+  template expressions. They are rendered from scenario variables in the editor,
+  and from application inputs in production.
+
+The prompt editor detects both groups. The reference insertion menu can insert
+managed-variable references, and the template parameters panel lists the
+`{{...}}` values your scenario or application must provide.
+
+## 3. Test with a scenario
+
+Use the default system message:
+
+```text
+@{prompt}@
+```
+
+Add a user message:
+
+```handlebars
+Customer question: {{question}}
+```
+
+Add these scenario variables:
+
+| Name | Value |
+|------|-------|
+| `customer_name` | `Maya Chen` |
+| `tier` | `enterprise` |
+| `is_urgent` | `true` |
+| `question` | `The checkout page is charging customers twice.` |
+
+Run the scenario. The rendered system message should contain the composed brand
+profile and safety rules, plus the scenario-specific customer details:
+
+```text
+You are the support assistant for OrderDesk, made by Acme Support.
+
+You are helping Maya Chen (on the enterprise plan).
+
+Never reveal private account data. Acknowledge uncertainty. Ask for missing
+operational details before taking any irreversible action.
+
+This issue is urgent. Escalate to tier2@example.com after your first reply.
+```
+
+If a `@{...}@` reference cannot be resolved, the run reports a validation error.
+For prompt references, Logfire can suggest the backing variable name. For
+example, a reference to `@{support_agent}@` may suggest
+`@{prompt__support_agent}@`.
+
+## 4. Edit one fragment
+
+Go back to `support_safety_rules` in **Managed Variables** and save a new version:
+
+```text
+Never reveal private account data. Confirm the customer's identity before
+discussing billing. Ask for missing operational details before taking any
+irreversible action.
+```
+
+Move the serving label to the new version, then run the prompt scenario again.
+The support prompt picks up the changed safety text without editing or saving a
+new prompt version. That is the main benefit of composition: shared text is
+owned once, while prompts refer to it by name.
+
+## 5. Reuse another prompt
+
+Prompts are backed by managed variables whose names use
+`prompt__<slug_with_underscores>`. If you create a prompt with slug
+`support-style`, another prompt can reference it as:
+
+```handlebars
+@{prompt__support_style}@
+```
+
+Use prompt references for reusable prompt-sized sections, such as a style guide,
+a routing policy, or a domain-specific decision procedure. Use regular managed
+variables for smaller text fragments and structured facts.
+
+## 6. Ship the composed prompt
+
+Save a prompt version and promote it by moving the serving label on the prompt's
+backing managed variable. In application code, fetch the prompt as usual:
+
+```python skip="true"
+from pydantic import BaseModel
+
+import logfire
+
+logfire.configure()
+
+
+class SupportPromptInputs(BaseModel):
+    customer_name: str
+    tier: str
+    is_urgent: bool
+
+
+prompt_var = logfire.template_var(
+    name='prompt__support_agent',
+    type=str,
+    default='',
+    inputs_type=SupportPromptInputs,
+)
+
+with prompt_var.get(
+    SupportPromptInputs(customer_name='Maya Chen', tier='enterprise', is_urgent=True),
+    label='production',
+    targeting_key='customer-123',
+) as resolved:
+    prompt = resolved.value
+```
+
+`prompt_var.get(...)` expands the `@{...}@` references using the current managed
+variable configuration, then renders the remaining `{{...}}` placeholders with
+the request-specific inputs before returning the final prompt text. If you fetch
+the prompt with `logfire.var()` instead, render the remaining Handlebars
+placeholders yourself before sending the final prompt to your model.
+
+## Rendering order
+
+For prompt scenarios, Logfire renders in this order:
+
+1. Expand composition references such as `@{support_safety_rules}@` in the prompt
+   template.
+2. Render the prompt template's `{{...}}` placeholders with scenario variables.
+3. Preserve the scenario-only `@{prompt}@` alias, expand other composition
+   references in scenario messages or tool fields, and render their `{{...}}`
+   placeholders with the same scenario variables.
+4. Replace the scenario-only `@{prompt}@` alias with the rendered prompt.
+
+For application code, `logfire.template_var()` uses the same order: expand
+`@{...}@` references during resolution, then render `{{...}}` placeholders with
+the inputs passed to `get(inputs)`. If you use `logfire.var()` to fetch the raw
+template, your application is responsible for rendering those remaining
+Handlebars placeholders.
+
+## When to use composition
+
+Use composition when a fragment has its own owner, version history, or rollout:
+
+- shared safety, brand, tone, or escalation instructions,
+- structured facts that many prompts need,
+- a reusable prompt section consumed by several prompts,
+- a fragment that should be canaried or rolled back independently.
+
+Keep request-specific values as `{{...}}` placeholders. Composition is for
+managed configuration; templating is for per-run inputs.

--- a/docs/reference/advanced/prompt-management/concepts.md
+++ b/docs/reference/advanced/prompt-management/concepts.md
@@ -20,6 +20,47 @@ A **version** is an immutable snapshot of a prompt's template text. Versions are
 !!! important "A version freezes the template — nothing else"
     Saving a version stores only the template text. If you test "v2" today and test "v2" again later, you will get v2's template but whatever settings are current at execution time.
 
+### Backing managed variable
+
+Every prompt is backed by a managed variable. That backing variable is what your
+application fetches, and it is where labels, targeting, and rollout rules live.
+
+The backing variable name is derived from the prompt slug:
+
+```text
+prompt__<slug_with_underscores>
+```
+
+For example, a prompt with slug `welcome-email` has the backing variable
+`prompt__welcome_email`.
+
+Use Prompt Management to author the prompt and save versions. Use Managed
+Variables to promote a version by moving labels such as `production`, `canary`,
+or `staging`, or to configure rollout and targeting rules.
+
+!!! note "The backing variable is system-managed"
+    Names starting with `prompt__` are reserved for Prompt Management. Create and
+    rename prompts from the Prompts page rather than creating `prompt__...`
+    variables directly.
+
+### Fragments and references
+
+Prompts can compose reusable fragments with `@{...}@` references. A prompt can
+reference a regular managed variable:
+
+```handlebars
+@{support_safety_rules}@
+```
+
+It can also reference another prompt through that prompt's backing variable:
+
+```handlebars
+@{prompt__support_style}@
+```
+
+Use composition for shared configuration that should have its own owner, version
+history, or rollout. Use `{{...}}` template parameters for per-request inputs.
+
 For prompt testing workflows, see [Test Prompts](./scenarios.md).
 
 ## Identifiers you will see

--- a/docs/reference/advanced/prompt-management/index.md
+++ b/docs/reference/advanced/prompt-management/index.md
@@ -46,7 +46,7 @@ flowchart LR
 - You **save versions** as you iterate — each version freezes the template text at that moment.
 - You **test** with scenarios, datasets, and runs to see how the prompt behaves before promotion.
 - You **promote** a version by pointing a label (for example, `production`) at it on the Managed Variables page for that prompt.
-- Your **application fetches** the prompt by label through the Logfire SDK and renders the template against its runtime variables.
+- Your **application fetches and renders** the prompt through the Logfire SDK, using labels or rollout targeting to select the served version.
 
 ## When to use prompts vs. the Playground
 
@@ -66,6 +66,9 @@ The Playground is exploratory: its inputs come from a specific trace and its out
 ## Where to go next
 
 - New to the feature? Start with [Concepts](./concepts.md) for the production contract (`prompt`, `version`) and the supporting testing artifacts around it.
+- Looking for the UI workflow? See the [Prompt Management UI guide](./ui.md).
 - Writing your first template? See [Templates](./templates.md) and the full [Template reference](./template-reference.md).
+- Reusing shared prompt fragments? Follow the [Prompt composition walkthrough](./composition-walkthrough.md).
+- Ready to ship? See [Promote and Roll Out Prompts](./promotion-and-rollouts.md).
 - Setting up saved test inputs, tool-calling rehearsal, tool definitions, or dataset runs? See [Test Prompts](./scenarios.md).
 - Shipping prompts from Logfire into your application? See [Use Prompts in Your Application](./application.md).

--- a/docs/reference/advanced/prompt-management/promotion-and-rollouts.md
+++ b/docs/reference/advanced/prompt-management/promotion-and-rollouts.md
@@ -1,0 +1,168 @@
+---
+title: "Promote and Roll Out Prompts"
+description: "How to promote prompt versions, canary changes, and roll back with managed-variable labels."
+---
+
+# Promote and roll out prompts
+
+Prompt versions are served through the same labels, targeting, and rollout system
+used by managed variables. The Prompts page is where you author and save prompt
+versions. The Managed Variables page is where you decide which version production
+traffic receives.
+
+## Production workflow
+
+The normal production workflow is:
+
+1. Edit and test a prompt draft in Prompt Management.
+2. Save a new prompt version.
+3. Open the prompt's backing managed variable.
+4. Move a serving label, such as `production`, to the new version.
+5. Watch traces, runs, or evaluation results.
+6. Move the label back if you need to roll back.
+
+The backing variable name follows this pattern:
+
+```text
+prompt__<slug_with_underscores>
+```
+
+For example, the prompt slug `support-agent` maps to
+`prompt__support_agent`.
+
+## Promote a version
+
+Suppose `support-agent` has:
+
+| Version | Template |
+|---|---|
+| v1 | Current production support prompt |
+| v2 | New prompt with clearer escalation instructions |
+
+To promote v2:
+
+1. Open **Managed Variables**.
+2. Open `prompt__support_agent`.
+3. On the **Values** tab, select the `production` label.
+4. Edit from v2 or assign `production` to v2.
+5. Save the label change.
+
+Application code fetching `prompt__support_agent` with `label='production'`
+receives v2 on the next variable resolution. No redeploy is required.
+
+## Canary a prompt version
+
+To canary a prompt version before moving all production traffic:
+
+1. Save the new prompt as v2.
+2. Create or move a `canary` label to v2.
+3. Keep `production` pointing at v1.
+4. In **Targeting**, route a small percentage of traffic to `canary` and the
+   rest to `production`.
+
+For example:
+
+| Label | Weight |
+|---|---:|
+| `production` | 90% |
+| `canary` | 10% |
+
+Use a stable `targeting_key` when fetching the prompt so users or tenants keep a
+consistent prompt assignment during the test.
+
+```python skip="true"
+from pydantic import BaseModel
+
+import logfire
+
+logfire.configure()
+
+
+class SupportPromptInputs(BaseModel):
+    customer_name: str
+    tier: str
+
+
+prompt_var = logfire.template_var(
+    name='prompt__support_agent',
+    type=str,
+    default='',
+    inputs_type=SupportPromptInputs,
+)
+
+with prompt_var.get(
+    SupportPromptInputs(customer_name='Maya Chen', tier='enterprise'),
+    targeting_key='tenant-123',
+) as resolved:
+    prompt = resolved.value
+```
+
+If you explicitly pass `label='production'`, the SDK bypasses rollout weights and
+always requests that label. Omit `label` when you want rollout percentages and
+targeting rules to decide the served version.
+
+## Target a segment
+
+Use conditional targeting rules when a prompt should only change for a segment,
+such as internal users, beta tenants, or enterprise customers.
+
+For example:
+
+| Condition | Routing |
+|---|---|
+| `plan` equals `enterprise` | `enterprise_support` = 100% |
+| Default | `production` = 100% |
+
+Then pass matching attributes from application code:
+
+```python skip="true"
+with prompt_var.get(
+    SupportPromptInputs(customer_name='Maya Chen', tier='enterprise'),
+    targeting_key='tenant-123',
+    attributes={'plan': 'enterprise'},
+) as resolved:
+    prompt = resolved.value
+```
+
+## Roll back
+
+Rollback is a label move:
+
+1. Open the prompt's backing variable.
+2. Move `production` back to the previous version.
+3. Save.
+
+The next prompt resolution gets the restored version. Existing traces still show
+which prompt label and version were active for each request, so you can compare
+behavior before and after the rollback.
+
+## Measure the change
+
+Prompt resolution happens inside Logfire's managed-variable system. When you use
+the SDK context manager, downstream spans carry baggage that identifies the
+served variable label and version.
+
+Use that data to compare:
+
+- response quality from online evaluations,
+- escalation or task-success rates,
+- latency and token usage,
+- user or operator feedback,
+- error rates by prompt label or version.
+
+If your prompt also composes shared fragments with `@{...}@`, inspect traces to
+see which fragment versions were involved in a resolution.
+
+## What versions do and do not freeze
+
+A prompt version freezes the prompt template text. It does not freeze:
+
+- scenario messages or scenario variables,
+- dataset mappings,
+- model or tool settings used for UI test runs,
+- composed managed-variable fragments,
+- labels, rollout weights, or targeting rules.
+
+This is intentional. Prompt versions give you stable template snapshots, while
+labels and composed fragments let you change serving behavior without creating a
+new prompt version for every operational adjustment.

--- a/docs/reference/advanced/prompt-management/template-reference.md
+++ b/docs/reference/advanced/prompt-management/template-reference.md
@@ -7,11 +7,11 @@ description: "The authoritative grammar used by Logfire Prompt Management templa
 
 This page is the canonical specification for the template grammar used by Prompt Management.
 
-Most prompt authors only need variable substitution and a few standard Handlebars block helpers. Scenario-specific additions, such as `@{prompt}@`, are collected later on this page.
+Most prompt authors only need variable substitution and a few standard Handlebars block helpers. Prompt Management also supports `@{variable_name}@` composition references for reusable fragments. Scenario-specific additions, such as `@{prompt}@`, are collected later on this page.
 
 ## Grammar at a glance
 
-The supported grammar is **standard Handlebars** with the default helper set. Prompt Management also adds one non-Handlebars convention used only in scenario messages: the `@{prompt}@` alias.
+The supported grammar is **standard Handlebars** with the default helper set. Prompt Management also adds composition references with `@{variable_name}@` and one convention used only in scenario messages: the `@{prompt}@` alias.
 
 ### Mustache expressions
 
@@ -36,9 +36,38 @@ Prompt Management enables the standard Handlebars block helpers.
 | `{{lookup obj key}}` | Look up a field by computed key |
 | `{{log value}}` | Log to server (no output; useful during debugging) |
 
+## Composition references
+
+Composition references use `@{...}@` delimiters and are expanded before normal
+Handlebars rendering.
+
+| Form | Meaning |
+|---|---|
+| `@{support_safety_rules}@` | Insert the resolved value of a managed variable |
+| `@{support_brand_profile.product}@` | Insert a field from a structured managed variable |
+| `@{prompt__support_style}@` | Insert another prompt through its backing managed variable |
+
+The composition pass uses managed-variable resolution, so labels, rollouts,
+targeting, and aliases apply. Missing or invalid composition references are
+reported as validation errors when the prompt is previewed or run.
+
+To render a literal composition reference, escape the opening delimiter:
+
+```handlebars
+\@{support_safety_rules}@
+```
+
+See the [Prompt composition walkthrough](./composition-walkthrough.md) for a
+complete example.
+
 ## Rendering order for prompt templates
 
-Prompt templates render against the current variable set using standard Handlebars rules.
+Prompt templates render in two passes:
+
+1. Expand `@{...}@` composition references against the current managed-variable
+   configuration.
+2. Render the resulting template against the current `{{...}}` variable set using
+   standard Handlebars rules.
 
 ## Scenario-only additions
 
@@ -56,14 +85,16 @@ Scenarios reuse the same grammar, but the testing surface adds a few extra rules
 
 ```mermaid
 flowchart TD
-    A[Prompt template] -->|Handlebars render with scenario variables| B[Rendered prompt]
-    C[Scenario message] -->|Handlebars render with scenario variables| D[Rendered message]
-    B -.inject.-> D
-    D -->|Replace every literal @{prompt}@ with Rendered prompt| E[Final message sent to model]
+    A[Prompt template] -->|Expand composition refs| B[Composed prompt template]
+    B -->|Render Handlebars with scenario variables| C[Rendered prompt]
+    D[Scenario message] -->|Preserve prompt alias; expand other composition refs| E[Composed scenario message]
+    E -->|Render Handlebars with scenario variables| F[Rendered scenario message]
+    C -.inject.-> F
+    F -->|Replace literal prompt alias with rendered prompt| G[Final message sent to model]
 ```
 
-1. The **prompt template** is rendered through Handlebars against the scenario's variables, producing the *rendered prompt*.
-2. For each **scenario message** (and every templated field within it — text content, tool-call args, tool-return content), the message is rendered through Handlebars against the same scenario variables.
+1. The **prompt template** expands composition references, then renders through Handlebars against the scenario's variables, producing the *rendered prompt*.
+2. For each **scenario message** (and every templated field within it — text content, tool-call args, tool-return content), Logfire preserves the scenario-only `@{prompt}@` alias, expands other composition references, and renders through Handlebars against the same scenario variables.
 3. Finally, every literal occurrence of `@{prompt}@` in the rendered message is replaced with the rendered prompt from step 1.
 
 This order matters: the prompt template never sees `@{prompt}@` as a payload, and scenario messages never see un-rendered Handlebars from the prompt template.
@@ -101,8 +132,17 @@ Rendering errors fall into a small set of categories:
 
 ## Compatibility with the SDK
 
-The Logfire SDK returns the raw template string, so your application renders it locally before passing the result to your model.
+Use `logfire.template_var()` when you want the SDK to render prompt templates
+with typed runtime inputs. It resolves the prompt variable, expands `@{...}@`
+composition references, renders the remaining `{{...}}` placeholders, and
+returns the final prompt text.
 
-If your application uses simple substitution, stick to flat `{{variable}}` references. If you want to use dotted paths or block helpers, use a renderer that supports the same Handlebars features documented here.
+If you fetch the prompt with `logfire.var()` instead, the SDK returns the
+post-composition template string. Your application then renders the remaining
+`{{...}}` placeholders locally before passing the result to your model.
+
+If your application renders manually and uses simple substitution, stick to flat
+`{{variable}}` references. If you want to use dotted paths or block helpers, use
+a renderer that supports the same Handlebars features documented here.
 
 See [Use Prompts in Your Application](./application.md) for the current integration workflow.

--- a/docs/reference/advanced/prompt-management/templates.md
+++ b/docs/reference/advanced/prompt-management/templates.md
@@ -7,8 +7,12 @@ description: "How to write Logfire prompt templates with variables and standard 
 
 A prompt template is a string. At render time, Logfire walks that string with a Handlebars engine and substitutes in the current variables.
 
-!!! note "Your application renders the template at runtime"
-    Prompt Management stores the template, but your application is responsible for substituting runtime variables before sending the rendered prompt to your model client. See [Use Prompts in Your Application](./application.md).
+!!! note "Runtime inputs are supplied by your application"
+    Prompt Management stores the template. In application code, prefer
+    `logfire.template_var()` to substitute runtime variables before sending the
+    rendered prompt to your model client. If you fetch the raw template with
+    `logfire.var()`, your application must render the remaining `{{...}}`
+    placeholders itself. See [Use Prompts in Your Application](./application.md).
 
 If you already know Handlebars, the short version is: Logfire uses the standard Handlebars.js helper set, with no custom helpers enabled by default.
 
@@ -75,6 +79,27 @@ The standard Handlebars block helpers work:
 !!! note "Undefined variables render as empty strings"
     If a template references a variable you did not define (for example, you wrote `{{name}}` but never added a `name` variable), Handlebars renders an empty string rather than raising an error. The editor surfaces the list of variables the template references so you can spot typos before running.
 
+## Reusable fragments
+
+Use `@{variable_name}@` to compose managed-variable values into a prompt before
+the prompt's `{{...}}` placeholders are rendered.
+
+```handlebars
+You are the support assistant for @{support_brand_profile.product}@.
+
+@{support_safety_rules}@
+
+Reply to {{customer_name}} on the {{tier}} plan.
+```
+
+Composition is useful when a fragment should have its own version history,
+targeting, or owner. A prompt can reference regular managed variables such as
+`@{support_safety_rules}@` and other prompts through their backing variable names,
+such as `@{prompt__support_style}@`.
+
+For a full example, see the
+[Prompt composition walkthrough](./composition-walkthrough.md).
+
 ## Scenario-specific rendering
 
 The prompt editor reuses the same template engine for saved test scenarios, including scenario messages, tool-call arguments, and tool-return content.
@@ -98,9 +123,16 @@ If you need transformation logic that is not expressible in plain Handlebars, do
 
 ## Rendering from your application
 
-The Logfire SDK returns the prompt template unchanged, so your application renders it before passing the result to your model client.
+The Logfire SDK can render prompt templates for you with `logfire.template_var()`.
+If you fetch a prompt with `logfire.var()` instead, `.get()` returns the prompt
+template after `@{...}@` composition has been expanded, and your application
+renders the remaining `{{...}}` placeholders before passing the result to your
+model client.
 
-If you want to keep rendering simple in application code, prefer flat variables such as `{{customer_name}}`. If you want to use dotted paths or block helpers, make sure your application uses a renderer that supports the same Handlebars features described here.
+If you want to keep manual rendering simple, prefer flat variables such as
+`{{customer_name}}`. If you want to use dotted paths or block helpers, make sure
+your application uses a renderer that supports the same Handlebars features
+described here.
 
 See [Use Prompts in Your Application](./application.md) for the current integration workflow.
 

--- a/docs/reference/advanced/prompt-management/ui.md
+++ b/docs/reference/advanced/prompt-management/ui.md
@@ -1,0 +1,144 @@
+---
+title: "Prompt Management UI Guide"
+description: "How to author, test, version, and inspect prompts in the Logfire UI."
+---
+
+# Prompt Management UI guide
+
+The Prompt Management UI is the prompt-authoring surface. Use it to write prompt
+templates, test them with saved scenarios, inspect rendered messages, and save
+versions. Promotion, targeting, and rollout still happen on the prompt's backing
+managed variable.
+
+## Prompts list
+
+Open **Prompt Management** from your project navigation. The list shows the
+prompts in the project, with their display names and slugs. Create one prompt per
+runtime prompt your application fetches, such as `support-agent`,
+`incident-triage`, or `welcome-email`.
+
+Each prompt has a backing managed variable named
+`prompt__<slug_with_underscores>`. For example, a prompt with slug
+`support-agent` is fetched from application code as `prompt__support_agent`.
+
+## Prompt detail page
+
+The prompt detail page has three jobs:
+
+- author the current draft template,
+- test the draft or a saved version against scenarios,
+- inspect the run output before saving or promoting a version.
+
+### Template editor
+
+The template editor is where you write the prompt text. It supports two kinds of
+placeholders:
+
+| Syntax | Purpose |
+|---|---|
+| `{{customer_name}}` | Runtime template input rendered from scenario variables or application data |
+| `@{support_safety_rules}@` | Managed-variable composition reference expanded from Logfire configuration |
+| `@{prompt__support_style}@` | Prompt composition reference expanded through another prompt's backing variable |
+
+The editor detects template parameters and composition references. Use those
+detected chips to check that names match what your scenarios or managed variables
+provide.
+
+### Insert reference
+
+Use **Insert reference** to add a managed-variable or prompt reference without
+typing the `@{...}@` syntax by hand. Regular managed variables are inserted by
+their variable name. Prompts are inserted through their backing managed-variable
+name, such as `@{prompt__support_style}@`.
+
+If you type a prompt slug without the backing prefix, Logfire can suggest the
+correct `prompt__...` name when preview or run validation fails.
+
+### Template parameters
+
+Template parameters are the `{{...}}` values that must be available at render
+time. In the editor, those values usually come from the active scenario's
+variables. In production, your application supplies the same values to
+`logfire.template_var().get(inputs)` or to its own renderer before passing the
+prompt to the model.
+
+Use plain names for simple values:
+
+```text
+customer_name = Maya Chen
+```
+
+Use dotted names for nested values:
+
+```text
+customer.name = Maya Chen
+customer.tier = enterprise
+```
+
+Dotted values are available as `{{customer.name}}` and `{{customer.tier}}`.
+
+## Scenarios panel
+
+Scenarios are saved test cases for the prompt. A scenario contains messages and a
+set of variables. The default scenario starts with a system message containing:
+
+```text
+@{prompt}@
+```
+
+That scenario-only alias is replaced with the rendered prompt during a run. Add
+user messages, prior assistant messages, and tool messages when you need to test
+a realistic conversation.
+
+For example:
+
+```text
+system: @{prompt}@
+user: Customer question: {{question}}
+```
+
+Then define `question` in the scenario variables panel.
+
+## Preview and run output
+
+Preview shows the rendered messages before they are sent to the model. It is the
+first place to check when output looks surprising:
+
+- `@{...}@` references should already be expanded.
+- `{{...}}` placeholders should be replaced with scenario values.
+- `@{prompt}@` should be replaced inside scenario messages.
+- Tool-call `args` and tool-return `content` should render string fields
+  recursively.
+
+If preview reports a validation error, fix the template, scenario variables, or
+managed-variable references before running the prompt against a model.
+
+## Versions
+
+Saving a version freezes the prompt template text. Versions do not freeze
+scenario messages, model settings, tool definitions, managed-variable fragments,
+or rollout rules.
+
+Use versions as the stable points you can compare, promote, or roll back to.
+Draft edits are not served by production traffic until you save a version and
+move a serving label to it.
+
+## Settings and tools
+
+Prompt settings control the test environment used by Prompt Management. Tool
+definitions, model selection, and advanced gateway settings affect prompt runs in
+the UI. They do not become part of the prompt template your application fetches.
+
+If your production application needs tools, configure those tools in application
+code as well.
+
+## Promotion
+
+After saving a version, promote it from the backing managed variable:
+
+1. Open the prompt's backing variable in **Managed Variables**.
+2. Move a label such as `production`, `canary`, or `staging` to the prompt
+   version you want to serve.
+3. Configure rollout or targeting rules if you want a partial rollout.
+
+For the full workflow, see [Promote and Roll Out Prompts](./promotion-and-rollouts.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -242,7 +242,10 @@ nav:
           - Prompt Management:
               - Overview: reference/advanced/prompt-management/index.md
               - Core Concepts: reference/advanced/prompt-management/concepts.md
+              - UI Guide: reference/advanced/prompt-management/ui.md
               - Writing Templates: reference/advanced/prompt-management/templates.md
+              - Prompt Composition Walkthrough: reference/advanced/prompt-management/composition-walkthrough.md
+              - Promote and Roll Out Prompts: reference/advanced/prompt-management/promotion-and-rollouts.md
               - Test Prompts: reference/advanced/prompt-management/scenarios.md
               - Use Prompts in Your Application: reference/advanced/prompt-management/application.md
               - Template Reference: reference/advanced/prompt-management/template-reference.md


### PR DESCRIPTION
## Summary

- Add a Prompt Management UI guide covering the prompt list, template editor, reference insertion, scenarios, preview, versions, settings, and promotion handoff.
- Add a prompt promotion and rollout workflow for labels, canaries, targeting, rollback, and measuring prompt changes.
- Add a prompt composition walkthrough for managed-variable fragments and prompt-backed references.
- Expand Prompt Management concepts with the backing managed-variable model and prompt/reference naming.
- Update application and template docs for the current `logfire.template_var()` compose-and-render SDK path, while keeping `logfire.var()` documented for manual rendering.
- Align the scenario rendering diagram with the composition-then-Handlebars rendering order identified by cubic.
- Wire the new pages into `mkdocs.yml` and `docs/nav.json`.

## Validation

- `uv run pytest tests/test_docs.py::test_formatting -q`
- `git diff --check`
