### PR TITLE
Scope the docs acronym rule to field-specific terms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ This is not dumbing down. Precise terms stay — they're often the thing the use
 
 When you write or touch a docs page, check:
 
-- **Acronyms are spelled out at first use on each page** — "OpenTelemetry Protocol (OTLP)", "personally identifiable information (PII)". Assume the reader opens the page directly from a search; no acronym is "already established" by another page.
+- **Field-specific acronyms are spelled out at first use on each page** — "OpenTelemetry Protocol (OTLP)", "personally identifiable information (PII)". Assume the reader opens the page directly from a search; no acronym is "already established" by another page. Don't take this too far, though: acronyms the whole space already reads as words — AI, LLM, SDK, API, HTTP, JSON, URL, CLI — are left alone. The test is whether spelling it out teaches the reader something; expand the terms that are specific to observability or to Logfire, not the ones every developer uses daily.
 - **The page says what it's for.** It opens with what this is and why you'd use it, before any code or configuration. A feature name is not a description.
 - **Copy describes the user's goal, not our mechanism.** "See every request your app handles", not "Attach the ASGI middleware span processor". If a word names a piece of our internals, it doesn't belong in the docs.
 - **Instructions say where.** "Run this in your terminal", "Copy this from your project settings page in Logfire". A step asking for a value the user has to fetch from somewhere else must say where that somewhere is.


### PR DESCRIPTION
The `## Writing standard` section (added in #2052) tells writers to spell out acronyms at first use on each page. Coding agents have been reading this too literally — mechanically expanding ubiquitous acronyms like AI, LLM, and SDK that any reader in the space already reads as words.

This narrows the rule to genuinely field-specific acronyms:

- Retitles the bullet to **"Field-specific acronyms are spelled out at first use"**.
- Explicitly exempts the acronyms the whole space uses daily — AI, LLM, SDK, API, HTTP, JSON, URL, CLI.
- Adds the guiding test: expand a term only when spelling it out teaches the reader something (observability- or Logfire-specific), not the ones every developer already knows.

The OTLP/PII-style expansions the standard actually cares about are unchanged.

https://claude.ai/code/session_01Grb6q1C8DzwkHqg6VLGwEF

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

