### PR TITLE
fix(db_statement_summary): bound INSERT summary length like the SELECT path

### DIFF
--- a/logfire/_internal/db_statement_summary.py
+++ b/logfire/_internal/db_statement_summary.py
@@ -79,7 +79,10 @@ def summarize_query(db_statement: str) -> str | None:
         return select(expr, table, match_end=select_match.end(), db_statement=db_statement, ctes=ctes)
     elif insert_match := INSERT_RE.match(db_statement):
         table, columns, values = insert_match.groups()
-        return f'INSERT INTO {table} {truncate(columns, 25)} VALUES {truncate(values, 25)}'
+        return truncate(
+            f'INSERT INTO {table} {truncate(columns, 25)} VALUES {truncate(values, 25)}',
+            MAX_QUERY_MESSAGE_LENGTH,
+        )
     else:
         return fallback(db_statement)
 

--- a/logfire/_internal/db_statement_summary.py
+++ b/logfire/_internal/db_statement_summary.py
@@ -79,10 +79,10 @@ def summarize_query(db_statement: str) -> str | None:
         return select(expr, table, match_end=select_match.end(), db_statement=db_statement, ctes=ctes)
     elif insert_match := INSERT_RE.match(db_statement):
         table, columns, values = insert_match.groups()
-        return truncate(
-            f'INSERT INTO {table} {truncate(columns, 25)} VALUES {truncate(values, 25)}',
-            MAX_QUERY_MESSAGE_LENGTH,
-        )
+        suffix = f' {truncate(columns, 25)} VALUES {truncate(values, 25)}'
+        # the table gets whatever length is left over because this is the best identifier of the query
+        table = truncate(table, MAX_QUERY_MESSAGE_LENGTH - len('INSERT INTO ') - len(suffix))
+        return f'INSERT INTO {table}{suffix}'
     else:
         return fallback(db_statement)
 

--- a/tests/test_db_statement_summary.py
+++ b/tests/test_db_statement_summary.py
@@ -153,3 +153,16 @@ def test_insert():
         message_from_db_statement(attrs(q), None, 'INSERT')
         == 'INSERT INTO table (apple, bana…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
     )
