### PR TITLE
Avoid truncating rich console arguments

### DIFF
--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -283,9 +283,10 @@ class SimpleConsoleSpanExporter(SpanExporter):
         """Print logfire arguments in color using rich, particularly with syntax highlighting."""
         assert self._console is not None
 
+        syntax = Syntax('', 'python', background_color='default')
         for k, value_code in arguments.items():
-            highlighted = Syntax(value_code, 'python', background_color='default').highlight(value_code)
-            highlighted.plain = highlighted.plain[: len(value_code)]
+            highlighted = syntax.highlight(f'{value_code}\n')
+            highlighted.right_crop(1)
 
             out = Text()
             for i, line in enumerate(highlighted.split('\n', allow_blank=True)):

--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -285,6 +285,9 @@ class SimpleConsoleSpanExporter(SpanExporter):
 
         syntax = Syntax('', 'python', background_color='default')
         for k, value_code in arguments.items():
+            # Rich adds a trailing newline when highlighting code without one.
+            # Append our own so cropping removes only that generated newline,
+            # preserving original trailing newlines and expanded tabs.
             highlighted = syntax.highlight(f'{value_code}\n')
             highlighted.right_crop(1)
 

--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -285,8 +285,7 @@ class SimpleConsoleSpanExporter(SpanExporter):
 
         for k, value_code in arguments.items():
             highlighted = Syntax(value_code, 'python', background_color='default').highlight(value_code)
-            if not value_code.endswith('\n'):
-                highlighted.right_crop(1)
+            highlighted.plain = highlighted.plain[: len(value_code)]
 
             out = Text()
             for i, line in enumerate(highlighted.split('\n', allow_blank=True)):

--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -18,7 +18,6 @@ from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
-from rich.columns import Columns
 from rich.console import Console, Group
 from rich.syntax import Syntax
 from rich.text import Text
@@ -284,25 +283,16 @@ class SimpleConsoleSpanExporter(SpanExporter):
         """Print logfire arguments in color using rich, particularly with syntax highlighting."""
         assert self._console is not None
 
-        chunks: list[Columns] = []
         for k, value_code in arguments.items():
-            key = Text(f'{k}=', style='blue')
-            value = Syntax(value_code, 'python', background_color='default')
-            barrier = Text(('│ \n' * (value_code.count('\n') + 1))[:-1], style='blue')
-            chunks.append(
-                Columns(
-                    (
-                        # Don't have a column for empty indent_str as it will still take space
-                        *[indent_str] * bool(indent_str),
-                        barrier,
-                        key,
-                        value,
-                    ),
-                    padding=(0, 0),
-                )
-            )
+            value_lines = value_code.splitlines() or ['']
+            prefix = Text.assemble((indent_str, ''), ('│ ', 'blue'), (f'{k}=', 'blue'))
+            self._console.print(prefix, end='')
+            self._console.print(Syntax(value_lines[0], 'python', background_color='default'))
 
-        self._console.print(Group(*chunks))
+            prefix = Text.assemble((indent_str, ''), ('│ ', 'blue'), (' ' * (len(k) + 1), ''))
+            for line in value_lines[1:]:
+                self._console.print(prefix, end='')
+                self._console.print(Syntax(line, 'python', background_color='default'))
 
     def _print_arguments_plain(self, arguments: dict[str, Any], indent_str: str) -> None:
         """Print logfire arguments without color using the built-in `print` function."""

--- a/logfire/_internal/exporters/console.py
+++ b/logfire/_internal/exporters/console.py
@@ -284,15 +284,23 @@ class SimpleConsoleSpanExporter(SpanExporter):
         assert self._console is not None
 
         for k, value_code in arguments.items():
-            value_lines = value_code.splitlines() or ['']
-            prefix = Text.assemble((indent_str, ''), ('│ ', 'blue'), (f'{k}=', 'blue'))
-            self._console.print(prefix, end='')
-            self._console.print(Syntax(value_lines[0], 'python', background_color='default'))
+            highlighted = Syntax(value_code, 'python', background_color='default').highlight(value_code)
+            if not value_code.endswith('\n'):
+                highlighted.right_crop(1)
 
-            prefix = Text.assemble((indent_str, ''), ('│ ', 'blue'), (' ' * (len(k) + 1), ''))
-            for line in value_lines[1:]:
-                self._console.print(prefix, end='')
-                self._console.print(Syntax(line, 'python', background_color='default'))
+            out = Text()
+            for i, line in enumerate(highlighted.split('\n', allow_blank=True)):
+                if i:
+                    out.append('\n')
+                out.append(indent_str)
+                out.append('│ ', style='blue')
+                if i == 0:
+                    out.append(f'{k}=', style='blue')
+                else:
+                    out.append(' ' * (len(k) + 1))
+                out.append_text(line)
+
+            self._console.print(out)
 
     def _print_arguments_plain(self, arguments: dict[str, Any], indent_str: str) -> None:
         """Print logfire arguments without color using the built-in `print` function."""

