### PR TITLE
Prevent double retrying of ConnectionErrors

### DIFF
--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -70,7 +70,7 @@ class OTLPExporterHttpSession(Session):
         start_time = time.time()
         try:
             return self._post(url, data, **kwargs)
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as e:
             # Wait a little before trying again normally, before resorting to disk retrying.
             # This has several advantages:
             #  - Writing to disk might be impossible.
@@ -81,20 +81,25 @@ class OTLPExporterHttpSession(Session):
             # So only do this if the first attempt took less than 10 seconds.
             end_time = time.time()
             if end_time - start_time > 10:  # pragma: no cover
-                self._add_task(data, url, kwargs)
+                self._add_task(data, url, kwargs, e)
                 raise
 
             time.sleep(1)
             try:
                 return self._post(url, data, **kwargs)
             except requests.exceptions.RequestException:
-                self._add_task(data, url, kwargs)
+                self._add_task(data, url, kwargs, e)
                 raise
 
-    def _add_task(self, data: bytes, url: str, kwargs: dict[str, Any]):
+    def _add_task(self, data: bytes, url: str, kwargs: dict[str, Any], exception: Exception):
         # No threads in Emscripten, we can't add a task to try later
         if not platform_is_emscripten():  # pragma: no branch
             self.retryer.add_task(data, {'url': url, **kwargs})
+
+            if isinstance(exception, requests.exceptions.ConnectionError):
+                # OTel already retries ConnectionError, so we don't want to surface that error as is,
+                # since that would create two layers of retrying and lead to duplicate exports.
+                raise RuntimeError()
 
     def _post(self, url: str, data: bytes, **kwargs: Any):
         response = super().post(url, data=data, **kwargs)

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -87,8 +87,8 @@ class OTLPExporterHttpSession(Session):
             time.sleep(1)
             try:
                 return self._post(url, data, **kwargs)
-            except requests.exceptions.RequestException:
-                self._add_task(data, url, kwargs, e)
+            except requests.exceptions.RequestException as e2:
+                self._add_task(data, url, kwargs, e2)
                 raise
 
     def _add_task(self, data: bytes, url: str, kwargs: dict[str, Any], exception: Exception):
@@ -99,7 +99,7 @@ class OTLPExporterHttpSession(Session):
             if isinstance(exception, requests.exceptions.ConnectionError):
                 # OTel already retries ConnectionError, so we don't want to surface that error as is,
                 # since that would create two layers of retrying and lead to duplicate exports.
-                raise RuntimeError()
+                raise SuppressedConnectionError()
 
     def _post(self, url: str, data: bytes, **kwargs: Any):
         response = super().post(url, data=data, **kwargs)
@@ -293,13 +293,17 @@ class BodyTooLargeError(Exception):
         self.max_size = max_size
 
 
+class SuppressedConnectionError(Exception):
+    pass
+
+
 class QuietSpanExporter(WrapperSpanExporter):
     """A SpanExporter that catches request exceptions to prevent OTEL from logging a huge traceback."""
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         try:
             return super().export(spans)
-        except requests.exceptions.RequestException:
+        except (requests.exceptions.RequestException, SuppressedConnectionError):
             # Rely on OTLPExporterHttpSession/DiskRetryer to log this kind of error periodically.
             return SpanExportResult.FAILURE
 
@@ -310,6 +314,6 @@ class QuietLogExporter(WrapperLogExporter):
     def export(self, batch: Sequence[ReadableLogRecord]):
         try:
             return super().export(batch)
-        except requests.exceptions.RequestException:
+        except (requests.exceptions.RequestException, SuppressedConnectionError):
             # Rely on OTLPExporterHttpSession/DiskRetryer to log this kind of error periodically.
             return LogRecordExportResult.FAILURE

--- a/logfire/_internal/exporters/quiet_metrics.py
+++ b/logfire/_internal/exporters/quiet_metrics.py
@@ -3,6 +3,7 @@ from typing import Any
 import requests
 from opentelemetry.sdk.metrics.export import MetricExportResult, MetricsData
 
+from .otlp import SuppressedConnectionError
 from .wrapper import WrapperMetricExporter
 
 
@@ -12,6 +13,6 @@ class QuietMetricExporter(WrapperMetricExporter):
     def export(self, metrics_data: MetricsData, timeout_millis: float = 10_000, **kwargs: Any) -> MetricExportResult:
         try:
             return super().export(metrics_data, timeout_millis, **kwargs)
-        except requests.exceptions.RequestException:
+        except (requests.exceptions.RequestException, SuppressedConnectionError):
             # Rely on OTLPExporterHttpSession to log this kind of error periodically.
             return MetricExportResult.FAILURE

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -61,6 +61,7 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
 
     sleep_mock = Mock(return_value=0)
     monkeypatch.setattr('time.sleep', sleep_mock)
+    monkeypatch.setattr('time.monotonic', Mock(side_effect=range(0, 1000, 30)))
     monkeypatch.setattr('random.random', Mock(return_value=0.5))
 
     class ConnectionErrorAdapter(HTTPAdapter):
@@ -145,6 +146,17 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
     # While there's still tasks to process, the base sleep time is reduced to 0.2 seconds.
     # When that loop ends, a new task may still be added and the loop restarts with a base time of 1 second.
     assert all(t in {0.2 * 1.5, 1.0 * 1.5} for t in sleep_times_after)
