### PR TITLE
docs: add unified docs preview command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,12 @@ We'd love anyone interested to contribute to the Logfire SDK and documentation.
 6. Run `make test-update-examples` to format and update examples in the docs
 7. Run `make format` to format code
 8. Run `make lint` to lint code
-9. Docs are rendered by the `pydantic/unified-docs` pipeline; there is no local MkDocs build in this repository
+9. Preview documentation through the unified site:
+   - Pydantic organization members can run `make docs-serve`
+   - External contributors can ask a maintainer to add the `trigger:docs` label to their pull request
 
 You're now set up to start contributing!
+
+Local preview requires Node.js 24, pnpm, uv, and access to the private `pydantic/unified-docs`
+repository. Put its checkout beside this repository or set
+`UNIFIED_DOCS_PATH=/path/to/unified-docs`. Set `DOCS_PORT=4322` to use a different local port.

--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,13 @@ test-pyodide:
 	uv build
 	cd pyodide_test && npm install && npm test
 
-.PHONY: docs docs-serve  # Documentation is built by pydantic/unified-docs
-docs docs-serve:
+.PHONY: docs  # Documentation is built by pydantic/unified-docs
+docs:
 	@echo "Logfire docs are built by pydantic/unified-docs; this repo no longer runs MkDocs."
+
+.PHONY: docs-serve  # Preview documentation with pydantic/unified-docs
+docs-serve:
+	uv run --no-project python scripts/docs_serve.py
 
 .PHONY: all
 all: format lint test

--- a/scripts/docs_serve.py
+++ b/scripts/docs_serve.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Mapping
+from pathlib import Path
+
+
+class _DocsServeError(RuntimeError):
+    pass
+
+
+def _run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=capture,
+    )
+    return result.stdout.strip() if capture else ''
+
+
+def _pnpm_command() -> str:
+    return 'pnpm.cmd' if os.name == 'nt' else 'pnpm'
+
+
+def _checkout_path(logfire_root: Path, environment: Mapping[str, str]) -> Path:
+    if override := environment.get('UNIFIED_DOCS_PATH'):
+        return Path(override).expanduser().resolve()
+
+    sibling = logfire_root.parent / 'unified-docs'
+    if sibling.is_dir():
+        return sibling.resolve()
+
+    raise _DocsServeError(
+        'Local preview requires access to pydantic/unified-docs. '
+        'Set UNIFIED_DOCS_PATH to an existing checkout; external contributors should request '
+        'a hosted preview with the trigger:docs pull-request label.'
+    )
+
+
+def _validate_checkout(checkout: Path) -> None:
+    required = [checkout / 'package.json', checkout / 'scripts' / 'docs-dev.mjs']
+    missing = [path.relative_to(checkout) for path in required if not path.is_file()]
+    if missing:
+        missing_list = ', '.join(map(str, missing))
+        raise _DocsServeError(f'{checkout} is not a usable unified-docs checkout (missing {missing_list})')
+
+
+def _check_node_version() -> None:
+    version = _run(['node', '--version'], capture=True).removeprefix('v')
+    if version.split('.', 1)[0] != '24':
+        raise _DocsServeError(f'Node.js 24 is required to preview the docs (current: {version})')
+
+
+def _dependencies_missing(checkout: Path) -> bool:
+    astro = 'astro.cmd' if os.name == 'nt' else 'astro'
+    python = (
+        checkout / '.venv' / 'Scripts' / 'python.exe' if os.name == 'nt' else checkout / '.venv' / 'bin' / 'python3'
+    )
+    return not (checkout / 'node_modules' / '.bin' / astro).is_file() or not python.is_file()
+
+
+def _prepare_dependencies(checkout: Path) -> None:
+    if not _dependencies_missing(checkout):
+        return
+
+    print('Preparing unified-docs dependencies...')
+    _run([_pnpm_command(), 'install', '--frozen-lockfile'], cwd=checkout)
+    _run(['uv', 'sync'], cwd=checkout)
+
+
+def _launch(checkout: Path, logfire_root: Path, environment: Mapping[str, str]) -> None:
+    command = [
+        _pnpm_command(),
+        'docs:dev',
+        '--library',
+        'logfire',
+        '--source',
+        str(logfire_root),
+    ]
+    if port := environment.get('DOCS_PORT'):
+        command.extend(['--', '--port', port])
+    _run(command, cwd=checkout)
+
+
+def _main(environment: Mapping[str, str] = os.environ) -> int:
+    logfire_root = Path(__file__).resolve().parents[1]
+    checkout = _checkout_path(logfire_root, environment)
+    _validate_checkout(checkout)
+    _check_node_version()
+    _prepare_dependencies(checkout)
+    _launch(checkout, logfire_root, environment)
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        raise SystemExit(_main())
+    except _DocsServeError as error:
+        raise SystemExit(str(error)) from error
+    except FileNotFoundError as error:
+        command = error.filename or 'required command'
+        raise SystemExit(f'{command} is required to preview the docs') from error
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(error.returncode) from error
+    except KeyboardInterrupt:
+        raise SystemExit(130) from None

