### PR TITLE
docs: add "Open in Logfire" inline links across the UI guides

### DIFF
--- a/docs/guides/web-ui/alerts.md
+++ b/docs/guides/web-ui/alerts.md
@@ -2,7 +2,7 @@
 title: "Logfire Alerts: Status Monitoring & Error Notifications"
 description: "Learn how to create alerts based on SQL query conditions (e.g., error count threshold). Use Logfire to track status changes and send notifications to Slack."
 ---
-With **Logfire**, use Alerts to notify you when certain conditions are met.
+With **Logfire**, use <OpenInLogfire path="alerts" variant="inline" label="Alerts" /> to notify you when certain conditions are met.
 
 ![Logfire alerts screen](../../images/guide/browser-alerts-full.png)
 

--- a/docs/guides/web-ui/dashboards.md
+++ b/docs/guides/web-ui/dashboards.md
@@ -73,7 +73,7 @@ Both variants include the following metrics:
 
 To enable a standard dashboard:
 
-1. Go to the **Dashboards** tab in the top navigation bar.
+1. Go to the <OpenInLogfire path="dashboards" variant="inline" label="Dashboards" /> tab in the top navigation bar.
 2. Click the **+ Dashboard** button.
 3. Browse the list of available dashboards under the **Standard** tab.
 ![Standard dashboards](../../images/guide/browser-standard-dashboards-list.png)

--- a/docs/guides/web-ui/docker.md
+++ b/docs/guides/web-ui/docker.md
@@ -7,7 +7,7 @@ description: "Browse every Docker container, image and Compose project shipping 
 !!! note "Beta: feedback welcome"
     The Docker view is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
 
-The **Docker view** shows every Docker container reporting stats to your project (CPU, memory, network and block I/O) alongside the application traces those containers produced. The same stats are folded three ways: by **container**, by **image**, and by **Compose project**.
+The <OpenInLogfire path="docker" variant="inline" label="Docker view" /> shows every Docker container reporting stats to your project (CPU, memory, network and block I/O) alongside the application traces those containers produced. The same stats are folded three ways: by **container**, by **image**, and by **Compose project**.
 
 You'll find Docker in the project sidebar under **Infrastructure**, after **Kubernetes**.
 

--- a/docs/guides/web-ui/explore.md
+++ b/docs/guides/web-ui/explore.md
@@ -2,7 +2,7 @@
 title: "Logfire SQL Workbench: Query & Inspect Your Data"
 description: Run arbitrary SQL queries against traces and metric data. Use the Logfire SQL Workbench to investigate and analyze records.
 ---
-With **Logfire**, you can use SQL Workbench to run arbitrary SQL queries against your trace and metric data to
+With **Logfire**, you can use the <OpenInLogfire path="explore" variant="inline" label="SQL Workbench" /> to run arbitrary SQL queries against your trace and metric data to
 analyze and investigate your system.
 
 ![Logfire SQL Workbench](../../images/guide/browser-explore-full.png)
@@ -37,7 +37,7 @@ See the [SQL Reference](../../reference/sql.md) for details on the SQL syntax su
 After running a query, you can take any `trace_id` and/or `span_id` and use it to look up data shown as traces
 in the Live View.
 
