### PR TITLE
Add capfire.reconfigure()

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -122,6 +122,7 @@ from .utils import (
     handle_internal_errors,
     platform_is_emscripten,
     suppress_instrumentation,
+    track_explicit_fields,
 )
 
 if TYPE_CHECKING:
@@ -178,6 +179,9 @@ class ConsoleOptions:
     """The output stream to write console output to (default: stdout)."""
 
 
+# `track_explicit_fields` lets `logfire.testing.CaptureLogfire.reconfigure` merge a user-supplied
+# instance with its own defaults without silently dropping fields explicitly set to a default value.
+@track_explicit_fields
 @dataclass
 class AdvancedOptions:
     """Options primarily used for testing by Logfire developers."""
@@ -300,6 +304,8 @@ class PydanticPlugin:
     """Exclude specific modules from instrumentation."""
 
 
+# See the comment on `AdvancedOptions`.
+@track_explicit_fields
 @dataclass
 class MetricsOptions:
     """Configuration of metrics."""

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import hashlib
 import inspect
@@ -390,6 +391,43 @@ def maybe_capture_server_headers(capture: bool):
 
 def is_asgi_send_receive_span_name(name: str) -> bool:
     return name.endswith((' http send', ' http receive', ' websocket send', ' websocket receive'))
+
+
+_EXPLICIT_FIELDS_ATTRIBUTE = '_logfire_explicit_fields'
+
+
+def track_explicit_fields(cls: type[T]) -> type[T]:
+    """Make a dataclass remember which fields were passed explicitly to `__init__`.
+
+    Options dataclasses have meaningful defaults, so code that merges a user-supplied instance with
+    its own values can't tell 'the caller left this field alone' from 'the caller passed a value
+    which happens to equal the default' just by looking at the values, and would silently discard
+    the latter. Instances of a decorated class record the names of the fields actually passed,
+    which `explicitly_set_fields` reads back.
+    """
+    original_init = cls.__init__
+    field_names = [f.name for f in dataclasses.fields(cast('Any', cls))]
+
+    @functools.wraps(original_init)
+    def __init__(self: Any, *args: Any, **kwargs: Any) -> None:
+        original_init(self, *args, **kwargs)
+        setattr(self, _EXPLICIT_FIELDS_ATTRIBUTE, frozenset((*field_names[: len(args)], *kwargs)))
+
+    cls.__init__ = __init__
+    return cls
+
+
+def explicitly_set_fields(obj: Any) -> frozenset[str]:
+    """The names of the fields explicitly passed when `obj` was constructed.
+
+    Only works for instances of classes decorated with `track_explicit_fields`. Other objects are
+    treated as fully specified, i.e. all their fields count as explicitly set, since there's no way
+    to tell which values the caller chose.
+    """
+    fields: frozenset[str] | None = getattr(obj, _EXPLICIT_FIELDS_ATTRIBUTE, None)
+    if fields is None:  # pragma: no cover
+        return frozenset(f.name for f in dataclasses.fields(obj))
+    return fields
 
 
 def _default_ms_timestamp_generator() -> int:

--- a/logfire/testing.py
+++ b/logfire/testing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from dataclasses import dataclass
 from typing import Any, cast
@@ -92,10 +93,95 @@ class CaptureLogfire:
     """The metric reader."""
     log_exporter: TestLogExporter
     """The log exporter."""
+    id_generator: IncrementalIdGenerator
+    """The id generator used by `capfire`."""
+    ns_timestamp_generator: TimeGenerator
+    """The timestamp generator used by `capfire`."""
 
     def get_collected_metrics(self):
         """Get the collected metrics as a list of dictionaries."""
         return get_collected_metrics(self.metrics_reader)
