### PR TITLE
Fix OFREP provider config in client-side feature flags guide; add Python section

### DIFF
--- a/docs/how-to-guides/client-side-feature-flags.md
+++ b/docs/how-to-guides/client-side-feature-flags.md
@@ -43,15 +43,17 @@ const LOGFIRE_API_KEY = 'your-api-key'  // project:read_external_variables scope
 const LOGFIRE_API_HOST = 'logfire-api.pydantic.dev'  // or your self-hosted API host
 
 const provider = new OFREPWebProvider({
-  baseUrl: `https://${LOGFIRE_API_HOST}/v1/ofrep/v1`,
-  fetchImplementation: (input, init) =>
-    fetch(input, {
-      ...init,
-      headers: {
-        ...Object.fromEntries(new Headers(init?.headers).entries()),
-        Authorization: `Bearer ${LOGFIRE_API_KEY}`,
-      },
-    }),
+  // The provider appends `/ofrep/v1/evaluate/flags` itself, so this is the `/v1` root.
+  baseUrl: `https://${LOGFIRE_API_HOST}/v1`,
+  fetchImplementation: (input, init) => {
+    // Keep the headers the provider already set (it sends `Content-Type:
+    // application/json`, which the endpoint requires) and add the API key.
+    const headers = new Headers(input instanceof Request ? input.headers : undefined)
+    new Headers(init?.headers).forEach((value, key) => headers.set(key, value))
+    headers.set('Authorization', `Bearer ${LOGFIRE_API_KEY}`)
+    headers.set('Content-Type', 'application/json')
+    return fetch(input, { ...init, headers })
+  },
 })
 
 OpenFeature.setProvider(provider)
@@ -161,15 +163,14 @@ import { OpenFeature } from '@openfeature/web-sdk'
 // Initialize once at app startup
 function initFeatureFlags(apiKey: string, apiHost: string) {
   const provider = new OFREPWebProvider({
-    baseUrl: `https://${apiHost}/v1/ofrep/v1`,
-    fetchImplementation: (input, init) =>
-      fetch(input, {
-        ...init,
-        headers: {
-          ...Object.fromEntries(new Headers(init?.headers).entries()),
-          Authorization: `Bearer ${apiKey}`,
-        },
-      }),
+    baseUrl: `https://${apiHost}/v1`,
+    fetchImplementation: (input, init) => {
+      const headers = new Headers(input instanceof Request ? input.headers : undefined)
+      new Headers(init?.headers).forEach((value, key) => headers.set(key, value))
+      headers.set('Authorization', `Bearer ${apiKey}`)
+      headers.set('Content-Type', 'application/json')
+      return fetch(input, { ...init, headers })
+    },
   })
   OpenFeature.setProvider(provider)
 }
