### PR TITLE
Add minimal install CI smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,38 +63,7 @@ jobs:
       - name: Smoke test minimal install
         run: |
           cd "$(mktemp -d)"
-          "$GITHUB_WORKSPACE/.minimal-venv/bin/python" - <<'PY'
-          from importlib import metadata, util
-
-          def assert_not_available(package: str) -> None:
-              if util.find_spec(package) is not None:
-                  raise AssertionError(f'{package} should not be importable')
-
-              try:
-                  metadata.version(package)
-              except metadata.PackageNotFoundError:
-                  pass
-              else:
-                  raise AssertionError(f'{package} should not be installed')
-
-          for package in ('pytest', 'pydantic', 'httpx'):
-              assert_not_available(package)
-
-          import logfire
-
-          for package in ('pytest', 'pydantic', 'httpx'):
-              assert_not_available(package)
-
-          logfire.configure(send_to_logfire=False, console=False, inspect_arguments=False)
-          logfire.info('minimal install info', answer=42)
-          with logfire.span('minimal install span', answer=42):
-              logfire.debug('inside minimal install span')
-
-          counter = logfire.metric_counter('minimal_install_counter')
-          counter.add(1)
-          assert logfire.force_flush()
-          assert logfire.shutdown()
-          PY
+          "$GITHUB_WORKSPACE/.minimal-venv/bin/python" "$GITHUB_WORKSPACE/.github/workflows/scripts/minimal_install_smoke.py"
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,13 +52,10 @@ jobs:
           version: "0.11.1"
           enable-cache: true  # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
 
-      - name: Build logfire wheel
-        run: uv build --wheel --out-dir dist-minimal
-
       - name: Install only logfire
         run: |
-          uv venv --python 3.12 .minimal-venv
-          uv pip install --python .minimal-venv dist-minimal/logfire-*.whl
+          uv venv --python 3.14 .minimal-venv
+          uv pip install --python .minimal-venv .
 
       - name: Smoke test minimal install
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,64 @@ jobs:
         env:
           SKIP: no-commit-to-branch
 
+  minimal-install:
+    name: test minimal install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.1"
+          enable-cache: true  # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+
+      - name: Build logfire wheel
+        run: uv build --wheel --out-dir dist-minimal
+
+      - name: Install only logfire
+        run: |
+          uv venv --python 3.12 .minimal-venv
+          uv pip install --python .minimal-venv dist-minimal/logfire-*.whl
+
+      - name: Smoke test minimal install
+        run: |
+          cd "$(mktemp -d)"
+          "$GITHUB_WORKSPACE/.minimal-venv/bin/python" - <<'PY'
+          from importlib import metadata, util
+
+          def assert_not_available(package: str) -> None:
+              if util.find_spec(package) is not None:
+                  raise AssertionError(f'{package} should not be importable')
+
+              try:
+                  metadata.version(package)
+              except metadata.PackageNotFoundError:
+                  pass
+              else:
+                  raise AssertionError(f'{package} should not be installed')
+
+          for package in ('pytest', 'pydantic', 'httpx'):
+              assert_not_available(package)
+
+          import logfire
+
+          for package in ('pytest', 'pydantic', 'httpx'):
+              assert_not_available(package)
+
+          logfire.configure(send_to_logfire=False, console=False, inspect_arguments=False)
+          logfire.info('minimal install info', answer=42)
+          with logfire.span('minimal install span', answer=42):
+              logfire.debug('inside minimal install span')
+
+          counter = logfire.metric_counter('minimal_install_counter')
+          counter.add(1)
+          assert logfire.force_flush()
+          assert logfire.shutdown()
+          PY
+
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
     # Use Depot 4-core runners for maintainer PRs (faster CPUs/more cores)
@@ -171,7 +229,7 @@ jobs:
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
-    needs: [ lint, test, coverage, test-pyodide ]
+    needs: [ lint, minimal-install, test, coverage, test-pyodide ]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/scripts/minimal_install_smoke.py
+++ b/.github/workflows/scripts/minimal_install_smoke.py
@@ -27,6 +27,10 @@ def assert_import_error(label: str, func: Callable[[], object]) -> None:
         raise AssertionError(f'{label} should fail without its extra dependencies')
 
 
+class NotJsonSerializable:
+    """A simple object for exercising non-JSON attribute handling."""
+
+
 def main() -> None:
     """Smoke-test core logfire APIs in a minimal installation."""
     for package in ('pytest', 'pydantic', 'httpx'):
@@ -47,8 +51,9 @@ def main() -> None:
         assert_not_available(package)
 
     logfire.configure(send_to_logfire=False)
-    logfire.info('minimal install info', answer=42)
-    with logfire.span('minimal install span', answer=42):
+    not_json_serializable = NotJsonSerializable()
+    logfire.info('minimal install info', answer=42, not_json_serializable=not_json_serializable)
+    with logfire.span('minimal install span', answer=42, not_json_serializable=not_json_serializable):
         logfire.debug('inside minimal install span')
 
     counter = logfire.metric_counter('minimal_install_counter')

--- a/.github/workflows/scripts/minimal_install_smoke.py
+++ b/.github/workflows/scripts/minimal_install_smoke.py
@@ -17,12 +17,13 @@ def assert_not_available(package: str) -> None:
         raise AssertionError(f'{package} should not be installed')
 
 
-def assert_import_error(label: str, func: Callable[[], object]) -> None:
+def assert_import_error(label: str, func: Callable[[], object], expected_message: str) -> None:
     """Assert that an optional feature fails without its extra dependencies."""
     try:
         func()