--- a/tests/test_console_exporter.py
+++ b/tests/test_console_exporter.py
@@ -989,6 +989,16 @@ def test_console_exporter_rich_long_argument_not_truncated() -> None:
     assert f"x='{long_value}'" in plain_output
 
 
+def test_console_exporter_rich_argument_preserves_expanded_tab() -> None:
+    out = io.StringIO()
+    exporter = SimpleConsoleSpanExporter(output=out, verbose=True, colors='always', include_timestamp=False)
+
+    exporter._print_arguments_rich({'x': '\t'}, '')
+
+    plain_output = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', out.getvalue())
+    assert plain_output == '│ x=    \n'
+
+
 def test_other_json_schema_types(capsys: pytest.CaptureFixture[str]) -> None:
     logfire.configure(
         send_to_logfire=False,

--- a/tests/test_console_exporter.py
+++ b/tests/test_console_exporter.py
@@ -452,10 +452,10 @@ def test_verbose_attributes(exporter: TestExporter) -> None:
             '\x1b[32m00:00:01.000\x1b[0m Hello world!',
             '             \x1b[34m│\x1b[0m\x1b[36m test_console_exporter.py:123\x1b[0m info',
             "             \x1b[34m│ \x1b[0m\x1b[34mname=\x1b[0m\x1b[93;49m'\x1b[0m\x1b[93;49mworld\x1b[0m\x1b[93;49m'\x1b[0m",
-            '             \x1b[34m│ \x1b[0m\x1b[34md=\x1b[0m\x1b[97;49m{\x1b[0m          ',
+            '             \x1b[34m│ \x1b[0m\x1b[34md=\x1b[0m\x1b[97;49m{\x1b[0m',
             "             \x1b[34m│ \x1b[0m  \x1b[97;49m    \x1b[0m\x1b[93;49m'\x1b[0m\x1b[93;49ma\x1b[0m\x1b[93;49m'\x1b[0m\x1b[97;49m:\x1b[0m\x1b[97;49m \x1b[0m\x1b[37;49m1\x1b[0m\x1b[97;49m,\x1b[0m",
             "             \x1b[34m│ \x1b[0m  \x1b[97;49m    \x1b[0m\x1b[93;49m'\x1b[0m\x1b[93;49mb\x1b[0m\x1b[93;49m'\x1b[0m\x1b[97;49m:\x1b[0m\x1b[97;49m \x1b[0m\x1b[37;49m2\x1b[0m\x1b[97;49m,\x1b[0m",
-            '             \x1b[34m│ \x1b[0m  \x1b[97;49m}\x1b[0m          ',
+            '             \x1b[34m│ \x1b[0m  \x1b[97;49m}\x1b[0m',
         ]
     )
 
@@ -960,6 +960,33 @@ def test_truncated_json(capsys: pytest.CaptureFixture[str]) -> None:
                 "│ x='[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1'",
             ]
         )
+
+
+def test_console_exporter_rich_long_argument_not_truncated() -> None:
+    long_value = 'a' * 1000
+    span = ReadableSpan(
+        name='hi',
+        context=trace.SpanContext(trace_id=1, span_id=1, is_remote=False),
+        parent=None,
+        attributes={
+            'logfire.span_type': 'log',
+            'logfire.level_num': 9,
+            'logfire.msg': 'hi',
+            'x': long_value,
+            'logfire.json_schema': json.dumps({'type': 'object', 'properties': {'x': {}}}),
+        },
+        events=[],
+        start_time=NANOSECONDS_PER_SECOND,
+        end_time=NANOSECONDS_PER_SECOND,
+    )
+
+    out = io.StringIO()
+    SimpleConsoleSpanExporter(output=out, verbose=True, colors='always', include_timestamp=False).export([span])
+
+    plain_output = re.sub(r'\x1b\[[0-?]*[ -/]*[@-~]', '', out.getvalue())
+    assert '…' not in plain_output
+    assert plain_output.count('a') == len(long_value)
+    assert f"x='{long_value}'" in plain_output
 
 
 def test_other_json_schema_types(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- render verbose Rich console arguments directly instead of through `Columns`
- add a regression test for long colored console argument output

## Tests
- `uv run pytest tests/test_console_exporter.py`
- `uv run ruff check logfire/_internal/exporters/console.py tests/test_console_exporter.py`
- `uv run pyright logfire/_internal/exporters/console.py tests/test_console_exporter.py`
- PTY repro of `scratch_3007.py` with this checkout on `PYTHONPATH`
