### PR TITLE
fix(anthropic): preserve thinking blocks in output spans

### DIFF
--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any, cast
 import anthropic
 import httpx
 from anthropic.lib.bedrock import AnthropicBedrock, AsyncAnthropicBedrock
-from anthropic.types import Message, TextBlock, TextDelta, ToolUseBlock
-from anthropic.types.beta import BetaMessage, BetaTextBlock, BetaTextDelta, BetaToolUseBlock
+from anthropic.types import Message, TextBlock, TextDelta, ThinkingBlock, ToolUseBlock
+from anthropic.types.beta import BetaMessage, BetaTextBlock, BetaTextDelta, BetaThinkingBlock, BetaToolUseBlock
 
 from logfire._internal.utils import handle_internal_errors
 
@@ -32,6 +32,7 @@ from .semconv import (
     InputMessages,
     MessagePart,
     OutputMessage,
+    ReasoningPart,
     SemconvVersion,
     SystemInstructions,
     TextPart,
@@ -239,6 +240,8 @@ def convert_response_to_semconv(message: Message | BetaMessage) -> OutputMessage
         text = getattr(block, 'text', None)
         if isinstance(block, (TextBlock, BetaTextBlock)) and text is not None:
             parts.append(TextPart(type='text', content=text))
+        elif isinstance(block, (ThinkingBlock, BetaThinkingBlock)):
+            parts.append(ReasoningPart(type='reasoning', content=block.thinking))
         elif isinstance(block, (ToolUseBlock, BetaToolUseBlock)):
             parts.append(
                 make_tool_call_part(
@@ -331,6 +334,8 @@ def on_response(
             for block in response.content:
                 if block.type == 'text':
                     message['content'] = block.text
+                elif block.type == 'thinking':
+                    message.setdefault('reasoning', []).append(block.thinking)
                 elif block.type == 'tool_use':
                     message.setdefault('tool_calls', []).append(
                         {

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -14,6 +14,7 @@ from anthropic.types import (
     MessageDeltaUsage,
     MessageStartEvent,
     MessageStopEvent,
+    ThinkingBlock,
     TextBlock,
     TextDelta,
     Usage,
@@ -1238,6 +1239,35 @@ def test_convert_messages_content_none() -> None:
     assert (input_messages, system_instructions) == snapshot(([{'role': 'user', 'parts': []}], []))
 
 
+def test_convert_response_with_thinking_block() -> None:
+    """Anthropic thinking blocks should map to semconv reasoning parts."""
+    from logfire._internal.integrations.llm_providers.anthropic import convert_response_to_semconv
+
+    message = Message.model_construct(
+        id='test_id',
+        content=[
+            ThinkingBlock(signature='sig', thinking='First, I should reason through the request.', type='thinking'),
+            TextBlock(text='Final answer', type='text'),
+        ],
+        model='claude-3-haiku-20240307',
+        role='assistant',
+        type='message',
+        stop_reason='end_turn',
+        usage=Usage(input_tokens=2, output_tokens=3),
+    )
+
+    assert convert_response_to_semconv(message) == snapshot(
+        {
+            'role': 'assistant',
+            'parts': [
+                {'type': 'reasoning', 'content': 'First, I should reason through the request.'},
+                {'type': 'text', 'content': 'Final answer'},
+            ],
+            'finish_reason': 'end_turn',
+        }
+    )
+
+
 def test_on_response_unknown_block_type() -> None:
     """Test on_response with a block that's neither text nor tool_use."""
     from logfire._internal.integrations.llm_providers.anthropic import on_response
@@ -1274,6 +1304,49 @@ def test_on_response_unknown_block_type() -> None:
 
     assert span.attributes.get('response_data') == snapshot(
         {'message': {'role': 'assistant', 'content': 'Hello'}, 'usage': Usage(input_tokens=2, output_tokens=3)}
+    )
+
+
+def test_on_response_with_thinking_block_legacy_response_data() -> None:
+    """Legacy Anthropic response_data should preserve thinking blocks."""
+    from logfire._internal.integrations.llm_providers.anthropic import on_response
+
+    message = Message.model_construct(
+        id='test_id',
+        content=[
+            ThinkingBlock(signature='sig', thinking='Need to inspect the tool result first.', type='thinking'),
+            TextBlock(text='Done', type='text'),
+        ],
+        model='claude-3-haiku-20240307',
+        role='assistant',
+        type='message',
+        stop_reason='end_turn',
+        usage=Usage(input_tokens=2, output_tokens=3),
+    )
+
+    class MockSpan:
+        def __init__(self):
+            self.attributes: dict[str, Any] = {}
+
+        def set_attribute(self, key: str, value: Any) -> None:
+            self.attributes[key] = value
+
+        def set_attributes(self, attributes: dict[str, Any]) -> None:
+            for key, value in attributes.items():
+                self.set_attribute(key, value)
+
+    span = MockSpan()
+    on_response(message, span, version=1)  # type: ignore
+
+    assert span.attributes.get('response_data') == snapshot(
+        {
+            'message': {
+                'role': 'assistant',
+                'reasoning': ['Need to inspect the tool result first.'],
+                'content': 'Done',
+            },
+            'usage': Usage(input_tokens=2, output_tokens=3),
+        }
     )
 
 


### PR DESCRIPTION
## Summary
- map Anthropic `thinking` / `beta thinking` blocks to Logfire semconv `reasoning` parts
- preserve Anthropic thinking content in legacy `response_data.message` for the default instrumentation path
- add regression coverage for both the semconv conversion helper and legacy response payload

## Why
Fixes the missing Anthropic thinking-block capture behind issue #1737, where extended/interleaved thinking content was not preserved cleanly in Logfire's output span data.

## Validation
- direct Python smoke check for `convert_response_to_semconv(...)` and `on_response(..., version=1)` with `ThinkingBlock`
- `git diff --check`

## Environment limits
- `pytest tests/otel_integrations/test_anthropic.py ...` is currently blocked in this environment by an import-time `PendingDeprecationWarning` from the MCP test bootstrap (`python_multipart` / `multipart`)
- `python -m compileall ...` hit local `OSError: [Errno 28] No space left on device`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

