### PR TITLE
Use parameterized `default_factory` to drop `reportUnknownVariableType` ignores

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -268,9 +268,9 @@ class PydanticPlugin:
     * `failure`: Send metrics for all validations and traces only for validation failures.
     * `metrics`: Send only metrics.
     """
-    include: set[str] = field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    include: set[str] = field(default_factory=set[str])
     """By default, third party modules are not instrumented. This option allows you to include specific modules."""
-    exclude: set[str] = field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    exclude: set[str] = field(default_factory=set[str])
     """Exclude specific modules from instrumentation."""
 
 

--- a/logfire/_internal/logs.py
+++ b/logfire/_internal/logs.py
@@ -22,9 +22,9 @@ class ProxyLoggerProvider(LoggerProvider):
 
     provider: LoggerProvider
 
-    loggers: WeakSet[ProxyLogger] = dataclasses.field(default_factory=WeakSet)  # pyright: ignore[reportUnknownVariableType]
+    loggers: WeakSet[ProxyLogger] = dataclasses.field(default_factory=WeakSet['ProxyLogger'])
     lock: Lock = dataclasses.field(default_factory=Lock)
-    suppressed_scopes: set[str] = dataclasses.field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    suppressed_scopes: set[str] = dataclasses.field(default_factory=set[str])
     min_level: int = 0
 
     def get_logger(

--- a/logfire/_internal/metrics.py
+++ b/logfire/_internal/metrics.py
@@ -33,9 +33,9 @@ from .utils import handle_internal_errors
 @dataclasses.dataclass
 class ProxyMeterProvider(MeterProvider):
     provider: MeterProvider
-    meters: WeakSet[_ProxyMeter] = dataclasses.field(default_factory=WeakSet)  # pyright: ignore[reportUnknownVariableType]
+    meters: WeakSet[_ProxyMeter] = dataclasses.field(default_factory=WeakSet['_ProxyMeter'])
     lock: Lock = dataclasses.field(default_factory=Lock)
-    suppressed_scopes: set[str] = dataclasses.field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    suppressed_scopes: set[str] = dataclasses.field(default_factory=set[str])
 
     def get_meter(
         self,

--- a/logfire/_internal/tracer.py
+++ b/logfire/_internal/tracer.py
@@ -57,9 +57,11 @@ class ProxyTracerProvider(TracerProvider):
 
     provider: TracerProvider
     config: LogfireConfig
-    tracers: WeakKeyDictionary[_ProxyTracer, Callable[[], Tracer]] = field(default_factory=WeakKeyDictionary)  # pyright: ignore[reportUnknownVariableType]
+    tracers: WeakKeyDictionary[_ProxyTracer, Callable[[], Tracer]] = field(
+        default_factory=WeakKeyDictionary['_ProxyTracer', Callable[[], Tracer]]
+    )
     lock: Lock = field(default_factory=Lock)
-    suppressed_scopes: set[str] = field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
+    suppressed_scopes: set[str] = field(default_factory=set[str])
 
     def set_provider(self, provider: SDKTracerProvider) -> None:
         with self.lock:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -16,7 +16,7 @@ from logfire.testing import SeededRandomIdGenerator, TestExporter
 @dataclass
 class SpanNode:
     name: str | None = None
-    children: list[SpanNode] = field(default_factory=list)  # type: ignore[reportUnknownVariableType]
+    children: list[SpanNode] = field(default_factory=list['SpanNode'])
 
 
 # TODO(Marcelo): Remove pragma when this file is covered by tests.


### PR DESCRIPTION
## What

Replace `dataclasses.field(default_factory=<bare builtin>)` (paired with `# pyright: ignore[reportUnknownVariableType]`) with the **parameterized generic alias** as the factory:

```python
# before
include: set[str] = field(default_factory=set)  # pyright: ignore[reportUnknownVariableType]
# after
include: set[str] = field(default_factory=set[str])
```

`set[str]()` / `list[str]()` / `WeakSet[X]()` construct an empty collection at runtime exactly like the bare builtin, but pyright can now infer the element type, so the ignore comments are no longer needed. With `reportUnnecessaryTypeIgnoreComment = true` enabled project-wide, this also means there are simply fewer ignores to drift out of date. This already matches the house style elsewhere (e.g. `default_factory=dict[str, str]` in `ai_tools.py` / `variable.py`).

## Why

These `reportUnknownVariableType` ignores are avoidable noise — the parameterized factory expresses the same intent without suppressing a type check.

## Notes

- **Forward-ref strings** (`WeakSet['_ProxyMeter']`, `WeakKeyDictionary['_ProxyTracer', ...]`, `list['SpanNode']`) are used where the type argument isn't bound at runtime when the class body executes — classes defined later in the same module, or self-referential ones. The quoted name is stored as data, so there's no `NameError`, and pyright still resolves it. `WeakSet`/`WeakKeyDictionary` have had `__class_getitem__` since 3.9, so this is safe on the 3.10 floor.
- Files touched: `_internal/config.py`, `_internal/logs.py`, `_internal/metrics.py`, `_internal/tracer.py`, `tests/test_sampling.py`.

The same cleanup for `logfire/variables/` (new files in #1954) rides along with that PR, since those files don't exist on `main` yet.

## Verification

- Full-project `uv run pyright`: 0 errors, 0 warnings, 0 informations.
- Confirmed every touched `default_factory` constructs the correct empty collection at runtime.
- `ruff format` + `ruff check` clean; relevant test suites pass.