### PR TITLE
docs: Ruby and PHP instrumentation pages

### DIFF
--- a/docs/instrument/index.md
+++ b/docs/instrument/index.md
@@ -1,0 +1,33 @@
+---
+title: "Instrument your app"
+description: "Get your application's telemetry into Logfire: choose your language and add a few lines, or attach an agent."
+---
+
+# Instrument your app
+
+Instrumentation is how your app's work reaches Logfire. You add a few lines (or attach an agent) once, and every request, database query, and error shows up as a **trace** (the full journey of one request, made of nested **spans**, where a span is one unit of work with a name, a start, and a duration). From then on you read the traces instead of adding logging by hand.
+
+Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open industry standard for collecting traces, metrics, and logs, so it works with any language OpenTelemetry supports.
+
+## Choose your language
+
+Each guide takes you from install to your first trace in a few minutes:
+
+- **[Python](../guides/onboarding-checklist/index.md)**: the Logfire Python SDK, with a framework picker and auto-tracing.
+- **[TypeScript](https://pydantic.dev/docs/logfire/typescript-sdk/)**: the Logfire TypeScript SDK for Node.js, browsers, and edge runtimes.
+- **[Rust](../languages/rust.md)**: the first-party `logfire` crate.
+- **[Go](../languages/go.md)**: the standard OpenTelemetry Go SDK.
+- **[.NET](../languages/dotnet.md)**: the standard OpenTelemetry .NET SDK.
+- **[Java](../languages/java.md)**: the zero-code OpenTelemetry agent, no code changes.
+- **[Ruby](../languages/ruby.md)**: the standard OpenTelemetry Ruby SDK.
+- **[PHP](../languages/php.md)**: the standard OpenTelemetry PHP SDK.
+
+Using something else? Any OpenTelemetry-compatible client can send to Logfire: see [Alternative clients](../how-to-guides/alternative-clients.md).
+
+## Next steps
+
+Once your app is sending data:
+
+- **See it arrive** in the [Live view](../guides/web-ui/live.md).
+- **Instrument the libraries you already use** (web framework, database driver, HTTP client) with [Integrations](../integrations/index.md).
+- **New to tracing?** [Core concepts](../concepts.md) explains spans and traces and how to read them.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -19,5 +19,7 @@ For a language without a dedicated SDK, you send data with the standard OpenTele
 - [Go](languages/go.md)
 - [.NET](languages/dotnet.md)
 - [Java](languages/java.md)
+- [Ruby](languages/ruby.md)
+- [PHP](languages/php.md)
 
 For any other language, see [Alternative clients](how-to-guides/alternative-clients.md).

--- a/docs/languages/php.md
+++ b/docs/languages/php.md
@@ -1,0 +1,83 @@
+---
+title: "Send traces from PHP"
+description: "Send traces from a PHP application to Logfire using the standard OpenTelemetry SDK."
+---
+
+# PHP
+
+See what your PHP application is doing in Logfire: the requests it handles, how long each one took, and which ones failed. This takes about five minutes.
+
+PHP does not have a dedicated Logfire SDK, but Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open industry standard for collecting traces, metrics, and logs. The standard OpenTelemetry PHP SDK sends data straight to Logfire once you point it at the right endpoint, and you get **traces** (the full journey of one request, made of nested **spans**, where a span is one unit of work with a name, a start, and a duration) in the Logfire UI.
+
+## Before you start
+
+You need:
+
+- A Logfire project and a **write token** (the credential your app uses to send data to a Logfire project). Copy one from **Project → Settings → Write tokens**; see [Create Write Tokens](../how-to-guides/create-write-tokens.md).
+- PHP 8.1 or newer and [Composer](https://getcomposer.org/).
+
+!!! note "This sends your data to Logfire"
+    The steps below send your app's data to Logfire, where it is stored. To keep data on your own infrastructure while you evaluate, [send it to a local backend](../how-to-guides/alternative-backends.md) instead. Your write token is a secret, so keep it out of source control.
+
+## Send your first trace
+
+**1. Install the OpenTelemetry packages**
+
+```sh
+composer require open-telemetry/sdk open-telemetry/exporter-otlp php-http/guzzle7-adapter
+```
+
+The OTLP exporter needs an HTTP client; `php-http/guzzle7-adapter` provides one.
+
+**2. Configure the exporter**
+
+```sh
+export OTEL_PHP_AUTOLOAD_ENABLED=true
+export OTEL_SERVICE_NAME=hello-php
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+With `OTEL_PHP_AUTOLOAD_ENABLED=true`, the SDK builds a tracer provider from these variables when your app loads and flushes it automatically when the script ends. The endpoint above is for the US [data region](../reference/data-regions.md); use `https://logfire-eu.pydantic.dev` for the EU region.
+
+**3. Add the code**
+
+```php title="hello.php"
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+\OpenTelemetry\API\Globals::tracerProvider()
+    ->getTracer('hello-php')
+    ->spanBuilder('Hello World')
+    ->startSpan()
+    ->end();
+```
+
+**4. Run it**
+
+```sh
+php hello.php
+```
+
+## See it in the Live view
+
+Open the [**Live view**](../guides/web-ui/live.md) in Logfire. Your `Hello World` span appears as it arrives:
+
+![Traces arriving in the Logfire Live view](../images/logfire-live-view.png)
+
+Each row is one span, with its service, name, and duration. The screenshot shows a busier app; your run appears as its own row, service `hello-php` and span `Hello World`, which you can click to open the full trace.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `composer require` or the run fails: no PSR-18 HTTP client found | The OTLP exporter needs an HTTP client that isn't installed | Install `php-http/guzzle7-adapter` (or another PSR-18 client) |
+| The script runs but nothing appears | Autoloading is off, so no tracer provider is built | Set `OTEL_PHP_AUTOLOAD_ENABLED=true` |
+| Nothing arrives from a self-hosted instance with a private certificate | PHP's HTTP client does not trust the private CA, and the OpenTelemetry certificate variable is ignored | Set `openssl.cafile=/path/to/ca.pem` in your `php.ini` (or pass `php -d openssl.cafile=/path/to/ca.pem`) |
+
+## Next steps
+
+- **New to tracing?** [Core concepts](../concepts.md) explains spans and traces and how to read them.
+- **Want automatic traces?** Add the [`ext-opentelemetry` extension](https://opentelemetry.io/docs/zero-code/php/) and the matching `open-telemetry/opentelemetry-auto-*` packages to instrument your framework, HTTP clients, and database calls with no code changes.
+- **Another language?** See [Language support](../languages.md), or [Alternative clients](../how-to-guides/alternative-clients.md) for the generic pattern.

--- a/docs/languages/ruby.md
+++ b/docs/languages/ruby.md
@@ -1,0 +1,88 @@
+---
+title: "Send traces from Ruby"
+description: "Send traces from a Ruby application to Logfire using the standard OpenTelemetry SDK."
+---
+
+# Ruby
+
+See what your Ruby application is doing in Logfire: the requests it handles, how long each one took, and which ones failed. This takes about five minutes.
+
+Ruby does not have a dedicated Logfire SDK, but Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open industry standard for collecting traces, metrics, and logs. The standard OpenTelemetry Ruby SDK sends data straight to Logfire once you point it at the right endpoint, and you get **traces** (the full journey of one request, made of nested **spans**, where a span is one unit of work with a name, a start, and a duration) in the Logfire UI.
+
+## Before you start
+
+You need:
+
+- A Logfire project and a **write token** (the credential your app uses to send data to a Logfire project). Copy one from **Project → Settings → Write tokens**; see [Create Write Tokens](../how-to-guides/create-write-tokens.md).
+- A working Ruby toolchain (Ruby 3.0 or newer).
+
+!!! note "This sends your data to Logfire"
+    The steps below send your app's data to Logfire, where it is stored. To keep data on your own infrastructure while you evaluate, [send it to a local backend](../how-to-guides/alternative-backends.md) instead. Your write token is a secret, so keep it out of source control.
+
+## Send your first trace
+
+**1. Install the OpenTelemetry gems**
+
+```sh
+gem install opentelemetry-sdk opentelemetry-exporter-otlp
+```
+
+Using Bundler? Run `bundle add opentelemetry-sdk opentelemetry-exporter-otlp` instead.
+
+**2. Configure the exporter**
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+```
+
+The endpoint above is for the US [data region](../reference/data-regions.md). If your project is in the EU region, use `https://logfire-eu.pydantic.dev` instead. The Ruby exporter sends over OpenTelemetry Protocol (OTLP) on HTTP, which is what Logfire accepts, so you do not set a protocol.
+
+**3. Add the code**
+
+```ruby title="hello.rb"
+require 'opentelemetry/sdk'
+require 'opentelemetry/exporter/otlp'
+
+# Reads OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS from the environment.
+OpenTelemetry::SDK.configure do |c|
+  c.service_name = 'hello-ruby'
+end
+
+tracer = OpenTelemetry.tracer_provider.tracer('hello-ruby')
+tracer.in_span('Hello World') do |span|
+  # your work here
+end
+
+# Flush the batch before the process exits, or the span may never be sent.
+OpenTelemetry.tracer_provider.shutdown
+```
+
+**4. Run it**
+
+```sh
+ruby hello.rb
+```
+
+## See it in the Live view
+
+Open the [**Live view**](../guides/web-ui/live.md) in Logfire. Your `Hello World` span appears as it arrives:
+
+![Traces arriving in the Logfire Live view](../images/logfire-live-view.png)
+
+Each row is one span, with its service, name, and duration. The screenshot shows a busier app; your run appears as its own row, service `hello-ruby` and span `Hello World`, which you can click to open the full trace.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| The script runs but nothing appears | The batch exports in the background, so a short script can exit before it flushes | Call `OpenTelemetry.tracer_provider.shutdown` before the process exits (as shown above) |
+| Nothing appears and you see no error | The Ruby exporter is quiet on both success and failure | Set `OTEL_LOG_LEVEL=debug` to surface export errors (a bad token or endpoint shows as "Unable to export") |
+| Spans show under `unknown_service` | The service name is not set | Set `c.service_name` in code, or `OTEL_SERVICE_NAME` |
+| Nothing arrives from a self-hosted instance with a private certificate | Ruby does not trust the private CA | Point the exporter at the CA: `OTEL_EXPORTER_OTLP_CERTIFICATE=/path/to/ca.pem` |
+
+## Next steps
+
+- **New to tracing?** [Core concepts](../concepts.md) explains spans and traces and how to read them.
+- **Want automatic traces?** Add the `opentelemetry-instrumentation-all` gem and call `c.use_all` in `configure` to instrument Rails, Sinatra, HTTP clients, and database drivers.
+- **Another language?** See [Language support](../languages.md), or [Alternative clients](../how-to-guides/alternative-clients.md) for the generic pattern.

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -141,6 +141,9 @@ navigation:
   - section: "Instrumentation"
     slug: ""
     contents:
+      - page: "Overview"
+        path: "instrument/index.md"
+        slug: "instrument"
       - section: "Python"
         contents:
           - page: "Onboarding Checklist"

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -298,6 +298,12 @@ navigation:
       - page: "Java"
         path: "languages/java.md"
         slug: "instrument/java"
+      - page: "Ruby"
+        path: "languages/ruby.md"
+        slug: "instrument/ruby"
+      - page: "PHP"
+        path: "languages/php.md"
+        slug: "instrument/php"
   - section: "Integrations"
     slug: ""
     contents:


### PR DESCRIPTION
## Summary
New Instrumentation pages for sending traces to Logfire from **Ruby** and **PHP** via OpenTelemetry, mirroring the Go/.NET/Java pages. Added to the Instrumentation nav (after Java) and the Supported Languages page.

- Ruby → in-process OpenTelemetry SDK (`opentelemetry-sdk` + `opentelemetry-exporter-otlp`)
- PHP → OpenTelemetry SDK with env-var autoloading (`open-telemetry/sdk` + `open-telemetry/exporter-otlp`)

Both are HTTP/protobuf-native, so neither needs the gRPC override that .NET does.

## Test plan
- Each sample was run against a live Logfire ingest and confirmed to appear in the Live view: `hello-ruby` and `hello-php`.
- Every command/API verified against the official OpenTelemetry Ruby/PHP docs.
- Self-hosted private-CA TLS handling documented per language (Ruby: `OTEL_EXPORTER_OTLP_CERTIFICATE`; PHP: `openssl.cafile`) — verified both.
- Links resolve, nav YAML valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