+
+    def reconfigure(self, **kwargs: Any) -> None:
+        """Reconfigure logfire from within a test, merging `kwargs` with the `capfire` defaults.
+
+        `additional_span_processors`, `advanced.log_record_processors`, and `metrics.additional_readers`
+        extend the capfire defaults. Other kwargs replace them. Pass `metrics=False` to disable metrics.
+
+        `exporter`, `log_exporter`, `id_generator`, and `ns_timestamp_generator` are reused as the base
+        values for the merge; if the user overrides `id_generator` or `ns_timestamp_generator` via
+        `advanced=`, the corresponding attribute on `self` is updated to reflect the new value.
+
+        `metrics_reader` is always replaced with a fresh `InMemoryMetricReader` (OTel forbids reusing one
+        across `MeterProvider` instances), so pre-reconfigure metrics are not queryable afterwards.
+        """
+        advanced = kwargs.pop('advanced', None)
+        metrics = kwargs.pop('metrics', None)
+        additional_span_processors = kwargs.pop('additional_span_processors', None)
+
+        self.metrics_reader = InMemoryMetricReader(preferred_temporality=METRICS_PREFERRED_TEMPORALITY)
+
+        base_advanced = logfire.AdvancedOptions(
+            id_generator=self.id_generator,
+            ns_timestamp_generator=self.ns_timestamp_generator,
+            log_record_processors=[SimpleLogRecordProcessor(self.log_exporter)],
+        )
+        base_metrics = logfire.MetricsOptions(additional_readers=[self.metrics_reader])
+
+        if advanced is None:
+            merged_advanced = base_advanced
+        else:
+            merged_advanced = _merge_dataclass(base_advanced, advanced, 'log_record_processors')
+            self.id_generator = merged_advanced.id_generator
+            self.ns_timestamp_generator = merged_advanced.ns_timestamp_generator
+
+        if metrics is None:
+            merged_metrics = base_metrics
+        elif metrics is False:
+            merged_metrics = False
+        else:
+            merged_metrics = _merge_dataclass(base_metrics, metrics, 'additional_readers')
+
+        base_processors = [SimpleSpanProcessor(self.exporter)]
+        if additional_span_processors is None:
+            merged_processors = base_processors
+        else:
+            merged_processors = [*base_processors, *additional_span_processors]
+
+        logfire.configure(
+            send_to_logfire=kwargs.pop('send_to_logfire', False),
+            console=kwargs.pop('console', False),
+            advanced=merged_advanced,
+            additional_span_processors=merged_processors,
+            metrics=merged_metrics,
+            **kwargs,
+        )
+
+
+def _merge_dataclass(default: Any, user: Any, extend_field: str) -> Any:
+    """Merge `user` into `default`, extending the `extend_field` list and overriding other non-default fields.
+
+    A field on `user` is treated as "overriding" only when its value differs from the field's dataclass
+    default. A user cannot explicitly reset a field to its default value (the override is silently
+    skipped). Identity-comparison fields (e.g. `ns_timestamp_generator`) look "set" when the user passes
+    a *different* object, but are silently skipped when the user passes the exact default object.
+    """
+    overrides: dict[str, Any] = {extend_field: [*getattr(default, extend_field), *getattr(user, extend_field)]}
+    for f in dataclasses.fields(user):
+        if f.name == extend_field:
+            continue
+        user_val = getattr(user, f.name)
+        if f.default is not dataclasses.MISSING:
+            if user_val != f.default:
+                overrides[f.name] = user_val
+        elif f.default_factory is not dataclasses.MISSING:
+            if user_val != f.default_factory():
+                overrides[f.name] = user_val
+        else:  # pragma: no cover
+            # No AdvancedOptions or MetricsOptions field is required today; this branch is a
+            # defensive guard for future fields without a default.
+            overrides[f.name] = user_val
+    return dataclasses.replace(default, **overrides)
 
 
 @pytest.fixture
@@ -105,11 +191,12 @@ def capfire() -> CaptureLogfire:
     metrics_reader = InMemoryMetricReader(preferred_temporality=METRICS_PREFERRED_TEMPORALITY)
     time_generator = TimeGenerator()
     log_exporter = TestLogExporter(time_generator)
