### PR TITLE
docs: improve discoverability of alternative OTel backends and clients

### DIFF
--- a/docs/how-to-guides/alternative-backends.md
+++ b/docs/how-to-guides/alternative-backends.md
@@ -6,7 +6,7 @@ description: Learn how to connect Logfire to any backend that supports OpenTelem
 
 **Logfire** uses the OpenTelemetry standard. This means that you can configure the SDK to export to any backend that supports OpenTelemetry.
 
-This page is for sending Logfire data to an **alternative observability backend / OTLP server** (Jaeger, Grafana Tempo, collector, self-hosted OpenTelemetry stack, etc.) instead of — or in addition to — the Logfire cloud service.
+This page is for sending Logfire data to an **alternative observability backend / OpenTelemetry Protocol (OTLP) server** (Jaeger, Grafana Tempo, collector, self-hosted OpenTelemetry stack, etc.) instead of, or in addition to, the Logfire cloud service.
 
 Looking for the inverse direction (standard OpenTelemetry SDKs in other languages writing *into* Logfire)? See [Alternative clients](./alternative-clients.md).
 

--- a/docs/how-to-guides/alternative-backends.md
+++ b/docs/how-to-guides/alternative-backends.md
@@ -6,6 +6,10 @@ description: Learn how to connect Logfire to any backend that supports OpenTelem
 
 **Logfire** uses the OpenTelemetry standard. This means that you can configure the SDK to export to any backend that supports OpenTelemetry.
 
+This page is for sending Logfire data to an **alternative observability backend / OTLP server** (Jaeger, Grafana Tempo, collector, self-hosted OpenTelemetry stack, etc.) instead of — or in addition to — the Logfire cloud service.
+
+Looking for the inverse direction (standard OpenTelemetry SDKs in other languages writing *into* Logfire)? See [Alternative clients](./alternative-clients.md).
+
 The easiest way is to set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to a URL that points to your backend.
 This will be used as a base, and the SDK will append `/v1/traces` and `/v1/metrics` to the URL to send traces and metrics, respectively.
 

--- a/docs/how-to-guides/alternative-clients.md
+++ b/docs/how-to-guides/alternative-clients.md
@@ -1,11 +1,11 @@
 ---
-title: Logfire OTel Integration with Alternative Clients
+title: Logfire OpenTelemetry Integration with Alternative Clients
 description: "Guide on how to use the standard OpenTelemetry SDK to export Node.js, Rust or Go data to Logfire."
 ---
 # Alternative clients
 
 **Logfire** uses the OpenTelemetry standard. This means that you can configure standard **OpenTelemetry client SDKs**
-in many languages (Node.js, Go, Rust, Java, …) to export telemetry to the **Logfire** backend / OTLP server endpoint, including those outside our
+in many languages (Node.js, Go, Rust, Java, and others) to export telemetry to the **Logfire** backend / OpenTelemetry Protocol (OTLP) server endpoint, including those outside our
 [first-class supported languages](../languages.md).
 
 If instead you want Logfire's Python SDK to export to a different backend or collector server, see [Alternative backends](./alternative-backends.md).

--- a/docs/how-to-guides/alternative-clients.md
+++ b/docs/how-to-guides/alternative-clients.md
@@ -4,9 +4,13 @@ description: "Guide on how to use the standard OpenTelemetry SDK to export Node.
 ---
 # Alternative clients
 
-**Logfire** uses the OpenTelemetry standard. This means that you can configure standard OpenTelemetry SDKs
-in many languages to export to the **Logfire** backend, including those outside our
-[first-class supported languages](../languages.md). Depending on your SDK, you may need to set only
+**Logfire** uses the OpenTelemetry standard. This means that you can configure standard **OpenTelemetry client SDKs**
+in many languages (Node.js, Go, Rust, Java, …) to export telemetry to the **Logfire** backend / OTLP server endpoint, including those outside our
+[first-class supported languages](../languages.md).
+
+If instead you want Logfire's Python SDK to export to a different backend or collector server, see [Alternative backends](./alternative-backends.md).
+
+Depending on your SDK, you may need to set only
 these [environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/):
 
 - `OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev` for both traces and metrics, or:

--- a/docs/why.md
+++ b/docs/why.md
@@ -178,7 +178,11 @@ Learn more about the [Pydantic Plugin here](integrations/pydantic.md).
 
 Because **Pydantic Logfire** is built on [OpenTelemetry](https://opentelemetry.io/), you can
 use a wealth of existing tooling and infrastructure, including
-[instrumentation for many common Python packages](https://opentelemetry-python-contrib.readthedocs.io/en/latest/index.html). Logfire also supports cross-language data integration and data export to any OpenTelemetry-compatible backend or proxy.
+[instrumentation for many common Python packages](https://opentelemetry-python-contrib.readthedocs.io/en/latest/index.html).
+
+**Cross-language / alternative clients:** use standard OpenTelemetry SDKs in other languages as clients that export into Logfire — see [Alternative clients](how-to-guides/alternative-clients.md).
+
+**Alternative backends / OTLP servers:** export Logfire (or any OTel) data to Jaeger, Grafana, collectors, or another OpenTelemetry-compatible backend — see [Alternative backends](how-to-guides/alternative-backends.md).
 
 For example, we can instrument a simple FastAPI app with just 2 lines of code:
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -180,9 +180,9 @@ Because **Pydantic Logfire** is built on [OpenTelemetry](https://opentelemetry.i
 use a wealth of existing tooling and infrastructure, including
 [instrumentation for many common Python packages](https://opentelemetry-python-contrib.readthedocs.io/en/latest/index.html).
 
-**Cross-language / alternative clients:** use standard OpenTelemetry SDKs in other languages as clients that export into Logfire — see [Alternative clients](how-to-guides/alternative-clients.md).
+**Cross-language / alternative clients:** use standard OpenTelemetry SDKs in other languages as clients that export into Logfire. See [Alternative clients](how-to-guides/alternative-clients.md).
 
-**Alternative backends / OTLP servers:** export Logfire (or any OTel) data to Jaeger, Grafana, collectors, or another OpenTelemetry-compatible backend — see [Alternative backends](how-to-guides/alternative-backends.md).
+**Alternative backends / OpenTelemetry Protocol (OTLP) servers:** export Logfire (or any OpenTelemetry) data to Jaeger, Grafana, collectors, or another OpenTelemetry-compatible backend. See [Alternative backends](how-to-guides/alternative-backends.md).
 
 For example, we can instrument a simple FastAPI app with just 2 lines of code:
 


### PR DESCRIPTION
## Summary

Improves docs discoverability for alternative OpenTelemetry backends and clients (#484):

1. **Alternative backends** — lead-in now explicitly mentions "OTLP server" / Jaeger / Grafana / collector so "server" searches hit the page; cross-links to alternative clients.
2. **Alternative clients** — lead-in emphasizes OpenTelemetry client SDKs (Node/Go/Rust/Java) writing *into* Logfire; cross-links to alternative backends.
3. **Why Logfire → OpenTelemetry** — splits the vague "cross-language data integration" line into two clear bullets with links to both guides.

## Testing

- Docs-only change; reviewed rendered markdown and internal relative links.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

