### PR TITLE
docs(nav): move OTel Collector setup guides under Logfire Guides

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -39,16 +39,7 @@
           { "label": "Sampling Strategies", "link": "/logfire/instrument/sampling/" },
           { "label": "Scrub Sensitive Data", "link": "/logfire/instrument/scrubbing/" },
           { "label": "Suppress Spans and Metrics", "link": "/logfire/instrument/suppress/" },
-          {
-            "label": "OpenTelemetry Collector",
-            "items": [
-              { "label": "Overview", "link": "/logfire/instrument/opentelemetry-collector/otel-collector-overview/" },
-              { "label": "Host Monitoring", "link": "/logfire/instrument/opentelemetry-collector/host-monitoring/" },
-              { "label": "Kubernetes Monitoring", "link": "/logfire/instrument/opentelemetry-collector/kubernetes-monitoring/" },
-              { "label": "Back up to AWS S3", "link": "/logfire/instrument/opentelemetry-collector/s3-backup/" },
-              { "label": "Advanced Scrubbing", "link": "/logfire/instrument/opentelemetry-collector/otel-collector-scrubbing/" }
-            ]
-          }
+          { "label": "Advanced Scrubbing", "link": "/logfire/instrument/opentelemetry-collector/otel-collector-scrubbing/" }
         ]
       },
       {
@@ -258,7 +249,16 @@
       { "label": "Collect Cloud Provider Metrics", "slug": "how-to-guides/cloud-metrics" },
       { "label": "Connect to MCP Server", "slug": "how-to-guides/mcp-server" },
       { "label": "Coding Agent Skills", "slug": "how-to-guides/skills" },
-      { "label": "Export Codex Activity", "slug": "how-to-guides/codex-logfire-exporter" }
+      { "label": "Export Codex Activity", "slug": "how-to-guides/codex-logfire-exporter" },
+      {
+        "label": "OpenTelemetry Collector",
+        "items": [
+          { "label": "Overview", "slug": "how-to-guides/otel-collector/otel-collector-overview" },
+          { "label": "Host Monitoring", "slug": "how-to-guides/otel-collector/host-monitoring" },
+          { "label": "Kubernetes Monitoring", "slug": "how-to-guides/otel-collector/kubernetes-monitoring" },
+          { "label": "Back up to AWS S3", "slug": "how-to-guides/otel-collector/s3-backup" }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
The Overview / Host Monitoring / Kubernetes Monitoring / Back up to AWS S3 pages are about setting up the OpenTelemetry Collector — an external service used by every Logfire SDK, not Python-specific. Hosting them under **Python SDK > Instrumentation** reads as if they're a Python concern.

Moving them to a new **OpenTelemetry Collector** subsection under **Guides**.

**Advanced Scrubbing** stays under Python SDK > Instrumentation:
- it pairs directly with the existing "Scrub Sensitive Data" Python SDK entry, and
- its URL was live before our recent PRs (since #1195), so keeping it in place avoids breaking inbound links.

Flattening the now-single-item OpenTelemetry Collector subsection under Instrumentation — with just Advanced Scrubbing left, the wrapper read as noise.

## Companion PR

pydantic/unified-docs — removes these four files from the "Instrument Your App" `include:` array and adds redirects from the old `/instrument/opentelemetry-collector/` URLs to the new `/guides/otel-collector/` URLs (the Overview page had been live since #1195 and may have inbound links).

## Test plan

- [ ] Merge alongside the unified-docs PR
- [ ] Confirm `pydantic.dev/docs/logfire/guides/otel-collector/{otel-collector-overview,host-monitoring,kubernetes-monitoring,s3-backup}/` all return 200
- [ ] Confirm the old `/logfire/instrument/opentelemetry-collector/otel-collector-overview/` URL redirects to the new Guides URL
- [ ] Confirm `/logfire/instrument/opentelemetry-collector/otel-collector-scrubbing/` (Advanced Scrubbing) still returns 200 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