@@ -193,12 +194,55 @@ function getFeatureFlags() {
 }
 ```
 
+## Python
+
+!!! note "Most Python services should use the Logfire SDK instead"
+    OFREP exists to evaluate variables from **untrusted** environments. If you're shipping a Python **application to untrusted end users** (a desktop/CLI app, an on-device agent), use OFREP as shown below so the full variable configuration is never exposed. For a **trusted backend** you control, skip all of this and use the pull-based [`logfire.var()`](../reference/advanced/managed-variables/index.md) — it evaluates locally with no per-flag network round-trip, and is the recommended path.
+
+OpenFeature for Python is two separate installs — the core SDK and the OFREP provider:
+
+```bash
+pip install openfeature-sdk openfeature-provider-ofrep
+```
+
+```python skip="true"
+from openfeature import api
+from openfeature.contrib.provider.ofrep import OFREPProvider
+from openfeature.evaluation_context import EvaluationContext
+
+# base_url is the `/v1` root; the provider appends `/ofrep/v1/evaluate/flags/{key}`.
+api.set_provider(
+    OFREPProvider(
+        base_url='https://logfire-api.pydantic.dev/v1',  # or your self-hosted API host
+        headers_factory=lambda: {'Authorization': 'Bearer YOUR_API_KEY'},
+    )
+)
+client = api.get_client()
+context = EvaluationContext(targeting_key='user-123')
+
+show_new_feature = client.get_boolean_value('show_new_feature', False, evaluation_context=context)
+```
+
+The provider — like the OpenFeature client in general — evaluates one named flag at a time. To read **every** variable in a single call, `POST` the bulk endpoint directly (there is no bulk method on the client):
+
+```python skip="true"
+import httpx
+
+response = httpx.post(
+    'https://logfire-api.pydantic.dev/v1/ofrep/v1/evaluate/flags',
+    headers={'Authorization': 'Bearer YOUR_API_KEY'},
+    json={'context': {'targetingKey': 'user-123'}},
+)
+flags = response.json()['flags']  # [{'key', 'value', 'variant', 'reason'}, ...]
+```
+
 ## Other Languages and Platforms
 
 OpenFeature provides SDKs and OFREP providers for many languages. You can use the same Logfire OFREP endpoint with any of them:
 
 | Platform | SDK | OFREP Provider |
 |----------|-----|---------------|
+| Python | [`openfeature-sdk`](https://pypi.org/project/openfeature-sdk/) | [`openfeature-provider-ofrep`](https://pypi.org/project/openfeature-provider-ofrep/) |
 | JavaScript (Web) | [`@openfeature/web-sdk`](https://www.npmjs.com/package/@openfeature/web-sdk) | [`@openfeature/ofrep-web-provider`](https://www.npmjs.com/package/@openfeature/ofrep-web-provider) |
 | JavaScript (Server) | [`@openfeature/server-sdk`](https://www.npmjs.com/package/@openfeature/server-sdk) | [`@openfeature/ofrep-provider`](https://www.npmjs.com/package/@openfeature/ofrep-provider) |
 | Kotlin / Android | [OpenFeature Kotlin SDK](https://openfeature.dev/docs/reference/technologies/client/kotlin) | [OFREP Provider](https://github.com/open-feature/kotlin-sdk-contrib) |

--- a/docs/how-to-guides/client-side-feature-flags.md
+++ b/docs/how-to-guides/client-side-feature-flags.md
@@ -223,7 +223,7 @@ context = EvaluationContext(targeting_key='user-123')
 show_new_feature = client.get_boolean_value('show_new_feature', False, evaluation_context=context)
 ```
 
-The provider — like the OpenFeature client in general — evaluates one named flag at a time. To read **every** variable in a single call, `POST` the bulk endpoint directly (there is no bulk method on the client):
+The provider — like the OpenFeature client in general — evaluates one named flag at a time. To read **every** variable in a single call, `POST` the bulk endpoint directly with any HTTP client (there is no bulk method on the client). This example uses [`httpx`](https://www.python-httpx.org/) (`pip install httpx`), which is separate from the OpenFeature packages above:
 
 ```python skip="true"
 import httpx


### PR DESCRIPTION
## What

Fixes two real bugs in the JavaScript setup in `docs/how-to-guides/client-side-feature-flags.md`, and adds a Python section.

### JS bugs (verified against a live local endpoint using the pinned `@openfeature/ofrep-web-provider@0.3.5`)

1. **`baseUrl` was wrong.** It was `https://${host}/v1/ofrep/v1`, but the provider appends `/ofrep/v1/evaluate/flags` itself, so requests went to `.../v1/ofrep/v1/ofrep/v1/evaluate/flags` → **404**. Corrected to the `/v1` root.
2. **`fetchImplementation` dropped headers.** The provider invokes it with a `Request` object and `init` undefined, so rebuilding headers from `init?.headers` discarded the provider's `Content-Type: application/json`. Without it the backend rejected the body with **`400 INVALID_CONTEXT`**. The fix preserves the request's headers and adds the API key — matching the working implementation already shipping in `logfire-frontend` (`packages/feature-flag/openfeature-provider.ts`, which forces `Content-Type` for exactly this reason).

Both fixes were confirmed end-to-end: with them, `client.getBooleanValue('agent_runs', false)` returns the real evaluated value.

### Python section (new)

Covers the three things that aren't obvious:

- It's **two separate installs** (`openfeature-sdk` + `openfeature-provider-ofrep`).
- `OFREPProvider(base_url='.../v1', headers_factory=...)` for per-flag evaluation.
- The provider/client has **no bulk method** — to read every variable at once you `POST` the bulk endpoint directly.

It opens with an admonition steering **trusted backends** to the pull-based `logfire.var()` SDK instead; OFREP is for distributing to **untrusted** end users. Both Python blocks are tagged `skip="true"` since `openfeature` isn't a docs test dependency.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

