### PR TITLE
Require configure before lazy remote variables

### DIFF
--- a/docs/reference/advanced/managed-variables/remote.md
+++ b/docs/reference/advanced/managed-variables/remote.md
@@ -20,7 +20,7 @@ agent_config = logfire.var(
 ```
 
 !!! tip "Automatic Remote Variables"
-    If `LOGFIRE_API_KEY` is set in your environment, variable APIs will **automatically** use the remote provider without needing `variables=VariablesOptions()` in `configure()`. The first time a variable is resolved, the SDK detects the API key and lazily initializes the remote provider with default options. You only need to pass `variables=VariablesOptions(...)` explicitly if you want to customize options like `polling_interval` or `block_before_first_resolve`.
+    If `LOGFIRE_API_KEY` is set in your environment, variable APIs will **automatically** use the remote provider after `logfire.configure()` is called, without needing `variables=VariablesOptions()` in `configure()`. The first time a variable is resolved after configuration, the SDK detects the API key and lazily initializes the remote provider with default options. You only need to pass `variables=VariablesOptions(...)` explicitly if you want to customize options like `polling_interval` or `block_before_first_resolve`.
 
 !!! note "API Key Required"
     Remote variables require an API key with the `project:read_variables` scope. This is different from the write token (`LOGFIRE_TOKEN`) used to send traces and logs. Set the API key via the `LOGFIRE_API_KEY` environment variable or pass it directly to `logfire.configure(api_key=...)`. See [External Variables and OFREP](external.md) for details on scopes and accessing variables from client-side applications.

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1504,23 +1504,23 @@ class LogfireConfig(_LogfireConfigData):
         This is used internally and should not be called by users of the SDK.
 
         If no provider has been explicitly configured (i.e. `variables=` was not passed to
-        `configure()`), but a `LOGFIRE_API_KEY` is available, a `LogfireRemoteVariableProvider`
-        will be lazily created on the first call.
+        `configure()`), but `configure()` has been called and a `LOGFIRE_API_KEY` is available,
+        a `LogfireRemoteVariableProvider` will be lazily created on the first call.
 
         Returns:
             The variable provider.
         """
         provider = self._variable_provider
-        if isinstance(provider, NoOpVariableProvider) and self.variables is None:
+        if self._initialized and isinstance(provider, NoOpVariableProvider) and self.variables is None:
             provider = self._lazy_init_variable_provider()
         return provider
 
     def _lazy_init_variable_provider(self) -> VariableProvider:
         """Attempt to lazily initialize a remote variable provider.
 
-        This is called when no explicit `variables=` option was passed to `configure()`,
-        but the user may have a `LOGFIRE_API_KEY` set in the environment. If so, we
-        create a `LogfireRemoteVariableProvider` with default options.
+        This is called after `configure()` when no explicit `variables=` option was passed,
+        but the user may have a `LOGFIRE_API_KEY` set in the environment. If so, we create a
+        `LogfireRemoteVariableProvider` with default options.
         """
         with self._lock:
             # Double-check after acquiring lock

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ValidationError
 from requests import Session
 
 import logfire
-from logfire._internal.config import LocalVariablesOptions, VariablesOptions
+from logfire._internal.config import LocalVariablesOptions, LogfireConfig, VariablesOptions
 from logfire.testing import TestExporter
 from logfire.variables.abstract import NoOpVariableProvider, ResolvedVariable, VariableProvider
 from logfire.variables.config import (
@@ -5130,6 +5130,16 @@ class TestVariableGetWithExplicitLabel:
 
 class TestLazyVariableProviderInit:
     """Tests for lazy initialization of the variable provider when LOGFIRE_API_KEY is set."""
+
+    def test_no_lazy_init_before_configure(self) -> None:
+        """LOGFIRE_API_KEY alone should not enable remote variables before configure()."""
+        config = LogfireConfig()
+
+        with unittest.mock.patch.dict('os.environ', {'LOGFIRE_API_KEY': REMOTE_TOKEN}):
+            provider = config.get_variable_provider()
+
+        assert isinstance(provider, NoOpVariableProvider)
+        assert isinstance(config._variable_provider, NoOpVariableProvider)
 
     def test_lazy_init_when_api_key_set(self, config_kwargs: dict[str, Any]) -> None:
         """When LOGFIRE_API_KEY is set but variables= is not passed, get_variable_provider()


### PR DESCRIPTION
## Summary

- Require `logfire.configure()` before `LOGFIRE_API_KEY` can lazily enable the remote variable provider
- Keep lazy remote provider initialization after configuration when `variables=` is omitted
- Update managed-variable docs to describe the configure-first behavior

## Tests

- `uv run pytest tests/test_variables.py::TestLazyVariableProviderInit -q`
- `uv run ruff check logfire/_internal/config.py tests/test_variables.py`
- Pre-commit via `gcap`: Ruff, Ruff Format, pyright
