### PR TITLE
docs: punchier getting-started opener + retitle the page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,11 @@
 ---
-title: "Get started with Logfire"
-description: "Logfire is an observability platform for your whole stack, from backends to AI agents. Pick a quickstart and send your first trace."
+title: "Getting started with Pydantic Logfire"
+description: "Logfire is Pydantic's end-to-end AI engineering platform for seeing what your agents, services, applications, and hosts are doing. Pick a quickstart and send your first trace."
 ---
 
-# Get started with Logfire
+# Getting started with Pydantic Logfire
 
-Logfire is an observability platform that shows you what your application is actually doing: every request, database query, LLM call, and error, with how long each one took, in your browser. It is built on OpenTelemetry (OTel), the open industry standard for collecting traces, metrics, and logs, and works across your whole stack, from traditional backends to AI agents. [Read why Logfire exists](why.md).
+Logfire is Pydantic's end-to-end AI engineering platform. It shows you what your agents, services, applications, and hosts are actually doing: every LLM call, request, and query, and how long each one took. Built on OpenTelemetry (OTel), the open standard for traces, metrics, and logs, it spans your whole stack, from AI agents to the databases and servers behind them. [Read why Logfire exists](why.md).
 
 New here? [Create a free account](https://logfire.pydantic.dev/login), then pick a starting point below, or follow a [guided path for your role](get-started/choose-your-path.md).
 

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -10,6 +10,7 @@ navigation:
         path: "index.md"
         source: "plain"
         slug: "get-started"
+        title: "Getting started with Pydantic Logfire"
         aliases:
           - "guides/first_steps"
           - "band-get-started"


### PR DESCRIPTION
Tightens the getting-started opener and leads with Logfire's positioning as Pydantic's end-to-end AI engineering platform, naming what it observes (agents, services, applications, hosts) in fewer words.

- **Opener** rewritten to be punchier and lead with the AI-engineering positioning.
- **Page title / H1** is now "Getting started with Pydantic Logfire" (set via the nav `title:`; the sidebar label stays the short "Logfire").
- Frontmatter `title`/`description` updated to match.

No structural changes to the quickstart/explore cards.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