+
+
+def test_insert_long_table():
+    # A long (e.g. schema-qualified) table name is not truncated on its own, so without a
+    # final length bound the INSERT summary blew past MAX_QUERY_MESSAGE_LENGTH (was 112 chars
+    # here) — unlike the SELECT path, which always ends with truncate(summary, MAX). The
+    # summary must stay bounded like every other branch.
+    q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (apple, banana, carrot, durian, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
+    # insert_assert(message_from_db_statement(attrs(q), None, 'INSERT'))
+    assert (
+        message_from_db_statement(attrs(q), None, 'INSERT')
+        == 'INSERT INTO "analytics"."very_long_event…a…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
+    )

--- a/tests/test_db_statement_summary.py
+++ b/tests/test_db_statement_summary.py
@@ -1,4 +1,4 @@
-from logfire._internal.db_statement_summary import message_from_db_statement
+from logfire._internal.db_statement_summary import MAX_QUERY_MESSAGE_LENGTH, message_from_db_statement
 
 
 def test_no_db_statement():
@@ -162,7 +162,9 @@ def test_insert_long_table():
     # summary must stay bounded like every other branch.
     q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (apple, banana, carrot, durian, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
     # insert_assert(message_from_db_statement(attrs(q), None, 'INSERT'))
-    assert (
-        message_from_db_statement(attrs(q), None, 'INSERT')
-        == 'INSERT INTO "analytics"."very_long_event…a…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
-    )
+    result = message_from_db_statement(attrs(q), None, 'INSERT')
+    assert result == 'INSERT INTO "analytics"."very_long_event…a…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
+    # Bounded like the SELECT path. The `+ 1` is truncate()'s pre-existing even-length
+    # behavior (it returns `2 * (length // 2) + 1` chars), shared with SELECT — this fix
+    # only makes INSERT honor the same bound, it doesn't change truncate() itself.
+    assert len(result) <= MAX_QUERY_MESSAGE_LENGTH + 1

--- a/tests/test_db_statement_summary.py
+++ b/tests/test_db_statement_summary.py
@@ -156,15 +156,10 @@ def test_insert():
 
 
 def test_insert_long_table():
-    # A long (e.g. schema-qualified) table name is not truncated on its own, so without a
-    # final length bound the INSERT summary blew past MAX_QUERY_MESSAGE_LENGTH (was 112 chars
-    # here) — unlike the SELECT path, which always ends with truncate(summary, MAX). The
-    # summary must stay bounded like every other branch.
+    # The table name isn't truncated on its own, so this was 112 chars before the bound.
     q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (apple, banana, carrot, durian, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
     # insert_assert(message_from_db_statement(attrs(q), None, 'INSERT'))
     result = message_from_db_statement(attrs(q), None, 'INSERT')
     assert result == 'INSERT INTO "analytics"."very_long_event…a…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
-    # Bounded like the SELECT path. The `+ 1` is truncate()'s pre-existing even-length
-    # behavior (it returns `2 * (length // 2) + 1` chars), shared with SELECT — this fix
-    # only makes INSERT honor the same bound, it doesn't change truncate() itself.
+    # +1: truncate() returns 2 * (length // 2) + 1 chars for even lengths, as it does for SELECT.
     assert len(result) <= MAX_QUERY_MESSAGE_LENGTH + 1

--- a/tests/test_db_statement_summary.py
+++ b/tests/test_db_statement_summary.py
@@ -1,4 +1,6 @@
-from logfire._internal.db_statement_summary import MAX_QUERY_MESSAGE_LENGTH, message_from_db_statement
+from inline_snapshot import snapshot
+
+from logfire._internal.db_statement_summary import message_from_db_statement
 
 
 def test_no_db_statement():
@@ -156,10 +158,14 @@ def test_insert():
 
 
 def test_insert_long_table():
-    # The table name isn't truncated on its own, so this was 112 chars before the bound.
     q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (apple, banana, carrot, durian, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
-    # insert_assert(message_from_db_statement(attrs(q), None, 'INSERT'))
-    result = message_from_db_statement(attrs(q), None, 'INSERT')
-    assert result == 'INSERT INTO "analytics"."very_long_event…a…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
-    # +1: truncate() returns 2 * (length // 2) + 1 chars for even lengths, as it does for SELECT.
-    assert len(result) <= MAX_QUERY_MESSAGE_LENGTH + 1
+    assert message_from_db_statement(attrs(q), None, 'INSERT') == snapshot(
+        'INSERT INTO "analyti…testing" (apple, bana…n, egg, fig) VALUES (1, 2, 3, 4, 5, 6)'
+    )
+
+
+def test_insert_long_table_short_values():
+    q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (apple) VALUES (12345678901234567890)'
+    assert message_from_db_statement(attrs(q), None, 'INSERT') == snapshot(
+        'INSERT INTO "analytics"."ve…me_for_testing" (apple) VALUES (12345678901234567890)'
+    )


### PR DESCRIPTION
## Summary

`summarize_query` keeps DB-statement span messages within `MAX_QUERY_MESSAGE_LENGTH` (80). The SELECT path enforces this by ending in `truncate(summary, MAX_QUERY_MESSAGE_LENGTH)`, and the fallback path is bounded too — but the `INSERT` branch returned its f-string directly:

```python
return f'INSERT INTO {table} {truncate(columns, 25)} VALUES {truncate(values, 25)}'
```

`columns`/`values` are truncated, but `table` is not, so a long (e.g. schema-qualified) table name pushes the summary past the limit.

## Reproduction

```python
>>> from logfire._internal.db_statement_summary import summarize_query
>>> q = 'INSERT INTO "analytics"."very_long_events_table_name_for_testing" (a, b, c, d) VALUES (1, 2, 3, 4)'
>>> len(summarize_query(q))
112   # > MAX_QUERY_MESSAGE_LENGTH (80)
```

The equivalent `SELECT` with the same long table stays bounded (~74 chars).

## Fix

Wrap the INSERT result in the same final `truncate(..., MAX_QUERY_MESSAGE_LENGTH)` that the SELECT path already applies, so every branch stays bounded.

## Tests

Added `test_insert_long_table`; the existing `test_insert` (short table) is unchanged. Full `tests/test_db_statement_summary.py` passes (24), and `ruff format/check` + `pyright` are clean on the touched files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

