### PR TITLE
Document creating OFREP-only API keys via the Advanced scope selector

### DIFF
--- a/docs/how-to-guides/client-side-feature-flags.md
+++ b/docs/how-to-guides/client-side-feature-flags.md
@@ -7,7 +7,7 @@ This guide shows how to set up a **JavaScript/TypeScript web application** using
 ## Prerequisites
 
 1. **Create your variables** in the Logfire UI (Settings > Variables) and mark them as **external** — see [External Variables and OFREP](../reference/advanced/managed-variables/external.md)
-2. **Create an API key** with the `project:read_external_variables` scope — this restricted scope is safe to use in client-side code since it only exposes variables you've explicitly marked as external
+2. **Create an API key** with the `project:read_external_variables` scope — expand the **Advanced** section of the API key form and select just this scope (the one-click presets bundle it into broader access). This restricted scope is safe to use in client-side code since it only exposes variables you've explicitly marked as external
 
 ## Installation
 

--- a/docs/reference/advanced/managed-variables/external.md
+++ b/docs/reference/advanced/managed-variables/external.md
@@ -75,7 +75,7 @@ httpx.post(
 ### Typical Setup
 
 1. Create an API key with `project:read_variables` for your backend services (full access to all variables via SDK)
-2. Create a separate API key with only `project:read_external_variables` for client-side or less trusted environments (OFREP access to external variables only)
+2. Create a separate API key with only `project:read_external_variables` for client-side or less trusted environments (OFREP access to external variables only). The one-click presets bundle this scope into broader access, so open the **Advanced** section of the API key form and select just `project:read_external_variables`.
 3. Mark variables as external that are safe to expose to those environments
 
 ## OpenFeature (OFREP) Endpoints


### PR DESCRIPTION
The Logfire API key creation form was redesigned to lead with one-click scope presets ([platform #23168](https://github.com/pydantic/platform/pull/23168)). `project:read_external_variables` is now part of the broad "Read" preset, so clicking a preset no longer produces a minimal OFREP-only key.

This updates the two places that tell users to create an OFREP key to point them at the right path: expand the **Advanced** section of the API key form and select just `project:read_external_variables`.

- `docs/reference/advanced/managed-variables/external.md` — Typical Setup, step 2
- `docs/how-to-guides/client-side-feature-flags.md` — Prerequisites, step 2

Kept deliberately label-light (references the stable scope id + the "Advanced" concept rather than exact navigation) so it does not rot if the form changes again.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

