### PR TITLE
fix: guard None text in Anthropic TextBlock during streaming

### DIFF
--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -236,8 +236,9 @@ def convert_response_to_semconv(message: Message | BetaMessage) -> OutputMessage
     parts: list[MessagePart] = []
 
     for block in message.content:
-        if isinstance(block, (TextBlock, BetaTextBlock)):
-            parts.append(TextPart(type='text', content=block.text))
+        text = getattr(block, 'text', None)
+        if isinstance(block, (TextBlock, BetaTextBlock)) and text is not None:
+            parts.append(TextPart(type='text', content=text))
         elif isinstance(block, (ToolUseBlock, BetaToolUseBlock)):
             parts.append(
                 make_tool_call_part(
@@ -284,7 +285,11 @@ class AnthropicMessageStreamState(StreamState):
     def get_response_data(self) -> Any:
         if self._message is None:
             return {'combined_chunk_content': '', 'chunk_count': 0}
-        texts = [block.text for block in self._message.content if isinstance(block, (TextBlock, BetaTextBlock))]
+        texts = [
+            text
+            for block in self._message.content
+            if isinstance(block, (TextBlock, BetaTextBlock)) and (text := getattr(block, 'text', None)) is not None
+        ]
         return {'combined_chunk_content': ''.join(texts), 'chunk_count': self._chunk_count}
 
     def get_attributes(self, span_data: dict[str, Any]) -> dict[str, Any]:

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -633,8 +633,8 @@ def test_messages_stream_text_block_none() -> None:
         usage=Usage(input_tokens=25, output_tokens=55),
     )
     state = AnthropicMessageStreamState()
-    state._message = message
-    state._chunk_count = 1
+    setattr(state, '_message', message)
+    setattr(state, '_chunk_count', 1)
 
     assert state.get_response_data() == snapshot({'combined_chunk_content': 'Visible text', 'chunk_count': 1})
     assert convert_response_to_semconv(message) == snapshot(

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -617,6 +617,35 @@ def test_sync_messages_stream(instrumented_client: anthropic.Anthropic, exporter
     )
 
 
+def test_messages_stream_text_block_none() -> None:
+    from logfire._internal.integrations.llm_providers.anthropic import (
+        AnthropicMessageStreamState,
+        convert_response_to_semconv,
+    )
+
+    message = Message.model_construct(
+        id='test_id',
+        content=[TextBlock.model_construct(text=None, type='text'), TextBlock(text='Visible text', type='text')],
+        model='claude-3-haiku-20240307',
+        role='assistant',
+        type='message',
+        stop_reason='end_turn',
+        usage=Usage(input_tokens=25, output_tokens=55),
+    )
+    state = AnthropicMessageStreamState()
+    state._message = message
+    state._chunk_count = 1
+
+    assert state.get_response_data() == snapshot({'combined_chunk_content': 'Visible text', 'chunk_count': 1})
+    assert convert_response_to_semconv(message) == snapshot(
+        {
+            'role': 'assistant',
+            'parts': [{'citations': None, 'text': None, 'type': 'text'}, {'type': 'text', 'content': 'Visible text'}],
+            'finish_reason': 'end_turn',
+        }
+    )
+
+
 async def test_async_messages_stream(
     instrumented_async_client: anthropic.AsyncAnthropic, exporter: TestExporter
 ) -> None:


### PR DESCRIPTION
Fixes #1998

## Problem

`instrument_anthropic` crashes with `TypeError` during streaming when Anthropic's API returns `TextBlock` objects with `text=None`. This happens with `web_search` and `web_fetch` tool results where `construct_type` produces blocks with `text=None`.

The crash occurs in two locations:

1. `get_response_data()`: `''.join(texts)` fails because `texts` contains `None` values from `[block.text for block in ...]`
2. `convert_response_to_semconv()`: passes `None` content to `TextPart`, which can cause downstream issues

## Fix

Guard both locations against `None` text using `getattr(block, 'text', None)` (pyright-compatible with Anthropic SDK's `str` annotation, since `model_construct` bypasses validation):

- `convert_response_to_semconv()`: skip TextBlock/BetaTextBlock when `text` is `None` (falls through to generic dict handler)
- `get_response_data()`: filter out blocks with `None` text from the joined content

## Tests

Added `test_messages_stream_text_block_none` that directly tests both crash sites:
- Creates a `Message` with a `text=None` TextBlock and a normal TextBlock
- Verifies `get_response_data()` returns only the non-None text
- Verifies `convert_response_to_semconv()` handles the None-text block gracefully

```
uv run pytest tests/otel_integrations/test_anthropic.py -k test_messages_stream_text_block_none
uv run pytest tests/otel_integrations/test_anthropic.py  # all 23 tests pass
uv run pyright logfire/_internal/integrations/llm_providers/anthropic.py  # 0 errors
uv run ruff format --check logfire/_internal/integrations/llm_providers/anthropic.py  # clean
```