+    id_generator = IncrementalIdGenerator()
     logfire.configure(
         send_to_logfire=False,
         console=False,
         advanced=logfire.AdvancedOptions(
-            id_generator=IncrementalIdGenerator(),
+            id_generator=id_generator,
             ns_timestamp_generator=time_generator,
             log_record_processors=[SimpleLogRecordProcessor(log_exporter)],
         ),
@@ -117,7 +204,13 @@ def capfire() -> CaptureLogfire:
         metrics=logfire.MetricsOptions(additional_readers=[metrics_reader]),
     )
 
-    return CaptureLogfire(exporter=exporter, metrics_reader=metrics_reader, log_exporter=log_exporter)
+    return CaptureLogfire(
+        exporter=exporter,
+        metrics_reader=metrics_reader,
+        log_exporter=log_exporter,
+        id_generator=id_generator,
+        ns_timestamp_generator=time_generator,
+    )
 
 
 def get_collected_metrics(metrics_reader: InMemoryMetricReader) -> list[dict[str, Any]]:

--- a/logfire/testing.py
+++ b/logfire/testing.py
@@ -18,7 +18,7 @@ import logfire
 from ._internal.config import METRICS_PREFERRED_TEMPORALITY
 from ._internal.constants import ONE_SECOND_IN_NANOSECONDS
 from ._internal.exporters.test import TestExporter, TestLogExporter
