### PR TITLE
docs: name the Metrics explorer card and drop its infra overlap

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ We recommend [letting your AI agent set you up with Logfire](first-trace.md#let-
 
   Run evaluations, manage prompts, and route models through the AI gateway.
 
-- <span class="lf-icon lf-icon--metrics"></span> [__Metrics and infrastructure__](guides/web-ui/metrics-explorer.md)
+- <span class="lf-icon lf-icon--metrics"></span> [__Metrics explorer__](guides/web-ui/metrics-explorer.md)
 
-  Monitor hosts, Kubernetes, and Docker next to your application metrics.
+  Browse the metrics you're sending and break any of them down by dimension, no SQL required.
 
 - <span class="lf-icon lf-icon--integrations"></span> [__Integrations__](integrations/index.md)
 


### PR DESCRIPTION
The getting-started Explore card "Metrics and infrastructure" duplicated the new "Monitor your infrastructure" quickstart (same icon, same hosts/Kubernetes copy) and didn't actually describe its own target.

Rename it to **Metrics explorer** and describe what that page does: browse the metrics you're sending and break them down by dimension, no SQL. The Quickstart card remains the infrastructure-monitoring entry point.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

