### PR TITLE
Harden managed variable provider fallbacks

### DIFF
--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2553,6 +2553,11 @@ class Logfire:
                     'When `default` is a resolve function (callable with targeting_key and attributes parameters), '
                     '`type` must be provided to specify the variable value type.'
                 )
+            if default is None:
+                raise TypeError(
+                    'When `default` is None, `type` must be provided (e.g. `type=Optional[int]`); '
+                    'the variable value type cannot be inferred from a None default.'
+                )
             tp = cast(Type[T], default.__class__)  # noqa UP006
         else:
             tp = type

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -686,7 +686,7 @@ class VariableProvider(ABC):
 
         labeled_value = config.labels.get(label)
         if labeled_value is None:
-            return ResolvedVariable(name=variable_name, value=None, reason='resolved')
+            return ResolvedVariable(name=variable_name, value=None, reason='missing_config')
 
         serialized, version = config.follow_ref(labeled_value)
         return ResolvedVariable(
@@ -694,7 +694,7 @@ class VariableProvider(ABC):
             value=serialized,
             label=label,
             version=version,
-            reason='resolved',
+            reason='resolved' if serialized is not None else 'missing_config',
         )
 
     def refresh(self, force: bool = False):

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -686,6 +686,8 @@ class VariableProvider(ABC):
 
         labeled_value = config.labels.get(label)
         if labeled_value is None:
+            # The variable exists but this label doesn't. `reason='resolved'` with value=None was
+            # misleading (resolved implies a usable value); report missing_config instead.
             return ResolvedVariable(name=variable_name, value=None, reason='missing_config')
 
         serialized, version = config.follow_ref(labeled_value)
@@ -694,6 +696,9 @@ class VariableProvider(ABC):
             value=serialized,
             label=label,
             version=version,
+            # A ref that resolves to nothing (e.g. a `code_default` ref the server can't supply) is
+            # not a successful resolution — surface missing_config so callers/baggage aren't told a
+            # value was used when it wasn't.
             reason='resolved' if serialized is not None else 'missing_config',
         )
 

--- a/logfire/variables/local.py
+++ b/logfire/variables/local.py
@@ -72,7 +72,10 @@ class LocalVariableProvider(VariableProvider):
         Returns:
             A VariablesConfig containing all variable configurations.
         """
-        return self._config
+        with self._lock:
+            # Return a deep copy under the lock so callers that iterate the config
+            # get a stable snapshot while concurrent writes mutate the provider.
+            return self._config.model_copy(deep=True)
 
     def create_variable(self, config: VariableConfig) -> VariableConfig:
         """Create a new variable configuration.

--- a/logfire/variables/local.py
+++ b/logfire/variables/local.py
@@ -73,8 +73,10 @@ class LocalVariableProvider(VariableProvider):
             A VariablesConfig containing all variable configurations.
         """
         with self._lock:
-            # Return a deep copy under the lock so callers that iterate the config
-            # get a stable snapshot while concurrent writes mutate the provider.
+            # Return a deep copy under the lock so callers (push diff / validation iterate
+            # `variables.items()`) get a stable snapshot. Without this, a concurrent
+            # create/update/delete_variable mutating `self._config.variables` in place can raise
+            # "dictionary changed size during iteration".
             return self._config.model_copy(deep=True)
 
     def create_variable(self, config: VariableConfig) -> VariableConfig:

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -113,17 +113,16 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._pid = os.getpid()
 
     def _at_fork_reinit(self):  # pragma: no cover
-        # If shutdown() ran before the fork, the child would otherwise inherit
-        # _shutdown=True and its freshly started worker/SSE threads would exit.
-        self._shutdown = False
-        self._shutdown_timeout_exceeded = False
+        was_shutdown = self._shutdown
+        if not was_shutdown:
+            self._shutdown_timeout_exceeded = False
         # Recreate all things threading related
         self._refresh_lock = threading.Lock()
         self._session_lock = threading.Lock()
         self._worker_awaken = threading.Event()
         self._force_refresh_event = threading.Event()
         # Only restart threads if we were started before the fork
-        if self._started:
+        if self._started and not was_shutdown:
             self._worker_thread = threading.Thread(
                 name='LogfireRemoteProvider',
                 target=self._worker,

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -113,6 +113,10 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._pid = os.getpid()
 
     def _at_fork_reinit(self):  # pragma: no cover
+        # If shutdown() ran before the fork, the child would otherwise inherit
+        # _shutdown=True and its freshly started worker/SSE threads would exit.
+        self._shutdown = False
+        self._shutdown_timeout_exceeded = False
         # Recreate all things threading related
         self._refresh_lock = threading.Lock()
         self._session_lock = threading.Lock()
@@ -219,9 +223,9 @@ class LogfireRemoteVariableProvider(VariableProvider):
                         reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)
                         continue
 
-                    # Connected successfully, reset delay
+                    # Do not reset the backoff until data arrives. A stream
+                    # that returns 200 and immediately closes is not healthy.
                     self._sse_connected = True
-                    reconnect_delay = 1.0
 
                     # Process SSE events
                     for line in response.iter_lines(decode_unicode=True):
@@ -237,6 +241,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
                         # SSE format: "data: {...json...}"
                         if line.startswith('data:'):
+                            reconnect_delay = 1.0
                             data_str = line[5:].strip()
                             try:
                                 event_data = json.loads(data_str)
@@ -249,6 +254,11 @@ class LogfireRemoteVariableProvider(VariableProvider):
                             except (json.JSONDecodeError, TypeError):
                                 # Invalid JSON, ignore
                                 pass
+
+                self._sse_connected = False
+                if not self._shutdown:
+                    self._wait_for_reconnect(reconnect_delay)
+                    reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)
 
             except Exception:
                 # Connection error, will retry
@@ -295,10 +305,6 @@ class LogfireRemoteVariableProvider(VariableProvider):
         Args:
             force: If True, fetch configuration even if the polling interval hasn't elapsed.
         """
-        if self._refresh_lock.locked():  # pragma: no cover
-            # If we're already fetching, we'll get a new value, so no need to force
-            force = False
-
         # Note: Eventually we may want to rework the client and server implementations to use a NotModifiedResponse
         #  to reduce the amount of overhead from polling. We could also use a websocket/SSE to get real time updates
         #  when the user makes changes.
@@ -320,6 +326,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
             except Exception as e:
                 # Catch all request/HTTP/JSON exceptions (ConnectionError, Timeout, UnexpectedResponse,
                 # JSONDecodeError, etc.) to prevent crashing the user's application on failures.
+                self._has_attempted_fetch = True
                 self._log_error('Error retrieving variables', e)
                 return
 
@@ -621,7 +628,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
                 response = self._session.get(urljoin(self._base_url, '/v1/variable-types/'), timeout=self._timeout)
                 UnexpectedResponse.raise_for_status(response)
                 types_data = response.json()
-        except UnexpectedResponse as e:
+        except (UnexpectedResponse, RequestException) as e:
             raise VariableWriteError(f'Failed to list variable types: {e}') from e
         result: dict[str, VariableTypeConfig] = {}
         for type_data in types_data:
@@ -664,7 +671,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
                     urljoin(self._base_url, '/v1/variable-types/'), json=body, timeout=self._timeout
                 )
                 UnexpectedResponse.raise_for_status(response)
