### PR TITLE
docs: add YouTube video walkthroughs to four docs pages

### DIFF
--- a/docs/guides/web-ui/organizations-and-projects.md
+++ b/docs/guides/web-ui/organizations-and-projects.md
@@ -25,6 +25,8 @@ to share your personal org's projects (which you may wish to keep private) with 
 
 ## Roles
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/akVKNpYZHuA" title="How to Manage Roles and Permissions in Pydantic Logfire" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 Logfire provides a fixed set of _organization_ and _project_ roles, that can be managed in the organization settings. Roles contain a set of permissions,
 and are assigned to team members either at the organization or project level.
 

--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -6,6 +6,8 @@ description: "Learn how to use Logfire to keep logs & sensitive data safe: Autom
 
 The **Logfire** SDK scans for and redacts potentially sensitive data from logs and spans before exporting them.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/uZU4cA6iI6c" title="How to Scrub, Delete & Audit Sensitive Data in Pydantic Logfire" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Disabling scrubbing
 
 To disable scrubbing entirely, set [`scrubbing`][logfire.configure(scrubbing)] to `False`:

--- a/docs/how-to-guides/sso-setup.md
+++ b/docs/how-to-guides/sso-setup.md
@@ -9,6 +9,8 @@ Logfire Enterprise Cloud supports Single Sign-On (SSO) through Microsoft Entra I
 
 This guide uses **Microsoft Azure Entra ID** as an example, but the general steps (registering an OIDC app, obtaining a Client ID, Client Secret, and Issuer URL, then connecting it in Logfire) also apply to Okta and Keycloak.
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/K9fOYokn8Lk" title="How to Set Up SSO in Pydantic Logfire (OIDC + Group-to-Role Mapping)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 !!! note "Enterprise Cloud Required"
     SSO is available exclusively on the **Enterprise Cloud** plan. Ensure your organization has Enterprise Cloud enabled before proceeding. [Contact sales](mailto:sales@pydantic.dev) if you need to upgrade.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -10,6 +10,8 @@ description: "Use the Logfire CLI to simplify project management. Use commands t
 {{ logfire_help }}
 ```
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/di0ToWrOEPw" title="API Keys, CLI Auth & Trust Policies in Pydantic Logfire" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## Authentication (`auth`)
 
 You need to be authenticated to use the **Logfire**.


### PR DESCRIPTION
Embeds four new YouTube video walkthroughs into the docs:

| Docs page | Video |
|---|---|
| [Organizations & Projects](https://pydantic.dev/docs/logfire/manage/organizations-and-projects/) (under the **Roles** section) | [How to Manage Roles and Permissions in Pydantic Logfire](https://youtu.be/akVKNpYZHuA) |
| [SSO Setup](https://pydantic.dev/docs/logfire/deploy/sso-setup/) | [How to Set Up SSO in Pydantic Logfire (OIDC + Group-to-Role Mapping)](https://youtu.be/K9fOYokn8Lk) |
| [CLI reference](https://pydantic.dev/docs/logfire/reference/cli/) | [API Keys, CLI Auth & Trust Policies in Pydantic Logfire](https://youtu.be/di0ToWrOEPw) |
| [Scrubbing](https://pydantic.dev/docs/logfire/instrument/scrubbing/) | [How to Scrub, Delete & Audit Sensitive Data in Pydantic Logfire](https://youtu.be/uZU4cA6iI6c) |

Each embed is a standard YouTube iframe placed after the page intro (or under the section the video covers). Verified against the unified-docs `sanitizeForMdx` transform — `iframe` is on its allowlist and all four embeds pass through unchanged, so the pydantic.dev docs pipeline renders them as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

