### PR TITLE
Docs: AI Gateway guide, web UI and reference updates

### DIFF
--- a/docs/ai-observability.md
+++ b/docs/ai-observability.md
@@ -45,7 +45,19 @@ Trace entire conversation flows across multiple turns and tool calls.
 
 ### Evaluations
 
-[pydantic-evals](https://github.com/pydantic/pydantic-evals) is a code-first evaluation framework that integrates with Logfire. A key difference from other eval tools: pydantic-evals can evaluate any Python function, not just LLM calls. This means you can test your tools, your data pipelines, your entire agent workflow. Define evals in Python, run them locally or in CI, and view results in Logfire. Unlike UI-managed evals in other tools, pydantic-evals treats evaluations as code: version-controlled, programmatically managed, and integrated with your existing test infrastructure.
+Logfire covers evals from both directions. [pydantic-evals](https://github.com/pydantic/pydantic-evals) is a code-first evaluation framework that can evaluate any Python function, not just LLM calls — define evals in Python, version-control them, and run them locally or in CI. The results land in Logfire's [Evals web UI](guides/web-ui/evals.md), where you can manage [datasets](evaluate/datasets/index.md), compare experiment runs side by side, and monitor [live evaluations](guides/web-ui/live-evals.md) grading real production traffic in the background.
+
+### Prompt Management & Playground
+
+Author, version, and test prompts in the [prompt editor](reference/advanced/prompt-management/index.md), compose reusable fragments, and promote new versions with labeled rollouts — no redeploy needed. The Playground lets you iterate on prompts, models, and tools interactively against real captured runs.
+
+### AI Gateway
+
+Route LLM calls from any SDK through the [AI Gateway](reference/advanced/gateway/index.md) for unified key management, spending limits, provider failover, and automatic tracing of every call — one endpoint across OpenAI, Anthropic, Google, Bedrock, and more.
+
+### LLMs Page
+
+A per-provider, per-model breakdown of every model call your project records — calls, error rate, latency, token mix, and cost — with click-through to the underlying traces. See the [LLMs view](guides/web-ui/llms.md).
 
 ## Quick Start
 

--- a/docs/comparisons/arize-phoenix.md
+++ b/docs/comparisons/arize-phoenix.md
@@ -10,7 +10,7 @@ Arize Phoenix is an ML observability platform focused on model monitoring, drift
 | **Strength**         | AI + application tracing                                       | Drift detection, model performance                              |
 | **Non-AI Tracing**   | Full support                                                   | Limited                                                         |
 | **Language Support** | Python, JS/TS, Rust (SDKs) + any OTel                          | Python-focused                                                  |
-| **Evals**            | Integrated web-UI - Code-based via `pydantic-evals` | Integrated web-UI - Code-based via external library |
+| **Evals**            | Web UI (datasets, experiments, live monitoring) + code-based via `pydantic-evals` | Web UI + code-based via external library |
 | **Pricing**          | Per-span ($2/million)*                                         | Usage-based                                                     |
 | **Setup**            | 3 lines of code                                                | OTel-based (several lines of code)                              |
 | **SQL Queries**      | Yes (Postgres-compatible)                                      | No. Use `SpanQuery` DSL                                         |

--- a/docs/comparisons/braintrust.md
+++ b/docs/comparisons/braintrust.md
@@ -23,9 +23,7 @@ Braintrust is an AI evaluation and observability platform focused on LLM testing
 
 ## When to Choose Braintrust
 
-- **Evaluation focus:** Your only need is UI-based AI evaluation workflows
-- **Prompt iteration:** You're heavily iterating on prompts and need that workflow
-- **UI-driven evals:** You prefer managing evaluations through a User Interface (UI)
+- **Deep Braintrust ecosystem investment:** You've already built your evaluation workflows around Braintrust's tooling (note that Logfire also offers [UI-based evals](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=comparison_docs), a [prompt editor](https://pydantic.dev/docs/logfire/prompt-management/?utm_source=comparison_docs), a playground, and an [AI gateway](../reference/advanced/gateway/index.md))
 - **AI-only scope:** You don't need full application observability
 
 ## Key Differences Explained

--- a/docs/comparisons/datadog.md
+++ b/docs/comparisons/datadog.md
@@ -51,7 +51,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 - **Custom metrics explosion:** OpenTelemetry metrics are treated as expensive "custom metrics" with cardinality charges
 - **Unpredictable costs:** Multiple billing dimensions make forecasting difficult
 
-**Logfire** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=datadog_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
+**Logfire** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=datadog_comparison_docs) start at $49/mo with the same 10M included, then $2 per million after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
 
 ### AI/LLM Support
 

--- a/docs/comparisons/datadog.md
+++ b/docs/comparisons/datadog.md
@@ -22,7 +22,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 | Scenario | Datadog    | Logfire Cloud*    | Savings |
 |----------|------------|-------------------|---------|
 | Hobby (2 hosts, 5M spans) | $101/mo    | $0/mo (free tier) | 100%    |
-| Startup (10 hosts, 100M spans) | $229/mo    | $180/mo           | 59%     |
+| Startup (10 hosts, 100M spans) | $229/mo    | $229/mo           | —       |
 | Scale-up (50-150 hosts, 500M spans) | $9,860/mo  | $1,229/mo         | 87%     |
 | High-volume (500 hosts, 2B spans) | $33,550/mo | $4,229/mo         | 87%     |
 
@@ -51,7 +51,7 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 - **Custom metrics explosion:** OpenTelemetry metrics are treated as expensive "custom metrics" with cardinality charges
 - **Unpredictable costs:** Multiple billing dimensions make forecasting difficult
 
-**Logfire** includes 10M traces for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=datadog_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
+**Logfire** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=datadog_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
 
 ### AI/LLM Support
 
@@ -64,6 +64,8 @@ Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-nati
 - Tool call inspection
 - Streaming support
 - Integration with MCP server to query & debug tracing data
+
+And observability is only half the story: Logfire also ships [evals in the web UI](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=datadog_comparison_docs) (datasets, experiments, and live production monitoring), [prompt management](https://pydantic.dev/docs/logfire/prompt-management/?utm_source=datadog_comparison_docs) with a playground, and an AI gateway with key management and spending controls — the full AI engineering loop in one platform, not a bolted-on add-on.
 
 ### OpenTelemetry
 

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -51,7 +51,8 @@ Logfire is a great fit when you:
 - **AI enabled workflows** - Use the [Logfire MCP server](https://pydantic.dev/docs/logfire/guides/mcp-server/?utm_source=comparison_docs) to query your app's telemetry data, analyze distributed traces, and fix errors with AI using Logfire's OTel-native API
 - **Have polyglot architectures** - Python backend + TypeScript frontend, microservices in different languages
 - **Want exceptional Python, TS/JS, Rust support** - While also supporting other languages via OTel
-- **Need code-first evals** - [pydantic-evals](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=comparison_docs) tests any Python function, not just LLM calls
+- **Want evals both ways** - [code-first evals with pydantic-evals](https://pydantic.dev/docs/logfire/evaluate/datasets/?utm_source=comparison_docs) that test any Python function, plus a [web UI for datasets, experiments, and live production monitoring](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=comparison_docs)
+- **Want the full AI engineering loop in one place** - [prompt management](https://pydantic.dev/docs/logfire/prompt-management/?utm_source=comparison_docs), a playground, and an [AI gateway](../reference/advanced/gateway/index.md) with key management and spending controls, next to your traces
 - **Prefer SQL-based querying** - Familiar PostgreSQL syntax over proprietary query languages
 - **Value simple, predictable pricing** - $2/million spans, scales to billions of spans per month
-- **Need enterprise features** - [SOC2, HIPAA, self-hosting](https://pydantic.dev/pricing#enterprise?utm_source=comparison_docs options
+- **Need enterprise features** - [SOC2, HIPAA, self-hosting](https://pydantic.dev/pricing?utm_source=comparison_docs#enterprise) options

--- a/docs/comparisons/langfuse.md
+++ b/docs/comparisons/langfuse.md
@@ -13,7 +13,7 @@ Both Logfire and Langfuse help you observe AI/LLM applications, but they take fu
 | **Pricing Model** | Per-span ($2/million)* | Per-event + usage-based |
 | **Python Support** | First-class (Pydantic team) | Good |
 | **Non-AI Tracing** | Full support | Limited |
-| **LLM Features** | Token tracking, costs, panels | Token tracking, costs, evals, prompt mgmt |
+| **LLM Features** | Token tracking, costs, panels, evals (UI + code), prompt mgmt, playground, AI gateway | Token tracking, costs, evals, prompt mgmt |
 | **OpenTelemetry** | Native | Export support |
 
 *Logfire Cloud pricing (Team or Growth plans). Enterprise pricing available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5).
@@ -60,7 +60,7 @@ When you're iterating on AI applications with coding agents, the agent needs to 
 
 **Langfuse Cloud** charges per event plus usage-based pricing.
 
-**Logfire Cloud (Team and Growth)** Free tier includes 10M traces. Plans start at $49/month, then charges $2 per million spans after the free tier (10M spans/month). Simple and predictable.
+**Logfire Cloud (Team and Growth)** Free tier includes 10M spans/logs/metrics per month. Plans start at $49/month, then charge $2 per million after the included allowance. Simple and predictable.
 
 ## Integration Comparison
 

--- a/docs/comparisons/langsmith.md
+++ b/docs/comparisons/langsmith.md
@@ -32,11 +32,12 @@ At scale, Logfire can be 50-100X cheaper than LangSmith. This isn't about Logfir
 - **Open standards:** You want OTel-compatible instrumentation that isn't locked to one vendor
 - **Framework flexibility:** You use multiple AI frameworks or may switch in the future
 - **Long-term cost efficiency:** You're scaling and costs matter
+- **The full AI engineering loop:** Evals (in code and the [web UI](https://pydantic.dev/docs/logfire/evaluate/evals/?utm_source=comparison_docs)), [prompt management](https://pydantic.dev/docs/logfire/prompt-management/?utm_source=comparison_docs), a playground, and an AI gateway — alongside your observability, not in a separate tool
 
 ## When to Choose LangSmith + LangChain
 
 - **LangChain investment:** You're heavily invested in the LangChain ecosystem
-- **R&D workflow:** You prioritize prompt iteration and playground features
+- **LangChain-native workflow:** You want prompt iteration tooling built specifically around LangChain primitives (Logfire also ships a [prompt editor](https://pydantic.dev/docs/logfire/prompt-management/?utm_source=comparison_docs) and [playground](https://pydantic.dev/docs/logfire/guides/web-ui/prompt-playground/?utm_source=comparison_docs))
 - **Quick prototyping:** You value LangChain's flexibility for rapid experimentation
 
 ## Key Differences Explained

--- a/docs/comparisons/sentry.md
+++ b/docs/comparisons/sentry.md
@@ -8,7 +8,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 |---------------------|----------------------------------------|------------------------------------------|
 | **Primary Focus**   | Full observability (logs, traces, AI)  | Error monitoring                         |
 | **App Tracing**     | Core capability                        | Available, not a core focus              |
-| **AI/LLM Support**  | First-class, automatic instrumentation | Generic function tracing only            |
+| **AI/LLM Support**  | First-class: auto-instrumentation, evals, prompt management, AI gateway | Generic function tracing only            |
 | **Logging**         | Structured logs with full context      | Error-focused                            |
 | **Live View**       | Real-time "pending spans"                | ❌                                        |
 | **Query Interface** | SQL (Postgres-compatible)              | Custom UI                                |
@@ -41,7 +41,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 **Logfire** provides full observability:
 
 - **Structured logs:** Every log/span/trace with full context, not just errors
-- **[Issue alerts](https://pydantic.dev/docs/logfire/observe/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
+- **[Issue alerts](https://pydantic.dev/docs/logfire/guides/web-ui/issues/?utm_source=sentry_comparison_docs):** Automatic exception grouping, fingerprinting, and webhook alerts to Slack
 - **Distributed traces:** See requests flow through your entire system
 - **Real-time monitoring:** Watch your application in real-time with "pending spans"
 - **AI visibility:** Automatic instrumentation for LLM calls, tool invocations, and more

--- a/docs/comparisons/sentry.md
+++ b/docs/comparisons/sentry.md
@@ -12,7 +12,7 @@ Sentry is a mature error monitoring platform. Logfire is an AI-native observabil
 | **Logging**         | Structured logs with full context      | Error-focused                            |
 | **Live View**       | Real-time "pending spans"                | ❌                                        |
 | **Query Interface** | SQL (Postgres-compatible)              | Custom UI                                |
-| **Pricing**         | 10M spans free, then $2/M              | Per-event + quotas                       |
+| **Pricing**         | 10M spans/logs/metrics free, then $2/M | Per-event + quotas                       |
 *Logfire Cloud pricing (Team or Growth plans). Enterprise pricing available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5).
 
 ## When to Choose Logfire

--- a/docs/comparisons/signoz.md
+++ b/docs/comparisons/signoz.md
@@ -16,7 +16,7 @@ This comparison covers both SigNoz deployment options so you can make an informe
 | **AI/LLM observability** | Native (one function call) + purpose-built UI                                                                       | Via OpenLLMetry                     | Via OpenLLMetry                        |
 | **SDKs**                | First-class Python, JS/TS, Rust                                                                                     | Standard OTel                       | No SDKs (standard OTel)                |
 | **Maintenance**         | Zero                                                                                                                | Zero                                | You manage it all                      |
-| **Pricing**         | 10M spans free, then $2/M (plus base plan fee)*                                                                     | Base plan fee + usage               | "Free" but infra + maintenance costs       |
+| **Pricing**         | 10M spans/logs/metrics free, then $2/M (plus base plan fee)*                                                                     | Base plan fee + usage               | "Free" but infra + maintenance costs       |
 | **Query language**      | PostgreSQL-compatible SQL                                                                                           | ClickHouse SQL                      | ClickHouse SQL                         |
 *Logfire Cloud pricing (Team or Growth plans). Enterprise pricing available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5).
 
@@ -47,7 +47,7 @@ Three lines and you're observing AI calls. SigNoz uses standard OpenTelemetry in
 
 **SDK flexibility.** The Logfire SDK can send data to any OTel-compatible backend, including SigNoz. If you like our SDK's simplicity but want to use their backend, you can.
 
-**Pricing** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=signoz_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
+**Pricing** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=signoz_comparison_docs) start at $49/mo with the same 10M included, then $2 per million after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
 
 
 ### When to Choose Each
@@ -81,7 +81,7 @@ This is the nature of self-hosted infrastructure. Some organizations need this l
 - Engineering time for setup, maintenance, and troubleshooting
 - On-call burden when your monitoring infrastructure has issues
 
-**Logfire pricing** is transparent: 10M spans free, then $2/million on Team or Growth plans. Enterprise pricing available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5). No hidden infrastructure costs.
+**Logfire pricing** is transparent: 10M spans/logs/metrics free, then $2/million on Team or Growth plans. Enterprise pricing available [on request](https://calendar.app.google/k9pkeuNMmzJAJ4Mx5). No hidden infrastructure costs.
 
 ### When to Choose Each
 

--- a/docs/comparisons/signoz.md
+++ b/docs/comparisons/signoz.md
@@ -1,6 +1,6 @@
 # Logfire vs SigNoz
 
-SigNoz is an open-source observability platform available as both a self-hosted solution and a managed cloud service. Logfire is an AI-native observability platform, also built on OpenTelemetry, with full-stack monitoring capabilities and (Enterprise) self=hosting options. Both platforms support logs, traces, and metrics, but they serve different needs..
+SigNoz is an open-source observability platform available as both a self-hosted solution and a managed cloud service. Logfire is an AI-native observability platform, also built on OpenTelemetry, with full-stack monitoring capabilities and (Enterprise) self-hosting options. Both platforms support logs, traces, and metrics, but they serve different needs.
 
 This comparison covers both SigNoz deployment options so you can make an informed choice.
 
@@ -10,7 +10,7 @@ This comparison covers both SigNoz deployment options so you can make an informe
 
 | Aspect                  | Logfire                                                                                                             | SigNoz Cloud                        | SigNoz Self-Hosted                     |
 |-------------------------|---------------------------------------------------------------------------------------------------------------------|-------------------------------------|----------------------------------------|
-| **Hosting**             | Managed SaaS (or [Enterprise](https://pydantic.dev/pricing#enterprise?utm_source=signoz_comparison_docs) self-host) | Managed SaaS                        | You host everything                    |
+| **Hosting**             | Managed SaaS (or [Enterprise](https://pydantic.dev/pricing?utm_source=signoz_comparison_docs#enterprise) self-host) | Managed SaaS                        | You host everything                    |
 | **Scope**               | AI-native and full-stack (logs, traces, metrics)                                                                    | Full-stack (logs, traces, metrics), | Full-stack (logs, traces, metrics)     |
 | **Setup**               | 3 lines of code                                                                                                     | OTel configuration                  | Deploy collectors, ClickHouse, storage |
 | **AI/LLM observability** | Native (one function call) + purpose-built UI                                                                       | Via OpenLLMetry                     | Via OpenLLMetry                        |
@@ -47,12 +47,12 @@ Three lines and you're observing AI calls. SigNoz uses standard OpenTelemetry in
 
 **SDK flexibility.** The Logfire SDK can send data to any OTel-compatible backend, including SigNoz. If you like our SDK's simplicity but want to use their backend, you can.
 
-**Pricing** includes 10M traces for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=signoz_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
+**Pricing** includes 10M spans/logs/metrics per month for free. [Paid plans](https://pydantic.dev/pricing/?utm_source=signoz_comparison_docs) start at $49/mo with 10M spans included, then $2 per million spans after that. That's it. No host fees, no custom metrics fees, no ingestion surprises.
 
 
 ### When to Choose Each
 
-**Choose Logfire** if you're building AI/LLM applications, want the simplest possible setup, or work heavily with AI coding tools, use MCP for debugging, and benefit from querying your data with standard SQL.
+**Choose Logfire** if you're building AI/LLM applications — you get evals, prompt management, a playground, and an AI gateway alongside observability — want the simplest possible setup, work heavily with AI coding tools, use MCP for debugging, and benefit from querying your data with standard SQL.
 
 **Choose SigNoz Cloud** if you need Prometheus-style infrastructure metrics alongside APM, prefer standard OTel instrumentation, or your team is already familiar with ClickHouse.
 
@@ -104,7 +104,7 @@ If you're running SigNoz and considering Logfire:
 ## Summary
 
 
-**Logfire** is for teams who want managed or self-hosted (via https://pydantic.dev/pricing#enterprise?utm_source=signoz_comparison_docs) AI-native observability with minimal operational overhead. It's built for developers who'd rather focus on their application than their monitoring infrastructure—especially those without dedicated DevOps resources. Beyond tracing, Logfire lets you query your telemetry data with SQL, build dashboards, visualize evals, and set up alerts all in one platform. You can even debug production errors via MCP server directly from your IDE.
+**Logfire** is for teams who want managed or self-hosted (via https://pydantic.dev/pricing?utm_source=signoz_comparison_docs#enterprise) AI-native observability with minimal operational overhead. It's built for developers who'd rather focus on their application than their monitoring infrastructure—especially those without dedicated DevOps resources. Beyond tracing, Logfire lets you query your telemetry data with SQL, build dashboards, visualize evals, and set up alerts all in one platform. You can even debug production errors via MCP server directly from your IDE.
 
 **SigNoz Cloud** is for teams who want managed observability with standard OTel instrumentation and ClickHouse's query capabilities.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,9 +45,12 @@ Yes: Logfire is _built_ for AI observability, and it's better at it because it s
 **AI-specific features:**
 
 - LLM-specific panels for conversation inspection
-- Token tracking and cost monitoring
+- Token tracking and cost monitoring, plus a per-model [LLMs view](guides/web-ui/llms.md)
 - Tool call inspection with full context
 - Streaming support
+- [Evals](guides/web-ui/evals.md): datasets, experiments, and [live production monitoring](guides/web-ui/live-evals.md) in the web UI, powered by code-first [pydantic-evals](https://github.com/pydantic/pydantic-evals)
+- [Prompt management](reference/advanced/prompt-management/index.md) with versioning, labeled rollouts, and a playground
+- An [AI Gateway](reference/advanced/gateway/index.md) with unified key management, spending limits, and provider failover
 
 **Better debugging:** When your AI agent fails, you don't just see the LLM error. You see the database timeout that caused it, the API rate limit that preceded it, and the user request that started it all.
 
@@ -73,14 +76,15 @@ Some tools focus only on LLM observability. Logfire takes a different approach: 
 
 ### Q: Does Logfire support evaluations (evals)?
 
-Yes. [pydantic-evals](https://github.com/pydantic/pydantic-evals) is a code-first evaluation framework that integrates with Logfire:
+Yes — both code-first and in the web UI.
+
+[pydantic-evals](https://github.com/pydantic/pydantic-evals) is a code-first evaluation framework that integrates with Logfire:
 
 - Evaluate any Python function, not just LLM calls (test your tools, data pipelines, entire agent workflows)
 - Define evals in Python, version-controlled like everything else
 - Run them programmatically, locally or in CI
-- View comparison results in Logfire
 
-This is a code-first approach. Some tools offer UI-managed evals; Pydantic's philosophy is that evals belong in your codebase alongside your tests.
+The results feed Logfire's [Evals web UI](guides/web-ui/evals.md), where you can manage hosted [datasets](evaluate/datasets/index.md), compare experiment runs side by side, and watch [live evaluations](guides/web-ui/live-evals.md) grade real production traffic in the background. The eval definitions stay in your codebase alongside your tests; the exploration, comparison, and monitoring happen in the UI.
 
 ---
 

--- a/docs/gateway-migration.md
+++ b/docs/gateway-migration.md
@@ -1,80 +1,30 @@
 ---
-title: "Migrating from Pydantic AI Gateway"
-description: "How to migrate from the legacy gateway.pydantic.dev to the AI Gateway on Pydantic Logfire."
+title: "Migration from gateway.pydantic.dev"
+description: "Historical reference: how the legacy gateway.pydantic.dev was migrated to the AI Gateway on Pydantic Logfire."
 ---
 
-# Pydantic AI Gateway is Moving to Pydantic Logfire
+# Pydantic AI Gateway Has Moved to Pydantic Logfire
 
-We're consolidating the AI Gateway into Logfire. This means [gateway.pydantic.dev](https://gateway.pydantic.dev/) is being deprecated, and the gateway is now managed through your Logfire account.
+!!! tip "Looking for the current gateway docs?"
+    For how to enable and use the AI Gateway in Logfire today — providers, API keys, routing, and spending controls — see the [AI Gateway overview](reference/advanced/gateway/index.md).
+
+We consolidated the AI Gateway into Logfire. The legacy standalone gateway at [gateway.pydantic.dev](https://gateway.pydantic.dev/) **has been shut down**, and the gateway is now managed through your Logfire account. This page remains as a historical reference for users migrating from the legacy platform.
 
 ## Shutdown Timeline
 
 | Date | Event |
 |------|-------|
-| **15 March 2026** | Self-service refunds available in the legacy gateway platform |
+| **15 March 2026** | Self-service refunds became available in the legacy gateway platform |
 | **13 April 2026 at 3pm UTC** | Legacy gateway fully shut down (end of life) |
-| **By end of April 2026** | Automatic refunds processed for any remaining balances |
+| **End of April 2026** | Automatic refunds processed for any remaining balances |
 
-**Please migrate before 13 April 2026.** If you need help, email us at [engineering@pydantic.dev](mailto:engineering@pydantic.dev).
+The legacy gateway service has been shut down; [gateway.pydantic.dev](https://gateway.pydantic.dev/) now shows a migration notice. If you have an outstanding question about a refund or your old account, email us at [engineering@pydantic.dev](mailto:engineering@pydantic.dev).
 
 ## Why We Made This Change
 
-Moving the gateway into Logfire unlocks a number of improvements:
+Moving the gateway into Logfire unlocked a number of improvements:
 
 - **Observability and gateway, side by side.** Because the gateway now lives in Logfire, you can instrument your LLM calls and trace them directly, with no context switching between separate products.
 - **Tighter integration with features that use the gateway.** The LLM Playground and other Logfire features that rely on the gateway are now in the same place, making them easier to discover and use together.
 - **Enterprise-grade controls, included.** The gateway now inherits Logfire's [enterprise features](enterprise.md) — including SSO, custom roles and permissions, and security group mapping — so teams with existing enterprise setups get those controls automatically.
 - **One account, one billing relationship.** Rather than managing a separate balance on a separate platform, gateway usage is consolidated into your Logfire account alongside any other plan charges.
-
----
-
-## Frequently Asked Questions
-
-### What happens to my current balance?
-
-From **15 March 2026**, you can request a refund of your remaining balance via the button in the [legacy gateway platform](https://gateway.pydantic.dev). The refund will be issued to the original payment method you used.
-
-If you do not request a refund manually, any outstanding credits will be refunded automatically before the end of April 2026.
-
-### Do I need to create a new account?
-
-Yes, you'll need to sign up at [logfire.pydantic.dev](https://logfire.pydantic.dev) if you don't already have an account.
-
-### Do I need to pay for Logfire to access the gateway?
-
-No. Every new Logfire account starts on the Personal plan, which is free. You don't need to upgrade your Logfire plan to use the gateway, but you will need to add a credit card on the Personal plan for gateway-related charges.
-
-### Do I need to add a credit card?
-
-It depends on your plan:
-
-- **Personal plan** (free): Yes, you'll need to add a credit card to use the gateway.
-- **Team or Growth plans**: No — you already have a card on file from your plan subscription, and that card will be used for gateway charges.
-
-### How do I set up the gateway on Logfire?
-
-1. Go to [logfire.pydantic.dev](https://logfire.pydantic.dev).
-2. Choose a region and create an account.
-3. Add a credit card if you're on the Personal plan.
-4. Go to your organization's Gateway settings and create an API key.
-5. Update your application to use the new API key.
-
-### I'm using Pydantic AI — what do I need to change?
-
-Make sure you have an up-to-date version of Pydantic AI installed, then swap your API key for the one generated in Logfire. If you're using the `gateway/` provider prefix (e.g., `Agent('gateway/openai:gpt-4o')`), this is all you need to change:
-
-```bash
-export PYDANTIC_AI_GATEWAY_API_KEY="pylf_v..."
-```
-
-### Does anything carry over from PAIG Console?
-
-No. This is a clean start — usage history, project settings, and API keys do not transfer. You'll configure everything fresh on Logfire.
-
-### Can you do the migration for me?
-
-Not right now, but if you'd like help, email us at [engineering@pydantic.dev](mailto:engineering@pydantic.dev).
-
-### What if I have questions or need help?
-
-Reach out to us at [engineering@pydantic.dev](mailto:engineering@pydantic.dev) and we'll be happy to help you through the transition.

--- a/docs/gateway-migration.md
+++ b/docs/gateway-migration.md
@@ -1,4 +1,5 @@
 ---
+robots: noindex
 title: "Migration from gateway.pydantic.dev"
 description: "Historical reference: how the legacy gateway.pydantic.dev was migrated to the AI Gateway on Pydantic Logfire."
 ---

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -238,6 +238,12 @@ my_function(3, 4)
 # Logs: Applying my_function to x=3 and y=4
 ```
 
+Other useful keyword arguments include:
+
+- `level`: the log level for the span, e.g. `@logfire.instrument(level='debug')`. The span is suppressed if the level is below the configured `min_level`.
+- `record_return`: set to `True` to record the function's return value as a span attribute.
+- `new_trace`: set to `True` to start a new trace (with a span link to the current span) instead of creating a child of the current span.
+
 !!! note
 
     - The [`@logfire.instrument`][logfire.Logfire.instrument] decorator MUST be applied first, i.e., UNDER any other decorators.

--- a/docs/guides/web-ui/alerts.md
+++ b/docs/guides/web-ui/alerts.md
@@ -10,8 +10,9 @@ With **Logfire**, use Alerts to notify you when certain conditions are met.
 
 Let's see in practice how to create an alert.
 
-1. Go to the **Alerts** tab in the left sidebar.
-2. Click the **Create alert** button.
+1. Go to **Alerts** in the **Notify** section of the left sidebar.
+2. Click the **New alert** button.
+3. Pick **Custom query** (or start from one of the templates).
 
 Then you'll see the following form:
 
@@ -34,19 +35,18 @@ WHERE
 1. The `SELECT ... FROM records` statement is the base query that will be executed. The **records** table contains the spans and logs data. `trace_id` links to the trace in the live view when viewing the alert run results in the web UI.
 2. The `attributes` field is a JSON field that contains additional information about the record. In this case, we're using the `http.route` attribute to filter the records by route.
 
-The **Time window** field allows you to specify the time range over which the query will be executed.
+Under **When this alert fires** you can pick the firing condition (**Fire when**), the time range over which the query is executed (**Look at rows from**), and how often it runs (**Check every**).
 
-The **Webhook URL** field is where you can specify a URL to which the alert will send a POST request when triggered.
-For now, **Logfire** alerts only send the requests in [Slack format].
+The **Send notifications to** section is where you choose which delivery channels receive a notification when the alert fires — Slack, Opsgenie, or a generic webhook endpoint. Click **Add channel** to create one inline, or manage them centrally as described in [Delivery channels and schedules](#delivery-channels-and-schedules) below. An alert without channels still shows up on the Alerts page — it just won't ping anyone outside **Logfire**.
 
 ??? tip "Get a Slack webhook URL"
-    To get a Slack webhook URL, follow the instructions in the [Slack documentation](https://api.slack.com/messaging/webhooks).
+    To get a Slack webhook URL, follow the instructions in the [Slack documentation](https://api.slack.com/messaging/webhooks), or see our [Slack alerts setup guide](../../how-to-guides/setup-slack-alerts.md).
 
 After filling in the form, click the **Create alert** button. And... Alert created! :tada:
 
 ## Notification modes
 
-The **"Notify me when"** setting controls when you receive notifications. There are four modes:
+The **Fire when** setting (under **When this alert fires**) controls when you receive notifications. There are four modes:
 
 ### The query has any results
 
@@ -72,6 +72,28 @@ You'll receive a notification whenever the **actual data** returned by the query
 
 **Example use case:** Detect when a service goes down by querying for health check spans and [using a `CASE` expression](../../how-to-guides/detect-service-is-down.md) to return `'up'` or `'down'`. You'll be notified when the status changes in either direction.
 
+## Delivery channels and schedules
+
+Channels and schedules are managed under **Delivery** in the **Notify** section of the left sidebar, on the **Channels** and **Schedules** tabs. Channels are shared across all projects in your organization.
+
+### Channels
+
+Click **New channel** to create a channel (you can also do this inline from the alert form with **Add channel**). Give it a name and pick a type:
+
+- **Auto** — a webhook where **Logfire** infers the payload format from the URL: Slack [Block Kit](https://api.slack.com/block-kit) for `hooks.slack.com` URLs, raw JSON data for `hooks.zapier.com` URLs, and a legacy [Slack format] payload for anything else. Discord webhook URLs work out of the box — **Logfire** automatically appends `/slack` so Discord accepts the Slack-format payload.
+- **Slack Webhook** — always sends Slack Block Kit payloads.
+- **Slack Legacy (for Discord, etc.)** — always sends legacy Slack-format payloads, which services other than Slack (such as Discord) also accept.
+- **Opsgenie** — sends alerts to the Opsgenie Alert API using an authorization key, with an optional custom base URL (e.g. `https://api.eu.opsgenie.com`).
+- **Webhook** — sends the raw alert data as JSON, for custom integrations.
+
+The **Test your channel** section lets you verify the configuration before saving: pick an alert variant, then click **Send a test alert** to deliver a sample notification to the channel. A successful test is required before you can create a webhook or Opsgenie channel (or change its URL or key). **Copy sample JSON payload** copies the exact JSON body **Logfire** would send for the selected variant, so you can build a custom receiver against it.
+
+### Schedules
+
+Schedules define time windows for alert notification delivery — for example, business hours only. A schedule has a timezone and one or more weekly windows (days of the week plus a start and end time). Create them on the **Schedules** tab with **New schedule**.
+
+On the alert form, each selected channel can be assigned a schedule (the default is **Always deliver**). Notifications triggered outside the configured delivery windows are dropped — they are not queued or deferred.
+
 ## Alert History
 
 After creating an alert, you'll be redirected to the alerts' list. There you can see the alerts you've created and their status.
@@ -84,7 +106,7 @@ Otherwise, you'll see the number of matches highlighted in orange.
 
 ![Alerts list with error](../../images/guide/browser-alerts-error.png)
 
-In this case, you'll also receive a notification in the Webhook URL you've set up.
+In this case, you'll also receive a notification on the channels you've set up.
 
 ## Edit an alert
 

--- a/docs/guides/web-ui/dashboards.md
+++ b/docs/guides/web-ui/dashboards.md
@@ -163,6 +163,19 @@ To add variables to a custom dashboard:
 
 Once defined, variables can be referenced in SQL queries using the format `$your_variable_name`
 
+#### Panel variables
+
+Besides dashboard-level variables, an individual panel can declare its own variables. A panel variable renders as a small selector inside the panel (below its title) and re-filters only that panel's queries — the dashboard toolbar and other panels are unaffected. This is useful for dashboards that mix fleet-wide panels with a drill-down panel, where a toolbar variable that re-filters everything would be too broad.
+
+To add a variable to a panel:
+
+1. Open the panel editor (when creating the panel, or via **Edit** on an existing panel).
+2. Switch to the **Variables** tab.
+3. Click **Add panel variable** and configure it — panel variables support the same **Text** and **List** types as dashboard variables.
+4. Save the variable, then save the panel.
+
+Panel variables are referenced in the panel's SQL with the same `$your_variable_name` syntax. If a panel variable has the same name as a dashboard variable, the panel variable takes precedence for that panel's queries. The variable definition is saved with the panel, so the selector persists across reloads.
+
 ---
 
 ## Writing Queries

--- a/docs/guides/web-ui/evals.md
+++ b/docs/guides/web-ui/evals.md
@@ -61,6 +61,12 @@ To compare multiple runs side by side:
 
 The comparison view highlights differences in outputs, score variations, performance changes, and regressions between runs.
 
+!!! tip
+    You can also generate a link to the comparison view for an experiment directly from code:
+    `logfire.url_from_eval(report)` takes an evaluation report from `pydantic_evals` and returns
+    the URL to view it in the web UI, or `None` if the project URL or trace/span IDs are not
+    available (e.g. when Logfire wasn't configured when the report was created).
+
 ## Integration with Traces
 
 Every evaluation experiment generates detailed OpenTelemetry traces that appear in Logfire:

--- a/docs/guides/web-ui/live.md
+++ b/docs/guides/web-ui/live.md
@@ -17,7 +17,7 @@ To search the live view, click `Search your spans` (keyboard shortcut `/`), this
 ### SQL Search
 
 For confident SQL users, write your queries directly here. For devs who want a bit of help,
-try the new [Pydantic AI](https://pydantic.dev/docs/ai/overview/) feature which generates a SQL query based on your prompt.
+you can [generate a SQL query from a natural-language prompt](#ask-in-language-get-sql) instead.
 You can also review the fields available and populate your SQL automatically using the `Reference` list, see more on this below.
 
 **WHERE clause**

--- a/docs/how-to-guides/client-side-feature-flags.md
+++ b/docs/how-to-guides/client-side-feature-flags.md
@@ -40,7 +40,7 @@ import { OFREPWebProvider } from '@openfeature/ofrep-web-provider'
 import { OpenFeature } from '@openfeature/web-sdk'
 
 const LOGFIRE_API_KEY = 'your-api-key'  // project:read_external_variables scope
-const LOGFIRE_API_HOST = 'logfire-api.pydantic.dev'  // or your self-hosted API host
+const LOGFIRE_API_HOST = 'logfire-us.pydantic.dev'  // or 'logfire-eu.pydantic.dev' for the EU region, or your self-hosted API host
 
 const provider = new OFREPWebProvider({
   // The provider appends `/ofrep/v1/evaluate/flags` itself, so this is the `/v1` root.
@@ -213,7 +213,7 @@ from openfeature.evaluation_context import EvaluationContext
 # base_url is the `/v1` root; the provider appends `/ofrep/v1/evaluate/flags/{key}`.
 api.set_provider(
     OFREPProvider(
-        base_url='https://logfire-api.pydantic.dev/v1',  # or your self-hosted API host
+        base_url='https://logfire-us.pydantic.dev/v1',  # or 'https://logfire-eu.pydantic.dev/v1' for EU, or your self-hosted API host
         headers_factory=lambda: {'Authorization': 'Bearer YOUR_API_KEY'},
     )
 )
@@ -229,7 +229,7 @@ The provider — like the OpenFeature client in general — evaluates one named 
 import httpx
 
 response = httpx.post(
-    'https://logfire-api.pydantic.dev/v1/ofrep/v1/evaluate/flags',
+    'https://logfire-us.pydantic.dev/v1/ofrep/v1/evaluate/flags',  # logfire-eu.pydantic.dev for EU
     headers={'Authorization': 'Bearer YOUR_API_KEY'},
     json={'context': {'targetingKey': 'user-123'}},
 )

--- a/docs/how-to-guides/codex-logfire-exporter.md
+++ b/docs/how-to-guides/codex-logfire-exporter.md
@@ -45,7 +45,7 @@ Example for Logfire Cloud:
 
 ```dotenv
 LOGFIRE_TOKEN=<your Logfire write token>
-LOGFIRE_BASE_URL=https://logfire-api.pydantic.dev
+LOGFIRE_BASE_URL=https://logfire-us.pydantic.dev  # or https://logfire-eu.pydantic.dev for the EU region
 ```
 
 For a local Logfire instance:

--- a/docs/how-to-guides/otel-collector/host-monitoring.md
+++ b/docs/how-to-guides/otel-collector/host-monitoring.md
@@ -42,7 +42,7 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: "https://logfire-eu.pydantic.info"  # or https://logfire-us.pydantic.info for the US region
+    endpoint: "https://logfire-eu.pydantic.dev"  # or https://logfire-us.pydantic.dev for the US region
     headers:
       Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
 
@@ -176,7 +176,7 @@ processors:
 
 exporters:
   otlphttp:
-    endpoint: "https://logfire-eu.pydantic.info"
+    endpoint: "https://logfire-eu.pydantic.dev"  # or https://logfire-us.pydantic.dev for the US region
     headers:
       Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
 

--- a/docs/how-to-guides/otel-collector/kubernetes-monitoring.md
+++ b/docs/how-to-guides/otel-collector/kubernetes-monitoring.md
@@ -35,7 +35,7 @@ collectors:
         otlphttp/logfire:
           endpoint: https://logfire-us.pydantic.dev   # or https://logfire-eu.pydantic.dev
           headers:
-            Authorization: ${env:LOGFIRE_TOKEN}
+            Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
       service:
         pipelines:
           traces:  {exporters: [otlphttp/logfire]}

--- a/docs/how-to-guides/query-api.md
+++ b/docs/how-to-guides/query-api.md
@@ -8,8 +8,8 @@ your data in a variety of ways.
 
 The API endpoint expects a POST request and is available at:
 
-* `https://logfire-us.pydantic.dev/v2/query` for the US [region](reference/data-regions.md).
-* `https://logfire-eu.pydantic.dev/v2/query` for the EU [region](reference/data-regions.md).
+* `https://logfire-us.pydantic.dev/v2/query` for the US [region](../reference/data-regions.md).
+* `https://logfire-eu.pydantic.dev/v2/query` for the EU [region](../reference/data-regions.md).
 
 It requires a **read token** for authentication, which can be generated from the Logfire web interface and provide secure access to your data.
 
@@ -69,6 +69,12 @@ the Logfire API. If blocking I/O is acceptable and you want to avoid the complex
 you can use the plain [`LogfireQueryClient`][logfire.query_client.LogfireQueryClient].
 
 Here's an example of how to use these clients:
+
+/// version-deprecated | v4.35.0
+The older `query_json()` method is deprecated in favor of `query_json_rows()`. Calling `query_json_rows()`,
+`query_arrow()`, or `query_csv()` without providing a `min_timestamp` is also deprecated — pass an explicit
+timestamp as shown below.
+///
 
 === "Async"
 
@@ -381,7 +387,7 @@ The Logfire API supports various response formats and body parameters to give yo
     - **`max_timestamp`**: Similar to `min_timestamp`, but serves as an upper bound for filtering `start_timestamp` in the `records` table or `recorded_timestamp` in the `metrics` table. The same filtering can also be done manually within the query itself.
     - **`limit`**: An optional parameter to limit the number of rows returned by the query. If not specified, **the default limit is 100**. The maximum allowed value is 10,000.
     - **`timezone`**: An optional timezone (e.g. `"Europe/Paris"`) to use for the query execution context.
-    - **`deployment_environment`**: Restrict rows to one or more [environments](../environments.md). Accepts a single environment string or a list of strings. To only match rows where no environment is set, use the empty string (`""`).
+    - **`deployment_environment`**: Restrict rows to one or more [environments](environments.md). Accepts a list of environment name strings (the Python client's `environment` argument also accepts a single string). To only match rows where no environment is set, use the empty string (`""`).
     - **`explain`**: Whether to explain the query or not.
 
 All body parameters besides `sql` and `min_timestamp` are optional and can be used in any combination to tailor the API response to your needs.

--- a/docs/how-to-guides/setup-slack-alerts.md
+++ b/docs/how-to-guides/setup-slack-alerts.md
@@ -37,8 +37,8 @@ There are a few ways to create an alert.  You can:
 We'll create an alert that will let us know if any HTTP request takes longer than a second to execute.
 
 * Login to **Logfire** and [navigate to your project](https://logfire-us.pydantic.dev/-/redirect/latest-project)
-* Click on **Alerts** in the top navigation bar
-* Select the **New Alert** button in the top right
+* Click on **Alerts** in the **Notify** section of the left sidebar
+* Select the **New alert** button in the top right, then pick **Custom query**
 * Let's give this Alert a name of **Slow Requests**
 * For the query, we'll group results by the http path and duration.  We want to include the **max** duration in a given time frame.  We also want to filter out any traces that aren't http requests, and order by the max duration, so we can see which routes are the slowest.  This query looks like:
   ```sql
@@ -59,10 +59,10 @@ We'll create an alert that will let us know if any HTTP request takes longer tha
 
     ![](../images/guide/browser-alerts-create-alert.png)
 
-* You can adjust when alerts are sent based upon the alert parameters.  With this style of alert, we just want to know if anything within the last 5 minutes has been slow.  So we can use the following options:
-    * **Execute the query**: every 5 minutes
-    * **Include rows from**: the last 5 minutes
-    * **Notify me when**: the query has any results
+* You can adjust when alerts are sent under the **When this alert fires** section.  With this style of alert, we just want to know if anything within the last 5 minutes has been slow.  So we can use the following options:
+    * **Fire when**: the query has any results
+    * **Look at rows from**: the last 5 minutes
+    * **Check every**: 5 minutes
 
     ![](../images/guide/browser-alerts-parameters.png)
 
@@ -72,14 +72,15 @@ Our alert is almost done, let's send it to a slack channel.
 
 For this, you will need the [Webhook URL](#creating-a-slack-incoming-webhook) you created & copied from the  Slack [Apps Management Dashboard](https://api.slack.com/apps).
 
-Let's set up a channel, then test that alerts can be sent with the URL:
+Let's set up a channel, then test that alerts can be sent with the URL.
+In the **Send notifications to** section of the alert form:
 
-* Select **New channel** to open the New Channel dialog
-* Put in a name such as **Logfire Alerts**.  This does need to be the name of your Slack     channel
-* Select **Slack** as the format
-* Paste in your Webhook URL from the Slack [Apps Management Dashboard]    (https://api.slack.com/apps)
-* Click on **Send a test alert** and check that you can see the alert in Slack.
-* Click **Create Channel** to create the channel and close the dialog
+* Select **Add channel** to open the New channel dialog (channels can also be managed from **Delivery** → **Channels** in the **Notify** section of the left sidebar — they are shared across all projects in your organization)
+* Put in a name such as **Logfire Alerts**.  This does not need to be the name of your Slack channel
+* Select **Slack Webhook** as the type (or leave it as **Auto** — the Slack format is inferred from `hooks.slack.com` URLs)
+* Paste in your Webhook URL from the Slack [Apps Management Dashboard](https://api.slack.com/apps)
+* Click on **Send a test alert** and check that you can see the alert in Slack.  A successful test is required before you can create the channel
+* Click **Create channel** to create the channel and close the dialog
 * Click the checkbox next to your new channel to select it
 
     ![](../images/guide/browser-alerts-create-channel.png)

--- a/docs/integrations/event-streams/airflow.md
+++ b/docs/integrations/event-streams/airflow.md
@@ -28,7 +28,8 @@ Where `${LOGFIRE_TOKEN}` is your [**Logfire** write token][write-token].
 ```ini title="airflow.cfg"
 [metrics]
 otel_on = True
-otel_host = logfire-api.pydantic.dev
+; use logfire-eu.pydantic.dev for the EU region
+otel_host = logfire-us.pydantic.dev
 otel_port = 443
 otel_prefix = airflow
 otel_interval_milliseconds = 30000  # The interval between exports, defaults to 60000
@@ -36,7 +37,8 @@ otel_ssl_active = True
 
 [traces]
 otel_on = True
-otel_host = logfire-api.pydantic.dev
+; use logfire-eu.pydantic.dev for the EU region
+otel_host = logfire-us.pydantic.dev
 otel_port = 443
 otel_prefix = airflow
 otel_ssl_active = True
@@ -84,7 +86,7 @@ receivers:  # (1)!
 exporters:  # (2)!
   debug:  # (3)!
   otlphttp:
-    endpoint: https://logfire-api.pydantic.dev/
+    endpoint: https://logfire-us.pydantic.dev/  # or https://logfire-eu.pydantic.dev/ for the EU region
     compression: gzip
     headers:
       Authorization: "Bearer ${env:LOGFIRE_TOKEN}"  # (4)!

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -229,7 +229,13 @@
       { "label": "Export Data", "slug": "how-to-guides/query-api" },
       { "label": "Feature Flags (OFREP)", "slug": "how-to-guides/client-side-feature-flags" },
       { "label": "Convert to Organization", "slug": "how-to-guides/convert-to-organization" },
-      { "label": "Gateway Migration", "slug": "gateway-migration" }
+      {
+        "label": "AI Gateway",
+        "items": [
+          { "label": "Overview", "slug": "reference/advanced/gateway/index" },
+          { "label": "Migration from gateway.pydantic.dev", "slug": "gateway-migration" }
+        ]
+      }
     ]
   },
   {

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -229,13 +229,7 @@
       { "label": "Export Data", "slug": "how-to-guides/query-api" },
       { "label": "Feature Flags (OFREP)", "slug": "how-to-guides/client-side-feature-flags" },
       { "label": "Convert to Organization", "slug": "how-to-guides/convert-to-organization" },
-      {
-        "label": "AI Gateway",
-        "items": [
-          { "label": "Overview", "slug": "reference/advanced/gateway/index" },
-          { "label": "Migration from gateway.pydantic.dev", "slug": "gateway-migration" }
-        ]
-      }
+      { "label": "AI Gateway", "slug": "reference/advanced/gateway/index" }
     ]
   },
   {

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -17,9 +17,6 @@ The gateway gives you:
 
 The gateway is configured per **organization** and is available on the Personal, Team, Growth, and Enterprise Cloud plans.
 
-!!! note "Migrating from gateway.pydantic.dev?"
-    The standalone Pydantic AI Gateway at `gateway.pydantic.dev` has been shut down and replaced by this integrated gateway. See [Migration from gateway.pydantic.dev](../../../gateway-migration.md).
-
 ## Getting started
 
 ### Enable the gateway
@@ -165,6 +162,6 @@ Or run just the proxy and configure a tool manually with `logfire gateway serve`
 
 ## See also
 
-- [Migration from gateway.pydantic.dev](../../../gateway-migration.md) — historical reference for users of the legacy standalone gateway.
+- [Gateway migration](../../../gateway-migration.md) — historical reference for users of the legacy standalone gateway.
 - [Prompt Management: Access and Prerequisites](../prompt-management/plan-requirements.md) — prompt runs execute through the gateway and spend gateway budget.
 - [Cost & Usage](../../../logfire-costs.md) — plan tiers and how usage is billed.

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -1,0 +1,170 @@
+---
+title: "AI Gateway"
+description: "Route LLM calls through a single Logfire-managed endpoint with built-in spending limits, fallbacks, and usage tracking."
+---
+
+# AI Gateway
+
+The Logfire AI Gateway lets you route LLM calls through a single endpoint with built-in spending limits, fallbacks, and usage tracking. Instead of scattering provider API keys across your applications, you point your existing SDKs (OpenAI, Anthropic, Google GenAI, Pydantic AI, or plain HTTP) at the gateway and authenticate with a gateway API key that you manage in Logfire.
+
+The gateway gives you:
+
+- **One endpoint, many providers** — call OpenAI, Anthropic, Google, AWS Bedrock, Groq, Mistral, and more through provider-compatible endpoints, using the SDKs you already have.
+- **Key management** — project-scoped and personal API keys with per-key spending limits and expiry, managed in the Logfire UI.
+- **Cost controls** — usage analytics plus daily, weekly, monthly, and total spending caps per key, and per-member limits.
+- **Failover and load balancing** — routing groups let you group providers with priorities and weights.
+- **Observability** — with telemetry enabled, every gateway request is traced into a Logfire project of your choice.
+
+The gateway is configured per **organization** and is available on the Personal, Team, Growth, and Enterprise Cloud plans.
+
+!!! note "Migrating from gateway.pydantic.dev?"
+    The standalone Pydantic AI Gateway at `gateway.pydantic.dev` has been shut down and replaced by this integrated gateway. See [Migration from gateway.pydantic.dev](../../../gateway-migration.md).
+
+## Getting started
+
+### Enable the gateway
+
+1. Open Logfire and select your organization.
+2. In the sidebar, under **AI Engineering**, click **Gateway**.
+3. Click **Enable recommended setup**.
+
+The recommended setup runs the whole onboarding in one go: it enables the gateway, activates built-in providers, turns on telemetry for a project, and creates your first API key (named **Quick Start**). When it finishes, click **Open Connect** to land on the Connect tab with a working snippet.
+
+If you prefer to wire things up yourself, **Manual setup** just turns the gateway on and leaves providers, telemetry, and keys to you.
+
+!!! note "Prerequisites"
+    - You need to be an **organization admin** to enable the gateway and manage providers, routing, and spending. Non-admin members see the **Connect** and **API Keys** tabs only.
+    - The organization needs at least one **project** — API keys and telemetry are scoped to a project.
+    - On the Personal, Team, and Growth plans, built-in providers are billed against a prepaid balance and require a payment method; the exact fees and initial balance are shown during activation. You can skip this entirely by adding your own provider credentials instead (see [Providers](#providers)).
+
+Once enabled, the Gateway page has these tabs: **Overview**, **Connect**, **API Keys**, **Providers**, **Routing**, **Spending**, and **Settings**.
+
+### Connect an SDK
+
+The **Connect** tab generates ready-to-run snippets: pick a provider, model, project, and API key, then copy the snippet for your SDK (curl, Pydantic AI, Python or TypeScript OpenAI SDK, Python Anthropic SDK, Google GenAI SDKs). You can also click **Try in playground** to test the same configuration in the Logfire Playground.
+
+The gateway base URL depends on your Logfire region:
+
+| Region | Gateway base URL |
+|--------|------------------|
+| US | `https://gateway-us.pydantic.dev/proxy` |
+| EU | `https://gateway-eu.pydantic.dev/proxy` |
+| Self-hosted | `https://<your-logfire-host>/proxy` |
+
+Requests are addressed to `<gateway-base-url>/<route>`, where `<route>` is a provider slug (or routing group slug) from your **Providers** tab, and authenticated with an `Authorization: Bearer` header carrying your gateway API key.
+
+For example, with an OpenAI-compatible provider whose slug is `openai`, in the US region:
+
+=== "curl"
+
+    ```bash
+    curl https://gateway-us.pydantic.dev/proxy/openai/chat/completions \
+      -H "Authorization: Bearer <YOUR_GATEWAY_API_KEY>" \
+      -H "Content-Type: application/json" \
+      -d '{
+        "model": "gpt-5.2",
+        "messages": [{"role": "user", "content": "Hello!"}]
+      }'
+    ```
+
+=== "Python (OpenAI SDK)"
+
+    ```python skip-run="true" skip-reason="external-connection"
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key='<YOUR_GATEWAY_API_KEY>',
+        base_url='https://gateway-us.pydantic.dev/proxy/openai',
+    )
+
+    response = client.chat.completions.create(
+        model='gpt-5.2',
+        messages=[{'role': 'user', 'content': 'Hello!'}],
+    )
+    print(response.choices[0].message.content)
+    ```
+
+=== "Pydantic AI"
+
+    ```python skip-run="true" skip-reason="external-connection"
+    import os
+
+    from pydantic_ai import Agent
+
+    os.environ['PYDANTIC_AI_GATEWAY_API_KEY'] = '<YOUR_GATEWAY_API_KEY>'
+    os.environ['PYDANTIC_AI_GATEWAY_BASE_URL'] = 'https://gateway-us.pydantic.dev/proxy'
+
+    agent = Agent('gateway/openai:gpt-5.2')
+    print(agent.run_sync('Hello!').output)
+    ```
+
+Anthropic-type providers expose the Anthropic Messages API instead — the same pattern with the Anthropic SDK:
+
+```python skip-run="true" skip-reason="external-connection"
+from anthropic import Anthropic
+
+client = Anthropic(
+    api_key='<YOUR_GATEWAY_API_KEY>',
+    base_url='https://gateway-us.pydantic.dev/proxy/anthropic',
+)
+
+response = client.messages.create(
+    model='claude-opus-4-8',
+    max_tokens=1024,
+    messages=[{'role': 'user', 'content': 'Hello!'}],
+)
+print(response.content[0].text)
+```
+
+Use the Connect tab as the source of truth for your organization: it substitutes your actual provider slugs, a model the provider supports, your region's gateway URL, and (for keys created in your session) the plaintext API key.
+
+## Concepts
+
+### Providers
+
+A provider is an upstream LLM service the gateway can forward requests to. Each provider has a **slug** which becomes the route segment in your request URL. There are two kinds:
+
+- **Built-in providers** are managed by Logfire — no upstream account or API key needed. Usage is billed to your organization through a prepaid gateway balance (with configurable auto-recharge). Activation is a separate step from enabling the gateway and, on card-based plans, requires a payment method.
+- **Bring-your-own-key (BYOK) providers** use credentials you supply on the **Providers** tab. Supported types include OpenAI, Anthropic, Google Vertex AI, Azure Foundry, AWS Bedrock, Groq, Hugging Face, Mistral, Ollama, Doubleword, and custom OpenAI-compatible endpoints. Upstream usage is billed directly by your provider.
+
+### API keys
+
+Gateway API keys authenticate requests to the gateway. Keys are scoped to a project and come in two flavors, both managed on the **API Keys** tab:
+
+- **Project keys** are created and managed by admins, for shared or production use.
+- **Personal keys** belong to an individual member (useful for local development); regular members can create and reveal their own.
+
+Each key can have an expiry date and its own **spending limits** — daily, weekly, monthly, and total. The recommended setup creates a first project key named **Quick Start**.
+
+### Routing groups
+
+Routing groups (the **Routing** tab) let you define fallback strategies by grouping multiple providers under a single slug. Each member provider has a **priority** (failover order) and a **weight** (load balancing between members at the same priority level). Use the group's slug in place of a provider slug in your request URL to route through the group.
+
+### Spending limits and balance
+
+The **Spending** tab shows usage analytics for the organization, broken down by project, member, and API key. Cost controls exist at several levels:
+
+- **Per-key limits** — daily, weekly, monthly, and total caps set on each API key.
+- **Per-member limits** — daily, weekly, and monthly caps that admins can set for individual organization members.
+- **Prepaid balance and auto-recharge** — built-in provider usage draws from a prepaid balance. You can enable auto-recharge with a threshold and a top-up target so the balance refills automatically before it runs out.
+
+### Telemetry
+
+The gateway can record every request as traces in a Logfire project, so you get full observability of your LLM traffic — models, latency, token usage, and conversation content — alongside the rest of your telemetry. The recommended setup turns this on for your chosen project; you can manage it later from the gateway **Settings** tab.
+
+## Using the gateway with AI coding tools
+
+The Logfire CLI can run a local authenticating proxy and launch supported AI coding tools against the gateway with short-lived credentials:
+
+```bash
+pip install "logfire[gateway]"
+logfire gateway launch claude
+```
+
+Or run just the proxy and configure a tool manually with `logfire gateway serve`. See the [CLI reference](../../cli.md#ai-gateway-gateway) for details.
+
+## See also
+
+- [Migration from gateway.pydantic.dev](../../../gateway-migration.md) — historical reference for users of the legacy standalone gateway.
+- [Prompt Management: Access and Prerequisites](../prompt-management/plan-requirements.md) — prompt runs execute through the gateway and spend gateway budget.
+- [Cost & Usage](../../../logfire-costs.md) — plan tiers and how usage is billed.

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -162,6 +162,5 @@ Or run just the proxy and configure a tool manually with `logfire gateway serve`
 
 ## See also
 
-- [Gateway migration](../../../gateway-migration.md) — historical reference for users of the legacy standalone gateway.
 - [Prompt Management: Access and Prerequisites](../prompt-management/plan-requirements.md) — prompt runs execute through the gateway and spend gateway budget.
 - [Cost & Usage](../../../logfire-costs.md) — plan tiers and how usage is billed.

--- a/docs/reference/advanced/managed-variables/external.md
+++ b/docs/reference/advanced/managed-variables/external.md
@@ -58,7 +58,7 @@ You can set a variable as external in the Logfire UI when creating a variable (v
 import httpx
 
 httpx.post(
-    'https://logfire-api.pydantic.dev/v1/variables/bulk/',
+    'https://logfire-us.pydantic.dev/v1/variables/bulk/',  # logfire-eu.pydantic.dev for EU
     headers={'Authorization': 'Bearer YOUR_API_KEY'},
     json=[
         {

--- a/docs/reference/advanced/migrate-to-new-project.md
+++ b/docs/reference/advanced/migrate-to-new-project.md
@@ -79,6 +79,6 @@ We offer functionality to export and import dashboards via JSON files. Refer to 
 [Dashboard Management](../../guides/web-ui/dashboards.md) guide for more
 details on exporting and importing dashboards.
 
-We plan to ease this transition by providing IaC (Infrastructure as Code) support in the future.
+You can also manage alerts, dashboards, channels, and tokens declaratively with the [Infrastructure as Code providers](../../how-to-guides/infrastructure-as-code.md) (Terraform, OpenTofu, and Pulumi), which makes recreating them a matter of pointing the provider at the new project.
 
 If you have any questions or need assistance during your migration, please [reach out](../../help.md).

--- a/docs/reference/advanced/prompt-management/plan-requirements.md
+++ b/docs/reference/advanced/prompt-management/plan-requirements.md
@@ -24,4 +24,4 @@ Prompt Management currently uses variable-level permissions:
 
 Because run history includes model outputs, treat `read_variables` as sensitive if your prompts handle sensitive data.
 
-For pricing details, plan tiers, and how gateway usage is metered, see [Cost & Usage](../../../logfire-costs.md). The gateway documentation in [Gateway Migration](../../../gateway-migration.md) covers the legacy-vs-integrated distinction that some projects may still be navigating.
+For pricing details and plan tiers, see [Cost & Usage](../../../logfire-costs.md). For how the gateway itself works — providers, API keys, and spending controls — see the [AI Gateway overview](../gateway/index.md).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,14 @@ Then, if you go back to the terminal, you'll see that you are authenticated! :ta
 
 ![Terminal screenshot with successful authentication](../images/cli/terminal-screenshot-auth-2.png)
 
+### Log out (`auth logout`)
+
+To log out and remove the locally stored credentials, run:
+
+```bash
+logfire auth logout
+```
+
 ## Clean (`clean`)
 
 To clean _most_ the files created by **Logfire**, run the following command:
@@ -111,14 +119,25 @@ This will output the projects you need to install to have optimal OpenTelemetry 
 
 ![Terminal screenshot with Logfire inspect command](../images/cli/terminal-screenshot-inspect.png)
 
+## Info (`info`)
+
+To print the versions of `logfire`, your operating system, and related (OpenTelemetry) packages — useful when reporting a bug — run:
+
+```bash
+logfire info
+```
+
 ## Who Am I (`whoami`)
 
-!!! warning "🚧 Work in Progress 🚧"
-    This section is yet to be written, [contact us](../help.md) if you have any questions.
+To show the currently authenticated user and the URL of the current **Logfire** project, run:
+
+```bash
+logfire whoami
+```
+
+If you have one or more tokens configured (e.g. via the `LOGFIRE_TOKEN` environment variable), this shows the project each token belongs to instead.
 
 ## Projects
-
-<!-- TODO(Marcelo): We can add the `logfire projects --help` here. -->
 
 ### List (`projects list`)
 
@@ -163,6 +182,46 @@ logfire projects new <project-name>
 ```
 
 Follow the instructions, and you'll have a new project created in no time! :partying_face:
+
+## Read tokens (`read-tokens`)
+
+To create a [read token](../how-to-guides/query-api.md) for a project and print it to stdout, run:
+
+```bash
+logfire read-tokens --project <org>/<project> create
+```
+
+Because the token is printed to stdout, this composes well with other tools, e.g. configuring the [Logfire MCP server](../how-to-guides/mcp-server.md):
+
+```bash
+claude mcp add logfire -e LOGFIRE_READ_TOKEN=$(logfire read-tokens --project <org>/<project> create) -- uvx logfire-mcp@latest
+```
+
+## Run (`run`)
+
+To run a Python script or module with **Logfire** instrumentation enabled automatically for all installed packages that have an available OpenTelemetry instrumentation, run:
+
+```bash
+logfire run script.py
+# or run a module, forwarding any arguments after it:
+logfire run -m my_module --my-arg
+```
+
+By default a summary box is printed to stderr showing which packages were instrumented; disable it with `--no-summary`. Use `--exclude` to skip instrumenting specific packages:
+
+```bash
+logfire run --exclude sqlalchemy,fastapi script.py
+```
+
+## Prompt (`prompt`)
+
+To generate a prompt for an LLM to investigate an issue in your project (assuming the [Logfire MCP server](../how-to-guides/mcp-server.md) is configured), run:
+
+```bash
+logfire prompt "why are my requests slow?"
+```
+
+Use `--claude`, `--codex`, or `--opencode` to verify (and set up) the MCP configuration for the respective coding tool, `--update` to replace an existing Logfire MCP server configuration, and `--project <org>/<project>` to select the project.
 
 [terms-of-service]: https://pydantic.dev/legal/terms-of-service
 [privacy_policy]: https://pydantic.dev/legal/privacy-policy

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -20,6 +20,17 @@ You can use the following environment variables to configure **Logfire**:
 
 {{ env_var_table }}
 
+Some parameters also accept an alternative environment variable, used only if the primary one above is not set:
+
+| Primary variable | Alias |
+|---|---|
+| `LOGFIRE_SERVICE_NAME` | `OTEL_SERVICE_NAME` |
+| `LOGFIRE_SERVICE_VERSION` | `OTEL_SERVICE_VERSION` |
+| `LOGFIRE_TRACE_SAMPLE_RATE` | `OTEL_TRACES_SAMPLER_ARG` |
+| `LOGFIRE_CONSOLE_SHOW_PROJECT_LINK` | `LOGFIRE_SHOW_SUMMARY` |
+
+In addition, `LOGFIRE_CONFIG_DIR` sets the directory containing the [configuration file](#using-a-configuration-file-pyprojecttoml) (defaults to the current directory).
+
 When using environment variables, you still need to call [`logfire.configure()`][logfire.configure],
 but you can leave out the arguments.
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -18,6 +18,14 @@ From the team behind Pydantic Validation, **Pydantic Logfire** is an observabili
 
   [:octicons-arrow-right-24: Read more](#simplicity-and-power)
 
+- :material-robot-outline:{ .lg .middle } **The Full AI Engineering Loop**
+
+  ***
+
+  Beyond tracing every LLM call with token and cost tracking, Logfire ships **evals** (in the web UI and in code), **prompt management** with a playground, and an **AI gateway** with key management and spending controls — one platform from prototype to production.
+
+  [:octicons-arrow-right-24: Read more](ai-observability.md)
+
 - :material-code-braces:{ .lg .middle } **Deep Language Integration**
 
   ***

--- a/logfire/_internal/config_params.py
+++ b/logfire/_internal/config_params.py
@@ -93,7 +93,7 @@ CONSOLE_VERBOSE = ConfigParam(env_vars=['LOGFIRE_CONSOLE_VERBOSE'], allow_file_c
 CONSOLE_MIN_LOG_LEVEL = ConfigParam(env_vars=['LOGFIRE_CONSOLE_MIN_LOG_LEVEL'], allow_file_config=True, default='info', tp=LevelName)
 """Minimum log level to show in the console."""
 CONSOLE_SHOW_PROJECT_LINK = ConfigParam(env_vars=['LOGFIRE_CONSOLE_SHOW_PROJECT_LINK', 'LOGFIRE_SHOW_SUMMARY'], allow_file_config=True, default=True, tp=bool)
-"""Whether to enable/disable the console exporter."""
+"""Whether to print the URL of the Logfire project after initialization."""
 PYDANTIC_PLUGIN_RECORD = ConfigParam(env_vars=['LOGFIRE_PYDANTIC_PLUGIN_RECORD'], allow_file_config=True, default='off', tp=PydanticPluginRecordValues)
 """Whether instrument Pydantic validation.."""
 PYDANTIC_PLUGIN_INCLUDE = ConfigParam(env_vars=['LOGFIRE_PYDANTIC_PLUGIN_INCLUDE'], allow_file_config=True, default=set(), tp=set[str])

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,9 +267,7 @@ nav:
           - Export Data: how-to-guides/query-api.md
           - Feature Flags (OFREP): how-to-guides/client-side-feature-flags.md
           - Convert to Organization: how-to-guides/convert-to-organization.md
-          - AI Gateway:
-              - Overview: reference/advanced/gateway/index.md
-              - Migration from gateway.pydantic.dev: gateway-migration.md
+          - AI Gateway: reference/advanced/gateway/index.md
       - Guides:
           - Use Alternative Clients: how-to-guides/alternative-clients.md
           - Collect Cloud Provider Metrics: how-to-guides/cloud-metrics.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -267,7 +267,9 @@ nav:
           - Export Data: how-to-guides/query-api.md
           - Feature Flags (OFREP): how-to-guides/client-side-feature-flags.md
           - Convert to Organization: how-to-guides/convert-to-organization.md
-          - Gateway Migration: gateway-migration.md
+          - AI Gateway:
+              - Overview: reference/advanced/gateway/index.md
+              - Migration from gateway.pydantic.dev: gateway-migration.md
       - Guides:
           - Use Alternative Clients: how-to-guides/alternative-clients.md
           - Collect Cloud Provider Metrics: how-to-guides/cloud-metrics.md


### PR DESCRIPTION
## Summary

- **AI Gateway**: add a usage guide (`reference/advanced/gateway/index.md`) covering setup, connecting SDKs, providers, API keys, routing groups, spending controls, and the gateway CLI; group it with the migration page under an "AI Gateway" nav entry, and update the migration page now that the legacy shutdown date has passed.
- **Web UI & reference docs**: document the delivery channels and schedules flow for alerts, per-panel dashboard variables, `logfire.url_from_eval()`, the remaining CLI subcommands (`whoami`, `auth logout`, `info`, `read-tokens`, `run`, `prompt`), additional configuration environment variables, newer `@logfire.instrument` options, and the v4.35 query client deprecation notes.
- **Comparisons & examples**: bring the comparison and AI overview pages up to date with the current feature set (evals in the web UI, prompt management, playground, AI gateway) and pricing units, and use region-specific US/EU endpoints consistently across configuration examples.

All UI labels, SDK signatures, endpoints, plan details, and links were checked against the product and the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SoYPsGwJvndvahMWV54Gr

---
_Generated by [Claude Code](https://claude.ai/code/session_012SoYPsGwJvndvahMWV54Gr)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

