### PR TITLE
Handle non-finite floats in JSON encoder

### DIFF
--- a/logfire/_internal/json_encoder.py
+++ b/logfire/_internal/json_encoder.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import datetime
 import json
+import math
 from collections.abc import Callable, Mapping, Sequence
 from decimal import Decimal
 from enum import Enum
@@ -244,7 +245,12 @@ def encoder_by_type() -> dict[type[Any], EncoderFunction]:
 
 def to_json_value(o: Any, seen: set[int]) -> JsonValue:
     try:
-        if isinstance(o, (int, float, str, bool, type(None))):
+        if isinstance(o, (int, str, bool, type(None))):
+            return o
+
+        if isinstance(o, float):
+            if not math.isfinite(o):
+                return str(o)
             return o
 
         if id(o) in seen:
@@ -300,11 +306,13 @@ def to_json_value(o: Any, seen: set[int]) -> JsonValue:
 
 def logfire_json_dumps(obj: Any) -> str:
     try:
-        return json.dumps(obj, default=lambda o: to_json_value(o, set()), separators=(',', ':'), ensure_ascii=False)
+        return json.dumps(
+            obj, default=lambda o: to_json_value(o, set()), separators=(',', ':'), ensure_ascii=False, allow_nan=False
+        )
     except Exception:
         # fallback to eagerly calling to_json_value to take care of object keys which are not strings
         # see https://github.com/pydantic/platform/pull/2045
-        return json.dumps(to_json_value(obj, set()), separators=(',', ':'), ensure_ascii=False)
+        return json.dumps(to_json_value(obj, set()), separators=(',', ':'), ensure_ascii=False, allow_nan=False)
 
 
 def is_sqlalchemy(obj: Any) -> bool:

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import inspect
 import json
+import math
 import sys
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
@@ -3357,7 +3358,11 @@ def prepare_otlp_attribute(value: Any) -> otel_types.AttributeValue:
             return str(value)
         else:
             return value
-    elif isinstance(value, (str, bool, float)):
+    elif isinstance(value, float):
+        if not math.isfinite(value):
+            return str(value)
+        return value
+    elif isinstance(value, (str, bool)):
         return value
     else:
         return logfire_json_dumps(value)

--- a/tests/test_json_args.py
+++ b/tests/test_json_args.py
@@ -178,6 +178,13 @@ ANYURL_REPR_CLASSNAME = repr(AnyUrl('http://test.com')).split('(')[0]
             id='list',
         ),
         pytest.param(
+            [float('nan'), float('inf'), float('-inf')],
+            '[nan, inf, -inf]',
+            '["nan","inf","-inf"]',
+            {'type': 'array'},
+            id='list_non_finite_floats',
+        ),
+        pytest.param(
             [],
             '[]',
             '[]',

--- a/tests/test_json_args.py
+++ b/tests/test_json_args.py
@@ -880,6 +880,23 @@ def test_log_non_scalar_args(
     assert json.loads(s.attributes['logfire.json_schema'])['properties']['var'] == json_schema  # type: ignore
 
 
+def test_log_non_finite_scalar_float_args(exporter: TestExporter) -> None:
+    logfire.info(
+        'test message',
+        nan=float('nan'),
+        pos_inf=float('inf'),
+        neg_inf=float('-inf'),
+        finite=1.5,
+    )
+
+    attributes = exporter.exported_spans[0].attributes
+    assert attributes
+    assert attributes['nan'] == 'nan'
+    assert attributes['pos_inf'] == 'inf'
+    assert attributes['neg_inf'] == '-inf'
+    assert attributes['finite'] == 1.5
+
+
 class SABase(MappedAsDataclass, DeclarativeBase):
     pass
 


### PR DESCRIPTION
## Summary

- Reject non-standard JSON `NaN` and `Infinity` output from `logfire_json_dumps`
- Encode non-finite floats as strings when normalizing values for JSON serialization
- Normalize bare non-finite float span attributes to strings while preserving finite floats as numbers
- Add regression coverage for list attributes and bare scalar attributes containing `nan`, `inf`, and `-inf`

## Tests

- `uv run pytest tests/test_json_args.py -k list_non_finite_floats`
- `uv run pytest tests/test_json_args.py -k test_log_non_scalar_args`
- `uv run pytest tests/test_json_args.py -k test_log_non_finite_scalar_float_args`
- `uv run pytest tests/test_json_args.py -k "test_log_non_finite_scalar_float_args or test_log_non_scalar_args"`
