### PR TITLE
docs(nav): publish the five new web-UI pages

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -178,6 +178,11 @@
     "label": "Observe & Investigate",
     "items": [
       { "label": "Live View", "slug": "guides/web-ui/live" },
+      { "label": "Services", "slug": "guides/web-ui/services" },
+      { "label": "Hosts", "slug": "guides/web-ui/hosts" },
+      { "label": "Kubernetes", "slug": "guides/web-ui/kubernetes" },
+      { "label": "LLMs", "slug": "guides/web-ui/llms" },
+      { "label": "Metrics explorer", "slug": "guides/web-ui/metrics-explorer" },
       { "label": "LLM Panels", "slug": "guides/web-ui/llm-panels" },
       { "label": "Dashboards", "slug": "guides/web-ui/dashboards" },
       { "label": "SQL Explorer", "slug": "guides/web-ui/explore" },

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -182,7 +182,7 @@
       { "label": "Hosts", "slug": "guides/web-ui/hosts" },
       { "label": "Kubernetes", "slug": "guides/web-ui/kubernetes" },
       { "label": "LLMs", "slug": "guides/web-ui/llms" },
-      { "label": "Metrics explorer", "slug": "guides/web-ui/metrics-explorer" },
+      { "label": "Metrics Explorer", "slug": "guides/web-ui/metrics-explorer" },
       { "label": "LLM Panels", "slug": "guides/web-ui/llm-panels" },
       { "label": "Dashboards", "slug": "guides/web-ui/dashboards" },
       { "label": "SQL Explorer", "slug": "guides/web-ui/explore" },


### PR DESCRIPTION
PR #2011 added \`docs/guides/web-ui/{services,hosts,kubernetes,llms,metrics-explorer}.md\` and listed them in \`mkdocs.yml\`, but missed adding them to \`docs/nav.json\` — the file unified-docs reads to decide which pages to publish (per its [`libraries.ts`](https://github.com/pydantic/unified-docs/blob/main/src/config/libraries.ts): `navJson: '../logfire/docs/nav.json'`).

The result: all five pages 404 at their canonical `pydantic.dev/docs/logfire/observe/<page>/` URLs despite the markdown existing on main.

This PR adds the five entries under **Observe & Investigate**, right after Live View, matching the `slug` schema used by every other entry in that section.

## Related: the three new how-to-guide pages

The three otel-collector pages added in #2016 (host-monitoring, kubernetes-monitoring, s3-backup) are 404 for a separate reason — the unified-docs `Instrument Your App` section has a hardcoded `include:` array. I'm opening a follow-up PR against `pydantic/unified-docs` to fix that.

## Test plan

- [ ] Merge, wait for the unified-docs build to run
- [ ] Confirm `pydantic.dev/docs/logfire/observe/{services,hosts,kubernetes,llms,metrics-explorer}/` all return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