-        except UnexpectedResponse as e:
+        except (UnexpectedResponse, RequestException) as e:
             raise VariableWriteError(f'Failed to upsert variable type: {e}') from e
 
         return config

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -245,8 +245,6 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
                         # SSE format: "data: {...json...}"
                         if line.startswith('data:'):
-                            # We're actually receiving data -- the connection is healthy, so reset
-                            # the reconnect backoff.
                             reconnect_delay = 1.0
                             data_str = line[5:].strip()
                             try:

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -115,6 +115,9 @@ class LogfireRemoteVariableProvider(VariableProvider):
     def _at_fork_reinit(self):  # pragma: no cover
         was_shutdown = self._shutdown
         if not was_shutdown:
+            # Reset shutdown-timeout state only for active providers. If shutdown()
+            # ran before the fork, keep `_shutdown=True` so the child does not
+            # restart worker/SSE threads using a session the parent already closed.
             self._shutdown_timeout_exceeded = False
         # Recreate all things threading related
         self._refresh_lock = threading.Lock()
@@ -222,8 +225,10 @@ class LogfireRemoteVariableProvider(VariableProvider):
                         reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)
                         continue
 
-                    # Do not reset the backoff until data arrives. A stream
-                    # that returns 200 and immediately closes is not healthy.
+                    # Connection opened. Do NOT reset the backoff here: a connection that returns
+                    # 200 but then immediately closes would otherwise reset the delay every loop and
+                    # reconnect in a tight busy loop. The delay is reset only once we actually
+                    # receive data (below), which proves the stream is healthy.
                     self._sse_connected = True
 
                     # Process SSE events
@@ -240,6 +245,8 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
                         # SSE format: "data: {...json...}"
                         if line.startswith('data:'):
+                            # We're actually receiving data -- the connection is healthy, so reset
+                            # the reconnect backoff.
                             reconnect_delay = 1.0
                             data_str = line[5:].strip()
                             try:
@@ -254,6 +261,8 @@ class LogfireRemoteVariableProvider(VariableProvider):
                                 # Invalid JSON, ignore
                                 pass
 
+                # The stream ended cleanly (e.g. a proxy/load-balancer max-lifetime close). Back off
+                # before reconnecting rather than immediately reopening in a tight loop.
                 self._sse_connected = False
                 if not self._shutdown:
                     self._wait_for_reconnect(reconnect_delay)
