### PR TITLE
Drop the Beta note from shipped web-UI guides

### DIFF
--- a/docs/guides/web-ui/hosts.md
+++ b/docs/guides/web-ui/hosts.md
@@ -4,9 +4,6 @@ description: "Browse every host shipping system metrics to your Logfire project.
 ---
 # Hosts
 
-!!! note "Beta — feedback welcome"
-    The Hosts view is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The **Hosts view** shows every host shipping system metrics to your project. It shows CPU, memory, load, disk and network alongside the application traces those hosts produced. Kubernetes nodes show up here too, tagged so you can tell them apart from bare VMs.
 
 You'll find Hosts in the project sidebar, between **Services** and **Kubernetes**.

--- a/docs/guides/web-ui/kubernetes.md
+++ b/docs/guides/web-ui/kubernetes.md
@@ -4,9 +4,6 @@ description: "Browse your Kubernetes clusters, namespaces, workloads, pods, node
 ---
 # Kubernetes
 
-!!! note "Beta — feedback welcome"
-    The Kubernetes view is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The **Kubernetes view** is the cluster-shaped browser for your Kubernetes telemetry. Six lenses on the same data — Clusters, Nodes, Namespaces, Workloads, Pods, and Images — all sortable, with one-click drill-down to the traces each pod produced in the [Live View](live.md).
 
 You'll find Kubernetes in the project sidebar, between **Hosts** and **Metrics**.

--- a/docs/guides/web-ui/llms.md
+++ b/docs/guides/web-ui/llms.md
@@ -4,9 +4,6 @@ description: "Browse every model and provider your application calls. See cost, 
 ---
 # LLMs
 
-!!! note "Beta — feedback welcome"
-    The LLMs page is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The **LLMs** page is the per-model inventory of every LLM your application is calling. Each row shows calls, latency, tokens and cost for one (provider, model) pair, and the LLM detail page links into the trace for each individual call.
 
 For inspecting an individual LLM call inside a trace, the [LLM Panels](llm-panels.md) guide covers the in-trace view; this page covers the per-model and per-agent analytics surfaces.

--- a/docs/guides/web-ui/metrics-explorer.md
+++ b/docs/guides/web-ui/metrics-explorer.md
@@ -4,9 +4,6 @@ description: "A three-step wizard for browsing the OpenTelemetry metrics you're 
 ---
 # Metrics explorer
 
-!!! note "Beta — feedback welcome"
-    The Metrics explorer is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The **Metrics explorer** is built for the moment when you know a metric exists somewhere but you can't remember what it's called, you don't know which labels are useful, and you don't want to write a query yet. Three steps: pick a namespace, pick a metric, see what dimensions you can break it down by. No SQL required. The SQL is on every card when you want it.
 
 You'll find Metrics in the project sidebar, after **Kubernetes**.

--- a/docs/guides/web-ui/services.md
+++ b/docs/guides/web-ui/services.md
@@ -4,9 +4,6 @@ description: "Browse every service shipping spans to your Logfire project. See r
 ---
 # Services
 
-!!! note "Beta — feedback welcome"
-    The Services view is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The **Services view** is the entry point for finding the service you want to investigate. Each service that ships spans to your project appears as one row, sorted by whatever metric matters right now (requests, error rate, latency). Click a row to drill into its detail page, click a recent failed trace, and you land in the [Live View](live.md) with the failing trace open.
 
 You'll find Services in the project sidebar, between [Explore](explore.md) and [Hosts](hosts.md).


### PR DESCRIPTION
Services, Hosts, Kubernetes, LLMs and the Metrics explorer are out of beta — their in-app badges moved from **Beta** to **New** — so this removes the `Beta — feedback welcome` admonition from those five guides. (The Docker guide keeps its Beta note; it's still in beta.)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