+
+    # A message gets logged once per minute when an export fails.
+    # time.monotonic is mocked to return a value increasing by 30 each time,
+    # so for 10 failed exports we get 5 messages.
+    assert len(caplog.messages) == 5
+    # This will always be the first message in case of failures.
+    # After that the number of failed exports is unpredictable because the main thread is adding to it
+    # at the same time as the retryer thread removes from it.
+    assert caplog.messages[0].startswith('Currently retrying 1 failed export(s) (')
+    for message in caplog.messages:
+        assert message == IsStr(regex=r'Currently retrying \d+ failed export\(s\) \(\d+ bytes\)')
 
 
 def test_disk_retryer_cleanup_after_logfire_shutdown(tmp_path: Path) -> None:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -12,11 +12,13 @@ import pytest
 import requests
 import requests.exceptions
 from dirty_equals import IsStr
-from inline_snapshot import snapshot
 from opentelemetry.sdk.trace.export import SpanExportResult
 from requests.models import PreparedRequest, Response as Response
 from requests.sessions import HTTPAdapter
 
+import logfire
+from logfire._internal.config import LogfireConfig
+from logfire._internal.exporters.dynamic_batch import DynamicBatchSpanProcessor
 from logfire._internal.exporters.otlp import (
     BodySizeCheckingOTLPSpanExporter,
     BodyTooLargeError,
@@ -24,7 +26,10 @@ from logfire._internal.exporters.otlp import (
     OTLPExporterHttpSession,
     cleanup_disk_retryers,
 )
+from logfire._internal.exporters.remove_pending import RemovePendingSpansExporter
+from logfire._internal.exporters.wrapper import WrapperSpanExporter
 from tests.exporters.test_retry_fewer_spans import TEST_SPANS
+from tests.test_configure import get_span_processors, wait_for_check_token_thread
 
 
 class SinkHTTPAdapter(HTTPAdapter):
@@ -52,9 +57,10 @@ def test_max_body_size_bytes() -> None:
 
 
 def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setattr(LogfireConfig, '_initialize_credentials_from_token', lambda *args: None)  # type: ignore
+
     sleep_mock = Mock(return_value=0)
     monkeypatch.setattr('time.sleep', sleep_mock)
-    monkeypatch.setattr('time.monotonic', Mock(side_effect=range(0, 1000, 30)))
     monkeypatch.setattr('random.random', Mock(return_value=0.5))
 
     class ConnectionErrorAdapter(HTTPAdapter):
@@ -63,18 +69,24 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
             self.mock = mock
 
         def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
-            assert request.body == b'123'
-            assert request.url == 'http://example.com/'
-            assert request.headers['User-Agent'] == 'logfire'
-            assert request.headers['Authorization'] == 'Bearer 123'
             return self.mock()
 
-    session = OTLPExporterHttpSession()
-    headers = {'User-Agent': 'logfire', 'Authorization': 'Bearer 123'}
-    session.headers.update(headers)
+    logfire.configure(send_to_logfire=True, console=False, token='foo')
+    wait_for_check_token_thread()
+
+    [send_to_logfire_processor, *_] = get_span_processors()
+
+    assert isinstance(send_to_logfire_processor, DynamicBatchSpanProcessor)
+    assert isinstance(send_to_logfire_processor.span_exporter, RemovePendingSpansExporter)
+    exporter = send_to_logfire_processor.span_exporter
+    while isinstance(exporter, WrapperSpanExporter):
+        exporter = exporter.wrapped_exporter
+    assert isinstance(exporter, BodySizeCheckingOTLPSpanExporter)
+
+    session: OTLPExporterHttpSession = exporter._session  # type: ignore
 
     # The main session always fails so that it defers to the retryer.
-    session.mount('http://', ConnectionErrorAdapter(Mock(side_effect=requests.exceptions.ConnectionError())))
+    session.mount('https://', ConnectionErrorAdapter(Mock(side_effect=requests.exceptions.ConnectionError())))
 
     # The retryer sessions fails at first to simulate logfire being down, then succeeds.
     failure = Response()
@@ -83,14 +95,14 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
     success.status_code = 200
     num_exports = 10
     session.retryer.session.mount(
-        'http://',
+        'https://',
         ConnectionErrorAdapter(Mock(side_effect=[failure] * num_exports + [success] * num_exports)),
     )
 
     # Create a bunch of failed exports.
     for _ in range(num_exports):
-        with pytest.raises(requests.exceptions.ConnectionError):
-            session.post('http://example.com/', data=b'123')
+        logfire.info('hi')
+        logfire.force_flush()
 
     # Wait for the retryer to finish.
     # time.sleep has been mocked to return 0 so this shouldn't take long.
@@ -133,15 +145,6 @@ def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytes
     # While there's still tasks to process, the base sleep time is reduced to 0.2 seconds.
     # When that loop ends, a new task may still be added and the loop restarts with a base time of 1 second.
     assert all(t in {0.2 * 1.5, 1.0 * 1.5} for t in sleep_times_after)
-
-    # A message gets logged once per minute when an export fails.
-    # time.monotonic is mocked to return a value increasing by 30 each time,
-    # so for 10 failed exports we get 5 messages.
-    assert len(caplog.messages) == 5
-    # This will always be the first message in case of failures.
-    # After that the number of failed exports is unpredictable because the main thread is adding to it
-    # at the same time as the retryer thread removes from it.
-    assert caplog.messages[0] == snapshot('Currently retrying 1 failed export(s) (3 bytes)')
 
 
 def test_disk_retryer_cleanup_after_logfire_shutdown(tmp_path: Path) -> None:


### PR DESCRIPTION
OTel already retries ConnectionErrors, which we don't want in addition to our own retrying.