@@ -304,6 +313,11 @@ class LogfireRemoteVariableProvider(VariableProvider):
         Args:
             force: If True, fetch configuration even if the polling interval hasn't elapsed.
         """
+        # Note: we intentionally do NOT downgrade `force` to False when a refresh is already in
+        # flight. An in-flight fetch may have *started before* a just-committed write (create/update/
+        # delete each call refresh(force=True) afterwards), so reusing its result could leave a stale
+        # cache until the next poll. A forced call instead waits for the lock and then fetches fresh,
+        # guaranteeing read-after-write at the cost of at most one extra request.
         # Note: Eventually we may want to rework the client and server implementations to use a NotModifiedResponse
         #  to reduce the amount of overhead from polling. We could also use a websocket/SSE to get real time updates
         #  when the user makes changes.
@@ -325,6 +339,10 @@ class LogfireRemoteVariableProvider(VariableProvider):
             except Exception as e:
                 # Catch all request/HTTP/JSON exceptions (ConnectionError, Timeout, UnexpectedResponse,
                 # JSONDecodeError, etc.) to prevent crashing the user's application on failures.
+                # Mark that we've attempted a fetch even on failure: otherwise `_has_attempted_fetch`
+                # stays False and every `get_serialized_value` call blocks on a fresh `refresh()`
+                # (when `block_before_first_resolve` is set) while the server is unreachable, despite
+                # the background worker already polling.
                 self._has_attempted_fetch = True
                 self._log_error('Error retrieving variables', e)
                 return
@@ -628,6 +646,9 @@ class LogfireRemoteVariableProvider(VariableProvider):
                 UnexpectedResponse.raise_for_status(response)
                 types_data = response.json()
         except (UnexpectedResponse, RequestException) as e:
+            # Match create/update/delete: surface network/HTTP/JSON failures as the documented
+            # VariableWriteError rather than leaking raw requests exceptions (ConnectionError,
+            # Timeout, JSONDecodeError on response.json(), ...).
             raise VariableWriteError(f'Failed to list variable types: {e}') from e
         result: dict[str, VariableTypeConfig] = {}
         for type_data in types_data:
@@ -671,6 +692,8 @@ class LogfireRemoteVariableProvider(VariableProvider):
                 )
                 UnexpectedResponse.raise_for_status(response)
         except (UnexpectedResponse, RequestException) as e:
+            # Match create/update/delete: surface network/HTTP failures as VariableWriteError
+            # rather than leaking raw requests exceptions.
             raise VariableWriteError(f'Failed to upsert variable type: {e}') from e
 
         return config

--- a/logfire/variables/variable.py
+++ b/logfire/variables/variable.py
@@ -311,8 +311,8 @@ class Variable(Generic[T_co]):
                     name=self.name,
                     value=self._get_default(targeting_key, attributes),
                     exception=serialized_result.exception,
-                    label=serialized_result.label,
-                    version=serialized_result.version,
+                    label=None,
+                    version=None,
                     reason='code_default',
                 )
 

--- a/logfire/variables/variable.py
+++ b/logfire/variables/variable.py
@@ -37,6 +37,15 @@ T_co = TypeVar('T_co', covariant=True)
 
 _VARIABLE_OVERRIDES: ContextVar[dict[str, Any] | None] = ContextVar('_VARIABLE_OVERRIDES', default=None)
 
+# Per-`get()`-call cache for the code-default value. Keyed by `id(variable)`.
+# Lets `_get_default_cached` short-circuit when the same callable default
+# would otherwise be invoked twice in one resolution. Each entry is
+# `(ok: bool, value_or_exception: Any)`: successful invocations cache the
+# returned value; raising invocations cache the exception so re-entry
+# re-raises without re-invoking the callable. Set up by `Variable._resolve`
+# at the top of the call and reset when it returns.
+_DEFAULT_CACHE: ContextVar[dict[int, tuple[bool, Any]] | None] = ContextVar('_DEFAULT_CACHE', default=None)
+
 
 @dataclass
 class _TargetingContextData:
@@ -117,6 +126,16 @@ def is_resolve_function(f: Any) -> TypeIs[ResolveFunction[Any]]:
 
 
 def _emit_resolution_warning(message: str, *, stacklevel: int = 3) -> None:
+    """Emit a non-fatal resolution warning without letting it abort or corrupt resolution.
+
+    Resolution is *filter-independent*: a ``-W error`` / ``filterwarnings=error`` config would
+    otherwise turn one of these informational ``RuntimeWarning``s into an exception, which the
+    broad fallback ``except`` in ``_resolve`` then catches -- replacing the correctly-computed
+    ``ResolvedVariable`` (whose ``reason``/``exception`` already carry the real signal) with a
+    bogus ``reason='other_error'`` and the ``RuntimeWarning`` as its exception. Suppressing the
+    escalation here guarantees callers always get the structured result regardless of the active
+    warning filter; the warning is still shown whenever the filter permits.
+    """
     try:
         warnings.warn(message, category=RuntimeWarning, stacklevel=stacklevel)
     except Exception:
@@ -248,7 +267,7 @@ class Variable(Generic[T_co]):
                 # Try to JSON serialize the value; if that fails, fall back to string representation.
                 try:
                     serialized_value = self.type_adapter.dump_json(result.value).decode('utf-8')
-                except Exception:
+                except (ValueError, TypeError, RuntimeError):
                     serialized_value = repr(result.value)
                 span.set_attributes(
                     {
@@ -272,6 +291,23 @@ class Variable(Generic[T_co]):
         span: logfire.LogfireSpan | None,
         label: str | None = None,
     ) -> ResolvedVariable[T_co]:
+        # `_DEFAULT_CACHE` memoises the code-default value across every
+        # `_get_default_cached` call inside this `get()` invocation, so a
+        # callable default isn't re-invoked when a downstream fallback path also
+        # needs it. Both values and exceptions are cached.
+        cache_token = _DEFAULT_CACHE.set({})
+        try:
+            return self._resolve_inner(targeting_key, attributes, span, label)
+        finally:
+            _DEFAULT_CACHE.reset(cache_token)
+
+    def _resolve_inner(
+        self,
+        targeting_key: str | None,
+        attributes: Mapping[str, Any] | None,
+        span: logfire.LogfireSpan | None,
+        label: str | None,
+    ) -> ResolvedVariable[T_co]:
         serialized_result: ResolvedVariable[str | None] | None = None
         try:
             if (context_overrides := _VARIABLE_OVERRIDES.get()) is not None and self.name in context_overrides:
@@ -292,15 +328,12 @@ class Variable(Generic[T_co]):
                         if span:  # pragma: no branch
                             span.set_attribute('invalid_serialized_label', serialized_result.label)
                             span.set_attribute('invalid_serialized_value', serialized_result.value)
-                        default, default_exc = self._get_default_or_exception(
-                            targeting_key, attributes, fallback_exception=value_or_exc
-                        )
                         self._warn_validation_fallback(value_or_exc)
                         return ResolvedVariable(
                             name=self.name,
-                            value=default,
-                            exception=default_exc or value_or_exc,
-                            reason='other_error' if default_exc is not None else 'validation_error',
+                            value=self._get_default_cached(targeting_key, attributes),
+                            exception=value_or_exc,
+                            reason='validation_error',
                             label=serialized_result.label,
                             version=serialized_result.version,
                         )
@@ -316,25 +349,7 @@ class Variable(Generic[T_co]):
             serialized_result = provider.get_serialized_value(self.name, targeting_key, attributes)
 
             if serialized_result.value is None:
-                default, default_exc = self._get_default_or_exception(
-                    targeting_key, attributes, fallback_exception=serialized_result.exception
-                )
-                if default_exc is not None:
-                    return ResolvedVariable(
-                        name=self.name,
-                        value=default,
-                        exception=default_exc,
-                        reason='other_error',
-                    )
-                # Provider had no value; surface that the code default was used.
-                return ResolvedVariable(
-                    name=self.name,
-                    value=default,
-                    exception=serialized_result.exception,
-                    label=None,
-                    version=None,
-                    reason='code_default',
-                )
+                return self._resolve_code_default(targeting_key, attributes, serialized_result=serialized_result)
 
             # Deserialize - returns T | Exception
             value_or_exc = self._deserialize(serialized_result.value)
@@ -342,15 +357,12 @@ class Variable(Generic[T_co]):
                 if span:  # pragma: no branch
                     span.set_attribute('invalid_serialized_label', serialized_result.label)
                     span.set_attribute('invalid_serialized_value', serialized_result.value)
-                default, default_exc = self._get_default_or_exception(
-                    targeting_key, attributes, fallback_exception=value_or_exc
-                )
                 self._warn_validation_fallback(value_or_exc)
                 return ResolvedVariable(
                     name=self.name,
-                    value=default,
-                    exception=default_exc or value_or_exc,
-                    reason='other_error' if default_exc is not None else 'validation_error',
+                    value=self._get_default_cached(targeting_key, attributes),
+                    exception=value_or_exc,
+                    reason='validation_error',
                     label=serialized_result.label,
                     version=serialized_result.version,
                 )
@@ -367,7 +379,14 @@ class Variable(Generic[T_co]):
             if span and serialized_result is not None:  # pragma: no cover
                 span.set_attribute('invalid_serialized_label', serialized_result.label)
                 span.set_attribute('invalid_serialized_value', serialized_result.value)
-            default, _ = self._get_default_or_exception(targeting_key, attributes, fallback_exception=e)
+            try:
+                default = self._get_default_cached(targeting_key, attributes)
+            except Exception as default_exc:
+                default = cast('T_co', None)
+                _emit_resolution_warning(
+                    f"Variable '{self.name}' could not be resolved and its code default raised; "
+                    f'returning None: {default_exc}'
+                )
             return ResolvedVariable(name=self.name, value=default, exception=e, reason='other_error')
 
     def _get_default(
@@ -378,21 +397,62 @@ class Variable(Generic[T_co]):
         else:
             return self.default
 
-    def _get_default_or_exception(
+    def _get_default_cached(
+        self, targeting_key: str | None = None, merged_attributes: Mapping[str, Any] | None = None
+    ) -> T_co:
+        """Return the code default, memoised for the duration of one `_resolve` call.
+
+        Avoids re-invoking a callable default twice when the same `get()`
+        consults it on multiple fallback paths. Both successful values and
+        raised exceptions are cached -- a callable that raises on first
+        invocation re-raises (without re-invoking) on subsequent calls, so a
+        failing default doesn't get called multiple times either. Outside a
+        `_resolve` call the cache is not set and this is a direct passthrough to
+        `_get_default`.
+        """
+        cache = _DEFAULT_CACHE.get()
+        if cache is None:  # pragma: no cover
+            # Defensive: every production call site is inside `_resolve`, which
+            # sets the cache. Falling back to a direct compute keeps the helper
+            # safe if someone reaches in from an unexpected entry point in the
+            # future.
+            return self._get_default(targeting_key, merged_attributes)
+        key = id(self)
+        if key not in cache:
+            try:
+                cache[key] = (True, self._get_default(targeting_key, merged_attributes))
+            except Exception as e:
+                cache[key] = (False, e)
+        ok, payload = cache[key]
+        if ok:
+            return cast('T_co', payload)
+        raise cast('Exception', payload)
+
+    def _get_serialized_default(
+        self, targeting_key: str | None = None, merged_attributes: Mapping[str, Any] | None = None
+    ) -> str | None:
+        """Return the code default serialized as JSON, or None if serialization fails."""
+        try:
+            default = self._get_default_cached(targeting_key, merged_attributes)
+            return self.type_adapter.dump_json(default).decode('utf-8')
+        except (ValueError, TypeError, RuntimeError):
+            return None
+
+    def _resolve_code_default(
         self,
         targeting_key: str | None,
-        merged_attributes: Mapping[str, Any] | None,
-        *,
-        fallback_exception: Exception | None,
-    ) -> tuple[T_co, Exception | None]:
-        try:
-            return self._get_default(targeting_key, merged_attributes), None
-        except Exception as default_exc:
-            cause = f' while handling {fallback_exception.__class__.__name__}' if fallback_exception is not None else ''
-            _emit_resolution_warning(
-                f"Variable '{self.name}' code default raised{cause}; returning None: {default_exc}"
-            )
-            return cast('T_co', None), default_exc
+        attributes: Mapping[str, Any] | None,
+        serialized_result: ResolvedVariable[str | None],
+    ) -> ResolvedVariable[T_co]:
+        """Build a ResolvedVariable from the registered code default."""
+        return ResolvedVariable(
+            name=self.name,
+            value=self._get_default_cached(targeting_key, attributes),
+            exception=serialized_result.exception,
+            label=None,
+            version=None,
+            reason='code_default',
+        )
 
     def _warn_validation_fallback(self, error: Exception) -> None:
         detail: object = (
@@ -436,13 +496,11 @@ class Variable(Generic[T_co]):
         # Get JSON schema from the type adapter
         json_schema = self.type_adapter.json_schema()
 
-        # Get the serialized default value as an example (if not a function)
+        # Get the serialized default value as an example (if not a function). Use
+        # `_get_serialized_default`, which tolerates a non-serializable default by returning None.
         example: str | None = None
         if not is_resolve_function(self.default):
-            try:
-                example = self.type_adapter.dump_json(self.default).decode('utf-8')
-            except (ValueError, TypeError, RuntimeError):
-                example = None
+            example = self._get_serialized_default()
 
         return VariableConfig(
             name=self.name,

--- a/logfire/variables/variable.py
+++ b/logfire/variables/variable.py
@@ -292,13 +292,15 @@ class Variable(Generic[T_co]):
                         if span:  # pragma: no branch
                             span.set_attribute('invalid_serialized_label', serialized_result.label)
                             span.set_attribute('invalid_serialized_value', serialized_result.value)
-                        default = self._get_default(targeting_key, attributes)
+                        default, default_exc = self._get_default_or_exception(
+                            targeting_key, attributes, fallback_exception=value_or_exc
+                        )
                         self._warn_validation_fallback(value_or_exc)
                         return ResolvedVariable(
                             name=self.name,
                             value=default,
-                            exception=value_or_exc,
-                            reason='validation_error',
+                            exception=default_exc or value_or_exc,
+                            reason='other_error' if default_exc is not None else 'validation_error',
                             label=serialized_result.label,
                             version=serialized_result.version,
                         )
@@ -314,10 +316,20 @@ class Variable(Generic[T_co]):
             serialized_result = provider.get_serialized_value(self.name, targeting_key, attributes)
 
             if serialized_result.value is None:
+                default, default_exc = self._get_default_or_exception(
+                    targeting_key, attributes, fallback_exception=serialized_result.exception
+                )
+                if default_exc is not None:
+                    return ResolvedVariable(
+                        name=self.name,
+                        value=default,
+                        exception=default_exc,
+                        reason='other_error',
+                    )
                 # Provider had no value; surface that the code default was used.
                 return ResolvedVariable(
                     name=self.name,
-                    value=self._get_default(targeting_key, attributes),
+                    value=default,
                     exception=serialized_result.exception,
                     label=None,
                     version=None,
@@ -330,13 +342,15 @@ class Variable(Generic[T_co]):
                 if span:  # pragma: no branch
                     span.set_attribute('invalid_serialized_label', serialized_result.label)
                     span.set_attribute('invalid_serialized_value', serialized_result.value)
-                default = self._get_default(targeting_key, attributes)
+                default, default_exc = self._get_default_or_exception(
+                    targeting_key, attributes, fallback_exception=value_or_exc
+                )
                 self._warn_validation_fallback(value_or_exc)
                 return ResolvedVariable(
                     name=self.name,
                     value=default,
-                    exception=value_or_exc,
-                    reason='validation_error',
+                    exception=default_exc or value_or_exc,
+                    reason='other_error' if default_exc is not None else 'validation_error',
                     label=serialized_result.label,
                     version=serialized_result.version,
                 )
@@ -353,13 +367,7 @@ class Variable(Generic[T_co]):
             if span and serialized_result is not None:  # pragma: no cover
                 span.set_attribute('invalid_serialized_label', serialized_result.label)
                 span.set_attribute('invalid_serialized_value', serialized_result.value)
-            try:
-                default = self._get_default(targeting_key, attributes)
-            except Exception:
-                default = cast('T_co', None)
-                _emit_resolution_warning(
-                    f"Variable '{self.name}' could not be resolved and its code default raised; returning None: {e}"
-                )
+            default, _ = self._get_default_or_exception(targeting_key, attributes, fallback_exception=e)
             return ResolvedVariable(name=self.name, value=default, exception=e, reason='other_error')
 
     def _get_default(
@@ -369,6 +377,22 @@ class Variable(Generic[T_co]):
             return self.default(targeting_key, merged_attributes)
         else:
             return self.default
+
+    def _get_default_or_exception(
+        self,
+        targeting_key: str | None,
+        merged_attributes: Mapping[str, Any] | None,
+        *,
+        fallback_exception: Exception | None,
+    ) -> tuple[T_co, Exception | None]:
+        try:
+            return self._get_default(targeting_key, merged_attributes), None
+        except Exception as default_exc:
+            cause = f' while handling {fallback_exception.__class__.__name__}' if fallback_exception is not None else ''
+            _emit_resolution_warning(
+                f"Variable '{self.name}' code default raised{cause}; returning None: {default_exc}"
+            )
+            return cast('T_co', None), default_exc
 
     def _warn_validation_fallback(self, error: Exception) -> None:
         detail: object = (

--- a/logfire/variables/variable.py
+++ b/logfire/variables/variable.py
@@ -1,12 +1,13 @@
 from __future__ import annotations as _annotations
 
 import inspect
+import warnings
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from importlib.util import find_spec
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, cast
 
 from opentelemetry.trace import get_current_span
 from pydantic import TypeAdapter, ValidationError
@@ -115,6 +116,13 @@ def is_resolve_function(f: Any) -> TypeIs[ResolveFunction[Any]]:
         return required_positional <= 2 and total_positional >= 2
 
 
+def _emit_resolution_warning(message: str, *, stacklevel: int = 3) -> None:
+    try:
+        warnings.warn(message, category=RuntimeWarning, stacklevel=stacklevel)
+    except Exception:
+        pass
+
+
 class Variable(Generic[T_co]):
     """A managed variable that can be resolved dynamically based on configuration."""
 
@@ -157,11 +165,11 @@ class Variable(Generic[T_co]):
         self.logfire_instance = logfire_instance.with_settings(custom_scope_suffix='variables')
         self.type_adapter = TypeAdapter[T_co](type)
 
-    def _deserialize(self, serialized_value: str) -> T_co | Exception:
+    def _deserialize(self, serialized_value: str) -> T_co | ValidationError | ValueError | TypeError:
         """Deserialize a JSON string to the variable's type, returning an Exception on failure."""
         try:
             return self.type_adapter.validate_json(serialized_value)
