### PR TITLE
Add a docs writing standard to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,25 @@ Pre-commit automatically runs ruff and pyright, but you can also run `make forma
 
 Docs are rendered and deployed through the `pydantic/unified-docs` pipeline. Do not use MkDocs checks in this repository.
 
+# Writing for Users
+
+Every user-facing string this repo produces — docs pages, exception messages, warnings, CLI output, public docstrings — is held to one standard:
+
+> If an expert in some other field who has just started building with AI tools wouldn't know what it means, we spell out the acronym, we explain the term in place, or we rewrite the sentence to be human friendly.
+
+This reader is not a caricature of a confused user. They're smart, motivated, and perfectly capable of understanding anything we take a sentence to explain. What they haven't done is spend years marinating in observability infrastructure, so words that feel like plain English to us (`span`, `exporter`, `instrument`, `OTLP`, `sampling`, `scrubbing`) can be a closed door to them. A specialist walking us through their own field wouldn't drop a term of art and move on; they'd give the plain-language version the first time. We extend the same courtesy.
+
+This is not dumbing down. Precise terms stay — they're often the thing the user needs to learn to succeed with the product. The standard is about _introducing_ terms, not avoiding them: give the real word and, at its first use on a page, a plain-language hand-hold.
+
+When you write or touch a user-facing string, check:
+
+- **Acronyms are spelled out at first use on each page** — "OpenTelemetry Protocol (OTLP)", "personally identifiable information (PII)". Assume the reader opens the page directly from a search; no acronym is "already established" by another page.
+- **The page says what it's for.** Every docs page opens with what this is and why you'd use it, before any code or configuration. A feature name is not a description.
+- **Copy describes the user's goal, not our mechanism.** "See every request your app handles", not "Attach the ASGI middleware span processor". If a word names a piece of our internals, it doesn't belong in user-facing text.
+- **Instructions say where.** "Run this in your terminal", "Copy this from your project settings page in Logfire". A step asking for a value the user has to fetch from somewhere else must say where that somewhere is.
+- **Consequences are stated plainly** — especially when data leaves the user's machine, something costs money, or an action can't be undone. If a setting sends more telemetry, say so; if data is dropped or redacted, say what and when.
+- **Errors and warnings name what went wrong and what to do next.** Never a bare "invalid configuration", never an internal detail as the whole user-facing explanation. Say which value failed, why, and what a working one looks like.
+
 # Core Structure
 
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Every page in the public docs (`docs/`) is held to one standard:
 
 > If an expert in some other field who has just started building with AI tools wouldn't know what it means, we spell out the acronym, we explain the term in place, or we rewrite the sentence to be human friendly.
 
-This reader is not a caricature of a confused user. They're smart, motivated, and perfectly capable of understanding anything we take a sentence to explain. What they haven't done is spend years marinating in observability infrastructure, so words that feel like plain English to us (`span`, `exporter`, `instrument`, `OTLP`, `sampling`, `scrubbing`) can be a closed door to them. A specialist walking us through their own field wouldn't drop a term of art and move on; they'd give the plain-language version the first time. We extend the same courtesy.
+This reader is not a caricature of a confused user. They're smart, motivated, and perfectly capable of understanding anything we take a sentence to explain. But our docs sit at the intersection of observability and AI tooling, and few readers arrive fluent in both — so words that feel like plain English to us (`span`, `exporter`, `OTLP`, `evals`, `sampling`, `scrubbing`) can be a closed door to them. A specialist walking us through their own field wouldn't drop a term of art and move on; they'd give the plain-language version the first time. We extend the same courtesy.
 
 This is not dumbing down. Precise terms stay — they're often the thing the user needs to learn to succeed with the product. The standard is about _introducing_ terms, not avoiding them: give the real word and, at its first use on a page, a plain-language hand-hold.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ Pre-commit automatically runs ruff and pyright, but you can also run `make forma
 
 Docs are rendered and deployed through the `pydantic/unified-docs` pipeline. Do not use MkDocs checks in this repository.
 
-# Writing for Users
+## Writing standard
 
-Every user-facing string this repo produces — docs pages, exception messages, warnings, CLI output, public docstrings — is held to one standard:
+Every page in the public docs (`docs/`) is held to one standard:
 
 > If an expert in some other field who has just started building with AI tools wouldn't know what it means, we spell out the acronym, we explain the term in place, or we rewrite the sentence to be human friendly.
 
@@ -23,14 +23,15 @@ This reader is not a caricature of a confused user. They're smart, motivated, an
 
 This is not dumbing down. Precise terms stay — they're often the thing the user needs to learn to succeed with the product. The standard is about _introducing_ terms, not avoiding them: give the real word and, at its first use on a page, a plain-language hand-hold.
 
-When you write or touch a user-facing string, check:
+When you write or touch a docs page, check:
 
 - **Acronyms are spelled out at first use on each page** — "OpenTelemetry Protocol (OTLP)", "personally identifiable information (PII)". Assume the reader opens the page directly from a search; no acronym is "already established" by another page.
-- **The page says what it's for.** Every docs page opens with what this is and why you'd use it, before any code or configuration. A feature name is not a description.
-- **Copy describes the user's goal, not our mechanism.** "See every request your app handles", not "Attach the ASGI middleware span processor". If a word names a piece of our internals, it doesn't belong in user-facing text.
+- **The page says what it's for.** It opens with what this is and why you'd use it, before any code or configuration. A feature name is not a description.
+- **Copy describes the user's goal, not our mechanism.** "See every request your app handles", not "Attach the ASGI middleware span processor". If a word names a piece of our internals, it doesn't belong in the docs.
 - **Instructions say where.** "Run this in your terminal", "Copy this from your project settings page in Logfire". A step asking for a value the user has to fetch from somewhere else must say where that somewhere is.
 - **Consequences are stated plainly** — especially when data leaves the user's machine, something costs money, or an action can't be undone. If a setting sends more telemetry, say so; if data is dropped or redacted, say what and when.
-- **Errors and warnings name what went wrong and what to do next.** Never a bare "invalid configuration", never an internal detail as the whole user-facing explanation. Say which value failed, why, and what a working one looks like.
+
+This standard is for docs prose. Docstrings and other in-code text follow normal API-reference conventions and are not expected to introduce terms this way.
 
 # Core Structure
 


### PR DESCRIPTION
Adds a "Writing standard" subsection under the Documentation section of `CLAUDE.md`, holding every page in the public docs to one standard: a reader who is an expert in their own field but new to observability should be able to understand it.

Concretely, the checklist asks that:

- acronyms are spelled out at first use on each page,
- every page opens with what it's for and why you'd use it,
- copy describes the user's goal rather than our internals,
- instructions say where to run or fetch things, and
- consequences (data leaving the machine, cost, irreversibility) are stated plainly.

The point is introducing precise terms with a plain-language hand-hold at first use, not avoiding them. The standard is scoped to docs prose — docstrings and other in-code text follow normal API-reference conventions.

https://claude.ai/code/session_01VRXHUAwM4RjifoaouEwooF