### PR TITLE
Fix logfire docs for API keys page

### DIFF
--- a/docs/how-to-guides/client-side-feature-flags.md
+++ b/docs/how-to-guides/client-side-feature-flags.md
@@ -7,7 +7,7 @@ This guide shows how to set up a **JavaScript/TypeScript web application** using
 ## Prerequisites
 
 1. **Create your variables** in the Logfire UI (Settings > Variables) and mark them as **external** — see [External Variables and OFREP](../reference/advanced/managed-variables/external.md)
-2. **Create an API key** with the `project:read_external_variables` scope — expand the **Advanced** section of the API key form and select just this scope (the one-click presets bundle it into broader access). This restricted scope is safe to use in client-side code since it only exposes variables you've explicitly marked as external
+2. **Create an API key** with the `project:read_external_variables` scope — expand the **Advanced** section of the API key form and select just this scope (the one-click presets bundle it into broader access) by selecting the "Read external managed variables within a project via OFREP" item under the "Variables" section. This restricted scope is safe to use in client-side code since it only exposes variables you've explicitly marked as external
 
 ## Installation
 


### PR DESCRIPTION
More clearly describes where to find the OFREP when configuring an API key with the new screen.