### PR TITLE
Managed prompts: prompt()/template_prompt() consumption + prompts in variables_push()

### DIFF
--- a/docs/reference/advanced/prompt-management/application.md
+++ b/docs/reference/advanced/prompt-management/application.md
@@ -11,7 +11,7 @@ Once a prompt looks good in the editor, the production workflow is:
 2. Promote the version by moving a label such as `production`.
 3. Fetch that labeled prompt from your application.
 4. Render the template with runtime variables before sending it to your model,
-   preferably with `logfire.template_var()`.
+   preferably with `logfire.template_prompt()`.
 
 ## Promote a version
 
@@ -24,25 +24,30 @@ This lets you iterate on drafts without changing what production imports.
 
 ## Fetch and render the prompt from the SDK
 
-Each prompt is exposed to application code through its backing managed variable:
+`logfire.prompt()` and `logfire.template_prompt()` fetch a prompt by its slug.
+They are `logfire.var()` / `logfire.template_var()` specialized to prompts: they
+apply Logfire's prompt naming convention for you, so you pass the slug
+(`welcome-email`) rather than the backing managed-variable name
+(`prompt__welcome_email`).
 
-```text
-prompt__<slug_with_underscores>
-```
-
-If your prompt slug is `welcome-email`, the SDK name is
-`prompt__welcome_email`.
-
-Install the variables extra in applications that fetch prompt variables:
+Install the variables extra in applications that fetch prompts:
 
 ```bash
 pip install 'logfire[variables]'
 ```
 
-For prompts with runtime `{{...}}` inputs, prefer `logfire.template_var(...)`.
-It resolves the prompt variable, expands `@{...}@` composition references,
-renders the remaining Handlebars template with your typed inputs, and returns
-the final prompt text.
+!!! note "API Key Required"
+    Prompts resolve through the managed-variables API, which requires an **API key**
+    with the `project:read_variables` scope — this is different from the write token
+    (`LOGFIRE_TOKEN`) used to send traces and logs. Set it via the `LOGFIRE_API_KEY`
+    environment variable or pass `logfire.configure(api_key=...)`. **Without it, the
+    SDK never contacts Logfire for prompts and `.get()` silently returns your code
+    `default`.** See [Remote Variables](../managed-variables/remote.md) for details.
+
+For prompts with runtime `{{...}}` inputs, prefer `logfire.template_prompt(...)`.
+It resolves the prompt, expands `@{...}@` composition references, renders the
+remaining Handlebars template with your typed inputs, and returns the final
+prompt text.
 
 ```python skip="true"
 from pydantic import BaseModel
@@ -57,14 +62,13 @@ class WelcomeEmailInputs(BaseModel):
     topic: str
 
 
-prompt_var = logfire.template_var(
-    name='prompt__welcome_email',
-    type=str,
+welcome_email = logfire.template_prompt(
+    'welcome-email',
     default='',
     inputs_type=WelcomeEmailInputs,
 )
 
-with prompt_var.get(
+with welcome_email.get(
     WelcomeEmailInputs(customer_name='Taylor', topic='your recent order'),
     label='production',
 ) as resolved:
@@ -79,10 +83,39 @@ those references during `.get()`. See the
 [Prompt composition walkthrough](./composition-walkthrough.md) for the full
 workflow.
 
+## Create prompts from code
+
+If a prompt only exists in your code so far, you don't have to recreate it by
+hand in the UI. `logfire.variables_push()` pushes everything declared in code —
+managed variables *and* prompts. For each prompt that doesn't exist in the
+project yet, it creates the prompt and publishes your code `default` as version
+1, so it appears on the Prompts page ready for iteration and serves exactly what
+your code default already said. Prompts that already exist are never modified by
+a push — publish new versions on the Prompts page, over MCP, or via the prompts
+API.
+
+```python skip="true"
+import logfire
+
+logfire.configure()
+
+welcome_email = logfire.prompt(
+    'welcome-email',
+    default='Write a short welcome email about {{topic}} for {{customer_name}}.',
+    description='Transactional welcome email prompt',
+)
+
+if __name__ == '__main__':
+    logfire.variables_push()
+```
+
+Pushing requires the API key to carry the `project:write_variables` scope in
+addition to `project:read_variables`.
+
 ## Manual rendering
 
 If you need to control rendering yourself, fetch the prompt with
-`logfire.var(...)`. In that mode, `.get()` still expands `@{...}@` composition
+`logfire.prompt(...)`. In that mode, `.get()` still expands `@{...}@` composition
 references, but your application renders the remaining `{{...}}` placeholders.
 
 ```python skip="true"
@@ -91,9 +124,9 @@ from pydantic_handlebars import render
 
 logfire.configure()
 
-prompt_var = logfire.var(name='prompt__welcome_email', type=str, default='')
+welcome_email = logfire.prompt('welcome-email', default='')
 
