### PR TITLE
docs(nav): add Embeddings to the AI Gateway nav in nav.json

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -230,7 +230,13 @@
       { "label": "Export Data", "slug": "how-to-guides/query-api" },
       { "label": "Feature Flags (OFREP)", "slug": "how-to-guides/client-side-feature-flags" },
       { "label": "Convert to Organization", "slug": "how-to-guides/convert-to-organization" },
-      { "label": "AI Gateway", "slug": "reference/advanced/gateway/index" }
+      {
+        "label": "AI Gateway",
+        "items": [
+          { "label": "Overview", "slug": "reference/advanced/gateway/index" },
+          { "label": "Embeddings", "slug": "reference/advanced/gateway/embeddings" }
+        ]
+      }
     ]
   },
   {


### PR DESCRIPTION
Follow-up to #2063. That PR added the Gateway **Embeddings** reference page to the `mkdocs.yml` nav, but `docs/nav.json` — the separately hand-maintained navigation the embedded docs site renders from — still listed **AI Gateway** as a single leaf with no Embeddings child, so the page was missing from that navigation.

This mirrors the `mkdocs.yml` structure in `nav.json`: **AI Gateway** becomes a section with **Overview** + **Embeddings**.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

