### PR TITLE
Disable console logging for the 'Logfire configured' log

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1676,9 +1676,11 @@ def emit_configuration_span(config: LogfireConfig, logfire_instance: Logfire, *,
     else:  # pragma: no cover
         token_count = len(config.token)
 
-    logfire_instance.info(
+    logfire_instance.log(
+        'info',
         'Logfire configured',
-        **{  # type: ignore
+        console_log=False,
+        attributes={
             ATTRIBUTES_CONFIG: {
                 'local': local,
                 'send_to_logfire': config.send_to_logfire,

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1755,6 +1755,7 @@ def test_configuration_span_emitted_when_opted_in(config_kwargs: dict[str, Any],
                             'logfire.package_versions': {'type': 'object'},
                         },
                     },
+                    'logfire.disable_console_log': True,
                 },
             }
         ]


### PR DESCRIPTION
To prevent this with verbose logging:

<img width="628" height="1080" alt="Screenshot 2026-06-10 at 12 11 58" src="https://github.com/user-attachments/assets/8f7f4b5e-a57c-4094-9d03-d4e5986d5ba0" />

https://pydantic.slack.com/archives/C0813FX362E/p1780472863982879