-Simply go to the Live View and enter a query like:
+Simply go to the <OpenInLogfire path="" variant="inline" label="Live View" /> and enter a query like:
 
 ```
 trace_id = '7bda3ddf6e6d4a0c8386093209eb0bfc' -- replace with a real trace_id of your own

--- a/docs/guides/web-ui/hosts.md
+++ b/docs/guides/web-ui/hosts.md
@@ -4,7 +4,7 @@ description: "Browse every host shipping system metrics to your Logfire project.
 ---
 # Hosts
 
-The **Hosts view** shows every host shipping system metrics to your project. It shows CPU, memory, load, disk and network alongside the application traces those hosts produced. Kubernetes nodes show up here too, tagged so you can tell them apart from bare VMs.
+The <OpenInLogfire path="hosts" variant="inline" label="Hosts view" /> shows every host shipping system metrics to your project. It shows CPU, memory, load, disk and network alongside the application traces those hosts produced. Kubernetes nodes show up here too, tagged so you can tell them apart from bare VMs.
 
 You'll find Hosts in the project sidebar, between **Services** and **Kubernetes**.
 

--- a/docs/guides/web-ui/issues.md
+++ b/docs/guides/web-ui/issues.md
@@ -9,7 +9,7 @@ description: "Automatically group exceptions and track Pydantic issues in your a
     Please [create a GitHub issue](https://github.com/pydantic/logfire/issues/new/choose){:target="\_blank"}
     if you find bugs or have questions.
 
-Issues provide automatic exception tracking and grouping. Enable issues to identify, prioritize, and resolve problems in your application.
+The <OpenInLogfire path="issues" variant="inline" label="Issues" /> page provides automatic exception tracking and grouping. Enable it to identify, prioritize, and resolve problems in your application.
 
 ![Enable issues screen](../../images/guide/browser-issues-enable-issues.png)
 

--- a/docs/guides/web-ui/kubernetes.md
+++ b/docs/guides/web-ui/kubernetes.md
@@ -4,7 +4,7 @@ description: "Browse your Kubernetes clusters, namespaces, workloads, pods, node
 ---
 # Kubernetes
 
-The **Kubernetes view** is the cluster-shaped browser for your Kubernetes telemetry. Six lenses on the same data (Clusters, Nodes, Namespaces, Workloads, Pods, and Images) are all sortable, with one-click drill-down to the traces each pod produced in the [Live View](live.md).
+The <OpenInLogfire path="kubernetes" variant="inline" label="Kubernetes view" /> is the cluster-shaped browser for your Kubernetes telemetry. Six lenses on the same data (Clusters, Nodes, Namespaces, Workloads, Pods, and Images) are all sortable, with one-click drill-down to the traces each pod produced in the [Live View](live.md).
 
 You'll find Kubernetes in the project sidebar, between **Hosts** and **Metrics**.
 

--- a/docs/guides/web-ui/live.md
+++ b/docs/guides/web-ui/live.md
@@ -4,7 +4,7 @@ description: "Use Logfire Live View to watch traces and logs in real time. Pivot
 ---
 # Live View
 
-The live view is the focal point of **Logfire**, where you can see traces arrive in real-time.
+The <OpenInLogfire path="" variant="inline" label="live view" /> is the focal point of **Logfire**, where you can see traces arrive in real-time.
 
 The live view is useful for watching what's going on within your application in real-time (as the name suggests). You can also explore historical data in the **search pane**.
 

--- a/docs/guides/web-ui/llms.md
+++ b/docs/guides/web-ui/llms.md
@@ -4,7 +4,7 @@ description: "Browse every model and provider your application calls. See cost, 
 ---
 # LLMs
 
-The **LLMs** page is the per-model inventory of every LLM your application is calling. Each row shows calls, latency, tokens and cost for one (provider, model) pair, and the LLM detail page links into the trace for each individual call.
+The <OpenInLogfire path="llms" variant="inline" label="LLMs" /> page is the per-model inventory of every LLM your application is calling. Each row shows calls, latency, tokens and cost for one (provider, model) pair, and the LLM detail page links into the trace for each individual call.
 
 For inspecting an individual LLM call inside a trace, the [LLM Panels](llm-panels.md) guide covers the in-trace view; this page covers the per-model and per-agent analytics surfaces.
 

--- a/docs/guides/web-ui/metrics-explorer.md
+++ b/docs/guides/web-ui/metrics-explorer.md
@@ -6,7 +6,7 @@ description: "A three-step wizard for browsing the OpenTelemetry metrics you're 
 
 The **Metrics explorer** is built for the moment when you know a metric exists somewhere but you can't remember what it's called, you don't know which labels are useful, and you don't want to write a query yet. Three steps: pick a namespace, pick a metric, see what dimensions you can break it down by. No SQL required. The SQL is on every card when you want it.
 
-You'll find Metrics in the project sidebar, after **Kubernetes**.
+Open the <OpenInLogfire path="metrics" variant="inline" label="Metrics explorer" /> by clicking **Metrics** in the project sidebar, after **Kubernetes**.
 
 ![Metrics explorer step 1: pick a namespace](../../images/metrics/wizard-step1.png)
 

--- a/docs/guides/web-ui/prompt-playground.md
+++ b/docs/guides/web-ui/prompt-playground.md
@@ -4,7 +4,7 @@ description: "Prompt Playground: Experiment with agent prompts"
 ---
 # Prompt Playground
 
-The prompt playground gives you the ability to experiment with an agent run and its different parts. It is mostly useful when you want to iterate
+The <OpenInLogfire path="playground" variant="inline" label="Prompt Playground" /> gives you the ability to experiment with an agent run and its different parts. It is mostly useful when you want to iterate
 on the system prompt, and see if you can get better results by tweaking it. Taking the following agent run as an example:
 
 /// public-trace | https://logfire-eu.pydantic.dev/public-trace/bae009a7-e2cf-4c50-b623-bf255ebabe7c?spanId=26d6114284366b18

--- a/docs/guides/web-ui/services.md
+++ b/docs/guides/web-ui/services.md
@@ -4,7 +4,7 @@ description: "Browse every service shipping spans to your Logfire project. See r
 ---
 # Services
 
-The **Services view** is the entry point for finding the service you want to investigate. Each service that ships spans to your project appears as one row, sorted by whatever metric matters right now (requests, error rate, latency). Click a row to drill into its detail page, click a recent failed trace, and you land in the [Live View](live.md) with the failing trace open.
+The <OpenInLogfire path="services" variant="inline" label="Services view" /> is the entry point for finding the service you want to investigate. Each service that ships spans to your project appears as one row, sorted by whatever metric matters right now (requests, error rate, latency). Click a row to drill into its detail page, click a recent failed trace, and you land in the [Live View](live.md) with the failing trace open.
 
 You'll find Services in the project sidebar, between [SQL Workbench](explore.md) and [Hosts](hosts.md).
 

--- a/docs/how-to-guides/create-write-tokens.md
+++ b/docs/how-to-guides/create-write-tokens.md
@@ -2,7 +2,7 @@
 title: "Logfire Write Tokens: Setup Guide"
 description: "Step-by-step guide for creating a Logfire write token in the web UI by injecting LOGFIRE_TOKEN in apps & for optionally suppressing it in local development."
 ---
-To send data to **Logfire**, you need to create a write token.
+To send data to **Logfire**, you need to create a <OpenInLogfire path="settings/write-tokens" variant="inline" label="write token" />.
 A write token is a unique identifier that allows you to send data to a specific **Logfire** project.
 If you set up Logfire according to the [getting started guide](../index.md), you already have a write token locally tied to the project you created.
 But if you want to configure other computers to write to that project, for example in a deployed application, you need to create a new write token.

--- a/docs/how-to-guides/otel-collector/host-monitoring.md
+++ b/docs/how-to-guides/otel-collector/host-monitoring.md
@@ -272,7 +272,7 @@ For long-running deployments, wrap that in a systemd unit (or your init system o
 Within a minute or two of the Collector starting, the host shows up on the **Hosts** page keyed by `host.name`. From there:
 
 - Click the host to drill into per-host CPU, memory, disk, and network charts.
-- Open **SQL Workbench** to query the raw metric series: useful for ad-hoc questions like "show me every host where filesystem utilization is above 90%".
+- Open the <OpenInLogfire path="explore" variant="inline" label="SQL Workbench" /> to query the raw metric series: useful for ad-hoc questions like "show me every host where filesystem utilization is above 90%".
 - Build a dashboard on top of the metrics if you want a persistent view.
 
 If a host doesn't appear, the cause is almost always one of: missing `resourcedetection` (no `host.name`), wrong region in the `otlphttp` endpoint, or (in Kubernetes) a missing `root_path: /host` or one of the `hostPath` mounts, so the receiver is happily scraping the container's view instead of the node's.

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -12,7 +12,7 @@ description: Use Logfire to query your observability data using SQL (via Postgre
 
 Data is stored in two main tables: `records` and `metrics`.
 
-`records` is the table you'll usually care about and is what you'll see in the Live View. Each row in `records` is a span or log (essentially a span with no duration). A _trace_ is a collection of spans that share the same `trace_id`, structured as a tree.
+`records` is the table you'll usually care about and is what you'll see in the <OpenInLogfire path="" variant="inline" label="Live View" />. Each row in `records` is a span or log (essentially a span with no duration). A _trace_ is a collection of spans that share the same `trace_id`, structured as a tree.
 
 `metrics` contains pre-aggregated numerical data which is usually more efficient to query than `records` for certain use cases. There's currently no dedicated UI for metrics, but you can query it directly using SQL in SQL Workbench, Dashboards, Alerts, or the API, just like you would with `records`.
 


### PR DESCRIPTION
Adds inline "Open in Logfire" links wherever the UI-guide docs mention a specific feature. Each links through the region-less apex and lands the reader on that page in their own project (through login if needed).

16 links across the 12 web-UI guide pages, plus write-token setup, the SQL reference, and host monitoring. Only ungated features are linked; existing doc-to-doc links are untouched.

Depends on the `OpenInLogfire` component in pydantic/unified-docs#135 — merge that first so the tag renders.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