-        except Exception as e:
+        except (ValidationError, ValueError, TypeError) as e:
             return e
 
     @contextmanager
@@ -285,12 +293,12 @@ class Variable(Generic[T_co]):
                             span.set_attribute('invalid_serialized_label', serialized_result.label)
                             span.set_attribute('invalid_serialized_value', serialized_result.value)
                         default = self._get_default(targeting_key, attributes)
-                        reason: str = 'validation_error' if isinstance(value_or_exc, ValidationError) else 'other_error'
+                        self._warn_validation_fallback(value_or_exc)
                         return ResolvedVariable(
                             name=self.name,
                             value=default,
                             exception=value_or_exc,
-                            reason=reason,
+                            reason='validation_error',
                             label=serialized_result.label,
                             version=serialized_result.version,
                         )
@@ -323,12 +331,12 @@ class Variable(Generic[T_co]):
                     span.set_attribute('invalid_serialized_label', serialized_result.label)
                     span.set_attribute('invalid_serialized_value', serialized_result.value)
                 default = self._get_default(targeting_key, attributes)
-                reason: str = 'validation_error' if isinstance(value_or_exc, ValidationError) else 'other_error'
+                self._warn_validation_fallback(value_or_exc)
                 return ResolvedVariable(
                     name=self.name,
                     value=default,
                     exception=value_or_exc,
-                    reason=reason,
+                    reason='validation_error',
                     label=serialized_result.label,
                     version=serialized_result.version,
                 )
