### PR TITLE
Add aliases for agent-observed legacy Logfire URLs

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -296,6 +296,8 @@ navigation:
               - page: "Logging"
                 path: "integrations/logging.md"
                 slug: "integrations/logging/logging"
+                aliases:
+                  - "logging"
               - page: "Print"
                 path: "integrations/print.md"
                 slug: "integrations/logging/print"
@@ -777,6 +779,7 @@ navigation:
         aliases:
           - "guides/advanced/query_api"
           - "guides/advanced/query-api"
+          - "reference/query-api"
       - page: "Use Alternative Clients"
         path: "how-to-guides/alternative-clients.md"
         slug: "guides/alternative-clients"
@@ -880,6 +883,9 @@ navigation:
             path: "reference/self-hosted/overview.md"
             source: "plain"
             slug: "deploy/self-hosted-deployment/overview"
+            aliases:
+              - "reference/self-hosted/overview"
+              - "self-hosted"
           - page: "Local Quickstart"
             path: "reference/self-hosted/local-quickstart.md"
             source: "plain"
@@ -892,6 +898,8 @@ navigation:
             path: "reference/self-hosted/installation.md"
             source: "plain"
             slug: "deploy/self-hosted-deployment/installation"
+            aliases:
+              - "self-hosted/installation"
           - page: "Examples"
             path: "reference/self-hosted/examples.md"
             source: "plain"
@@ -917,6 +925,8 @@ navigation:
             path: "reference/configuration.md"
             slug: "manage/configuration"
             title: "Logfire Configuration Guide & Environment Variables"
+            aliases:
+              - "reference/configuration"
           - section: "API"
             contents:
               - page: "Logfire"
@@ -999,6 +1009,7 @@ navigation:
                 aliases:
                   - "guides/advanced/alternative_backends"
                   - "guides/advanced/alternative-backends"
+                  - "reference/advanced/alternative-backends"
                 title: "How to use Alternative Backends with Logfire"
               - page: "Multiple Configurations"
                 path: "how-to-guides/different-configurations.md"
@@ -1018,6 +1029,7 @@ navigation:
         slug: "resources/release-notes"
         aliases:
           - "release_notes"
+          - "release-notes"
 
 redirects:
   # Exact internal redirects live as aliases on their destination pages. These


### PR DESCRIPTION
## Problem

Cloudflare analytics found eight unambiguous legacy Logfire paths requested by interactive agent fetchers that currently return 404. They accounted for about 102 estimated 404 responses in the sampled seven-day window.

## Changes

Add each exact legacy path as an alias on its canonical page in `docs/navigation.yml`:

- logging
- query API
- configuration
- alternative backends
- release notes
- self-hosted overview, root, and installation

Keeping these as page aliases colocates compatibility URLs with the pages they describe; no top-level redirect rules are needed.

## Validation

- `make lint`
- `make typecheck`
- local Logfire-only build through unified-docs using this manifest
- all 16 emitted slash/no-slash rules were present
- all seven unique local destinations were built
- full redirect audit — 545 rules, 200 unique destinations, 0 missing


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

