### PR TITLE
Document unified docs link remapping

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,12 @@ Pre-commit automatically runs ruff and pyright, but you can also run `make forma
 
 Docs are rendered and deployed through the `pydantic/unified-docs` pipeline. Do not use MkDocs checks in this repository.
 
+When linking between pages in this repository, use source-relative `.md` links. Published routes can
+differ from source paths because `pydantic/unified-docs` remaps some sections. When adding or moving
+a docs section, check whether unified-docs remaps it and verify the page and any anchor in a rendered
+preview. Fix a missing remap in unified-docs instead of hard-coding a public route here, and never
+include the deployment-specific `/docs` prefix.
+
 ## Writing standard
 
 **The full documentation style guide is [`dev-docs/documentation-style-guide.md`](dev-docs/documentation-style-guide.md)** — page templates, the terminology glossary, the pre-publish checklist, the anti-pattern catalog, and the rules for AI-assisted authoring. Read it before writing or substantially editing a docs page.


### PR DESCRIPTION
## Summary

- tell documentation agents to use source-relative Markdown links
- clarify that unified-docs can publish sections at routes that differ from their source paths
- require rendered page and anchor verification, and prohibit hard-coded production routes and the deployment-specific `/docs` prefix

## Validation

- `uv run pytest tests/test_docs.py::test_formatting -q`
- pre-commit on `CLAUDE.md`
- `git diff --check`
- confirmed `AGENTS.md` still resolves to `CLAUDE.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