@@ -345,7 +353,13 @@ class Variable(Generic[T_co]):
             if span and serialized_result is not None:  # pragma: no cover
                 span.set_attribute('invalid_serialized_label', serialized_result.label)
                 span.set_attribute('invalid_serialized_value', serialized_result.value)
-            default = self._get_default(targeting_key, attributes)
+            try:
+                default = self._get_default(targeting_key, attributes)
+            except Exception:
+                default = cast('T_co', None)
+                _emit_resolution_warning(
+                    f"Variable '{self.name}' could not be resolved and its code default raised; returning None: {e}"
+                )
             return ResolvedVariable(name=self.name, value=default, exception=e, reason='other_error')
 
     def _get_default(
@@ -355,6 +369,14 @@ class Variable(Generic[T_co]):
             return self.default(targeting_key, merged_attributes)
         else:
             return self.default
+
+    def _warn_validation_fallback(self, error: Exception) -> None:
+        detail: object = (
+            error.errors(include_input=False, include_url=False) if isinstance(error, ValidationError) else error
+        )
+        _emit_resolution_warning(
+            f"Variable '{self.name}' value failed validation; falling back to code default: {detail}"
+        )
 
     def _get_merged_attributes(self, attributes: Mapping[str, Any] | None = None) -> Mapping[str, Any]:
         from logfire._internal.config import LocalVariablesOptions, VariablesOptions
@@ -393,7 +415,10 @@ class Variable(Generic[T_co]):
         # Get the serialized default value as an example (if not a function)
         example: str | None = None
         if not is_resolve_function(self.default):
-            example = self.type_adapter.dump_json(self.default).decode('utf-8')
+            try:
+                example = self.type_adapter.dump_json(self.default).decode('utf-8')
+            except (ValueError, TypeError, RuntimeError):
+                example = None
 
         return VariableConfig(
             name=self.name,

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1875,6 +1875,20 @@ class TestVariable:
         assert any('code default raised' in message and 'default failed' in message for message in messages)
         assert not any('returning None: missing' in message for message in messages)
 
+    def test_get_warns_when_missing_config_default_function_fails(self, config_kwargs: dict[str, Any]):
+        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+
+        def bad_default(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> str:
+            raise RuntimeError('default failed')
+
+        var = lf.var(name='unconfigured', default=bad_default, type=str)
+        with pytest.warns(RuntimeWarning, match='code default raised'):
+            result = var.get()
+        assert result.value is None
+        assert result.reason == 'other_error'
+        assert isinstance(result.exception, RuntimeError)
+
     def test_get_calls_failing_default_once_on_validation_error(self, config_kwargs: dict[str, Any]):
         config_kwargs['variables'] = LocalVariablesOptions(
             config=VariablesConfig(

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -20,7 +20,7 @@ from requests import Session
 import logfire
 from logfire._internal.config import LocalVariablesOptions, VariablesOptions
 from logfire.testing import TestExporter
-from logfire.variables.abstract import NoOpVariableProvider, ResolvedVariable, VariableProvider, VariableWriteError
+from logfire.variables.abstract import NoOpVariableProvider, ResolvedVariable, VariableProvider
 from logfire.variables.config import (
     KeyIsNotPresent,
     KeyIsPresent,
@@ -999,7 +999,6 @@ class TestLogfireRemoteVariableProvider:
                 assert result.value is None
                 assert provider._has_attempted_fetch is True
                 assert request_mocker.call_count == 1
-
                 # A second resolve must NOT issue another blocking refresh now that we've attempted once.
                 provider.get_serialized_value('test_var')
                 assert request_mocker.call_count == 1
@@ -2834,6 +2833,7 @@ class TestLogfireRemoteVariableProviderWriteOperations:
         """
         from requests.exceptions import ConnectionError as RequestsConnectionError
 
+        from logfire.variables.abstract import VariableWriteError
         from logfire.variables.config import VariableTypeConfig
 
         request_mocker = requests_mock_module.Mocker()

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -870,6 +870,23 @@ class TestLocalVariableProvider:
         assert result.value is None
         assert result.reason == 'resolved'
 
+    def test_get_all_variables_config_returns_isolated_snapshot(self, simple_config: VariablesConfig):
+        provider = LocalVariableProvider(simple_config)
+        snapshot = provider.get_all_variables_config()
+        assert set(snapshot.variables) == {'test_var'}
+
+        provider.create_variable(
+            VariableConfig(
+                name='added',
+                labels={'default': LabeledValue(version=1, serialized_value='"v"')},
+                rollout=Rollout(labels={'default': 1.0}),
+                overrides=[],
+            )
+        )
+
+        assert set(snapshot.variables) == {'test_var'}
+        assert set(provider.get_all_variables_config().variables) == {'test_var', 'added'}
+
 
 # =============================================================================
 # Test LogfireRemoteVariableProvider (using requests-mock)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -20,7 +20,7 @@ from requests import Session
 import logfire
 from logfire._internal.config import LocalVariablesOptions, VariablesOptions
 from logfire.testing import TestExporter
-from logfire.variables.abstract import NoOpVariableProvider, ResolvedVariable, VariableProvider
+from logfire.variables.abstract import NoOpVariableProvider, ResolvedVariable, VariableProvider, VariableWriteError
 from logfire.variables.config import (
     KeyIsNotPresent,
     KeyIsPresent,
@@ -937,6 +937,32 @@ class TestLogfireRemoteVariableProvider:
             finally:
                 provider.shutdown()
 
+    def test_network_failure_marks_attempted_fetch(self) -> None:
+        from requests.exceptions import ConnectionError as RequestsConnectionError
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', exc=RequestsConnectionError('boom'))
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=True,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            try:
+                with pytest.warns(RuntimeWarning, match='Error retrieving variables'):
+                    result = provider.get_serialized_value('test_var')
+                assert result.value is None
+                assert provider._has_attempted_fetch is True
+                assert request_mocker.call_count == 1
+
+                provider.get_serialized_value('test_var')
+                assert request_mocker.call_count == 1
+            finally:
+                provider.shutdown()
+
     def test_get_serialized_value_missing_config_no_block(self) -> None:
         request_mocker = requests_mock_module.Mocker()
         request_mocker.get(
@@ -1061,6 +1087,38 @@ class TestLogfireRemoteVariableProvider:
                 provider.refresh(force=True)
                 result = provider.get_serialized_value('test_var')
                 assert result.reason == 'unrecognized_variable'
+            finally:
+                provider.shutdown()
+
+    def test_refresh_force_fetches_even_when_lock_appears_busy(self) -> None:
+        from datetime import datetime, timezone
+
+        class FakeLock:
+            def locked(self) -> bool:
+                return True
+
+            def __enter__(self) -> None:
+                return None
+
+            def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+                return None
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            try:
+                provider._last_fetched_at = datetime.now(tz=timezone.utc)
+                provider._refresh_lock = FakeLock()  # type: ignore[assignment]
+                provider.refresh(force=True)
+                assert request_mocker.call_count == 1
             finally:
                 provider.shutdown()
 
@@ -2522,6 +2580,29 @@ class TestLogfireRemoteVariableProviderWriteOperations:
                 request_body = post_adapter.last_request.json()
                 assert request_body['aliases'] == ['old_name', 'legacy_name']
                 assert request_body['example'] == '"example_value"'
+            finally:
+                provider.shutdown()
+
+    def test_variable_types_network_error_raises_write_error(self) -> None:
+        from requests.exceptions import ConnectionError as RequestsConnectionError
+
+        from logfire.variables.config import VariableTypeConfig
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        request_mocker.get('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
+        request_mocker.post('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(block_before_first_resolve=False, polling_interval=timedelta(seconds=60)),
+            )
+            try:
+                with pytest.raises(VariableWriteError, match='Failed to list variable types'):
+                    provider.list_variable_types()
+                with pytest.raises(VariableWriteError, match='Failed to upsert variable type'):
+                    provider.upsert_variable_type(VariableTypeConfig(name='t', json_schema={'type': 'string'}))
             finally:
                 provider.shutdown()
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -14,7 +14,7 @@ from typing import Any
 import pytest
 import requests_mock as requests_mock_module
 from inline_snapshot import snapshot
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ValidationError, field_validator
 from requests import Session
 
 import logfire
@@ -1750,13 +1750,48 @@ class TestVariable:
         lf = logfire.configure(**config_kwargs)
 
         var = lf.var(name='invalid_var', default=999, type=int)
-        details = var.get()
+        with pytest.warns(RuntimeWarning, match='value failed validation'):
+            details = var.get()
         # Falls back to default when validation fails
         assert details.value == 999
         assert details.exception is not None
         assert details.reason == 'validation_error'
         assert details.label == 'default'
         assert details.version == 1
+
+    def test_get_details_with_validator_type_error(self, config_kwargs: dict[str, Any]):
+        class TypeErrorModel(BaseModel):
+            value: int
+
+            @field_validator('value')
+            @classmethod
+            def fail_for_one(cls, value: int) -> int:
+                if value == 1:
+                    raise TypeError('validator exploded')
+                return value
+
+        config_kwargs['variables'] = LocalVariablesOptions(
+            config=VariablesConfig(
+                variables={
+                    'type_error_var': VariableConfig(
+                        name='type_error_var',
+                        labels={'default': LabeledValue(version=1, serialized_value='{"value": 1}')},
+                        rollout=Rollout(labels={'default': 1.0}),
+                        overrides=[],
+                    )
+                }
+            )
+        )
+        lf = logfire.configure(**config_kwargs)
+
+        var = lf.var(name='type_error_var', default=TypeErrorModel(value=0), type=TypeErrorModel)
+        with pytest.warns(RuntimeWarning, match='value failed validation'):
+            result = var.get()
+        assert result.value == TypeErrorModel(value=0)
+        assert isinstance(result.exception, TypeError)
+        assert result.reason == 'validation_error'
+        assert result.label == 'default'
+        assert result.version == 1
 
     def test_get_uses_default_when_no_config(self, config_kwargs: dict[str, Any]):
         config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
@@ -1787,6 +1822,30 @@ class TestVariable:
         result = var.get()
         assert result.value == 'my_default'
         assert result.reason == 'code_default'
+        assert result.exception is provider_error
+
+    def test_get_warns_when_default_function_fails(
+        self, config_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ):
+        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        provider_error = RuntimeError('missing')
+
+        def failing_get(
+            variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
+        ) -> ResolvedVariable[str | None]:
+            raise provider_error
+
+        def bad_default(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> str:
+            raise RuntimeError('default failed')
+
+        monkeypatch.setattr(lf.config._variable_provider, 'get_serialized_value', failing_get)
+
+        var = lf.var(name='unconfigured', default=bad_default, type=str)
+        with pytest.warns(RuntimeWarning, match='code default raised'):
+            result = var.get()
+        assert result.value is None
+        assert result.reason == 'other_error'
         assert result.exception is provider_error
 
     def test_override_context_manager(self, config_kwargs: dict[str, Any], variables_config: VariablesConfig):
@@ -3848,6 +3907,13 @@ class TestVariableToConfig:
         config = var.to_config()
         assert config.name == 'func_var'
         # Example should be None when default is a function
+        assert config.example is None
+
+    def test_to_config_with_unserializable_default(self, config_kwargs: dict[str, Any]):
+        lf = logfire.configure(**config_kwargs)
+        var = lf.var(name='opaque', type=object, default=object())
+        config = var.to_config()
+        assert config.name == 'opaque'
         assert config.example is None
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -1095,6 +1095,30 @@ class TestLogfireRemoteVariableProvider:
             # 30% of 10000ms = 3000ms = 3.0s for SSE
             mock_sse.join.assert_called_once_with(timeout=3.0)
 
+    def test_at_fork_reinit_does_not_restart_after_shutdown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import logfire.variables.remote as remote_module
+
+        provider = LogfireRemoteVariableProvider(
+            base_url=REMOTE_BASE_URL,
+            token=REMOTE_TOKEN,
+            options=VariablesOptions(
+                block_before_first_resolve=False,
+                polling_interval=timedelta(seconds=60),
+            ),
+        )
+        provider._started = True
+        provider._shutdown = True
+        mock_thread_cls = unittest.mock.MagicMock()
+        mock_start_sse = unittest.mock.MagicMock()
+        monkeypatch.setattr(remote_module.threading, 'Thread', mock_thread_cls)
+        monkeypatch.setattr(provider, '_start_sse_listener', mock_start_sse)
+
+        provider._at_fork_reinit()
+
+        assert provider._shutdown is True
+        mock_thread_cls.assert_not_called()
+        mock_start_sse.assert_not_called()
+
     def test_refresh_with_force(self) -> None:
         request_mocker = requests_mock_module.Mocker()
         request_mocker.get(
@@ -1842,11 +1866,47 @@ class TestVariable:
         monkeypatch.setattr(lf.config._variable_provider, 'get_serialized_value', failing_get)
 
         var = lf.var(name='unconfigured', default=bad_default, type=str)
-        with pytest.warns(RuntimeWarning, match='code default raised'):
+        with pytest.warns(RuntimeWarning) as warnings:
             result = var.get()
         assert result.value is None
         assert result.reason == 'other_error'
         assert result.exception is provider_error
+        messages = [str(warning.message) for warning in warnings]
+        assert any('code default raised' in message and 'default failed' in message for message in messages)
+        assert not any('returning None: missing' in message for message in messages)
+
+    def test_get_calls_failing_default_once_on_validation_error(self, config_kwargs: dict[str, Any]):
+        config_kwargs['variables'] = LocalVariablesOptions(
+            config=VariablesConfig(
+                variables={
+                    'invalid_var': VariableConfig(
+                        name='invalid_var',
+                        labels={'default': LabeledValue(version=1, serialized_value='"bad"')},
+                        rollout=Rollout(labels={'default': 1.0}),
+                        overrides=[],
+                    )
+                }
+            )
+        )
+        lf = logfire.configure(**config_kwargs)
+        calls = 0
+
+        def bad_default(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> int:
+            nonlocal calls
+            calls += 1
+            raise RuntimeError('default failed')
+
+        var = lf.var(name='invalid_var', default=bad_default, type=int)
+        with pytest.warns(RuntimeWarning) as warnings:
+            result = var.get()
+
+        assert calls == 1
+        assert result.value is None
+        assert result.reason == 'other_error'
+        assert isinstance(result.exception, RuntimeError)
+        messages = [str(warning.message) for warning in warnings]
+        assert any('value failed validation' in message for message in messages)
+        assert any('code default raised' in message and 'default failed' in message for message in messages)
 
     def test_override_context_manager(self, config_kwargs: dict[str, Any], variables_config: VariablesConfig):
         config_kwargs['variables'] = LocalVariablesOptions(config=variables_config)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -738,6 +738,33 @@ class TestResolvedVariable:
             baggage = logfire.get_baggage()
             assert baggage == snapshot({'logfire.variables.no_version_var': '<code_default>'})
 
+    def test_latest_ref_without_version_reports_code_default_metadata(self, config_kwargs: dict[str, Any]):
+        config_kwargs['variables'] = LocalVariablesOptions(
+            config=VariablesConfig(
+                variables={
+                    'latest_before_v1': VariableConfig(
+                        name='latest_before_v1',
+                        labels={'latest': LabelRef(ref='latest')},
+                        rollout=Rollout(labels={'latest': 1.0}),
+                        overrides=[],
+                    ),
+                }
+            )
+        )
+        lf = logfire.configure(**config_kwargs)
+
+        var = lf.var(name='latest_before_v1', default='default', type=str)
+        details = var.get()
+
+        assert details.value == 'default'
+        assert details.reason == 'code_default'
+        assert details.label is None
+        assert details.version is None
+
+        with details:
+            baggage = logfire.get_baggage()
+            assert baggage == snapshot({'logfire.variables.latest_before_v1': '<code_default>'})
+
     def test_context_manager_returns_self(self, config_kwargs: dict[str, Any]):
         lf = logfire.configure(**config_kwargs)
         var = lf.var(name='cm_return_test', default='default', type=str)
@@ -5148,7 +5175,7 @@ class TestGetSerializedValueForLabelCodeDefault:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'v1')
         assert result.value is None
-        assert result.reason == 'resolved'
+        assert result.reason == 'missing_config'
 
 
 class TestGetSerializedValueForLabelNotFound:
@@ -5168,7 +5195,7 @@ class TestGetSerializedValueForLabelNotFound:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'nonexistent')
         assert result.value is None
-        assert result.reason == 'resolved'
+        assert result.reason == 'missing_config'
 
 
 class TestVariableGetWithExplicitLabel:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -4799,6 +4799,19 @@ class TestVarResolveFunctionWithoutType:
             lf.var(name='my_var', default=resolver)
 
 
+class TestVarNoneDefaultWithoutType:
+    """Test that var() raises when default is None but type is not provided."""
+
+    def test_none_default_without_type(self, config_kwargs: dict[str, Any]):
+        lf = logfire.configure(**config_kwargs)
+
+        with pytest.raises(TypeError, match='`type` must be provided'):
+            lf.var(name='none_var', default=None)
+
+        var = lf.var(name='optional_var', type=int | None, default=None)  # pyright: ignore[reportArgumentType]
+        assert var.get().value is None
+
+
 class TestVarDuplicateName:
     """Test that var() raises when registering a variable with a duplicate name."""
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -993,7 +993,7 @@ class TestLogfireRemoteVariableProvider:
             )
             try:
                 # First resolve triggers a blocking refresh that fails (logged as a RuntimeWarning
-                # since no logfire instance is bound) -- but the attempt must still be recorded.
+                # since no logfire instance is bound) — but the attempt must still be recorded.
                 with pytest.warns(RuntimeWarning, match='Error retrieving variables'):
                     result = provider.get_serialized_value('test_var')
                 assert result.value is None
@@ -2778,34 +2778,6 @@ class TestLogfireRemoteVariableProviderWriteOperations:
             finally:
                 provider.shutdown()
 
-    def test_variable_types_network_error_raises_write_error(self) -> None:
-        """list/upsert variable types surface network errors as VariableWriteError (D4).
-
-        Regression: these two methods caught only UnexpectedResponse, so a raw
-        ConnectionError/Timeout (a RequestException) leaked out, unlike create/update/delete.
-        """
-        from requests.exceptions import ConnectionError as RequestsConnectionError
-
-        from logfire.variables.config import VariableTypeConfig
-
-        request_mocker = requests_mock_module.Mocker()
-        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
-        request_mocker.get('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
-        request_mocker.post('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
-        with request_mocker:
-            provider = LogfireRemoteVariableProvider(
-                base_url=REMOTE_BASE_URL,
-                token=REMOTE_TOKEN,
-                options=VariablesOptions(block_before_first_resolve=False, polling_interval=timedelta(seconds=60)),
-            )
-            try:
-                with pytest.raises(VariableWriteError, match='Failed to list variable types'):
-                    provider.list_variable_types()
-                with pytest.raises(VariableWriteError, match='Failed to upsert variable type'):
-                    provider.upsert_variable_type(VariableTypeConfig(name='t', json_schema={'type': 'string'}))
-            finally:
-                provider.shutdown()
-
     def test_create_variable_already_exists(self) -> None:
         from logfire.variables.abstract import VariableAlreadyExistsError
 
@@ -2851,6 +2823,34 @@ class TestLogfireRemoteVariableProviderWriteOperations:
                 )
                 with pytest.raises(VariableWriteError, match='Failed to create variable'):
                     provider.create_variable(config)
+            finally:
+                provider.shutdown()
+
+    def test_variable_types_network_error_raises_write_error(self) -> None:
+        """list/upsert variable types surface network errors as VariableWriteError (D4).
+
+        Regression: these two methods caught only UnexpectedResponse, so a raw
+        ConnectionError/Timeout (a RequestException) leaked out, unlike create/update/delete.
+        """
+        from requests.exceptions import ConnectionError as RequestsConnectionError
+
+        from logfire.variables.config import VariableTypeConfig
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        request_mocker.get('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
+        request_mocker.post('http://localhost:8000/v1/variable-types/', exc=RequestsConnectionError('boom'))
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(block_before_first_resolve=False, polling_interval=timedelta(seconds=60)),
+            )
+            try:
+                with pytest.raises(VariableWriteError, match='Failed to list variable types'):
+                    provider.list_variable_types()
+                with pytest.raises(VariableWriteError, match='Failed to upsert variable type'):
+                    provider.upsert_variable_type(VariableTypeConfig(name='t', json_schema={'type': 'string'}))
             finally:
                 provider.shutdown()
 
@@ -5395,7 +5395,7 @@ class TestGetSerializedValueForLabelNotFound:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'nonexistent')
         assert result.value is None
-        # The variable exists but the label doesn't -- reported as missing_config, not 'resolved'.
+        # The variable exists but the label doesn't — reported as missing_config, not 'resolved'.
         assert result.reason == 'missing_config'
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -739,6 +739,7 @@ class TestResolvedVariable:
             assert baggage == snapshot({'logfire.variables.no_version_var': '<code_default>'})
 
     def test_latest_ref_without_version_reports_code_default_metadata(self, config_kwargs: dict[str, Any]):
+        """A 100% latest rollout falls back to the code default until the first version exists."""
         config_kwargs['variables'] = LocalVariablesOptions(
             config=VariablesConfig(
                 variables={
@@ -898,10 +899,15 @@ class TestLocalVariableProvider:
         assert result.reason == 'resolved'
 
     def test_get_all_variables_config_returns_isolated_snapshot(self, simple_config: VariablesConfig):
+        """get_all_variables_config() returns a deep-copied snapshot under the lock.
+
+        Regression test: it used to return the live `self._config`, so a concurrent
+        create/update/delete mutating `variables` in place could raise
+        "dictionary changed size during iteration" in the push/validation walkers.
+        """
         provider = LocalVariableProvider(simple_config)
         snapshot = provider.get_all_variables_config()
         assert set(snapshot.variables) == {'test_var'}
-
         provider.create_variable(
             VariableConfig(
                 name='added',
@@ -910,8 +916,9 @@ class TestLocalVariableProvider:
                 overrides=[],
             )
         )
-
+        # The previously-returned snapshot is unaffected by the later write...
         assert set(snapshot.variables) == {'test_var'}
+        # ...while a fresh snapshot reflects it.
         assert set(provider.get_all_variables_config().variables) == {'test_var', 'added'}
 
 
@@ -965,6 +972,12 @@ class TestLogfireRemoteVariableProvider:
                 provider.shutdown()
 
     def test_network_failure_marks_attempted_fetch(self) -> None:
+        """A failed fetch still marks `_has_attempted_fetch`, so resolves don't block on every call.
+
+        Regression test: the HTTP-failure path used to `return` before setting the flag, so with
+        `block_before_first_resolve` every `get_serialized_value` issued a fresh blocking refresh
+        while the server was unreachable.
+        """
         from requests.exceptions import ConnectionError as RequestsConnectionError
 
         request_mocker = requests_mock_module.Mocker()
@@ -979,12 +992,15 @@ class TestLogfireRemoteVariableProvider:
                 ),
             )
             try:
+                # First resolve triggers a blocking refresh that fails (logged as a RuntimeWarning
+                # since no logfire instance is bound) -- but the attempt must still be recorded.
                 with pytest.warns(RuntimeWarning, match='Error retrieving variables'):
                     result = provider.get_serialized_value('test_var')
                 assert result.value is None
                 assert provider._has_attempted_fetch is True
                 assert request_mocker.call_count == 1
 
+                # A second resolve must NOT issue another blocking refresh now that we've attempted once.
                 provider.get_serialized_value('test_var')
                 assert request_mocker.call_count == 1
             finally:
@@ -1783,7 +1799,32 @@ class TestVariable:
         assert details.label == 'default'
         assert details.version == 1
 
-    def test_get_details_with_validator_type_error(self, config_kwargs: dict[str, Any]):
+    def test_get_uses_default_when_no_config(self, config_kwargs: dict[str, Any]):
+        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+
+        var = lf.var(name='unconfigured', default='my_default', type=str)
+        result = var.get()
+        assert result.value == 'my_default'
+        assert result.reason == 'code_default'
+
+    def test_get_calls_function_default_once_when_no_config(self, config_kwargs: dict[str, Any]):
+        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        calls = 0
+
+        def default(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> str:
+            nonlocal calls
+            calls += 1
+            return 'my_default'
+
+        var = lf.var(name='unconfigured', default=default, type=str)
+        result = var.get()
+        assert result.value == 'my_default'
+        assert result.reason == 'code_default'
+        assert calls == 1
+
+    def test_get_preserves_metadata_with_deserialization_type_error(self, config_kwargs: dict[str, Any]):
         class TypeErrorModel(BaseModel):
             value: int
 
@@ -1813,18 +1854,12 @@ class TestVariable:
             result = var.get()
         assert result.value == TypeErrorModel(value=0)
         assert isinstance(result.exception, TypeError)
+        # A validator raising TypeError is still a deserialization failure, so the reason
+        # matches the "value failed validation" warning (rather than splitting on whether
+        # pydantic wrapped the error into a ValidationError).
         assert result.reason == 'validation_error'
         assert result.label == 'default'
         assert result.version == 1
-
-    def test_get_uses_default_when_no_config(self, config_kwargs: dict[str, Any]):
-        config_kwargs['variables'] = LocalVariablesOptions(config=VariablesConfig(variables={}))
-        lf = logfire.configure(**config_kwargs)
-
-        var = lf.var(name='unconfigured', default='my_default', type=str)
-        result = var.get()
-        assert result.value == 'my_default'
-        assert result.reason == 'code_default'
 
     def test_get_preserves_provider_exception_when_using_code_default(
         self, config_kwargs: dict[str, Any], monkeypatch: pytest.MonkeyPatch
@@ -2744,6 +2779,11 @@ class TestLogfireRemoteVariableProviderWriteOperations:
                 provider.shutdown()
 
     def test_variable_types_network_error_raises_write_error(self) -> None:
+        """list/upsert variable types surface network errors as VariableWriteError (D4).
+
+        Regression: these two methods caught only UnexpectedResponse, so a raw
+        ConnectionError/Timeout (a RequestException) leaked out, unlike create/update/delete.
+        """
         from requests.exceptions import ConnectionError as RequestsConnectionError
 
         from logfire.variables.config import VariableTypeConfig
@@ -3984,6 +4024,11 @@ class TestVariableToConfig:
         assert config.example is None
 
     def test_to_config_with_unserializable_default(self, config_kwargs: dict[str, Any]):
+        """to_config() tolerates a non-serializable default (example=None) instead of raising.
+
+        Resolution already degrades to no example for such a default, so building a config
+        (e.g. for variables_push) must not crash where resolution wouldn't.
+        """
         lf = logfire.configure(**config_kwargs)
         var = lf.var(name='opaque', type=object, default=object())
         config = var.to_config()
@@ -5328,6 +5373,8 @@ class TestGetSerializedValueForLabelCodeDefault:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'v1')
         assert result.value is None
+        # A label that refs code_default (which the provider can't supply a value for) is reported
+        # as missing_config, not a successful 'resolved'.
         assert result.reason == 'missing_config'
 
 
@@ -5348,6 +5395,7 @@ class TestGetSerializedValueForLabelNotFound:
         provider = LocalVariableProvider(config)
         result = provider.get_serialized_value_for_label('test_var', 'nonexistent')
         assert result.value is None
+        # The variable exists but the label doesn't -- reported as missing_config, not 'resolved'.
         assert result.reason == 'missing_config'
 
 


### PR DESCRIPTION
Extracts standalone managed-variable hardening from the #1954 review stack so it can be reviewed and shipped independently of composition/template support.

Changes:
- Return deep-copied local variable config snapshots to avoid concurrent mutation during diff/validation walks.
- Harden the remote variable provider around failed initial fetches, forced refresh read-after-write behavior, SSE reconnect backoff, fork reinit, and variable-type network errors.
- Fix code-default metadata for explicit-label misses, `code_default` refs, and `latest` labels before any version exists.
- Require an explicit `type=` for `logfire.var(default=None)`.
- Warn on variable validation/default fallback failures and keep deserialization failures under `reason='validation_error'`.

Verification:
- `uv run pytest tests/test_variables.py -q`
