### PR TITLE
Allow '/' as a namespace separator in dataset names

### DIFF
--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -84,7 +84,10 @@ _UNSET: Any = object()
 """Sentinel to distinguish 'not provided' from explicit None."""
 
 
-_DATASET_NAME_RE = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*$')
+# Mirrors the platform's `DatasetName` Pydantic type. Allows `/` as a namespace separator
+# (e.g. `team-a/support-routing`) so datasets can be grouped by prefix in the Logfire UI; each
+# `/`-delimited segment must start with a letter or digit (no leading, trailing, or repeated slashes).
+_DATASET_NAME_RE = re.compile(r'^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$')
 
 
 def _validate_dataset_name(name: str) -> None:
@@ -92,7 +95,8 @@ def _validate_dataset_name(name: str) -> None:
     if not _DATASET_NAME_RE.match(name):
         raise ValueError(
             f'Invalid dataset name {name!r}. '
-            'Names must start with a letter or digit and contain only letters, digits, dots, hyphens, and underscores.'
+            'Names must start with a letter or digit and contain only letters, digits, dots, hyphens, '
+            'underscores, and `/` (as a namespace separator, e.g. team-a/support-routing).'
         )
 
 

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -409,6 +409,9 @@ class TestValidateDatasetName:
         _validate_dataset_name('a')
         _validate_dataset_name('123')
         _validate_dataset_name('test_dataset-1.0')
+        # `/` is allowed as a namespace separator between well-formed segments.
+        _validate_dataset_name('team-a/support-routing')
+        _validate_dataset_name('team-a/rag/retrieval')
 
     def test_invalid_names(self):
         with pytest.raises(ValueError, match='Invalid dataset name'):
@@ -417,8 +420,13 @@ class TestValidateDatasetName:
             _validate_dataset_name('-starts-with-dash')
         with pytest.raises(ValueError, match='Invalid dataset name'):
             _validate_dataset_name('has spaces')
+        # A `/` must separate two well-formed segments: no leading, trailing, or repeated slashes.
         with pytest.raises(ValueError, match='Invalid dataset name'):
-            _validate_dataset_name('special/chars')
+            _validate_dataset_name('/leading-slash')
+        with pytest.raises(ValueError, match='Invalid dataset name'):
+            _validate_dataset_name('trailing-slash/')
+        with pytest.raises(ValueError, match='Invalid dataset name'):
+            _validate_dataset_name('double//slash')
 
 
 class TestPushDatasetHelpers:


### PR DESCRIPTION
## What

Relax `_DATASET_NAME_RE` (and its error message) in the experimental dataset API client so dataset names may contain `/` as a namespace separator between well-formed segments, e.g. `team-a/support-routing`. Leading, trailing, and repeated slashes remain rejected.

This mirrors the platform's `DatasetName` Pydantic type and unlocks **grouping datasets by prefix** in the Logfire UI.

## Why

Driven by user feedback that large numbers of datasets/experiments are hard to organize. The platform side adds a "group by prefix" view + pin/favorites for the datasets directory; for the SDK's hosted-dataset client to accept namespaced names, this regex needs to match the platform's relaxed validation.

## Scope / status (draft)

This is the SDK half of a cross-repo change and is intentionally a **draft** until the platform side lands and we agree on the path-encoding approach below.

- ✅ `_validate_dataset_name` now accepts `/`-separated names (+ tests for valid `/` names and rejected leading/trailing/double slashes).
- ⚠️ **Follow-up needed for full hosted round-trip:** the client interpolates names directly into URL paths (`/v1/datasets/{id_or_name}/`). For path-based by-name operations on a `/`-named hosted dataset to work, the name must be URL-encoded here **and** the platform's `/v1/datasets/{id_or_name}` route must accept an encoded slash (`:path`). Creating by name (POST with the name in the JSON body) already works. Local / code-defined (pydantic-evals) datasets don't go through this client and already support `/`.

Companion platform change relaxes `DatasetName` + the `ui_api` `by-name/{name:path}` route and regenerates the OpenAPI spec.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

