### PR TITLE
docs: OpenAI-compatible multi-model gateway example (DaoXE)

### DIFF
--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -78,6 +78,39 @@ Run your program, then open your project in the
 should see a span for the OpenAI call. Click it to read the conversation and see the token count and
 duration.
 
+## OpenAI-compatible gateways
+
+`instrument_openai()` works with any client that uses the official OpenAI Python SDK, including multi-model gateways that expose an OpenAI-compatible Chat Completions API. Point `base_url` at the gateway and pass the gateway API key:
+
+```python skip-run="true" skip-reason="external-connection"
+import openai
+
+import logfire
+
+client = openai.Client(
+    api_key='your_daoxe_api_key',
+    base_url='https://daoxe.com/v1',  # DaoXE multi-model gateway example
+)
+
+logfire.configure()
+logfire.instrument_openai(client)
+
+response = client.chat.completions.create(
+    model='your-account-model-id',  # exact ID from your DaoXE account / GET /v1/models
+    messages=[
+        {'role': 'user', 'content': 'Write a one-line haiku about observability.'},
+    ],
+)
+print(response.choices[0].message)
+```
+
+Notes:
+
+- Model IDs are account-scoped on many gateways; do not hardcode a static public catalog.
+- This path is OpenAI Chat Completions. Other protocols (for example Anthropic Messages) need their own SDK + instrumentation.
+- [DaoXE](https://daoxe.com) is not available in mainland China.
+- Contributor disclosure: this section was contributed by a DaoXE affiliate.
+
 ## Troubleshooting
 
 Not seeing your model calls in Logfire? Check these first:

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -101,7 +101,7 @@ response = client.chat.completions.create(
         {'role': 'user', 'content': 'Write a one-line haiku about observability.'},
     ],
 )
-print(response.choices[0].message)
+print(response.choices[0].message.content)
 ```
 
 Notes:


### PR DESCRIPTION
## Summary

Adds a short section to the OpenAI instrumentation docs showing that `logfire.instrument_openai()` works with OpenAI-compatible multi-model gateways via `openai.Client(base_url=...)`.

Example uses [DaoXE](https://daoxe.com) (`https://daoxe.com/v1`).

- Docs only: `docs/integrations/llms/openai.md`
- No SDK/runtime changes

### Notes

- Account-scoped model IDs
- Chat Completions path
- DaoXE not available in mainland China
- Contributor is affiliated with DaoXE

## Test plan

- [ ] Docs page renders the new section
- [ ] Optional: run sample with real key + model ID

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

