### PR TITLE
Add product page link to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
   <a href="https://pydantic.dev/docs/logfire/join-slack/"><img src="https://img.shields.io/badge/Slack-Join%20Slack-4A154B?logo=slack" alt="Join Slack" /></a>
 </p>
 
+**Product page**: [pydantic.dev/logfire](https://pydantic.dev/logfire?utm_source=github&utm_medium=readme&utm_campaign=logfire) · **Documentation**: [pydantic.dev/docs/logfire](https://pydantic.dev/docs/logfire/)
+
 From the team behind Pydantic Validation, **Pydantic Logfire** is an observability platform built on the same belief as our open source library — that the most powerful tools can be easy to use.
 
 What sets Logfire apart:


### PR DESCRIPTION
Pairs the existing docs link with a marketing/product page link in the README header so readers can land on either the technical docs or the product overview.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