-from ._internal.utils import SeededRandomIdGenerator
+from ._internal.utils import SeededRandomIdGenerator, explicitly_set_fields
 
 __all__ = [
     'capfire',
@@ -108,6 +108,11 @@ class CaptureLogfire:
         `additional_span_processors`, `advanced.log_record_processors`, and `metrics.additional_readers`
         extend the capfire defaults. Other kwargs replace them. Pass `metrics=False` to disable metrics.
 
+        Within `advanced=` and `metrics=`, only the fields you actually pass replace the capfire values,
+        so e.g. `advanced=logfire.AdvancedOptions(base_url=...)` keeps the deterministic ID and timestamp
+        generators, while `advanced=logfire.AdvancedOptions(ns_timestamp_generator=time.time_ns)` restores
+        real timestamps.
+
         `exporter`, `log_exporter`, `id_generator`, and `ns_timestamp_generator` are reused as the base
         values for the merge; if the user overrides `id_generator` or `ns_timestamp_generator` via
         `advanced=`, the corresponding attribute on `self` is updated to reflect the new value.
@@ -159,28 +164,15 @@ class CaptureLogfire:
 
 
 def _merge_dataclass(default: Any, user: Any, extend_field: str) -> Any:
-    """Merge `user` into `default`, extending the `extend_field` list and overriding other non-default fields.
+    """Merge `user` into `default`, extending the `extend_field` list and overriding other fields set by the user.
 
-    A field on `user` is treated as "overriding" only when its value differs from the field's dataclass
-    default. A user cannot explicitly reset a field to its default value (the override is silently
-    skipped). Identity-comparison fields (e.g. `ns_timestamp_generator`) look "set" when the user passes
-    a *different* object, but are silently skipped when the user passes the exact default object.
+    Only the fields explicitly passed when constructing `user` override `default`, so passing a value
+    that happens to equal the field's dataclass default (e.g. `ns_timestamp_generator=time.time_ns`)
+    still takes effect.
     """
     overrides: dict[str, Any] = {extend_field: [*getattr(default, extend_field), *getattr(user, extend_field)]}
-    for f in dataclasses.fields(user):
-        if f.name == extend_field:
-            continue
-        user_val = getattr(user, f.name)
-        if f.default is not dataclasses.MISSING:
-            if user_val != f.default:
-                overrides[f.name] = user_val
-        elif f.default_factory is not dataclasses.MISSING:
-            if user_val != f.default_factory():
-                overrides[f.name] = user_val
-        else:  # pragma: no cover
-            # No AdvancedOptions or MetricsOptions field is required today; this branch is a
-            # defensive guard for future fields without a default.
-            overrides[f.name] = user_val
+    for name in explicitly_set_fields(user) - {extend_field}:
+        overrides[name] = getattr(user, name)
     return dataclasses.replace(default, **overrides)
 
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,8 +1,46 @@
+from typing import Any
+
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry._logs import LogRecord, get_logger
+from opentelemetry.sdk._logs import LogRecordProcessor, ReadWriteLogRecord
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.trace import Span
 
 import logfire
-from logfire.testing import CaptureLogfire, TestExporter, TimeGenerator
+from logfire.testing import CaptureLogfire, IncrementalIdGenerator, TestExporter, TimeGenerator
+
+
+class _RecordingSpanProcessor(SpanProcessor):
+    def __init__(self) -> None:
+        self.spans: list[ReadableSpan] = []
+
+    def on_start(self, span: Span, parent_context: Any = None) -> None:
+        self.spans.append(span)  # type: ignore[arg-type]
+
+    def on_end(self, span: ReadableSpan) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+class _RecordingLogRecordProcessor(LogRecordProcessor):
+    def __init__(self) -> None:
+        self.records: list[ReadWriteLogRecord] = []
+
+    def on_emit(self, log_record: ReadWriteLogRecord) -> None:
+        self.records.append(log_record)
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
 
 
 def test_reset_exported_spans(exporter: TestExporter) -> None:
@@ -87,3 +125,126 @@ def test_time_generator():
     assert t() == 1000000000
     assert t() == 2000000000
     assert repr(t) == 'TimeGenerator(ns_time=2000000000)'
+
+
+def test_reconfigure_preserves_span_exporter(capfire: CaptureLogfire) -> None:
+    logfire.info('before')
+
+    capfire.reconfigure(min_level='error')
+
+    logfire.error('after')
+
+    names = [span.name for span in capfire.exporter.exported_spans]
+    assert names == ['before', 'after']
+
+
+def test_reconfigure_preserves_id_and_timestamp_generators(capfire: CaptureLogfire) -> None:
+    with logfire.span('before'):
+        pass
+
+    capfire.reconfigure()
+
+    with logfire.span('after'):
+        pass
+
+    spans = capfire.exporter.exported_spans_as_dict()
+    assert spans[0]['context']['trace_id'] == 1
+    assert spans[1]['context']['trace_id'] == 2
+    assert spans[0]['start_time'] == 1000000000
+    assert spans[1]['start_time'] == 3000000000
+
+
+def test_reconfigure_extends_additional_span_processors(capfire: CaptureLogfire) -> None:
+    extra = _RecordingSpanProcessor()
+
+    capfire.reconfigure(additional_span_processors=[extra])
+
+    logfire.info('hi')
+
+    assert len(capfire.exporter.exported_spans) == 1
+    assert len(extra.spans) == 1
+    assert capfire.exporter.exported_spans[0].name == 'hi'
+
+
+def test_reconfigure_extends_log_record_processors(capfire: CaptureLogfire) -> None:
+    extra = _RecordingLogRecordProcessor()
+
+    capfire.reconfigure(advanced=logfire.AdvancedOptions(log_record_processors=[extra]))
+
+    get_logger(__name__).emit(LogRecord(attributes={'event.name': 'hi'}))
+
+    assert len(capfire.log_exporter.get_finished_logs()) == 1
+    assert len(extra.records) == 1
+
+
+def test_reconfigure_extends_metrics_additional_readers(capfire: CaptureLogfire) -> None:
+    extra = InMemoryMetricReader()
+
+    capfire.reconfigure(metrics=logfire.MetricsOptions(additional_readers=[extra]))
+
+    logfire.metric_counter('a_counter').add(1)
+    capfire.metrics_reader.collect()
+    extra.collect()
+
+    assert capfire.metrics_reader.get_metrics_data() is not None
+    assert extra.get_metrics_data() is not None
+
+
+def test_reconfigure_swaps_metrics_reader(capfire: CaptureLogfire) -> None:
+    old_reader = capfire.metrics_reader
+
+    capfire.reconfigure()
+
+    assert capfire.metrics_reader is not old_reader
+
+
+def test_reconfigure_metrics_false(capfire: CaptureLogfire) -> None:
+    capfire.reconfigure(metrics=False)
+
+    logfire.metric_counter('a_counter').add(1)
+    capfire.metrics_reader.collect()
+
+    assert capfire.metrics_reader.get_metrics_data() is None
+
+
+def test_reconfigure_replaces_scrubbing(capfire: CaptureLogfire) -> None:
+    capfire.reconfigure(scrubbing=False)
+
+    logfire.info('hi', password='hunter2')
+
+    span = capfire.exporter.exported_spans_as_dict()[0]
+    assert span['attributes']['password'] == 'hunter2'
+
+
+def test_reconfigure_accepts_console_and_send_to_logfire_kwargs(capfire: CaptureLogfire) -> None:
+    capfire.reconfigure(console=False, send_to_logfire=False)
+
+    logfire.info('hi')
+
+    assert len(capfire.exporter.exported_spans) == 1
+
+
+def test_reconfigure_updates_id_generator_when_overridden(capfire: CaptureLogfire) -> None:
+    new_generator = IncrementalIdGenerator()
+    assert capfire.id_generator is not new_generator
+
+    capfire.reconfigure(advanced=logfire.AdvancedOptions(id_generator=new_generator))
+
+    assert capfire.id_generator is new_generator
+
+
+def test_reconfigure_updates_ns_timestamp_generator_when_overridden(capfire: CaptureLogfire) -> None:
+    new_generator = TimeGenerator(ns_time=42)
+    assert capfire.ns_timestamp_generator is not new_generator
+
+    capfire.reconfigure(advanced=logfire.AdvancedOptions(ns_timestamp_generator=new_generator))
+
+    assert capfire.ns_timestamp_generator is new_generator
+
+
+def test_reconfigure_keeps_default_id_generator_when_advanced_omits_it(capfire: CaptureLogfire) -> None:
+    original = capfire.id_generator
+
+    capfire.reconfigure(advanced=logfire.AdvancedOptions())
+
+    assert capfire.id_generator is original

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 import pytest
@@ -9,7 +10,13 @@ from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
 from opentelemetry.trace import Span
 
 import logfire
-from logfire.testing import CaptureLogfire, IncrementalIdGenerator, TestExporter, TimeGenerator
+from logfire.testing import (
+    CaptureLogfire,
+    IncrementalIdGenerator,
+    SeededRandomIdGenerator,
+    TestExporter,
+    TimeGenerator,
+)
 
 
 class _RecordingSpanProcessor(SpanProcessor):
@@ -134,8 +141,42 @@ def test_reconfigure_preserves_span_exporter(capfire: CaptureLogfire) -> None:
 
     logfire.error('after')
 
-    names = [span.name for span in capfire.exporter.exported_spans]
-    assert names == ['before', 'after']
+    assert capfire.exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'before',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 1000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 9,
+                    'logfire.msg_template': 'before',
+                    'logfire.msg': 'before',
+                    'code.filepath': 'test_testing.py',
+                    'code.function': 'test_reconfigure_preserves_span_exporter',
+                    'code.lineno': 123,
+                },
+            },
+            {
+                'name': 'after',
+                'context': {'trace_id': 2, 'span_id': 2, 'is_remote': False},
+                'parent': None,
+                'start_time': 2000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 17,
+                    'logfire.msg_template': 'after',
+                    'logfire.msg': 'after',
+                    'code.filepath': 'test_testing.py',
+                    'code.function': 'test_reconfigure_preserves_span_exporter',
+                    'code.lineno': 123,
+                },
+            },
+        ]
+    )
 
 
 def test_reconfigure_preserves_id_and_timestamp_generators(capfire: CaptureLogfire) -> None:
@@ -147,11 +188,40 @@ def test_reconfigure_preserves_id_and_timestamp_generators(capfire: CaptureLogfi
     with logfire.span('after'):
         pass
 
-    spans = capfire.exporter.exported_spans_as_dict()
-    assert spans[0]['context']['trace_id'] == 1
-    assert spans[1]['context']['trace_id'] == 2
-    assert spans[0]['start_time'] == 1000000000
-    assert spans[1]['start_time'] == 3000000000
+    assert capfire.exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'before',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_testing.py',
+                    'code.function': 'test_reconfigure_preserves_id_and_timestamp_generators',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'before',
+                    'logfire.msg': 'before',
+                    'logfire.span_type': 'span',
+                },
+            },
+            {
+                'name': 'after',
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'parent': None,
+                'start_time': 3000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'code.filepath': 'test_testing.py',
+                    'code.function': 'test_reconfigure_preserves_id_and_timestamp_generators',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'after',
+                    'logfire.msg': 'after',
+                    'logfire.span_type': 'span',
+                },
+            },
+        ]
+    )
 
 
 def test_reconfigure_extends_additional_span_processors(capfire: CaptureLogfire) -> None:
@@ -212,8 +282,28 @@ def test_reconfigure_replaces_scrubbing(capfire: CaptureLogfire) -> None:
 
     logfire.info('hi', password='hunter2')
 
-    span = capfire.exporter.exported_spans_as_dict()[0]
-    assert span['attributes']['password'] == 'hunter2'
+    assert capfire.exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'hi',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 1000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 9,
+                    'logfire.msg_template': 'hi',
+                    'logfire.msg': 'hi',
+                    'code.filepath': 'test_testing.py',
+                    'code.function': 'test_reconfigure_replaces_scrubbing',
+                    'code.lineno': 123,
+                    'password': 'hunter2',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'password': {}}},
+                },
+            }
+        ]
+    )
 
 
 def test_reconfigure_accepts_console_and_send_to_logfire_kwargs(capfire: CaptureLogfire) -> None:
@@ -248,3 +338,27 @@ def test_reconfigure_keeps_default_id_generator_when_advanced_omits_it(capfire: 
     capfire.reconfigure(advanced=logfire.AdvancedOptions())
 
     assert capfire.id_generator is original
+
+
+def test_reconfigure_honours_ns_timestamp_generator_equal_to_its_default(capfire: CaptureLogfire) -> None:
+    # `time.time_ns` is the `AdvancedOptions` default, but passing it explicitly must still replace
+    # capfire's `TimeGenerator` rather than being mistaken for 'the caller didn't set this'.
+    capfire.reconfigure(advanced=logfire.AdvancedOptions(ns_timestamp_generator=time.time_ns))
+
+    logfire.info('hi')
+
+    [span] = capfire.exporter.exported_spans
+    assert span.start_time is not None
+    # Real wall clock nanoseconds, not `TimeGenerator`'s 1_000_000_000.
+    assert span.start_time > 1_700_000_000_000_000_000
+
+
+def test_reconfigure_honours_id_generator_equal_to_its_default(capfire: CaptureLogfire) -> None:
+    capfire.reconfigure(advanced=logfire.AdvancedOptions(id_generator=SeededRandomIdGenerator(None)))
+
+    logfire.info('hi')
+
+    [span] = capfire.exporter.exported_spans
+    assert span.context is not None
+    # `IncrementalIdGenerator` would have produced 1.
+    assert span.context.trace_id != 1


### PR DESCRIPTION
Adds CaptureLogfire.reconfigure(**kwargs) so tests can call logfire.configure mid-test without losing capfire's exporter wiring. additional_span_processors, advanced.log_record_processors, and metrics.additional_readers extend capfire's defaults; other kwargs replace them. exporter and log_exporter are reused; id_generator and ns_timestamp_generator are reused as the base for the merge, and when overridden via advanced= the corresponding attribute on capfire is updated to match. metrics_reader is always replaced with a fresh InMemoryMetricReader (OTel forbids reusing one across MeterProvider instances). metrics=False disables metrics.

Closes #1689

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