-    except ImportError:
-        pass
+    except ImportError as exc:
+        if expected_message not in str(exc):
+            raise AssertionError(f'{label} raised an unexpected error message: {exc}') from exc
     else:
         raise AssertionError(f'{label} should fail without its extra dependencies')
 
@@ -41,11 +42,27 @@ def main() -> None:
     for package in ('pytest', 'pydantic', 'httpx'):
         assert_not_available(package)
 
-    assert_import_error('testing helpers', lambda: import_module('logfire.testing'))
-    assert_import_error('query client', lambda: import_module('logfire.query_client'))
-    assert_import_error('datasets client', lambda: import_module('logfire.experimental.api_client'))
-    assert_import_error('managed variable imports', lambda: getattr(import_module('logfire.variables'), 'Variable'))
-    assert_import_error('managed variable usage', lambda: logfire.var('minimal_install_flag', default=False))
+    assert_import_error('testing helpers', lambda: import_module('logfire.testing'), "No module named 'pytest'")
+    assert_import_error(
+        'query client',
+        lambda: import_module('logfire.query_client'),
+        'httpx is required to use the Logfire query clients',
+    )
+    assert_import_error(
+        'datasets client',
+        lambda: import_module('logfire.experimental.api_client'),
+        "No module named 'pydantic'",
+    )
+    assert_import_error(
+        'managed variable imports',
+        lambda: getattr(import_module('logfire.variables'), 'Variable'),
+        'Using managed variables requires the `pydantic` package',
+    )
+    assert_import_error(
+        'managed variable usage',
+        lambda: logfire.var('minimal_install_flag', default=False),
+        "No module named 'pydantic'",
+    )
 
     for package in ('pytest', 'pydantic', 'httpx'):
         assert_not_available(package)

--- a/.github/workflows/scripts/minimal_install_smoke.py
+++ b/.github/workflows/scripts/minimal_install_smoke.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from importlib import metadata, util
+from collections.abc import Callable
+from importlib import import_module, metadata, util
 
 
 def assert_not_available(package: str) -> None:
@@ -16,12 +17,31 @@ def assert_not_available(package: str) -> None:
         raise AssertionError(f'{package} should not be installed')
 
 
+def assert_import_error(label: str, func: Callable[[], object]) -> None:
+    """Assert that an optional feature fails without its extra dependencies."""
+    try:
+        func()
+    except ImportError:
+        pass
+    else:
+        raise AssertionError(f'{label} should fail without its extra dependencies')
+
+
 def main() -> None:
     """Smoke-test core logfire APIs in a minimal installation."""
     for package in ('pytest', 'pydantic', 'httpx'):
         assert_not_available(package)
 
     import logfire
+
+    for package in ('pytest', 'pydantic', 'httpx'):
+        assert_not_available(package)
+
+    assert_import_error('testing helpers', lambda: import_module('logfire.testing'))
+    assert_import_error('query client', lambda: import_module('logfire.query_client'))
+    assert_import_error('datasets client', lambda: import_module('logfire.experimental.api_client'))
+    assert_import_error('managed variable imports', lambda: getattr(import_module('logfire.variables'), 'Variable'))
+    assert_import_error('managed variable usage', lambda: logfire.var('minimal_install_flag', default=False))
 
     for package in ('pytest', 'pydantic', 'httpx'):
         assert_not_available(package)

--- a/.github/workflows/scripts/minimal_install_smoke.py
+++ b/.github/workflows/scripts/minimal_install_smoke.py
@@ -26,7 +26,7 @@ def main() -> None:
     for package in ('pytest', 'pydantic', 'httpx'):
         assert_not_available(package)
 
-    logfire.configure(send_to_logfire=False, console=False)
+    logfire.configure(send_to_logfire=False)
     logfire.info('minimal install info', answer=42)
     with logfire.span('minimal install span', answer=42):
         logfire.debug('inside minimal install span')

--- a/.github/workflows/scripts/minimal_install_smoke.py
+++ b/.github/workflows/scripts/minimal_install_smoke.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from importlib import metadata, util
+
+
+def assert_not_available(package: str) -> None:
+    """Assert that a package is neither installed nor importable."""
+    if util.find_spec(package) is not None:
+        raise AssertionError(f'{package} should not be importable')
+
+    try:
+        metadata.version(package)
+    except metadata.PackageNotFoundError:
+        pass
+    else:
+        raise AssertionError(f'{package} should not be installed')
+
+
+def main() -> None:
+    """Smoke-test core logfire APIs in a minimal installation."""
+    for package in ('pytest', 'pydantic', 'httpx'):
+        assert_not_available(package)
+
+    import logfire
+
+    for package in ('pytest', 'pydantic', 'httpx'):
+        assert_not_available(package)
+
+    logfire.configure(send_to_logfire=False, console=False)
+    logfire.info('minimal install info', answer=42)
+    with logfire.span('minimal install span', answer=42):
+        logfire.debug('inside minimal install span')
+
+    counter = logfire.metric_counter('minimal_install_counter')
+    counter.add(1)
+    assert logfire.force_flush()
+    assert logfire.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a minimal-install CI job that builds the logfire wheel and installs it into a fresh venv
- smoke test import/configure/log/span/metric/flush/shutdown from outside the checkout
- assert pytest, pydantic, and httpx are neither installed nor importable before and after importing logfire

## Tests
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/main.yml")'
- local fresh-wheel minimal install smoke script
- uv run pre-commit run --files .github/workflows/main.yml