--- a/tests/test_docs_serve.py
+++ b/tests/test_docs_serve.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 # pyright: reportPrivateUsage=false
+import os
 from pathlib import Path
 
 import pytest
@@ -70,10 +71,14 @@ def test_dependencies_are_prepared_when_missing(tmp_path: Path, monkeypatch: pyt
 def test_checkout_is_not_reinstalled_when_dependencies_exist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     checkout = tmp_path / 'unified-docs'
     _make_checkout(checkout)
+    astro = 'astro.cmd' if os.name == 'nt' else 'astro'
+    python = (
+        checkout / '.venv' / 'Scripts' / 'python.exe' if os.name == 'nt' else checkout / '.venv' / 'bin' / 'python3'
+    )
     (checkout / 'node_modules' / '.bin').mkdir(parents=True)
-    (checkout / 'node_modules' / '.bin' / 'astro').write_text('')
-    (checkout / '.venv' / 'bin').mkdir(parents=True)
-    (checkout / '.venv' / 'bin' / 'python3').write_text('')
+    (checkout / 'node_modules' / '.bin' / astro).write_text('')
+    python.parent.mkdir(parents=True)
+    python.write_text('')
     calls: list[list[str]] = []
 
     def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:

--- a/tests/test_docs_serve.py
+++ b/tests/test_docs_serve.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+# pyright: reportPrivateUsage=false
+from pathlib import Path
+
+import pytest
+
+from scripts import docs_serve
+
+
+def _make_checkout(path: Path) -> None:
+    (path / 'scripts').mkdir(parents=True)
+    (path / 'package.json').write_text('{}')
+    (path / 'scripts' / 'docs-dev.mjs').write_text('')
+
+
+def test_checkout_path_prefers_explicit_override(tmp_path: Path) -> None:
+    checkout = docs_serve._checkout_path(
+        tmp_path / 'logfire',
+        {
+            'UNIFIED_DOCS_PATH': str(tmp_path / 'custom'),
+        },
+    )
+
+    assert checkout == tmp_path / 'custom'
+
+
+def test_checkout_path_discovers_sibling(tmp_path: Path) -> None:
+    logfire_root = tmp_path / 'logfire'
+    sibling = tmp_path / 'unified-docs'
+    logfire_root.mkdir()
+    sibling.mkdir()
+
+    assert docs_serve._checkout_path(logfire_root, {}) == sibling
+
+
+def test_checkout_path_explains_private_preview_requirement(tmp_path: Path) -> None:
+    with pytest.raises(docs_serve._DocsServeError, match='requires access.*UNIFIED_DOCS_PATH'):
+        docs_serve._checkout_path(tmp_path / 'logfire', {})
+
+
+def test_validate_checkout_rejects_missing_unified_docs_files(tmp_path: Path) -> None:
+    checkout = tmp_path / 'unified-docs'
+    checkout.mkdir()
+
+    with pytest.raises(docs_serve._DocsServeError, match=r'missing package\.json, scripts/docs-dev\.mjs'):
+        docs_serve._validate_checkout(checkout)
+
+
+def test_dependencies_are_prepared_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    checkout = tmp_path / 'unified-docs'
+    _make_checkout(checkout)
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+        calls.append((command, cwd))
+        return ''
+
+    monkeypatch.setattr(docs_serve, '_run', run)
+    monkeypatch.setattr(docs_serve, '_pnpm_command', lambda: 'pnpm')
+
+    docs_serve._prepare_dependencies(checkout)
+
+    assert calls == [
+        (['pnpm', 'install', '--frozen-lockfile'], checkout),
+        (['uv', 'sync'], checkout),
+    ]
+
+
+def test_checkout_is_not_reinstalled_when_dependencies_exist(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    checkout = tmp_path / 'unified-docs'
+    _make_checkout(checkout)
+    (checkout / 'node_modules' / '.bin').mkdir(parents=True)
+    (checkout / 'node_modules' / '.bin' / 'astro').write_text('')
+    (checkout / '.venv' / 'bin').mkdir(parents=True)
+    (checkout / '.venv' / 'bin' / 'python3').write_text('')
+    calls: list[list[str]] = []
+
+    def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+        calls.append(command)
+        return 'local-head'
+
+    monkeypatch.setattr(docs_serve, '_run', run)
+    docs_serve._prepare_dependencies(checkout)
+
+    assert calls == []
+
+
+def test_launch_passes_absolute_logfire_source_and_optional_port(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    checkout = tmp_path / 'unified-docs'
+    logfire_root = tmp_path / 'logfire'
+    calls: list[tuple[list[str], Path | None]] = []
+
+    def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+        calls.append((command, cwd))
+        return ''
+
+    monkeypatch.setattr(docs_serve, '_run', run)
+    monkeypatch.setattr(docs_serve, '_pnpm_command', lambda: 'pnpm')
+
+    docs_serve._launch(checkout, logfire_root, {'DOCS_PORT': '4322'})
+
+    assert calls == [
+        (
+            [
+                'pnpm',
+                'docs:dev',
+                '--library',
+                'logfire',
+                '--source',
+                str(logfire_root),
+                '--',
+                '--port',
+                '4322',
+            ],
+            checkout,
+        )
+    ]
+
+
+def test_wrong_node_version_is_actionable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def run(command: list[str], *, cwd: Path | None = None, capture: bool = False) -> str:
+        return '22.0.0'
+
+    monkeypatch.setattr(docs_serve, '_run', run)
+
+    with pytest.raises(docs_serve._DocsServeError, match='Node.js 24.*22.0.0'):
+        docs_serve._check_node_version()

--- a/tests/test_docs_serve.py
+++ b/tests/test_docs_serve.py
@@ -36,7 +36,7 @@ def test_checkout_path_discovers_sibling(tmp_path: Path) -> None:
 
 
 def test_checkout_path_explains_private_preview_requirement(tmp_path: Path) -> None:
-    with pytest.raises(docs_serve._DocsServeError, match='requires access.*UNIFIED_DOCS_PATH'):
+    with pytest.raises(docs_serve._DocsServeError, match=r'requires access.*UNIFIED_DOCS_PATH'):
         docs_serve._checkout_path(tmp_path / 'logfire', {})
 
 
@@ -131,5 +131,5 @@ def test_wrong_node_version_is_actionable(monkeypatch: pytest.MonkeyPatch) -> No
 
     monkeypatch.setattr(docs_serve, '_run', run)
 
-    with pytest.raises(docs_serve._DocsServeError, match='Node.js 24.*22.0.0'):
+    with pytest.raises(docs_serve._DocsServeError, match=r'Node.js 24.*22.0.0'):
         docs_serve._check_node_version()


### PR DESCRIPTION
## Summary

- make `make docs-serve` preview only Logfire through the unified-docs mixed-source command
- use an existing private unified-docs checkout from `UNIFIED_DOCS_PATH` or `../unified-docs`; never clone or pull it
- install missing unified-docs dependencies, validate Node 24, and provide actionable errors
- document hosted `trigger:docs` previews as the path for external contributors

This is the Logfire-only source-repository rollout from pydantic/unified-docs#61. It does not change the existing `make docs` behavior or any MkDocs/navigation inputs.

## Validation

- `make lint`
- `make typecheck`
- `uv run --no-sync pytest -q tests/test_docs_serve.py` — 8 passed
- real `make docs-serve` smoke using this checkout as `--source`: `/logfire/integrations/` returned 200; Pydantic and Pydantic AI roots returned 404 in the Logfire-only server
- no-checkout smoke: fails before any network operation and points external contributors to `trigger:docs`
- `make test` — 2,229 passed, 9 skipped, 2 xfailed; five xdist-run failures all passed in one serial rerun (shared SQLite file, xdist metadata, cassette state, and a 3-second timeout)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

