### PR TITLE
Add `logfire.variables_used` array attribute listing managed variables in scope

### DIFF
--- a/docs/reference/advanced/managed-variables/index.md
+++ b/docs/reference/advanced/managed-variables/index.md
@@ -226,6 +226,12 @@ The recommended pattern is to use the variable's `.get()` method as a context ma
 
 When using the Logfire SDK, baggage values are automatically added as attributes to all downstream spans. This means any spans created inside the context manager will be tagged with which label and version was used, making it easy to filter and compare behavior in the Logfire UI.
 
+Concretely, spans created inside the context manager get:
+
+- `logfire.variables.<name>`: the selected label (or `<code_default>` when no label was selected)
+- `logfire.variables.<name>.version`: the resolved version, when a versioned value was used
+- `logfire.variables_used`: an array of the names of all variables currently in scope, so you can efficiently query for spans that used a given variable without knowing every possible attribute key
+
 ```python skip="true"
 from pydantic_ai import Agent
 

--- a/logfire/_internal/baggage.py
+++ b/logfire/_internal/baggage.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from opentelemetry import baggage, context
 from opentelemetry.sdk.trace import Span, SpanProcessor
 
+from .constants import ATTRIBUTES_VARIABLES_PREFIX, ATTRIBUTES_VARIABLES_USED_KEY
 from .json_encoder import logfire_json_dumps
 
 __all__ = (
@@ -87,8 +88,15 @@ class NoForceFlushSpanProcessor(SpanProcessor):
 class DirectBaggageAttributesSpanProcessor(NoForceFlushSpanProcessor):
     def on_start(self, span: Span, parent_context: context.Context | None = None) -> None:
         existing_attrs = span.attributes or {}
-        attrs: dict[str, str] = {}
+        attrs: dict[str, str | list[str]] = {}
+        variable_names: list[str] = []
         for k, v in baggage.get_all(parent_context).items():
+            if k.startswith(ATTRIBUTES_VARIABLES_PREFIX):
+                name = k[len(ATTRIBUTES_VARIABLES_PREFIX) :]
+                # Variable names can't contain dots, so a dotted suffix is a companion
+                # entry like `logfire.variables.<name>.version`, not a variable itself.
+                if '.' not in name:
+                    variable_names.append(name)
             if not isinstance(v, str):
                 # Since this happens for every span, don't try converting to string, which could be expensive.
                 warnings.warn(
@@ -106,4 +114,11 @@ class DirectBaggageAttributesSpanProcessor(NoForceFlushSpanProcessor):
                     continue
                 k = 'baggage_conflict.' + k
             attrs[k] = v
+        if variable_names:
+            # Also emit the variable names as a single array-valued attribute: querying
+            # "spans that used variable X" by *value* doesn't require enumerating every
+            # possible `logfire.variables.<name>` key, and array element values can be
+            # indexed for file pruning where JSON key-existence checks cannot.
+            variable_names.sort()
+            attrs[ATTRIBUTES_VARIABLES_USED_KEY] = variable_names
         span.set_attributes(attrs)

--- a/logfire/_internal/constants.py
+++ b/logfire/_internal/constants.py
@@ -112,6 +112,22 @@ ATTRIBUTES_PENDING_SPAN_REAL_PARENT_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.pendi
 ATTRIBUTES_TAGS_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.tags'
 """The key within OTEL attributes where logfire puts tags."""
 
+ATTRIBUTES_VARIABLES_PREFIX = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.variables.'
+"""Prefix of the per-variable baggage/attribute keys set while a managed variable resolution is in scope.
+
+Each resolved variable contributes `logfire.variables.<name> = <label>` and, when a versioned
+value resolved, `logfire.variables.<name>.version = <version>`.
+"""
+
+ATTRIBUTES_VARIABLES_USED_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.variables_used'
+"""Attribute holding the sorted array of managed variable names in scope when a span started.
+
+Derived from the `logfire.variables.<name>` baggage entries. Emitting the names as an
+array attribute *value* (rather than only as per-variable attribute *keys*) lets the
+backend query "spans that used variable X" without enumerating every possible key, and
+makes the predicate indexable for file pruning.
+"""
+
 ATTRIBUTES_MESSAGE_TEMPLATE_KEY = f'{LOGFIRE_ATTRIBUTES_NAMESPACE}.msg_template'
 """The message template for a log."""
 

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -138,16 +138,17 @@ class ResolvedVariable(Generic[T_co]):
         self._exit_stack.__enter__()
 
         import logfire
+        from logfire._internal.constants import ATTRIBUTES_VARIABLES_PREFIX
 
         baggage_entries: dict[str, str] = {
-            f'logfire.variables.{self.name}': self.label or '<code_default>',
+            f'{ATTRIBUTES_VARIABLES_PREFIX}{self.name}': self.label or '<code_default>',
         }
         # Propagate the version alongside the label so downstream spans can be
         # filtered or grouped by `(label, version)` directly. Only set when a
         # version actually resolved — code-default resolutions have version=None
         # and shouldn't add a baggage entry whose value would be misleading.
         if self.version is not None:
-            baggage_entries[f'logfire.variables.{self.name}.version'] = str(self.version)
+            baggage_entries[f'{ATTRIBUTES_VARIABLES_PREFIX}{self.name}.version'] = str(self.version)
         self._exit_stack.enter_context(logfire.set_baggage(**baggage_entries))
 
         return self

--- a/tests/test_baggage.py
+++ b/tests/test_baggage.py
@@ -157,6 +157,42 @@ def _get_simplified_spans(exporter: TestExporter) -> list[dict[str, Any]]:
     ]
 
 
+def test_variables_baggage_derives_variables_used_attribute(config_kwargs: dict[str, Any], exporter: TestExporter):
+    config_kwargs['add_baggage_to_attributes'] = True
+    logfire.configure(**config_kwargs)
+    with logfire.set_baggage(
+        **{
+            # Deliberately unsorted to check the derived array is sorted.
+            'logfire.variables.var_b': 'production',
+            # `.version` companion entries are not variables and must be excluded.
+            'logfire.variables.var_b.version': '3',
+            'logfire.variables.var_a': '<code_default>',
+            'unrelated': 'x',
+        }
+    ):
+        with logfire.span('span'):
+            pass
+
+    [span] = [s for s in exporter.exported_spans_as_dict() if s['attributes']['logfire.span_type'] == 'span']
+    attrs = span['attributes']
+    assert list(attrs['logfire.variables_used']) == ['var_a', 'var_b']
+    # The per-variable entries are still copied through as usual.
+    assert attrs['logfire.variables.var_a'] == '<code_default>'
+    assert attrs['logfire.variables.var_b'] == 'production'
+    assert attrs['logfire.variables.var_b.version'] == '3'
+
+
+def test_no_variables_baggage_no_variables_used_attribute(config_kwargs: dict[str, Any], exporter: TestExporter):
+    config_kwargs['add_baggage_to_attributes'] = True
+    logfire.configure(**config_kwargs)
+    with logfire.set_baggage(a='1'):
+        with logfire.span('span'):
+            pass
+
+    [span] = [s for s in exporter.exported_spans_as_dict() if s['attributes']['logfire.span_type'] == 'span']
+    assert 'logfire.variables_used' not in span['attributes']
+
+
 def test_baggage_scrubbed(config_kwargs: dict[str, Any], exporter: TestExporter):
     config_kwargs['add_baggage_to_attributes'] = True
     logfire.configure(**config_kwargs)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -698,6 +698,31 @@ class TestResolvedVariable:
         baggage_after = logfire.get_baggage()
         assert 'logfire.variables.context_test_var' not in baggage_after
 
+    def test_context_manager_sets_variables_used_span_attribute(
+        self, config_kwargs: dict[str, Any], exporter: TestExporter
+    ):
+        config_kwargs['add_baggage_to_attributes'] = True
+        lf = logfire.configure(**config_kwargs)
+
+        var_b = lf.var(name='used_var_b', default='default', type=str)
+        var_a = lf.var(name='used_var_a', default='default', type=str)
+
+        with var_b.get(), var_a.get():
+            with lf.span('inside'):
+                pass
+        with lf.span('outside'):
+            pass
+
+        spans = {s['name']: s for s in exporter.exported_spans_as_dict()}
+        inside_attrs = spans['inside']['attributes']
+        # Per-variable keys are still present, and the names are aggregated
+        # (sorted) into the array-valued `logfire.variables_used` attribute.
+        assert inside_attrs['logfire.variables.used_var_a'] == '<code_default>'
+        assert inside_attrs['logfire.variables.used_var_b'] == '<code_default>'
+        assert list(inside_attrs['logfire.variables_used']) == ['used_var_a', 'used_var_b']
+        # Spans outside any variable resolution context don't get the attribute.
+        assert 'logfire.variables_used' not in spans['outside']['attributes']
+
     def test_context_manager_sets_label_in_baggage(self, config_kwargs: dict[str, Any]):
         variables_config = VariablesConfig(
             variables={


### PR DESCRIPTION
## Motivation

Managed variables stamp spans with one attribute key per variable (`logfire.variables.<name> = <label>`, propagated via baggage). Answering "which spans used variable X?" therefore requires JSON **key-existence** predicates, which the Logfire backend cannot index or prune — every such query is a full scan of the time window, and the caller must enumerate every possible key from the project's variable definitions up front. On a large project this made the agent-detail page's managed-variables query time out (it was ~30 unprunable full scans; mitigated server-side in pydantic/platform#23417, but a full scan remains the floor).

Emitting the variable names as an attribute **value** turns this into a term query: no key enumeration, and the backend can shred + index the array so file pruning applies (fusionfire already supports `array_has` pruning predicates for indexed array columns — follow-up on the platform side).

## Change

Spans created while managed variables are in scope get one additional array-valued attribute alongside the existing per-variable keys:

```
logfire.variables.agent_prompt = 'production'          # existing
logfire.variables.agent_prompt.version = '3'           # existing
logfire.variables_used = ['agent_prompt', 'ai_chat']   # new
```

- Derived in `DirectBaggageAttributesSpanProcessor.on_start`, which already iterates baggage entries on every span start — no extra pass; spans with no variables in scope don't get the attribute.
- `.version` companion entries are excluded; unambiguous because variable names match `^[a-zA-Z_][a-zA-Z0-9_]*$` (no dots).
- New `ATTRIBUTES_VARIABLES_PREFIX` / `ATTRIBUTES_VARIABLES_USED_KEY` constants; `variables/abstract.py` now builds its baggage keys from the same prefix constant so the two sides can't drift.
- Since variables propagate via baggage, downstream-service spans get the array too — same coverage as the per-variable keys.
- Docs: `managed-variables/index.md` now lists the concrete attributes downstream spans receive.