### PR TITLE
Add `system.cpu.load_average.1m` and `system.process.count`

### DIFF
--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -83,6 +83,8 @@ logfire.instrument_system_metrics({
     'system.cpu.simple_utilization': None,  # (2)!
     'system.memory.utilization': ['available'],  # (3)!
     'system.swap.utilization': ['used'],  # (4)!
+    'system.cpu.load_average.1m': None,  # (5)!
+    'system.process.count': None,  # (6)!
 })
 ```
 
@@ -90,6 +92,10 @@ logfire.instrument_system_metrics({
 2. The `None` value means that there are no fields to configure for this metric. The value of this metric is [`psutil.cpu_percent()`](https://psutil.readthedocs.io/en/latest/#psutil.cpu_percent)`/100`, i.e. the fraction of CPU time used by the whole system, where 1 means using 100% of all CPU cores.
 3. The value here is a list of 'modes' of memory. The full list can be seen in the [`psutil` documentation](https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory). `available` is "the memory that can be given instantly to processes without the system going into swap. This is calculated by summing different memory metrics that vary depending on the platform. It is supposed to be used to monitor actual memory usage in a cross platform fashion." The value of the metric is a number between 0 and 1, and subtracting the value from 1 gives the fraction of memory used.
 4. This is the fraction of available swap used. The value is a number between 0 and 1.
+5. The average number of processes waiting to run over the last minute, from [`psutil.getloadavg()`](https://psutil.readthedocs.io/en/latest/#psutil.getloadavg). On Windows this is emulated: the first reading is 0 and later readings update every few seconds.
+6. The total number of processes on the system, from the length of [`psutil.pids()`](https://psutil.readthedocs.io/en/latest/#psutil.pids).
+
+`system.cpu.load_average.1m` and `system.process.count` fill the **1-minute load** and **Running process count** columns of the [Hosts](../guides/web-ui/hosts.md) page. Each is a single number per collection, so they are included by default.
 
 To collect lots of detailed data about all available metrics, use `logfire.instrument_system_metrics(base='full')`.
 
@@ -120,6 +126,8 @@ logfire.instrument_system_metrics({
     'system.network.errors': ['transmit', 'receive'],
     'system.network.io': ['transmit', 'receive'],
     'system.thread_count': None,
+    'system.cpu.load_average.1m': None,
+    'system.process.count': None,
     'process.context_switches': ['involuntary', 'voluntary'],
     'process.runtime.gc_count': None,
     'process.open_file_descriptor.count': None,

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -31,6 +31,7 @@ MetricName: type[
         'system.cpu.simple_utilization',
         'system.cpu.time',
         'system.cpu.utilization',
+        'system.cpu.load_average.1m',
         'system.memory.usage',
         'system.memory.utilization',
         'system.swap.usage',
@@ -43,6 +44,7 @@ MetricName: type[
         'system.network.errors',
         'system.network.io',
         'system.network.connections',
+        'system.processes.count',
         'system.thread_count',
         'process.open_file_descriptor.count',
         'process.context_switches',
@@ -62,6 +64,7 @@ MetricName: type[
     'system.cpu.simple_utilization',
     'system.cpu.time',
     'system.cpu.utilization',
+    'system.cpu.load_average.1m',
     'system.memory.usage',
     'system.memory.utilization',
     'system.swap.usage',
@@ -74,6 +77,7 @@ MetricName: type[
     'system.network.errors',
     'system.network.io',
     'system.network.connections',
+    'system.processes.count',
     'system.thread_count',
     'process.open_file_descriptor.count',
     'process.context_switches',
@@ -109,6 +113,11 @@ FULL_CONFIG: Config = {
     'process.cpu.core_utilization': None,
     'system.cpu.time': CPU_FIELDS,
     'system.cpu.utilization': CPU_FIELDS,
+    # The Hosts page reads these — upstream `_DEFAULT_CONFIG` doesn't include
+    # them and they aren't expensive (one number per scrape each), so add them
+    # so `base='full'` covers the page without a follow-up `config={…}` knob.
+    'system.cpu.load_average.1m': None,
+    'system.processes.count': None,
     # For usage, knowing the total amount of bytes available might be handy.
     'system.memory.usage': MEMORY_FIELDS + ['total'],
     # For utilization, the total is always just 1 (100%), so it's not included.
@@ -172,6 +181,14 @@ def instrument_system_metrics(logfire_instance: Logfire, config: Config | None =
         # Override OTEL here to avoid emitting 0 in the first measurement.
         measure_process_cpu_utilization(logfire_instance)
         del config['process.cpu.utilization']
+
+    if 'system.cpu.load_average.1m' in config:
+        measure_system_cpu_load_average_1m(logfire_instance)
+        del config['system.cpu.load_average.1m']
+
+    if 'system.processes.count' in config:
+        measure_system_processes_count(logfire_instance)
+        del config['system.processes.count']
 
     instrumentor = SystemMetricsInstrumentor(config=config)  # pyright: ignore[reportArgumentType]
     instrumentor.instrument(meter_provider=logfire_instance.config.get_meter_provider())
@@ -247,4 +264,42 @@ def measure_process_cpu_core_utilization(logfire_instance: Logfire):
         [callback],
         description='Runtime CPU utilization, not divided by the number of available cores.',
         unit='core',
+    )
+
+
+def measure_system_cpu_load_average_1m(logfire_instance: Logfire):
+    """1-minute system load average (run-queue length, smoothed).
+
+    Upstream `SystemMetricsInstrumentor` doesn't include this metric; we add it
+    so `base='full'` covers the Hosts page's `Load 1m` column. On Windows,
+    `psutil.getloadavg()` is an emulated polling shim — first call returns 0
+    and subsequent values update every ~5s.
+    """
+
+    def callback(_options: CallbackOptions) -> Iterable[Observation]:
+        yield Observation(psutil.getloadavg()[0])
+
+    logfire_instance.metric_gauge_callback(
+        'system.cpu.load_average.1m',
+        [callback],
+        description='Average system load over the last minute.',
+        unit='{run_queue_item}',
+    )
+
+
+def measure_system_processes_count(logfire_instance: Logfire):
+    """Total number of processes on the system.
+
+    Upstream `SystemMetricsInstrumentor` doesn't include this metric; we add
+    it so `base='full'` covers the Hosts page's `Procs` column.
+    """
+
+    def callback(_options: CallbackOptions) -> Iterable[Observation]:
+        yield Observation(len(psutil.pids()))
+
+    logfire_instance.metric_gauge_callback(
+        'system.processes.count',
+        [callback],
+        description='Total number of processes on the system.',
+        unit='{process}',
     )

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -44,7 +44,7 @@ MetricName: type[
         'system.network.errors',
         'system.network.io',
         'system.network.connections',
-        'system.processes.count',
+        'system.process.count',
         'system.thread_count',
         'process.open_file_descriptor.count',
         'process.context_switches',
@@ -77,7 +77,7 @@ MetricName: type[
     'system.network.errors',
     'system.network.io',
     'system.network.connections',
-    'system.processes.count',
+    'system.process.count',
     'system.thread_count',
     'process.open_file_descriptor.count',
     'process.context_switches',
@@ -113,11 +113,9 @@ FULL_CONFIG: Config = {
     'process.cpu.core_utilization': None,
     'system.cpu.time': CPU_FIELDS,
     'system.cpu.utilization': CPU_FIELDS,
-    # The Hosts page reads these — upstream `_DEFAULT_CONFIG` doesn't include
-    # them and they aren't expensive (one number per scrape each), so add them
-    # so `base='full'` covers the page without a follow-up `config={…}` knob.
+    # Also in BASIC_CONFIG — see the note there.
     'system.cpu.load_average.1m': None,
-    'system.processes.count': None,
+    'system.process.count': None,
     # For usage, knowing the total amount of bytes available might be handy.
     'system.memory.usage': MEMORY_FIELDS + ['total'],
     # For utilization, the total is always just 1 (100%), so it's not included.
@@ -146,6 +144,11 @@ BASIC_CONFIG: Config = {
     # The actually used memory ratio can be calculated as `1 - available`.
     'system.memory.utilization': ['available'],
     'system.swap.utilization': ['used'],
+    # The Hosts page shows these in its default table, and each costs one number
+    # per scrape with no attributes, so they're cheap enough for the basic base.
+    # Upstream `SystemMetricsInstrumentor` emits neither.
+    'system.cpu.load_average.1m': None,
+    'system.process.count': None,
 }
 
 Base = Literal['basic', 'full', None]
@@ -186,9 +189,9 @@ def instrument_system_metrics(logfire_instance: Logfire, config: Config | None =
         measure_system_cpu_load_average_1m(logfire_instance)
         del config['system.cpu.load_average.1m']
 
-    if 'system.processes.count' in config:
-        measure_system_processes_count(logfire_instance)
-        del config['system.processes.count']
+    if 'system.process.count' in config:
+        measure_system_process_count(logfire_instance)
+        del config['system.process.count']
 
     instrumentor = SystemMetricsInstrumentor(config=config)  # pyright: ignore[reportArgumentType]
     instrumentor.instrument(meter_provider=logfire_instance.config.get_meter_provider())
@@ -268,11 +271,17 @@ def measure_process_cpu_core_utilization(logfire_instance: Logfire):
 
 
 def measure_system_cpu_load_average_1m(logfire_instance: Logfire):
-    """1-minute system load average (run-queue length, smoothed).
+    """1-minute system load average.
 
-    Upstream `SystemMetricsInstrumentor` doesn't include this metric; we add it
-    so `base='full'` covers the Hosts page's `Load 1m` column. On Windows,
-    `psutil.getloadavg()` is an emulated polling shim — first call returns 0
+    OTel semconv defines no load average metric. The system metrics spec only
+    floats `system.linux.cpu.load_1m` as a hypothetical illustration of OS-prefixed
+    naming, so there's nothing to conform to. The name, gauge instrument, and
+    `{thread}` unit here match the OTel Collector's `hostmetrics` load scraper,
+    which is where most host load averages reaching Logfire come from. Matching it
+    means SDK-reported and Collector-reported hosts land on one series instead of two.
+
+    Upstream `SystemMetricsInstrumentor` doesn't emit this. On Windows,
+    `psutil.getloadavg()` is an emulated polling shim — the first call returns 0
     and subsequent values update every ~5s.
     """
 
@@ -283,22 +292,30 @@ def measure_system_cpu_load_average_1m(logfire_instance: Logfire):
         'system.cpu.load_average.1m',
         [callback],
         description='Average system load over the last minute.',
-        unit='{run_queue_item}',
+        unit='{thread}',
     )
 
 
-def measure_system_processes_count(logfire_instance: Logfire):
+def measure_system_process_count(logfire_instance: Logfire):
     """Total number of processes on the system.
 
-    Upstream `SystemMetricsInstrumentor` doesn't include this metric; we add
-    it so `base='full'` covers the Hosts page's `Procs` column.
+    Name, instrument, and unit follow OTel semconv's `system.process.count`
+    (an UpDownCounter in `{process}`). Its `process.state` attribute is omitted:
+    `psutil.pids()` is a single cheap syscall, while splitting by state needs a
+    `process_iter` over every process and multiplies the series count. This metric
+    is in the basic base, so that cost would land on every default install.
+
+    Note that the OTel Collector's `hostmetrics` receiver still emits the older
+    `system.processes.count` for the same measurement.
+
+    Upstream `SystemMetricsInstrumentor` doesn't emit this.
     """
 
     def callback(_options: CallbackOptions) -> Iterable[Observation]:
         yield Observation(len(psutil.pids()))
 
-    logfire_instance.metric_gauge_callback(
-        'system.processes.count',
+    logfire_instance.metric_up_down_counter_callback(
+        'system.process.count',
         [callback],
         description='Total number of processes on the system.',
         unit='{process}',

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -67,6 +67,7 @@ def test_all_system_metrics_collection(metrics_reader: InMemoryMetricReader) -> 
             'process.open_file_descriptor.count',
             'process.runtime.cpython.gc_count',
             'process.thread.count',
+            'system.cpu.load_average.1m',
             'system.cpu.simple_utilization',
             'system.cpu.time',
             'system.cpu.utilization',
@@ -79,6 +80,7 @@ def test_all_system_metrics_collection(metrics_reader: InMemoryMetricReader) -> 
             'system.network.errors',
             'system.network.io',
             'system.network.packets',
+            'system.processes.count',
             'system.swap.usage',
             'system.swap.utilization',
             'system.thread_count',
@@ -90,6 +92,18 @@ def test_measure_process_runtime_cpu_utilization(metrics_reader: InMemoryMetricR
     # This metric is now deprecated by OTEL, but there isn't a strong reason to stop allowing it when requested
     logfire.instrument_system_metrics({'process.runtime.cpu.utilization': None}, base=None)  # type: ignore
     assert get_collected_metric_names(metrics_reader) == ['process.runtime.cpython.cpu.utilization']
+
+
+def test_system_cpu_load_average_1m(metrics_reader: InMemoryMetricReader) -> None:
+    """Load average isn't in upstream `SystemMetricsInstrumentor` — Logfire emits it."""
+    logfire.instrument_system_metrics({'system.cpu.load_average.1m': None}, base=None)
+    assert get_collected_metric_names(metrics_reader) == ['system.cpu.load_average.1m']
+
+
+def test_system_processes_count(metrics_reader: InMemoryMetricReader) -> None:
+    """Process count isn't in upstream `SystemMetricsInstrumentor` — Logfire emits it."""
+    logfire.instrument_system_metrics({'system.processes.count': None}, base=None)
+    assert get_collected_metric_names(metrics_reader) == ['system.processes.count']
 
 
 def test_custom_system_metrics_collection(metrics_reader: InMemoryMetricReader) -> None:
@@ -186,6 +200,8 @@ def test_full_base():
         'cpython.gc.collected_objects': None,
         'cpython.gc.collections': None,
         'cpython.gc.uncollectable_objects': None,
+        'system.cpu.load_average.1m': None,
+        'system.processes.count': None,
     }, 'Docs and the MetricName type need to be updated if this test fails'
 
 

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -40,8 +40,10 @@ def test_default_system_metrics_collection(metrics_reader: InMemoryMetricReader)
     assert get_collected_metric_names(metrics_reader) == snapshot(
         [
             'process.cpu.utilization',
+            'system.cpu.load_average.1m',
             'system.cpu.simple_utilization',
             'system.memory.utilization',
+            'system.process.count',
             'system.swap.utilization',
         ]
     )
@@ -80,7 +82,7 @@ def test_all_system_metrics_collection(metrics_reader: InMemoryMetricReader) -> 
             'system.network.errors',
             'system.network.io',
             'system.network.packets',
-            'system.processes.count',
+            'system.process.count',
             'system.swap.usage',
             'system.swap.utilization',
             'system.thread_count',
@@ -100,10 +102,10 @@ def test_system_cpu_load_average_1m(metrics_reader: InMemoryMetricReader) -> Non
     assert get_collected_metric_names(metrics_reader) == ['system.cpu.load_average.1m']
 
 
-def test_system_processes_count(metrics_reader: InMemoryMetricReader) -> None:
+def test_system_process_count(metrics_reader: InMemoryMetricReader) -> None:
     """Process count isn't in upstream `SystemMetricsInstrumentor` — Logfire emits it."""
-    logfire.instrument_system_metrics({'system.processes.count': None}, base=None)
-    assert get_collected_metric_names(metrics_reader) == ['system.processes.count']
+    logfire.instrument_system_metrics({'system.process.count': None}, base=None)
+    assert get_collected_metric_names(metrics_reader) == ['system.process.count']
 
 
 def test_custom_system_metrics_collection(metrics_reader: InMemoryMetricReader) -> None:
@@ -130,6 +132,8 @@ def test_basic_base():
         'system.cpu.simple_utilization': None,
         'system.memory.utilization': ['available'],
         'system.swap.utilization': ['used'],
+        'system.cpu.load_average.1m': None,
+        'system.process.count': None,
     }, 'Docs need to be updated if this test fails'
 
 
@@ -201,7 +205,7 @@ def test_full_base():
         'cpython.gc.collections': None,
         'cpython.gc.uncollectable_objects': None,
         'system.cpu.load_average.1m': None,
-        'system.processes.count': None,
+        'system.process.count': None,
     }, 'Docs and the MetricName type need to be updated if this test fails'
 
 


### PR DESCRIPTION
Upstream `SystemMetricsInstrumentor` emits neither metric, so the Logfire wrapper adds both via the same callback pattern as `system.cpu.simple_utilization`.

Closes the gap where the Hosts page's **1-minute load** and **Running process count** columns were permanently empty for SDK-instrumented hosts.

## Naming

Review asked for both metrics to be renamed toward OTel semantic conventions. Only one of them is actually semconv:

- **`system.process.count` is semconv** — an UpDownCounter in `{process}` with a Recommended `process.state` attribute. Renamed from `system.processes.count` and switched from a gauge to `metric_up_down_counter_callback` accordingly. `process.state` is left out: `psutil.pids()` is one cheap syscall, whereas splitting by state needs a `process_iter` over every process and multiplies the series count — which matters now that this is in the basic base.
- **`system.cpu.load_average.1m` stays.** Semconv defines no load-average metric. The [system metrics spec](https://opentelemetry.io/docs/specs/semconv/system/system-metrics/) mentions `system.linux.cpu.load_1m` only as a hypothetical illustration of OS-prefixed naming ("could be named"), not as a definition. The name, gauge instrument, and `{thread}` unit here match the OTel Collector's `hostmetrics` load scraper, which is where most host load averages reaching Logfire come from — so SDK-reported and Collector-reported hosts land on one series rather than two.

## Basic base

Both metrics moved from `base='full'` to the basic base. Each is a single number per collection with no attributes, and both fill columns the Hosts page shows by default.

## Follow-up needed on the platform side

The Hosts inventory query matches on `system.processes.count` only. It needs `system.process.count` added alongside it, or the **Running process count** column stays empty for SDK-instrumented hosts. The Collector keeps emitting the older `system.processes.count`, so both names need to be accepted.

## Notes

- On Windows, `psutil.getloadavg()` is an emulated polling shim: the first call returns 0 and values update every ~5s. Documented in the helper's docstring.
- Our recommended Collector config for the Hosts page sets `load: cpu_average: true`, which normalises load by CPU count; `psutil.getloadavg()` does not. Same metric name, slightly different scale depending on source. Left as raw load average here since that is the conventional meaning, but worth a look.