-with prompt_var.get(label='production', targeting_key='customer-123') as resolved:
+with welcome_email.get(label='production', targeting_key='customer-123') as resolved:
     template = resolved.value
 
 prompt = render(

--- a/docs/reference/advanced/prompt-management/composition-walkthrough.md
+++ b/docs/reference/advanced/prompt-management/composition-walkthrough.md
@@ -149,7 +149,9 @@ variables for smaller text fragments and structured facts.
 ## 6. Ship the composed prompt
 
 Save a prompt version and promote it by moving the serving label on the prompt's
-backing managed variable. In application code, fetch the prompt as usual:
+backing managed variable. In application code, fetch the prompt as usual
+(remember prompts resolve via `LOGFIRE_API_KEY`, not the write token — see
+[Use Prompts in Your Application](./application.md#fetch-and-render-the-prompt-from-the-sdk)):
 
 ```python skip="true"
 from pydantic import BaseModel
@@ -165,9 +167,8 @@ class SupportPromptInputs(BaseModel):
     is_urgent: bool
 
 
-prompt_var = logfire.template_var(
-    name='prompt__support_agent',
-    type=str,
+prompt_var = logfire.template_prompt(
+    'support-agent',
     default='',
     inputs_type=SupportPromptInputs,
 )
@@ -183,7 +184,7 @@ with prompt_var.get(
 `prompt_var.get(...)` expands the `@{...}@` references using the current managed
 variable configuration, then renders the remaining `{{...}}` placeholders with
 the request-specific inputs before returning the final prompt text. If you fetch
-the prompt with `logfire.var()` instead, render the remaining Handlebars
+the prompt with `logfire.prompt()` instead, render the remaining Handlebars
 placeholders yourself before sending the final prompt to your model.
 
 ## Rendering order
@@ -198,9 +199,9 @@ For prompt scenarios, Logfire renders in this order:
    placeholders with the same scenario variables.
 4. Replace the scenario-only `@{prompt}@` alias with the rendered prompt.
 
-For application code, `logfire.template_var()` uses the same order: expand
+For application code, `logfire.template_prompt()` uses the same order: expand
 `@{...}@` references during resolution, then render `{{...}}` placeholders with
-the inputs passed to `get(inputs)`. If you use `logfire.var()` to fetch the raw
+the inputs passed to `get(inputs)`. If you use `logfire.prompt()` to fetch the raw
 template, your application is responsible for rendering those remaining
 Handlebars placeholders.
 

--- a/docs/reference/advanced/prompt-management/promotion-and-rollouts.md
+++ b/docs/reference/advanced/prompt-management/promotion-and-rollouts.md
@@ -47,8 +47,9 @@ To promote v2:
 4. Edit from v2 or assign `production` to v2.
 5. Save the label change.
 
-Application code fetching `prompt__support_agent` with `label='production'`
-receives v2 on the next variable resolution. No redeploy is required.
+Application code fetching the prompt with `logfire.prompt('support-agent')` (or
+`logfire.template_prompt(...)`) and `label='production'` receives v2 on the next
+resolution. No redeploy is required.
 
 ## Canary a prompt version
 
@@ -68,7 +69,9 @@ For example:
 | `canary` | 10% |
 
 Use a stable `targeting_key` when fetching the prompt so users or tenants keep a
-consistent prompt assignment during the test.
+consistent prompt assignment during the test. (Prompts resolve via
+`LOGFIRE_API_KEY`, not the write token — see
+[Use Prompts in Your Application](./application.md#fetch-and-render-the-prompt-from-the-sdk).)
 
 ```python skip="true"
 from pydantic import BaseModel
@@ -83,9 +86,8 @@ class SupportPromptInputs(BaseModel):
     tier: str
 
 
-prompt_var = logfire.template_var(
-    name='prompt__support_agent',
-    type=str,
+prompt_var = logfire.template_prompt(
+    'support-agent',
     default='',
     inputs_type=SupportPromptInputs,
 )

--- a/docs/reference/advanced/prompt-management/template-reference.md
+++ b/docs/reference/advanced/prompt-management/template-reference.md
@@ -132,12 +132,12 @@ Rendering errors fall into a small set of categories:
 
 ## Compatibility with the SDK
 
-Use `logfire.template_var()` when you want the SDK to render prompt templates
-with typed runtime inputs. It resolves the prompt variable, expands `@{...}@`
+Use `logfire.template_prompt()` when you want the SDK to render prompt templates
+with typed runtime inputs. It resolves the prompt, expands `@{...}@`
 composition references, renders the remaining `{{...}}` placeholders, and
 returns the final prompt text.
 
-If you fetch the prompt with `logfire.var()` instead, the SDK returns the
+If you fetch the prompt with `logfire.prompt()` instead, the SDK returns the
 post-composition template string. Your application then renders the remaining
 `{{...}}` placeholders locally before passing the result to your model.
 

--- a/docs/reference/advanced/prompt-management/templates.md
+++ b/docs/reference/advanced/prompt-management/templates.md
@@ -9,9 +9,9 @@ A prompt template is a string. At render time, Logfire walks that string with a 
 
 !!! note "Runtime inputs are supplied by your application"
     Prompt Management stores the template. In application code, prefer
-    `logfire.template_var()` to substitute runtime variables before sending the
+    `logfire.template_prompt()` to substitute runtime variables before sending the
     rendered prompt to your model client. If you fetch the raw template with
-    `logfire.var()`, your application must render the remaining `{{...}}`
+    `logfire.prompt()`, your application must render the remaining `{{...}}`
     placeholders itself. See [Use Prompts in Your Application](./application.md).
 
 If you already know Handlebars, the short version is: Logfire uses the standard Handlebars.js helper set, with no custom helpers enabled by default.
@@ -123,8 +123,8 @@ If you need transformation logic that is not expressible in plain Handlebars, do
 
 ## Rendering from your application
 
-The Logfire SDK can render prompt templates for you with `logfire.template_var()`.
-If you fetch a prompt with `logfire.var()` instead, `.get()` returns the prompt
+The Logfire SDK can render prompt templates for you with `logfire.template_prompt()`.
+If you fetch a prompt with `logfire.prompt()` instead, `.get()` returns the prompt
 template after `@{...}@` composition has been expanded, and your application
 renders the remaining `{{...}}` placeholders before passing the result to your
 model client.

--- a/docs/reference/advanced/prompt-management/ui.md
+++ b/docs/reference/advanced/prompt-management/ui.md
@@ -59,7 +59,7 @@ correct `prompt__...` name when preview or run validation fails.
 Template parameters are the `{{...}}` values that must be available at render
 time. In the editor, those values usually come from the active scenario's
 variables. In production, your application supplies the same values to
-`logfire.template_var().get(inputs)` or to its own renderer before passing the
+`logfire.template_prompt().get(inputs)` or to its own renderer before passing the
 prompt to the model.
 
 Use plain names for simple values:

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -102,6 +102,8 @@ metric_up_down_counter_callback = DEFAULT_LOGFIRE_INSTANCE.metric_up_down_counte
 # Variables
 var = DEFAULT_LOGFIRE_INSTANCE.var
 template_var = DEFAULT_LOGFIRE_INSTANCE.template_var
+prompt = DEFAULT_LOGFIRE_INSTANCE.prompt
+template_prompt = DEFAULT_LOGFIRE_INSTANCE.template_prompt
 variables_clear = DEFAULT_LOGFIRE_INSTANCE.variables_clear
 variables_get = DEFAULT_LOGFIRE_INSTANCE.variables_get
 variables_push = DEFAULT_LOGFIRE_INSTANCE.variables_push
@@ -203,6 +205,8 @@ __all__ = (
     'variables',
     'var',
     'template_var',
+    'prompt',
+    'template_prompt',
     'variables_clear',
     'variables_get',
     'variables_push',

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2747,6 +2747,112 @@ class Logfire:
 
         return variable
 
+    def prompt(
+        self,
+        name: str,
+        *,
+        default: str | ResolveFunction[str],
+        description: str | None = None,
+    ) -> Variable[str]:
+        """Define a managed prompt.
+
+        A prompt is a managed string variable holding prompt text. This is `var()` specialized to
+        prompts: the value type is fixed to `str`, and the name is translated to Logfire's prompt
+        convention before the variable is declared. `logfire.prompt('support-agent', ...)` declares
+        the backing variable `prompt__support_agent` -- the `prompt__` prefix is added and hyphens
+        become underscores, matching the naming Logfire's
+        [prompt management](https://logfire.pydantic.dev/docs/reference/advanced/prompt-management/)
+        uses. The return value is a plain `Variable[str]`; resolve it with `.get()` exactly like
+        `var()`.
+
+        ```py
+        import logfire
+
+        logfire.configure()
+
+        # declares the managed variable `prompt__support_agent`
+        support = logfire.prompt('support-agent', default='You are a helpful support agent.')
+
+        with support.get(label='production') as resolved:
+            system_prompt = resolved.value
+        ```
+
+        For prompts whose text contains Handlebars `{{placeholder}}` templates that need runtime
+        inputs, use [`template_prompt()`][logfire.Logfire.template_prompt].
+
+        Args:
+            name: The prompt name (e.g. `support-agent`). The backing variable name is derived from
+                it; pass the bare name rather than the `prompt__`-prefixed variable name.
+            default: Default prompt text used when no remote configuration is found. Can also be a
+                callable with `targeting_key` and `attributes` parameters.
+            description: Optional human-readable description of what the prompt controls.
+        """
+        from logfire.variables._prompt import prompt_variable_name
+
+        return self.var(prompt_variable_name(name), type=str, default=default, description=description)
+
+    def template_prompt(
+        self,
+        name: str,
+        *,
+        default: str | ResolveFunction[str],
+        inputs_type: type[InputsT],
+        description: str | None = None,
+        template_mismatch_policy: TemplateMismatchPolicy | None = None,
+    ) -> TemplateVariable[str, InputsT]:
+        """Define a managed prompt whose text is a Handlebars template.
+
+        This is to [`prompt()`][logfire.Logfire.prompt] what
+        [`template_var()`][logfire.Logfire.template_var] is to [`var()`][logfire.Logfire.var]: the
+        value type is fixed to `str` and the name is translated to Logfire's prompt convention
+        (`prompt__<name>`, hyphens to underscores), but `get(inputs)` renders the Handlebars
+        `{{placeholder}}` markup in the resolved prompt before returning.
+
+        ```py skip-run="true" skip-reason="requires-pydantic-handlebars"
+        from pydantic import BaseModel
+
+        import logfire
+
+        logfire.configure()
+
+
+        class PromptInputs(BaseModel):
+            customer_name: str
+
+
+        support = logfire.template_prompt(
+            'support-agent',
+            default='You are helping {{customer_name}}. Be friendly and concise.',
+            inputs_type=PromptInputs,
+        )
+
+        with support.get(PromptInputs(customer_name='Alice')) as resolved:
+            assert resolved.value == 'You are helping Alice. Be friendly and concise.'
+        ```
+
+        Args:
+            name: The prompt name (e.g. `support-agent`). The backing variable name is derived from
+                it; pass the bare name rather than the `prompt__`-prefixed variable name.
+            default: Default prompt text used when no remote configuration is found. Can also be a
+                callable with `targeting_key` and `attributes` parameters.
+            inputs_type: The type (typically a Pydantic `BaseModel`) describing the expected template
+                inputs. Used for type-safe `get(inputs)` calls and JSON schema generation.
+            description: Optional human-readable description of what the prompt controls.
+            template_mismatch_policy: How to react when the resolved prompt references a `{{field}}`
+                not declared in `inputs_type`. See
+                [`template_var()`][logfire.Logfire.template_var] for the full semantics.
+        """
+        from logfire.variables._prompt import prompt_variable_name
+
+        return self.template_var(
+            prompt_variable_name(name),
+            type=str,
+            default=default,
+            inputs_type=inputs_type,
+            description=description,
+            template_mismatch_policy=template_mismatch_policy,
+        )
+
     def variables_clear(self) -> None:
         """Clear all registered variables from this Logfire instance.
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2757,7 +2757,7 @@ class Logfire:
         """Define a managed prompt.
 
         A prompt is a managed string variable holding prompt text. This is `var()` specialized to
-        prompts: the value type is fixed to `str`, and the name is translated to Logfire's prompt
+        prompts: the value type is fixed to `str`, and the slug is translated to Logfire's prompt
         convention before the variable is declared. `logfire.prompt('support-agent', ...)` declares
         the backing variable `prompt__support_agent` -- the `prompt__` prefix is added and hyphens
         become underscores, matching the naming Logfire's
@@ -2781,15 +2781,17 @@ class Logfire:
         inputs, use [`template_prompt()`][logfire.Logfire.template_prompt].
 
         Args:
-            name: The prompt name (e.g. `support-agent`). The backing variable name is derived from
-                it; pass the bare name rather than the `prompt__`-prefixed variable name.
+            name: The prompt slug, e.g. `support-agent` (the identifier in the prompt's URL). Must be
+                1-100 characters of lowercase letters, digits, and hyphens; the backing variable name
+                is derived from it, so pass the bare slug rather than the `prompt__`-prefixed variable
+                name. Raises `ValueError` if it is not a valid slug.
             default: Default prompt text used when no remote configuration is found. Can also be a
                 callable with `targeting_key` and `attributes` parameters.
             description: Optional human-readable description of what the prompt controls.
         """
         from logfire.variables._prompt import prompt_variable_name
 
-        return self.var(prompt_variable_name(name), type=str, default=default, description=description)
+        return self.var(prompt_variable_name(name, stacklevel=3), type=str, default=default, description=description)
 
     def template_prompt(
         self,
@@ -2804,8 +2806,8 @@ class Logfire:
 
         This is to [`prompt()`][logfire.Logfire.prompt] what
         [`template_var()`][logfire.Logfire.template_var] is to [`var()`][logfire.Logfire.var]: the
-        value type is fixed to `str` and the name is translated to Logfire's prompt convention
-        (`prompt__<name>`, hyphens to underscores), but `get(inputs)` renders the Handlebars
+        value type is fixed to `str` and the slug is translated to Logfire's prompt convention
+        (`prompt__<slug>`, hyphens to underscores), but `get(inputs)` renders the Handlebars
         `{{placeholder}}` markup in the resolved prompt before returning.
 
         ```py skip-run="true" skip-reason="requires-pydantic-handlebars"
@@ -2831,8 +2833,10 @@ class Logfire:
         ```
 
         Args:
-            name: The prompt name (e.g. `support-agent`). The backing variable name is derived from
-                it; pass the bare name rather than the `prompt__`-prefixed variable name.
+            name: The prompt slug, e.g. `support-agent` (the identifier in the prompt's URL). Must be
+                1-100 characters of lowercase letters, digits, and hyphens; the backing variable name
+                is derived from it, so pass the bare slug rather than the `prompt__`-prefixed variable
+                name. Raises `ValueError` if it is not a valid slug.
             default: Default prompt text used when no remote configuration is found. Can also be a
                 callable with `targeting_key` and `attributes` parameters.
             inputs_type: The type (typically a Pydantic `BaseModel`) describing the expected template
@@ -2845,7 +2849,7 @@ class Logfire:
         from logfire.variables._prompt import prompt_variable_name
 
         return self.template_var(
-            prompt_variable_name(name),
+            prompt_variable_name(name, stacklevel=3),
             type=str,
             default=default,
             inputs_type=inputs_type,
@@ -2881,9 +2885,16 @@ class Logfire:
         - Creates new variables that don't exist in the provider
         - Updates JSON schemas for existing variables if they've changed
         - Warns about existing label values that are incompatible with new schemas
+        - Prompts declared with `prompt()` / `template_prompt()` are pushed through the
+          prompts API under the hood: missing prompts are created — publishing a
+          static-string code `default` as version 1, so the prompt is immediately
+          editable on the Prompts page and serves the same content the code default
+          would have — while prompts that already exist are never modified from here
+          (publish new versions on the Prompts page, over MCP, or via the prompts API).
 
         The provider is determined by the Logfire configuration. For remote providers,
-        this requires proper authentication (via VariablesOptions or LOGFIRE_API_KEY).
+        this requires proper authentication (via VariablesOptions or LOGFIRE_API_KEY);
+        pushing needs the `project:write_variables` scope on the API key.
 
         Args:
             variables: Variable instances to push. If None, all variables

--- a/logfire/variables/__init__.py
+++ b/logfire/variables/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations as _annotations
 
 from typing import TYPE_CHECKING
 
+from logfire.variables._prompt import PROMPT_VARIABLE_PREFIX, prompt_variable_name
 from logfire.variables.abstract import (
     ResolutionReason,
     ResolvedVariable,
@@ -79,6 +80,9 @@ __all__ = [
     'ValueDoesNotMatchRegex',
     # Context managers and utilities
     'targeting_context',
+    # Prompt naming
+    'PROMPT_VARIABLE_PREFIX',
+    'prompt_variable_name',
     # Types
     'ComposedReference',
     'ResolutionReason',

--- a/logfire/variables/_prompt.py
+++ b/logfire/variables/_prompt.py
@@ -1,34 +1,75 @@
 from __future__ import annotations
 
+import re
 import warnings
 
 PROMPT_VARIABLE_PREFIX = 'prompt__'
 """Prefix the Logfire backend uses for the managed variable that backs a prompt."""
 
+_PROMPT_SLUG_PATTERN = re.compile(r'^[a-z0-9-]{1,100}$')
+"""Valid prompt slugs, matching the identifier the Logfire backend assigns: 1-100 characters of
+lowercase letters, digits, and hyphens."""
 
-def prompt_variable_name(name: str) -> str:
-    """Translate a prompt name into the name of the managed variable that backs it.
+
+def prompt_variable_name(name: str, *, stacklevel: int = 2) -> str:
+    """Translate a prompt slug into the name of the managed variable that backs it.
 
     Prepends the `prompt__` prefix and normalizes hyphens to underscores, matching the naming
     the Logfire backend uses for prompt-backed variables, so `support-agent` becomes
-    `prompt__support_agent`. This is the one translation shared by `logfire.prompt()`,
-    `logfire.template_prompt()`, and the pydantic-ai `ManagedPrompt` capability, so the
-    backing-variable name a prompt resolves to does not depend on which entry point declared it.
+    `prompt__support_agent`. This is the one translation used by `logfire.prompt()` and
+    `logfire.template_prompt()` (and intended for reuse by future integrations, e.g.
+    pydantic-ai managed prompts), so the backing-variable name a prompt resolves to does
+    not depend on which entry point declared it.
 
-    Raises `ValueError` if the resulting variable name is not a valid Python identifier.
+    The slug must match the identifier the Logfire backend assigns a prompt: 1-100 characters of
+    lowercase letters, digits, and hyphens (as shown in the prompt's URL, e.g. `support-agent`).
+    Anything else -- most commonly an uppercased name, or the underscored backing-variable name --
+    would resolve to a *different* managed variable than the backend stores and silently fall back
+    to the code default, so it raises `ValueError` instead.
+
+    Args:
+        name: The prompt slug, e.g. `support-agent`.
+        stacklevel: Stack level for the accidental-prefix warning. Defaults to `2`, so a direct
+            `prompt_variable_name(...)` call points the warning at its caller; `logfire.prompt()`
+            and `logfire.template_prompt()` pass `3` so it points at the user's call site instead.
+
+    Raises:
+        ValueError: If `name` is not a valid prompt slug.
     """
     if name.startswith(PROMPT_VARIABLE_PREFIX):
         warnings.warn(
             f'The {PROMPT_VARIABLE_PREFIX!r} prefix is added automatically; '
-            f'pass the bare prompt name rather than {name!r}.',
-            stacklevel=3,
+            f'pass the bare prompt slug rather than {name!r}.',
+            stacklevel=stacklevel,
         )
         name = name[len(PROMPT_VARIABLE_PREFIX) :]
 
-    variable_name = f'{PROMPT_VARIABLE_PREFIX}{name.replace("-", "_")}'
-    if not variable_name.isidentifier():
+    if not _PROMPT_SLUG_PATTERN.fullmatch(name):
         raise ValueError(
-            f'Prompt name {name!r} produces an invalid variable name {variable_name!r}; '
-            'prompt names may only contain letters, digits, hyphens, and underscores.'
+            f'Invalid prompt slug {name!r}. Prompt slugs must be 1-100 characters and contain only '
+            "lowercase letters, digits, and hyphens (e.g. 'support-agent'), matching the slug "
+            'Logfire assigns the prompt.'
         )
-    return variable_name
+
+    return f'{PROMPT_VARIABLE_PREFIX}{name.replace("-", "_")}'
+
+
+def prompt_slug_from_variable_name(variable_name: str) -> str:
+    """Translate a prompt's backing-variable name back to its slug.
+
+    The exact inverse of `prompt_variable_name()`: strips the `prompt__` prefix and
+    normalizes underscores back to hyphens, so `prompt__support_agent` becomes
+    `support-agent`. Safe because slugs cannot contain underscores — every underscore
+    in a backing name came from a hyphen.
+
+    Args:
+        variable_name: The backing managed-variable name, e.g. `prompt__support_agent`.
+
+    Raises:
+        ValueError: If `variable_name` does not carry the `prompt__` prefix.
+    """
+    if not variable_name.startswith(PROMPT_VARIABLE_PREFIX):
+        raise ValueError(
+            f'{variable_name!r} is not a prompt-backed variable name; expected the {PROMPT_VARIABLE_PREFIX!r} prefix.'
+        )
+    return variable_name[len(PROMPT_VARIABLE_PREFIX) :].replace('_', '-')

--- a/logfire/variables/_prompt.py
+++ b/logfire/variables/_prompt.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import warnings
+
+PROMPT_VARIABLE_PREFIX = 'prompt__'
+"""Prefix the Logfire backend uses for the managed variable that backs a prompt."""
+
+
+def prompt_variable_name(name: str) -> str:
+    """Translate a prompt name into the name of the managed variable that backs it.
+
+    Prepends the `prompt__` prefix and normalizes hyphens to underscores, matching the naming
+    the Logfire backend uses for prompt-backed variables, so `support-agent` becomes
+    `prompt__support_agent`. This is the one translation shared by `logfire.prompt()`,
+    `logfire.template_prompt()`, and the pydantic-ai `ManagedPrompt` capability, so the
+    backing-variable name a prompt resolves to does not depend on which entry point declared it.
+
+    Raises `ValueError` if the resulting variable name is not a valid Python identifier.
+    """
+    if name.startswith(PROMPT_VARIABLE_PREFIX):
+        warnings.warn(
+            f'The {PROMPT_VARIABLE_PREFIX!r} prefix is added automatically; '
+            f'pass the bare prompt name rather than {name!r}.',
+            stacklevel=3,
+        )
+        name = name[len(PROMPT_VARIABLE_PREFIX) :]
+
+    variable_name = f'{PROMPT_VARIABLE_PREFIX}{name.replace("-", "_")}'
+    if not variable_name.isidentifier():
+        raise ValueError(
+            f'Prompt name {name!r} produces an invalid variable name {variable_name!r}; '
+            'prompt names may only contain letters, digits, hyphens, and underscores.'
+        )
+    return variable_name

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -9,6 +9,8 @@ from contextlib import ExitStack
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast
 
+from logfire.variables._prompt import PROMPT_VARIABLE_PREFIX
+
 SyncMode = Literal['merge', 'replace']
 
 if TYPE_CHECKING:
@@ -1311,6 +1313,42 @@ class VariableProvider(ABC):
             stacklevel=2,
         )
 
+    def create_prompt(
+        self,
+        *,
+        slug: str,
+        name: str,
+        description: str | None = None,
+        template: str | None = None,
+        template_inputs_schema: dict[str, Any] | None = None,
+    ) -> None:
+        """Create a prompt, optionally publishing its first version from `template`.
+
+        Prompts are managed variables under the hood (backed by a `prompt__<slug>`
+        variable), but they are authored through the prompts surface rather than the
+        variables API — the variables API rejects writes to prompt identity/schema.
+
+        Args:
+            slug: The prompt slug, e.g. `support-agent`.
+            name: Human-readable prompt name shown on the Prompts page.
+            description: Optional prompt description.
+            template: When set, published as the prompt's first version so the prompt
+                is immediately editable (and served) with this content.
+            template_inputs_schema: JSON Schema for the prompt's `{{field}}` template
+                inputs, set on the backing variable.
+
+        Raises:
+            VariableAlreadyExistsError: If a prompt with this slug already exists.
+
+        Note:
+            Subclasses should override this method to provide actual implementations.
+            The default implementation emits a warning.
+        """
+        warnings.warn(
+            f'{type(self).__name__} does not persist prompt writes',
+            stacklevel=2,
+        )
+
     def batch_update(self, updates: dict[str, VariableConfig | None]) -> None:
         """Update multiple variables atomically.
 
@@ -1507,7 +1545,17 @@ class VariableProvider(ABC):
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
         """
-        if not variables:
+        # Prompt-backed variables (declared via `logfire.prompt()` / `logfire.template_prompt()`)
+        # go through the prompts surface instead of the variables API (which rejects writes to
+        # prompt identity/schema): missing prompts are created — publishing a static-string code
+        # default as version 1 — and existing prompts are never modified from here.
+        from logfire.variables._prompt import prompt_slug_from_variable_name
+        from logfire.variables.variable import get_template_inputs_schema
+
+        prompt_variables = [v for v in variables if v.name.startswith(PROMPT_VARIABLE_PREFIX)]
+        variables = [v for v in variables if not v.name.startswith(PROMPT_VARIABLE_PREFIX)]
+
+        if not variables and not prompt_variables:
             print('No variables to push. Create variables using logfire.var() first.')
             return False
 
@@ -1524,11 +1572,37 @@ class VariableProvider(ABC):
             print(f'{ANSI_RED}Error fetching current config: {e}{ANSI_RESET}')
             return False
 
+        existing_prompts = [v for v in prompt_variables if v.name in server_config.variables]
+        missing_prompts = [v for v in prompt_variables if v.name not in server_config.variables]
+
         # Compute diff
         diff = _compute_diff(variables, server_config)
+        # Prompt-backed rows aren't "orphaned variables" — they have their own sections below
+        # (and their own page in the UI), so keep the server-only list to general variables.
+        diff.orphaned_server_variables = [
+            name for name in diff.orphaned_server_variables if not name.startswith(PROMPT_VARIABLE_PREFIX)
+        ]
 
         # Show diff
         print(_format_diff(diff))
+
+        if existing_prompts:
+            existing_slugs = ', '.join(sorted(prompt_slug_from_variable_name(v.name) for v in existing_prompts))
+            print(
+                f'{len(existing_prompts)} prompt(s) already exist and are left untouched ({existing_slugs}). '
+                'Publish new versions on the Prompts page, over MCP, or via the prompts API.'
+            )
+        if missing_prompts:
+            print(f'\n{ANSI_GREEN}=== Prompts to CREATE ==={ANSI_RESET}')
+            for prompt_variable in missing_prompts:
+                slug = prompt_slug_from_variable_name(prompt_variable.name)
+                if isinstance(prompt_variable.default, str):
+                    detail = ' (publishes version 1 from the code default)'
+                else:
+                    detail = ' (no initial version — the code default is a function)'
+                print(f'  {ANSI_GREEN}+ {slug}{detail}{ANSI_RESET}')
+                if prompt_variable.description:
+                    print(f'    {ANSI_DIM}{prompt_variable.description}{ANSI_RESET}')
 
         # Cycles are unconditionally unresolvable (no environment satisfies `A -> B -> A`),
         # so block them even in non-strict mode. Missing references, by contrast, may
@@ -1595,7 +1669,7 @@ class VariableProvider(ABC):
             else:
                 print(f'\n{ANSI_YELLOW}Warning: {message}{ANSI_RESET}')
 
-        if not diff.has_changes:
+        if not diff.has_changes and not missing_prompts:
             print(f'\n{ANSI_GREEN}No changes needed. Provider is up to date.{ANSI_RESET}')
             return False
 
@@ -1620,6 +1694,16 @@ class VariableProvider(ABC):
         print('\nApplying changes...')
         try:
             _apply_changes(self, diff, server_config)
+            for prompt_variable in missing_prompts:
+                slug = prompt_slug_from_variable_name(prompt_variable.name)
+                self.create_prompt(
+                    slug=slug,
+                    name=slug.replace('-', ' ').capitalize(),
+                    description=prompt_variable.description,
+                    template=prompt_variable.default if isinstance(prompt_variable.default, str) else None,
+                    template_inputs_schema=get_template_inputs_schema(prompt_variable),
+                )
+                print(f'  {ANSI_GREEN}Created prompt: {slug}{ANSI_RESET}')
         except Exception as e:
             print(f'{ANSI_RED}Error applying changes: {e}{ANSI_RESET}')
             return False

--- a/logfire/variables/local.py
+++ b/logfire/variables/local.py
@@ -1,16 +1,25 @@
 from __future__ import annotations as _annotations
 
+import json
 import threading
 from collections.abc import Mapping
 from typing import Any
 
+from logfire.variables._prompt import prompt_variable_name
 from logfire.variables.abstract import (
     ResolvedVariable,
     VariableAlreadyExistsError,
     VariableNotFoundError,
     VariableProvider,
 )
-from logfire.variables.config import VariableConfig, VariablesConfig
+from logfire.variables.config import (
+    LabeledValue,
+    LabelRef,
+    LatestVersion,
+    Rollout,
+    VariableConfig,
+    VariablesConfig,
+)
 
 __all__ = ('LocalVariableProvider',)
 
@@ -117,6 +126,56 @@ class LocalVariableProvider(VariableProvider):
             self._config.variables[name] = config
             self._config._invalidate_alias_map()  # pyright: ignore[reportPrivateUsage]
         return config
+
+    def create_prompt(
+        self,
+        *,
+        slug: str,
+        name: str,
+        description: str | None = None,
+        template: str | None = None,
+        template_inputs_schema: dict[str, Any] | None = None,
+    ) -> None:
+        """Create a prompt in the local configuration.
+
+        Mirrors the platform shape: a `prompt__<slug>` variable with no JSON schema; when
+        `template` is given, a first version is stored and served via the implicit `latest`
+        label (matching a fresh platform prompt's default rollout).
+
+        Args:
+            slug: The prompt slug, e.g. `support-agent`.
+            name: Human-readable prompt name (not represented in the local config model).
+            description: Optional prompt description.
+            template: When set, stored as version 1 and served as `latest`.
+            template_inputs_schema: JSON Schema for `{{field}}` template inputs.
+
+        Raises:
+            VariableAlreadyExistsError: If a prompt with this slug already exists.
+        """
+        variable_name = prompt_variable_name(slug)
+        labels: dict[str, LabeledValue | LabelRef] = {}
+        rollout = Rollout(labels={})
+        latest_version: LatestVersion | None = None
+        if template is not None:
+            labels = {'latest': LabelRef(version=1, ref='latest')}
+            rollout = Rollout(labels={'latest': 1.0})
+            latest_version = LatestVersion(version=1, serialized_value=json.dumps(template))
+
+        config = VariableConfig(
+            name=variable_name,
+            description=description,
+            labels=labels,
+            rollout=rollout,
+            overrides=[],
+            latest_version=latest_version,
+            json_schema=None,
+            template_inputs_schema=template_inputs_schema,
+        )
+        with self._lock:
+            if variable_name in self._config.variables:
+                raise VariableAlreadyExistsError(f"Prompt '{slug}' already exists")
+            self._config.variables[variable_name] = config
+            self._config._invalidate_alias_map()  # pyright: ignore[reportPrivateUsage]
 
     def delete_variable(self, name: str) -> None:
         """Delete a variable configuration.

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -19,6 +19,7 @@ from logfire._internal.client import UA_HEADER
 from logfire._internal.config import VariablesOptions
 from logfire._internal.server_response import ServerResponseCallback, install_logfire_response_hook
 from logfire._internal.utils import UnexpectedResponse
+from logfire.variables._prompt import prompt_variable_name
 from logfire.variables.abstract import (
     ResolvedVariable,
     VariableAlreadyExistsError,
@@ -517,6 +518,62 @@ class LogfireRemoteVariableProvider(VariableProvider):
         # Refresh cache after successful write
         self.refresh(force=True)
         return config
+
+    def create_prompt(
+        self,
+        *,
+        slug: str,
+        name: str,
+        description: str | None = None,
+        template: str | None = None,
+        template_inputs_schema: dict[str, Any] | None = None,
+    ) -> None:
+        """Create a prompt via the remote prompts API.
+
+        Creates the prompt with `POST /v1/prompts/` (requires an API key with the
+        `project:write_variables` scope), publishes `template` as version 1 when given,
+        and sets `template_inputs_schema` on the backing variable (the one prompt field
+        the variables API accepts).
+
+        Args:
+            slug: The prompt slug, e.g. `support-agent`.
+            name: Human-readable prompt name shown on the Prompts page.
+            description: Optional prompt description.
+            template: When set, published as the prompt's first version.
+            template_inputs_schema: JSON Schema for `{{field}}` template inputs.
+
+        Raises:
+            VariableAlreadyExistsError: If a prompt with this slug already exists.
+            VariableWriteError: If any API request fails.
+        """
+        body: dict[str, Any] = {'name': name, 'slug': slug}
+        if description is not None:
+            body['description'] = description
+        try:
+            with self._session_lock:
+                response = self._session.post(urljoin(self._base_url, '/v1/prompts/'), json=body, timeout=self._timeout)
+                if response.status_code == 409:
+                    raise VariableAlreadyExistsError(f"Prompt '{slug}' already exists")
+                UnexpectedResponse.raise_for_status(response)
+                if template is not None:
+                    response = self._session.post(
+                        urljoin(self._base_url, f'/v1/prompts/{slug}/versions/'),
+                        json={'template': template},
+                        timeout=self._timeout,
+                    )
+                    UnexpectedResponse.raise_for_status(response)
+                if template_inputs_schema is not None:
+                    response = self._session.put(
+                        urljoin(self._base_url, f'/v1/variables/{prompt_variable_name(slug)}/'),
+                        json={'template_inputs_schema': template_inputs_schema},
+                        timeout=self._timeout,
+                    )
+                    UnexpectedResponse.raise_for_status(response)
+        except (UnexpectedResponse, RequestException) as e:
+            raise VariableWriteError(f'Failed to create prompt: {e}') from e
+
+        # Refresh cache after successful write
+        self.refresh(force=True)
 
     def delete_variable(self, name: str) -> None:
         """Delete a variable configuration via the remote API.

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -133,6 +133,8 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     for name in [
         'var',
         'template_var',
+        'prompt',
+        'template_prompt',
         'variables',
         'variables_clear',
         'variables_get',

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,139 @@
+"""Tests for managed prompts (`logfire.prompt` / `logfire.template_prompt`)."""
+
+# pyright: reportPrivateUsage=false
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+import logfire
+from logfire._internal.config import LocalVariablesOptions
+from logfire.variables import PROMPT_VARIABLE_PREFIX, prompt_variable_name
+from logfire.variables.config import (
+    LabeledValue,
+    Rollout,
+    VariableConfig,
+    VariablesConfig,
+)
+
+
+def _make_lf(variables_config: VariablesConfig, config_kwargs: dict[str, Any]) -> logfire.Logfire:
+    config_kwargs['variables'] = LocalVariablesOptions(config=variables_config)
+    return logfire.configure(**config_kwargs)
+
+
+def _prompt_config(variable_name: str, serialized_value: str) -> VariablesConfig:
+    """A minimal config for one prompt-backed variable with a `production` label."""
+    return VariablesConfig(
+        variables={
+            variable_name: VariableConfig(
+                name=variable_name,
+                labels={'production': LabeledValue(version=1, serialized_value=serialized_value)},
+                rollout=Rollout(labels={'production': 1.0}),
+                overrides=[],
+            ),
+        },
+    )
+
+
+class TestPromptVariableName:
+    def test_prefix_constant(self):
+        assert PROMPT_VARIABLE_PREFIX == 'prompt__'
+
+    def test_prepends_prefix(self):
+        assert prompt_variable_name('support') == 'prompt__support'
+
+    def test_normalizes_hyphens(self):
+        assert prompt_variable_name('support-agent') == 'prompt__support_agent'
+
+    def test_warns_and_strips_accidental_prefix(self):
+        with pytest.warns(UserWarning, match='added automatically'):
+            assert prompt_variable_name('prompt__support-agent') == 'prompt__support_agent'
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(ValueError, match='invalid variable name'):
+            prompt_variable_name('has space')
+
+
+class TestPrompt:
+    def test_declares_backing_variable(self):
+        support = logfire.prompt('support-agent', default='Be helpful.')
+        assert support.name == 'prompt__support_agent'
+        # The declared variable is the same object as the registered one.
+        assert logfire.variables_get() == [support]
+
+    def test_resolves_code_default(self):
+        p = logfire.prompt('greeting', default='Hello there.')
+        resolved = p.get()
+        assert resolved.value == 'Hello there.'
+        assert resolved.reason == 'code_default'
+
+    def test_resolves_remote_value(self, config_kwargs: dict[str, Any]):
+        lf = _make_lf(_prompt_config('prompt__support_agent', json.dumps('Remote prompt text.')), config_kwargs)
+        p = lf.prompt('support-agent', default='Code default.')
+        resolved = p.get(label='production')
+        assert resolved.value == 'Remote prompt text.'
+        assert resolved.label == 'production'
+        assert resolved.version == 1
+
+    def test_resolve_function_default(self):
+        def make_default(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> str:
+            return 'Computed default.'
+
+        p = logfire.prompt('dynamic', default=make_default)
+        assert p.get().value == 'Computed default.'
+
+    def test_duplicate_name_raises(self):
+        logfire.prompt('dup', default='a')
+        with pytest.raises(ValueError, match='already been registered'):
+            logfire.prompt('dup', default='b')
+
+    def test_accidental_prefix_warns(self):
+        with pytest.warns(UserWarning, match='added automatically'):
+            p = logfire.prompt('prompt__warned', default='x')
+        assert p.name == 'prompt__warned'
+
+    def test_invalid_name_raises(self):
+        with pytest.raises(ValueError, match='invalid variable name'):
+            logfire.prompt('has space', default='x')
+
+
+class TestTemplatePrompt:
+    def test_renders_template_default(self):
+        class Inputs(BaseModel):
+            customer_name: str
+
+        p = logfire.template_prompt('support-agent', default='Helping {{customer_name}}.', inputs_type=Inputs)
+        assert p.name == 'prompt__support_agent'
+        resolved = p.get(Inputs(customer_name='Alice'))
+        assert resolved.value == 'Helping Alice.'
+
+    def test_renders_remote_template(self, config_kwargs: dict[str, Any]):
+        class Inputs(BaseModel):
+            customer_name: str
+
+        lf = _make_lf(_prompt_config('prompt__support_agent', json.dumps('Hi {{customer_name}}!')), config_kwargs)
+        p = lf.template_prompt('support-agent', default='default', inputs_type=Inputs)
+        resolved = p.get(Inputs(customer_name='Alice'), label='production')
+        assert resolved.value == 'Hi Alice!'
+        assert resolved.label == 'production'
+
+    def test_normalizes_name(self):
+        class Inputs(BaseModel):
+            name: str
+
+        p = logfire.template_prompt('my-prompt', default='Hi {{name}}', inputs_type=Inputs)
+        assert p.name == 'prompt__my_prompt'
+
+    def test_accidental_prefix_warns(self):
+        class Inputs(BaseModel):
+            name: str
+
+        with pytest.warns(UserWarning, match='added automatically'):
+            p = logfire.template_prompt('prompt__warned', default='Hi {{name}}', inputs_type=Inputs)
+        assert p.name == 'prompt__warned'

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -9,11 +9,19 @@ from collections.abc import Mapping
 from typing import Any
 
 import pytest
+import requests_mock as requests_mock_module
 from pydantic import BaseModel
 
 import logfire
-from logfire._internal.config import LocalVariablesOptions
+from logfire._internal.config import LocalVariablesOptions, VariablesOptions
 from logfire.variables import PROMPT_VARIABLE_PREFIX, prompt_variable_name
+from logfire.variables._prompt import prompt_slug_from_variable_name
+from logfire.variables.abstract import (
+    ResolvedVariable,
+    VariableAlreadyExistsError,
+    VariableProvider,
+    VariableWriteError,
+)
 from logfire.variables.config import (
     LabeledValue,
     Rollout,
@@ -21,6 +29,15 @@ from logfire.variables.config import (
     VariablesConfig,
 )
 from logfire.variables.local import LocalVariableProvider
+from logfire.variables.remote import LogfireRemoteVariableProvider
+
+
+def _make_remote_provider() -> LogfireRemoteVariableProvider:
+    return LogfireRemoteVariableProvider(
+        base_url='http://localhost:8000/',
+        token='pylf_v1_local_test_token',
+        options=VariablesOptions(block_before_first_resolve=False),
+    )
 
 
 def _make_lf(variables_config: VariablesConfig, config_kwargs: dict[str, Any]) -> logfire.Logfire:
@@ -267,3 +284,100 @@ class TestPushPrompts:
         assert '+ support-agent' in captured.out
         assert 'Dry run mode' in captured.out
         assert provider._config.variables == {}
+
+
+class TestCreatePromptPrimitive:
+    def test_slug_from_variable_name_rejects_non_prompt_name(self):
+        with pytest.raises(ValueError, match='is not a prompt-backed variable name'):
+            prompt_slug_from_variable_name('plain_var')
+
+    def test_base_create_prompt_warns(self):
+        """The base provider's create_prompt is a warn-only default, like create_variable."""
+
+        class MinimalProvider(VariableProvider):
+            def get_serialized_value(
+                self, variable_name: str, targeting_key: str | None = None, attributes: Mapping[str, Any] | None = None
+            ) -> ResolvedVariable[str | None]:
+                return ResolvedVariable(name=variable_name, value=None, reason='no_provider')  # pragma: no cover
+
+        provider = MinimalProvider()
+        with pytest.warns(UserWarning, match='does not persist prompt writes'):
+            provider.create_prompt(slug='support-agent', name='Support agent')
+
+    def test_local_create_prompt_duplicate_raises(self):
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        provider.create_prompt(slug='support-agent', name='Support agent', template='v1')
+        with pytest.raises(VariableAlreadyExistsError, match="Prompt 'support-agent' already exists"):
+            provider.create_prompt(slug='support-agent', name='Support agent', template='v2')
+
+    def test_remote_create_prompt_full(self):
+        """Remote create_prompt POSTs the prompt, publishes v1, and PUTs the inputs schema."""
+        request_mocker = requests_mock_module.Mocker()
+        create = request_mocker.post('http://localhost:8000/v1/prompts/', json={'slug': 'welcome'}, status_code=201)
+        version = request_mocker.post(
+            'http://localhost:8000/v1/prompts/welcome/versions/', json={'version': 1}, status_code=201
+        )
+        schema_put = request_mocker.put('http://localhost:8000/v1/variables/prompt__welcome/', json={})
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = _make_remote_provider()
+            try:
+                provider.create_prompt(
+                    slug='welcome',
+                    name='Welcome',
+                    description='Welcome email prompt',
+                    template='Hi {{name}}!',
+                    template_inputs_schema={'type': 'object', 'properties': {'name': {'type': 'string'}}},
+                )
+            finally:
+                provider.shutdown()
+        assert create.last_request is not None
+        assert create.last_request.json() == {
+            'name': 'Welcome',
+            'slug': 'welcome',
+            'description': 'Welcome email prompt',
+        }
+        assert version.last_request is not None
+        assert version.last_request.json() == {'template': 'Hi {{name}}!'}
+        assert schema_put.last_request is not None
+        assert schema_put.last_request.json() == {
+            'template_inputs_schema': {'type': 'object', 'properties': {'name': {'type': 'string'}}}
+        }
+
+    def test_remote_create_prompt_minimal(self):
+        """No description/template/inputs schema — only the create POST fires."""
+        request_mocker = requests_mock_module.Mocker()
+        create = request_mocker.post('http://localhost:8000/v1/prompts/', json={'slug': 'bare'}, status_code=201)
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = _make_remote_provider()
+            try:
+                provider.create_prompt(slug='bare', name='Bare')
+            finally:
+                provider.shutdown()
+        assert create.last_request is not None
+        assert create.last_request.json() == {'name': 'Bare', 'slug': 'bare'}
+
+    def test_remote_create_prompt_conflict(self):
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.post('http://localhost:8000/v1/prompts/', status_code=409)
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = _make_remote_provider()
+            try:
+                with pytest.raises(VariableAlreadyExistsError, match="Prompt 'dup' already exists"):
+                    provider.create_prompt(slug='dup', name='Dup')
+            finally:
+                provider.shutdown()
+
+    def test_remote_create_prompt_http_error(self):
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.post('http://localhost:8000/v1/prompts/', status_code=500, text='boom')
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = _make_remote_provider()
+            try:
+                with pytest.raises(VariableWriteError, match='Failed to create prompt'):
+                    provider.create_prompt(slug='broken', name='Broken')
+            finally:
+                provider.shutdown()

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -20,6 +20,7 @@ from logfire.variables.config import (
     VariableConfig,
     VariablesConfig,
 )
+from logfire.variables.local import LocalVariableProvider
 
 
 def _make_lf(variables_config: VariablesConfig, config_kwargs: dict[str, Any]) -> logfire.Logfire:
@@ -56,8 +57,23 @@ class TestPromptVariableName:
             assert prompt_variable_name('prompt__support-agent') == 'prompt__support_agent'
 
     def test_invalid_name_raises(self):
-        with pytest.raises(ValueError, match='invalid variable name'):
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
             prompt_variable_name('has space')
+
+    def test_uppercase_rejected(self):
+        # Backend slugs are always lowercase, so an uppercased slug would silently resolve to a
+        # different variable and fall back to the code default. Reject it loudly instead.
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
+            prompt_variable_name('SupportAgent')
+
+    def test_underscore_rejected(self):
+        # The slug uses hyphens; underscores belong only to the derived backing-variable name.
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
+            prompt_variable_name('support_agent')
+
+    def test_empty_rejected(self):
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
+            prompt_variable_name('')
 
 
 class TestPrompt:
@@ -99,8 +115,12 @@ class TestPrompt:
         assert p.name == 'prompt__warned'
 
     def test_invalid_name_raises(self):
-        with pytest.raises(ValueError, match='invalid variable name'):
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
             logfire.prompt('has space', default='x')
+
+    def test_uppercase_slug_raises(self):
+        with pytest.raises(ValueError, match='Invalid prompt slug'):
+            logfire.prompt('SupportAgent', default='x')
 
 
 class TestTemplatePrompt:
@@ -137,3 +157,113 @@ class TestTemplatePrompt:
         with pytest.warns(UserWarning, match='added automatically'):
             p = logfire.template_prompt('prompt__warned', default='Hi {{name}}', inputs_type=Inputs)
         assert p.name == 'prompt__warned'
+
+
+class TestPushPrompts:
+    """`variables_push()` handles prompts too, routing them through the prompts surface.
+
+    A single push entry point covers everything declared in code — general variables go
+    through the variables API, prompt-backed variables (which the variables API rejects
+    writes to) are created via the prompts API.
+    """
+
+    def test_push_creates_missing_prompt_and_variable(
+        self, capsys: pytest.CaptureFixture[str], config_kwargs: dict[str, Any]
+    ):
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.prompt('support-agent', default='You are helpful.', description='Support system prompt')
+        var = lf.var(name='plain_var', default='default', type=str)
+
+        result = provider.push_variables([prompt, var], yes=True)
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert '+ support-agent (publishes version 1 from the code default)' in captured.out
+        assert 'Created prompt: support-agent' in captured.out
+        assert 'plain_var' in provider._config.variables
+
+        created = provider._config.variables['prompt__support_agent']
+        assert created.json_schema is None
+        assert created.description == 'Support system prompt'
+        assert created.latest_version is not None
+        assert created.latest_version.serialized_value == json.dumps('You are helpful.')
+        # A fresh prompt serves its latest version, matching platform defaults.
+        assert created.rollout.labels == {'latest': 1.0}
+
+    def test_pushed_prompt_resolves_from_provider(self, config_kwargs: dict[str, Any]):
+        """After a push, `prompt().get()` serves the pushed version, not the code default."""
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.prompt('greeting', default='Hello from code.')
+        provider.push_variables([prompt], yes=True)
+
+        resolved = provider.get_serialized_value('prompt__greeting')
+        assert resolved.value == json.dumps('Hello from code.')
+        assert resolved.reason == 'resolved'
+
+    def test_push_existing_prompt_untouched(self, capsys: pytest.CaptureFixture[str], config_kwargs: dict[str, Any]):
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        provider.create_prompt(slug='support-agent', name='Support agent', template='Server version.')
+
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.prompt('support-agent', default='Different code default.')
+
+        result = provider.push_variables([prompt], yes=True)
+        assert result is False
+
+        captured = capsys.readouterr()
+        assert 'prompt(s) already exist and are left untouched (support-agent)' in captured.out
+        assert 'No changes needed' in captured.out
+        existing = provider._config.variables['prompt__support_agent']
+        assert existing.latest_version is not None
+        assert existing.latest_version.serialized_value == json.dumps('Server version.')
+
+    def test_push_template_prompt_includes_inputs_schema(self, config_kwargs: dict[str, Any]):
+        class Inputs(BaseModel):
+            customer_name: str
+
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.template_prompt('welcome', default='Hi {{customer_name}}!', inputs_type=Inputs)
+
+        result = provider.push_variables([prompt], yes=True)
+        assert result is True
+
+        created = provider._config.variables['prompt__welcome']
+        assert created.template_inputs_schema is not None
+        assert created.template_inputs_schema['properties'] == {
+            'customer_name': {'title': 'Customer Name', 'type': 'string'}
+        }
+
+    def test_push_prompt_function_default_creates_without_version(
+        self, capsys: pytest.CaptureFixture[str], config_kwargs: dict[str, Any]
+    ):
+        def resolve_fn(targeting_key: str | None, attributes: Mapping[str, Any] | None) -> str:
+            return 'computed'  # pragma: no cover
+
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.prompt('dynamic', default=resolve_fn)
+
+        result = provider.push_variables([prompt], yes=True)
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert '+ dynamic (no initial version — the code default is a function)' in captured.out
+        created = provider._config.variables['prompt__dynamic']
+        assert created.latest_version is None
+        assert created.rollout.labels == {}
+
+    def test_push_prompts_dry_run(self, capsys: pytest.CaptureFixture[str], config_kwargs: dict[str, Any]):
+        provider = LocalVariableProvider(VariablesConfig(variables={}))
+        lf = logfire.configure(**config_kwargs)
+        prompt = lf.prompt('support-agent', default='You are helpful.')
+
+        result = provider.push_variables([prompt], dry_run=True)
+        assert result is True
+
+        captured = capsys.readouterr()
+        assert '+ support-agent' in captured.out
+        assert 'Dry run mode' in captured.out
+        assert provider._config.variables == {}

--- a/tests/type_checking.py
+++ b/tests/type_checking.py
@@ -27,3 +27,17 @@ my_template_variable = logfire.template_var(
 )
 assert_type(my_template_variable, TemplateVariable[str, PromptInputs])
 assert_type(my_template_variable.get(PromptInputs(name='Alice')).value, str)
+
+
+# `prompt()` is `var()` specialized to `str`, and `template_prompt()` mirrors `template_var()`.
+my_prompt = logfire.prompt(name='my-prompt', default='Be helpful.')
+assert_type(my_prompt, Variable[str])
+assert_type(my_prompt.get().value, str)
+
+my_template_prompt = logfire.template_prompt(
+    name='my-template-prompt',
+    default='Hello {{name}}',
+    inputs_type=PromptInputs,
+)
+assert_type(my_template_prompt, TemplateVariable[str, PromptInputs])
+assert_type(my_template_prompt.get(PromptInputs(name='Alice')).value, str)


### PR DESCRIPTION
Adds first-class **managed prompt** support to the SDK: slug-based consumption helpers, and code-first prompt creation via `variables_push()`.

## Consumption: `logfire.prompt()` / `logfire.template_prompt()`

Prompts in Logfire are managed variables under the hood, distinguished by a `prompt__` name prefix. Before this PR you consumed a prompt by manually declaring its backing variable (`logfire.var(name='prompt__support_agent', type=str, ...)`); these helpers hide the naming convention behind the slug:

```python
# Plain prompt (string value)
support = logfire.prompt('support-agent', default='You are a helpful support agent.')
with support.get(label='production') as resolved:
    system_prompt = resolved.value

# Handlebars-templated prompt with typed inputs
support = logfire.template_prompt('support-agent', default='Helping {{name}}.', inputs_type=MyInputs)
with support.get(MyInputs(name='Alice'), label='production') as resolved:
    system_prompt = resolved.value  # -> 'Helping Alice.'
```

- `prompt()` is `var()` specialized to prompts: value type fixed to `str`, slug translated to the backing-variable name. Returns `Variable[str]`.
- `template_prompt()` is the same specialization of `template_var()` (adds `inputs_type` + `template_mismatch_policy`). Returns `TemplateVariable[str, InputsT]`.
- Both delegate entirely to the existing `var()`/`template_var()` infrastructure.

### Naming / validation

`logfire/variables/_prompt.py` holds the single slug↔name translation (`prompt_variable_name()` and its inverse `prompt_slug_from_variable_name()`). Slugs are validated against the backend's exact rule (`^[a-z0-9-]{1,100}$`) and raise `ValueError` loudly at declaration time — a mismatched name (e.g. uppercased) would silently resolve to a *different* variable and fall back to the code default. Hyphens→underscores is injective over the slug charset, so there is no collision or round-trip loss. An accidental `prompt__` prefix warns and strips.

## Authoring: `variables_push()` now creates prompts

`logfire.variables_push()` pushes **everything declared in code** — general variables through the variables API as before, and prompt-backed variables through the prompts API (`POST /v1/prompts/`, requires `project:write_variables`):

- **Missing prompts are created**, publishing a static-string code `default` as version 1 — the prompt appears on the Prompts page ready for iteration and serves exactly what the code default already said (fresh prompts serve `latest`). Function defaults create the prompt with no initial version.
- **Existing prompts are never modified** by a push — new versions are published on the Prompts page, over MCP, or via the prompts API. This mirrors `variables_push`'s "never touch values" stance.
- `template_prompt()` declarations also push their `template_inputs_schema` (the one prompt field the variables API accepts for prompt rows).

> **Design choice we're not sure about:** prompts are handled *inside* `variables_push()` (one entry point pushes everything, routing per-kind under the hood) rather than a dedicated `prompts_push()`. The upside is you don't have to remember N `<thing>_push()` calls; the downside is `variables_push` semantics get less uniform (prompts publish a v1 on create, variables never create versions). Feedback welcome — a split into `prompts_push()` would be mechanical.

## Docs

- `application.md` gains a prominent **"API Key Required"** callout: prompts resolve through the managed-variables API, which needs `LOGFIRE_API_KEY` (scope `project:read_variables`) — *not* the write token. Without it the SDK never contacts Logfire and `.get()` silently serves the code default. The composition and rollout pages link back to it.
- New **"Create prompts from code"** section documenting the push flow.
- All prompt-management examples use the new helpers.

## Scope boundaries

- The full `logfire.prompts_*()` management family (get/list/update/settings/labels) from the design doc is still pending; MCP already covers interactive authoring.
- `logfire-api` shim excludes these names (like the whole variables family); prompt users need `logfire[variables]`.
- pydantic-ai `ManagedPrompt` integration (delegating its naming to `prompt_variable_name()`) lives in the pydantic-ai repo, not here.

## Testing

- `tests/test_prompts.py`: naming (incl. inverse), resolution, templating, validation, and the push flows (create with v1, existing untouched, template inputs schema, function default, dry run) — driven through `LocalVariableProvider`, which implements the same `create_prompt` primitive as the remote provider.
- Verified end-to-end against a local platform stack running the `/v1/prompts/` branch (pydantic/platform#23832): push creates the prompt via the API, the Prompts page shows it, and `prompt().get()` resolves the pushed version.
- `pyright`, `ruff`, docs-example tests all green.
