### PR TITLE
Rename Explore to SQL Workbench in docs

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -216,7 +216,7 @@ When you're iterating on AI applications with a coding agent, the agent needs to
 
 *Logfire uses [Apache DataFusion](https://datafusion.apache.org/) as its query engine, with syntax designed to match PostgreSQL conventions.*
 
-[SQL Explorer](guides/web-ui/explore.md)
+[SQL Workbench](guides/web-ui/explore.md)
 
 ---
 

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -41,9 +41,9 @@ Note that:
 2. Spans have a start and an end time, and thus a duration. This span took 3 seconds to complete.
 3. For logs, the start and end time are the same, so they don't have a duration. But you can still see in the UI that the log was created 1 second after the span started and 2 seconds before it ended.
 
-If you click on the 'Explore' link in the top navbar, you can write SQL to explore further, e.g:
+If you click on the **SQL Workbench** link in the top navbar, you can write SQL to explore further, e.g:
 
-![Query in Explore view: select extract('seconds' from end_timestamp - start_timestamp) as duration, kind, message, trace_id, span_id, parent_span_id from records order by start_timestamp ](../../images/guide/manual-tracing-explore-basic.png)
+![Query in SQL Workbench: select extract('seconds' from end_timestamp - start_timestamp) as duration, kind, message, trace_id, span_id, parent_span_id from records order by start_timestamp ](../../images/guide/manual-tracing-explore-basic.png)
 
 Note:
 
@@ -90,7 +90,7 @@ for name in ['Alice', 'Bob', 'Carol']:
     logfire.info('Hello {name}', name=name)
 ```
 
-![Query in Explore view: select span_name, attributes->>'name' as name, message from records order by start_timestamp](../../images/guide/manual-tracing-span-names.png)
+![Query in SQL Workbench: select span_name, attributes->>'name' as name, message from records order by start_timestamp](../../images/guide/manual-tracing-span-names.png)
 
 Here you can see that:
 

--- a/docs/guides/web-ui/explore.md
+++ b/docs/guides/web-ui/explore.md
@@ -1,11 +1,11 @@
 ---
-title: "Logfire SQL Explorer: Query & Inspect Your Data"
-description: Run arbitrary SQL queries against traces and metric data. Use the Logfire SQL Explorer to investigate and analyze records.
+title: "Logfire SQL Workbench: Query & Inspect Your Data"
+description: Run arbitrary SQL queries against traces and metric data. Use the Logfire SQL Workbench to investigate and analyze records.
 ---
-With **Logfire**, you can use the Explore page to run arbitrary SQL queries against your trace and metric data to
+With **Logfire**, you can use SQL Workbench to run arbitrary SQL queries against your trace and metric data to
 analyze and investigate your system.
 
-![Logfire explore screen](../../images/guide/browser-explore-full.png)
+![Logfire SQL Workbench](../../images/guide/browser-explore-full.png)
 
 ## Querying Traces
 
@@ -118,11 +118,11 @@ for the full list of metric functions.
 
 To execute a query, type or paste it into the query editor and click the "Run Query" button.
 
-![Logfire explore screen](../../images/guide/browser-explore-run-query.png)
+![Logfire SQL Workbench running a query](../../images/guide/browser-explore-run-query.png)
 
 You can modify the time range of the query using the dropdown next to the button. There is also a "Limit" dropdown that
 controls the maximum number of result rows returned.
 
-The Explore page provides a flexible interface to query your traces and metrics using standard SQL.
+SQL Workbench provides a flexible interface to query your traces and metrics using standard SQL.
 
 Happy querying! :rocket:

--- a/docs/guides/web-ui/kubernetes.md
+++ b/docs/guides/web-ui/kubernetes.md
@@ -96,7 +96,7 @@ If you have not set anything up yet, the empty state on each tab has a **Set up*
 
 ## Where Kubernetes events surface today
 
-The chart's `kubernetesEvents` preset turns Kubernetes events (pod scheduling, OOMKills, image pull failures, deployment progress) into log records via the `k8sobjects` receiver and ships them to your project. There is no dedicated **Events** tab in the Kubernetes view yet. To read them, open the [Live View](live.md) and filter on the relevant pod, namespace or `k8s.*` attribute, or query the `records` table directly in the [SQL Explorer](explore.md). Watch this space. An events feed in the Kubernetes view is in our backlog.
+The chart's `kubernetesEvents` preset turns Kubernetes events (pod scheduling, OOMKills, image pull failures, deployment progress) into log records via the `k8sobjects` receiver and ships them to your project. There is no dedicated **Events** tab in the Kubernetes view yet. To read them, open the [Live View](live.md) and filter on the relevant pod, namespace or `k8s.*` attribute, or query the `records` table directly in [SQL Workbench](explore.md). Watch this space. An events feed in the Kubernetes view is in our backlog.
 
 ## Troubleshooting
 

--- a/docs/guides/web-ui/live.md
+++ b/docs/guides/web-ui/live.md
@@ -25,7 +25,7 @@ As the greyed out `SELECT * FROM RECORDS WHERE` implies, you're searching inside
 It has auto-complete & schema hints, so try typing something to get a reminder. To run your query click `Run` or
 keyboard shortcut `cmd+enter` (or `ctrl+enter` on Windows/Linux).
 
-Note: you can run more complex queries on the [explore screen](explore.md)
+Note: you can run more complex queries in [SQL Workbench](explore.md).
 
 The records table fields are documented in the [SQL reference](../../reference/sql.md).
 

--- a/docs/guides/web-ui/llms.md
+++ b/docs/guides/web-ui/llms.md
@@ -134,7 +134,7 @@ Refresh the LLMs page. A row for `gpt-4o-mini` (provider `openai`) should appear
 
 ## Slicing by environment, agent or user
 
-The inventory groups rows by `(provider, model)`. Beyond the text search at the top, there are no dropdowns for filtering by environment, agent or user *on this page yet*. For per-environment, per-agent, per-user, per-feature or per-tenant breakdowns, query the `records` table directly in the [SQL Explorer](explore.md). Every GenAI span carries the `gen_ai.*` attributes alongside `deployment.environment.name` and any custom resource attributes you've set, so you can slice cost, latency or token usage by whatever dimension matters.
+The inventory groups rows by `(provider, model)`. Beyond the text search at the top, there are no dropdowns for filtering by environment, agent or user *on this page yet*. For per-environment, per-agent, per-user, per-feature or per-tenant breakdowns, query the `records` table directly in [SQL Workbench](explore.md). Every GenAI span carries the `gen_ai.*` attributes alongside `deployment.environment.name` and any custom resource attributes you've set, so you can slice cost, latency or token usage by whatever dimension matters.
 
 ## Troubleshooting
 

--- a/docs/guides/web-ui/metrics-explorer.md
+++ b/docs/guides/web-ui/metrics-explorer.md
@@ -29,7 +29,7 @@ Step 3 shows you a small chart per dimension (label) on the metric, with the car
 Each card has:
 
 - **View SQL**: opens a dialog with the exact SQL that produced the chart. Copy it for a dashboard, or send it to a teammate.
-- **Open in Explore**: drops you into the [SQL Explorer](explore.md) with that query already populated, so you can extend it.
+- **Open in SQL Workbench**: opens [SQL Workbench](explore.md) with that query already populated, so you can extend it.
 
 Aggregations default sensibly by metric kind, with the rest available from the dropdown:
 
@@ -41,11 +41,11 @@ Aggregations default sensibly by metric kind, with the rest available from the d
 | Exponential histogram | `avg` | `avg`, `sum`, `min`, `max`, `count` |
 
 !!! note "Percentiles on histograms"
-    The wizard does not expose `p50`/`p95`/`p99` directly on histogram-typed metrics today: pre-aggregated histograms (e.g. `http.server.request.duration` from OTel SDK instrumentations) report `avg`, `min`, `max`, `count` and `sum` in the wizard. For percentiles over a histogram, switch to the [SQL Explorer](explore.md) and use the histogram bucket columns; the **Open in Explore** button on every card hands you a query you can extend.
+    The wizard does not expose `p50`/`p95`/`p99` directly on histogram-typed metrics today: pre-aggregated histograms (e.g. `http.server.request.duration` from OTel SDK instrumentations) report `avg`, `min`, `max`, `count` and `sum` in the wizard. For percentiles over a histogram, switch to [SQL Workbench](explore.md) and use the histogram bucket columns; the **Open in SQL Workbench** button on every card hands you a query you can extend.
 
 ## When the wizard isn't enough
 
-The wizard is for discovery. The [SQL Explorer](explore.md) is for the real work. The **View SQL** and **Open in Explore** buttons on every card are the on-ramp between them, so you can do as much as the wizard handles and graduate without retyping anything.
+The wizard is for discovery. [SQL Workbench](explore.md) is for the real work. The **View SQL** and **Open in SQL Workbench** buttons on every card are the on-ramp between them, so you can do as much as the wizard handles and graduate without retyping anything.
 
 The columns you see in the wizard live on the `metrics` table; the full schema is in the [SQL reference](../../reference/sql.md).
 
@@ -96,4 +96,4 @@ Refresh the Metrics view. `hello` appears in **Recently active** and as its own 
 | Custom metric lands in **Everything else** instead of its own namespace | The metric name has no dot (e.g. `requests_total` instead of `app.requests.total`). The grouping is structural: give the name a dotted prefix to create a namespace. |
 | Step 1 shows no namespaces at all | The project hasn't received any metric samples yet. The wizard reads from `metrics`-table data; if you're sending only spans, no namespaces will appear here. |
 | Two metric sources show up under `system.*` with overlapping series | The SDK's [system-metrics integration](../../integrations/system-metrics.md) and an OpenTelemetry Collector running `hostmetricsreceiver` are both running on the same host. See the [double-counting note](#how-the-data-flows-in). |
-| Promoting a dimension shows fewer series than the cardinality card claimed | The chart truncates after a fixed number of series. For full breakdowns of a high-cardinality dimension, jump into the [SQL Explorer](explore.md) via the **Open in Explore** button on the card. |
+| Promoting a dimension shows fewer series than the cardinality card claimed | The chart truncates after a fixed number of series. For full breakdowns of a high-cardinality dimension, open [SQL Workbench](explore.md) from the **Open in SQL Workbench** button on the card. |

--- a/docs/guides/web-ui/saved-searches.md
+++ b/docs/guides/web-ui/saved-searches.md
@@ -88,5 +88,5 @@ flowchart TD
 
 **Next Steps:**
 
-- [Explore more about querying with SQL](explore.md)
+- [Learn more about querying with SQL](explore.md)
 - [Learn about dashboards and alerts](dashboards.md), (alerts.md)

--- a/docs/guides/web-ui/services.md
+++ b/docs/guides/web-ui/services.md
@@ -6,7 +6,7 @@ description: "Browse every service shipping spans to your Logfire project. See r
 
 The **Services view** is the entry point for finding the service you want to investigate. Each service that ships spans to your project appears as one row, sorted by whatever metric matters right now (requests, error rate, latency). Click a row to drill into its detail page, click a recent failed trace, and you land in the [Live View](live.md) with the failing trace open.
 
-You'll find Services in the project sidebar, between [Explore](explore.md) and [Hosts](hosts.md).
+You'll find Services in the project sidebar, between [SQL Workbench](explore.md) and [Hosts](hosts.md).
 
 ![Services inventory page](../../images/services/inventory.png)
 
@@ -36,7 +36,7 @@ You'll see:
 - **Top operations**: the highest-traffic and slowest spans inside the service.
 - **Recent errors**: a short list of failed traces, each linking straight to the [Live View](live.md) so you can investigate.
 
-Two buttons in the header ([Live view](live.md) and [Explore](explore.md)) hand the whole service off to the live view or the SQL editor in one click. The detail page defaults to the last 30 minutes.
+Two buttons in the header ([Live view](live.md) and [SQL Workbench](explore.md)) hand the whole service off to the live view or SQL Workbench in one click. The detail page defaults to the last 30 minutes.
 
 The topology graph and the operations / errors tables below the trends:
 

--- a/docs/how-to-guides/environments.md
+++ b/docs/how-to-guides/environments.md
@@ -30,7 +30,7 @@ Once set, you will see your environment in the environment picker in the Logfire
 The picker lives in the side navigation, directly below the project picker, and reads
 `all envs` until you narrow it down. It applies to observability pages like
 [Live View](../guides/web-ui/live.md), [Dashboards](../guides/web-ui/dashboards.md)
-and [Explore](../guides/web-ui/explore.md) (on pages where environments don't apply,
+and [SQL Workbench](../guides/web-ui/explore.md) (on pages where environments don't apply,
 the picker is shown disabled):
 
 ![Environments](../images/guide/environments.png)
@@ -46,7 +46,7 @@ Note that by default there are system generated environments:
 So `env not specified` is a subset of `all envs`.
 
 Any environments you create via the SDK will appear below the system generated environments.
-When you select an environment, all subsequent queries (e.g. on live view, dashboards or explore)
+When you select an environment, all subsequent queries (e.g. in Live view, Dashboards, or SQL Workbench)
 will filter by that environment. You can select more than one environment at a time, and
 hovering an environment reveals a pin icon to save it as your personal default for the
 project: that default is applied whenever you open the project.

--- a/docs/how-to-guides/otel-collector/host-monitoring.md
+++ b/docs/how-to-guides/otel-collector/host-monitoring.md
@@ -4,7 +4,7 @@ description: "Ship CPU, memory, disk, filesystem, network, and process metrics f
 ---
 # Host monitoring with the OTel Collector
 
-The OpenTelemetry Collector's [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) reads CPU, memory, disk, filesystem, network, paging and process metrics from the machine the Collector is running on and ships them to Logfire: no SDK required, no application changes. Hosts reporting these metrics show up on the **Hosts** page in Logfire, and the metric series are queryable in **Metrics**, **Explore**, and any dashboard you build on top of them.
+The OpenTelemetry Collector's [`hostmetrics` receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver) reads CPU, memory, disk, filesystem, network, paging and process metrics from the machine the Collector is running on and ships them to Logfire: no SDK required, no application changes. Hosts reporting these metrics show up on the **Hosts** page in Logfire, and the metric series are queryable in **Metrics**, **SQL Workbench**, and any dashboard you build on top of them.
 
 This is also the smallest possible working Collector configuration. The same shape works whether the Collector runs as a daemon on a bare VM, a sidecar next to your app, or a DaemonSet in Kubernetes; only the deployment wrapper changes.
 
@@ -272,7 +272,7 @@ For long-running deployments, wrap that in a systemd unit (or your init system o
 Within a minute or two of the Collector starting, the host shows up on the **Hosts** page keyed by `host.name`. From there:
 
 - Click the host to drill into per-host CPU, memory, disk, and network charts.
-- Open **Explore** to query the raw metric series: useful for ad-hoc questions like "show me every host where filesystem utilization is above 90%".
+- Open **SQL Workbench** to query the raw metric series: useful for ad-hoc questions like "show me every host where filesystem utilization is above 90%".
 - Build a dashboard on top of the metrics if you want a persistent view.
 
 If a host doesn't appear, the cause is almost always one of: missing `resourcedetection` (no `host.name`), wrong region in the `otlphttp` endpoint, or (in Kubernetes) a missing `root_path: /host` or one of the `hostPath` mounts, so the receiver is happily scraping the container's view instead of the node's.

--- a/docs/how-to-guides/otel-collector/s3-backup.md
+++ b/docs/how-to-guides/otel-collector/s3-backup.md
@@ -20,7 +20,7 @@ OpenTelemetry Collector, which will then forward the data to AWS S3.
 
 The pattern this page sets up is **dual-export**: every span, metric, and log is sent to *both* Logfire and S3 from the same Collector pipeline.
 
-- **Logfire** is your live querying surface. The UI, dashboards, alerts, and the Explore page all read from Logfire's backend.
+- **Logfire** is your live querying surface. The UI, dashboards, alerts, and SQL Workbench all read from Logfire's backend.
 - **S3** is the cold archive. Objects sit there cheaply for as long as your bucket policy keeps them, and you reach for them only when you need to audit, replay, or analyze data older than Logfire's retention window.
 
 You do not query S3 live. When you need archived data, you spin up a second Collector with the [`awss3receiver`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awss3receiver) and replay a time range into whatever destination you want: for example, back into Logfire under a different project, into a local file, or into another OTel-compatible tool.

--- a/docs/how-to-guides/write-dashboard-queries.md
+++ b/docs/how-to-guides/write-dashboard-queries.md
@@ -4,7 +4,7 @@ description: "Practical recipes and patterns for writing SQL queries in Logfire 
 ---
 # Writing SQL Queries for Dashboards
 
-This guide provides practical recipes and patterns for writing useful SQL queries in **Logfire**. We'll focus on querying the [`records`](../reference/sql.md#records-columns) table, which contains your logs and spans. The goal is to help you create useful dashboards, but we recommend using the Explore view to learn and experiment.
+This guide provides practical recipes and patterns for writing useful SQL queries in **Logfire**. We'll focus on querying the [`records`](../reference/sql.md#records-columns) table, which contains your logs and spans. The goal is to help you create useful dashboards, but we recommend using SQL Workbench to learn and experiment.
 
 For a complete list of available tables and columns, please see the [SQL Reference](../reference/sql.md).
 
@@ -12,7 +12,7 @@ For a complete list of available tables and columns, please see the [SQL Referen
 
 ### Simple examples
 
-Here are two quick useful examples to try out immediately in the Explore view.
+Here are two quick useful examples to try out immediately in SQL Workbench.
 
 To find the most common operations based on [`span_name`](../reference/sql.md#span_name):
 
@@ -66,7 +66,7 @@ LIMIT 10
 - The alias `AS count` allows us to refer to the count in the `ORDER BY` clause.
 - `ORDER BY count DESC` sorts the results to show the most common groups first.
 - `WHERE <filter_conditions>` is optional and depends on your specific use case.
-- `LIMIT 10` isn't usually needed in the Explore view, but is helpful when creating charts.
+- `LIMIT 10` isn't usually needed in SQL Workbench, but is helpful when creating charts.
 - `<columns_to_group_by>` can be one or more columns and should be the same in the `SELECT` and `GROUP BY` clauses.
 
 ### Useful things to group by
@@ -194,7 +194,7 @@ FROM records
 GROUP BY x
 ```
 
-Here the `time_bucket($resolution, start_timestamp)` is essential. [`$resolution` is a special variable that exists in all dashboards](../guides/web-ui/dashboards.md#resolution-variable) and adjusts automatically based on the time range. You can adjust it while viewing the dashboard using the dropdown in the top left corner. It doesn't exist in the Explore view, so you have to use a concrete interval like `time_bucket('1 hour', start_timestamp)` there. Tick **Show rendered query** in the panel editor to fill in the resolution and other variables so that you can copy the query to the Explore view.
+Here the `time_bucket($resolution, start_timestamp)` is essential. [`$resolution` is a special variable that exists in all dashboards](../guides/web-ui/dashboards.md#resolution-variable) and adjusts automatically based on the time range. You can adjust it while viewing the dashboard using the dropdown in the top left corner. It doesn't exist in SQL Workbench, so you have to use a concrete interval like `time_bucket('1 hour', start_timestamp)` there. Tick **Show rendered query** in the panel editor to fill in the resolution and other variables so that you can copy the query to SQL Workbench.
 
 !!! warning
     If you're querying `metrics`, use `recorded_timestamp` instead of `start_timestamp`.
@@ -358,7 +358,7 @@ ORDER BY x
 
 ## Linking to the Live view
 
-While aggregating data with `GROUP BY` is powerful for seeing trends, sometimes you need to investigate specific events, like a single slow operation or a costly API call. In these cases, it's good to include the [`trace_id`](../reference/sql.md#trace_id) column in your `SELECT` clause. Tables in dashboards, the explore view, or alert run results with this column will render the `trace_id` values as clickable links to the Live View.
+While aggregating data with `GROUP BY` is powerful for seeing trends, sometimes you need to investigate specific events, like a single slow operation or a costly API call. In these cases, it's good to include the [`trace_id`](../reference/sql.md#trace_id) column in your `SELECT` clause. Tables in dashboards, SQL Workbench, or alert run results with this column will render the `trace_id` values as clickable links to the Live View.
 
 For example, to find the 10 slowest spans in your system, you can create a 'Table' panel with this query:
 

--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -49,7 +49,7 @@ Your metrics then show up in several places in the Logfire UI:
   [use it as a template](../guides/web-ui/dashboards.md#using-a-standard-dashboard-as-a-template) for a custom
   dashboard.
 
-You can also query the metrics directly in the [Explore](../guides/web-ui/explore.md) view via the `metrics`
+You can also query the metrics directly in [SQL Workbench](../guides/web-ui/explore.md) via the `metrics`
 table (see the [SQL reference](../reference/sql.md)).
 
 ## Verify it worked

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -177,7 +177,7 @@
       { "label": "Metrics Explorer", "slug": "guides/web-ui/metrics-explorer" },
       { "label": "LLM Panels", "slug": "guides/web-ui/llm-panels" },
       { "label": "Dashboards", "slug": "guides/web-ui/dashboards" },
-      { "label": "SQL Explorer", "slug": "guides/web-ui/explore" },
+      { "label": "SQL Workbench", "slug": "guides/web-ui/explore" },
       { "label": "Issues", "slug": "guides/web-ui/issues" },
       { "label": "Alerts", "slug": "guides/web-ui/alerts" },
       { "label": "Saved Searches", "slug": "guides/web-ui/saved-searches" },

--- a/docs/reference/advanced/metrics-in-spans.md
+++ b/docs/reference/advanced/metrics-in-spans.md
@@ -46,7 +46,7 @@ with logfire.span('doing stuff'):
 ```
 
 The `doing stuff` span will now contain a `logfire.metrics` attribute that holds the aggregated total of the `my_amount` counter, i.e. `3`.
-Running the following query in the Explore view:
+Running the following query in SQL Workbench:
 
 ```sql
 SELECT attributes->>'logfire.metrics'->>'my_amount'->>'total' AS total_amount

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -14,7 +14,7 @@ Data is stored in two main tables: `records` and `metrics`.
 
 `records` is the table you'll usually care about and is what you'll see in the Live View. Each row in `records` is a span or log (essentially a span with no duration). A _trace_ is a collection of spans that share the same `trace_id`, structured as a tree.
 
-`metrics` contains pre-aggregated numerical data which is usually more efficient to query than `records` for certain use cases. There's currently no dedicated UI for metrics, but you can query it directly using SQL in the Explore view, Dashboards, Alerts, or the API, just like you would with `records`.
+`metrics` contains pre-aggregated numerical data which is usually more efficient to query than `records` for certain use cases. There's currently no dedicated UI for metrics, but you can query it directly using SQL in SQL Workbench, Dashboards, Alerts, or the API, just like you would with `records`.
 
 Technically `records` is a subset, the full table is called `records_all` which includes additional rows called pending spans, but you can ignore that for most use cases.
 
@@ -36,9 +36,9 @@ You will see this in the Live view:
 
 ![Basic columns example in the live view](../images/sql-reference/basic-columns-live.png)
 
-Here's an example of querying in the Explore view:
+Here's an example of querying in SQL Workbench:
 
-![Basic columns example in the explore view](../images/sql-reference/basic-columns-explore.png)
+![Basic columns example in SQL Workbench](../images/sql-reference/basic-columns-explore.png)
 
 #### `span_name`
 
@@ -105,7 +105,7 @@ The default level for spans is `info`, but can be higher in some cases:
 
 You can convert level names to numbers using the `level_num` SQL function, e.g. `level_num('warn')` returns `13`.
 
-You can also use the `level_name` SQL function to convert numbers to names, e.g. `SELECT level_name(level), ...` to see a human-readable level in the Explore view.
+You can also use the `level_name` SQL function to convert numbers to names, e.g. `SELECT level_name(level), ...` to see a human-readable level in SQL Workbench.
 
 The numerical values are based on the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber). Some common values: `info` is `9`, `warn` is `13`, and `error` is `17`.
 
@@ -119,7 +119,7 @@ This is a unique identifier for the trace that this span/log belongs to.
 
 A trace is a collection of one or more records that share the same `trace_id`, structured as a tree. It typically represents one high level operation such as an HTTP server request or a batch job.
 
-If you query individual records in the explore view, dashboard tables, or alerts, we recommend including `trace_id` in the `SELECT` clause. The values will become clickable links in the UI that will take you to the Live view filtered by that trace, making it easy to explore a record in context. For alerts sent as slack messages, note that this doesn't apply to the slack message itself, but the title of the slack message will link to the alert run results in the UI, and the table there will have clickable `trace_id` links.
+If you query individual records in SQL Workbench, dashboard tables, or alerts, we recommend including `trace_id` in the `SELECT` clause. The values will become clickable links in the UI that will take you to the Live view filtered by that trace, making it easy to explore a record in context. For alerts sent as slack messages, note that this doesn't apply to the slack message itself, but the title of the slack message will link to the alert run results in the UI, and the table there will have clickable `trace_id` links.
 
 Technically the trace ID is a 128-bit (16 byte) integer, but in the database it's represented as a 32-character hexadecimal string. For example, the following code:
 
@@ -189,7 +189,7 @@ This is the time shown on the left side of the list of records in the Live view.
 
 All views in the UI have some time range dropdown that filters on this column, so you usually don't have to. For example, in the Live view the default is set to 'Last 5 minutes'. But if you wanted to do this manually in SQL, you could use a `WHERE` clause like `start_timestamp >= now() - interval '5 minutes'`.
 
-In dashboard queries, a time series chart querying `records` should have `time_bucket($resolution, start_timestamp)` in the `SELECT` clause, which will be used as the x-axis. `$resolution` is a variable that will be replaced with the time resolution of the dashboard, e.g. `1 minute`. This variable doesn't exist outside of dashboards, so if you want to copy a query from a dashboard to the Explore view, tick 'Show rendered query' first. This will fill in the variable with the actual value, e.g. `time_bucket('1 minute', start_timestamp)`.
+In dashboard queries, a time series chart querying `records` should have `time_bucket($resolution, start_timestamp)` in the `SELECT` clause, which will be used as the x-axis. `$resolution` is a variable that will be replaced with the time resolution of the dashboard, e.g. `1 minute`. This variable doesn't exist outside of dashboards, so if you want to copy a query from a dashboard to SQL Workbench, tick 'Show rendered query' first. This will fill in the variable with the actual value, e.g. `time_bucket('1 minute', start_timestamp)`.
 
 !!! warning
     Prefer this column over `created_at`, which is an internal timestamp representing when the record was created in the database.

--- a/docs/why.md
+++ b/docs/why.md
@@ -280,7 +280,7 @@ FROM records
 WHERE attributes->'result'->>'country_code' = 'USA';
 ```
 
-![Logfire explore query screenshot](images/index/logfire-screenshot-explore-query.png)
+![Logfire SQL Workbench query screenshot](images/index/logfire-screenshot-explore-query.png)
 
 You can also filter to show only traces related to users in the USA in the live view with
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -220,7 +220,7 @@ nav:
           - Metrics explorer: guides/web-ui/metrics-explorer.md
           - LLM Panels: guides/web-ui/llm-panels.md
           - Dashboards: guides/web-ui/dashboards.md
-          - SQL Explorer: guides/web-ui/explore.md
+          - SQL Workbench: guides/web-ui/explore.md
           - Issues: guides/web-ui/issues.md
           - Alerts: guides/web-ui/alerts.md
           - Saved Searches: guides/web-ui/saved-searches.md


### PR DESCRIPTION
## Summary

- Rename the SQL querying surface from Explore and SQL Explorer to SQL Workbench across the docs.
- Update navigation, cross-links, action labels, metadata, and image alt text.
- Preserve the existing guides/web-ui/explore URL.

## Validation

- pre-commit run --files on all changed documentation files
- JSON validation for docs/nav.json
- Verified no stale product-name references remain

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

