### PR TITLE
docs: recommend AI-agent setup and add an infrastructure quickstart

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ New here? [Create a free account](https://logfire.pydantic.dev/login), then pick
 
 ## Quickstarts
 
+We recommend [letting your AI agent set you up with Logfire](first-trace.md#let-an-ai-agent-set-it-up).
+
 <div class="grid cards" markdown>
 
 - <span class="lf-icon lf-icon--trace"></span> [__Send your first trace__](first-trace.md)
@@ -21,9 +23,9 @@ New here? [Create a free account](https://logfire.pydantic.dev/login), then pick
 
   See the spans, tokens, cost, and tool calls behind your model-powered features.
 
-- <span class="lf-icon lf-icon--agent"></span> [__Let an AI coding agent set it up__](first-trace.md#let-an-ai-agent-set-it-up)
+- <span class="lf-icon lf-icon--metrics"></span> [__Monitor your infrastructure__](guides/web-ui/hosts.md)
 
-  Instructions for getting started with Logfire from Claude Code, Codex, Cursor, or a similar tool.
+  Monitor hosts, Kubernetes, and cloud infrastructure alongside your application.
 
 </div>
 


### PR DESCRIPTION
Getting-started Quickstarts tweaks (content only):

- Add a line above the cards recommending **[letting your AI agent set you up with Logfire](https://logfire.pydantic.dev/docs/get-started/first-trace/#let-an-ai-agent-set-it-up)**.
- Replace the "Let an AI coding agent set it up" card with **"Monitor your infrastructure"** (hosts, Kubernetes, cloud).

Note: this overlaps with the Explore "Metrics and infrastructure" card (same topic/icon); leaving both for now.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

