### PR TITLE
docs: Instrumentation landing page

### DIFF
--- a/docs/instrument/index.md
+++ b/docs/instrument/index.md
@@ -1,0 +1,33 @@
+---
+title: "Instrument your app"
+description: "Get your application's telemetry into Logfire: choose your language and add a few lines, or attach an agent."
+---
+
+# Instrument your app
+
+Instrumentation is how your app's work reaches Logfire. You add a few lines (or attach an agent) once, and every request, database query, and error shows up as a **trace** (the full journey of one request, made of nested **spans**, where a span is one unit of work with a name, a start, and a duration). From then on you read the traces instead of adding logging by hand.
+
+Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open industry standard for collecting traces, metrics, and logs, so it works with any language OpenTelemetry supports.
+
+## Choose your language
+
+Each guide takes you from install to your first trace in a few minutes:
+
+- **[Python](../guides/onboarding-checklist/index.md)**: the Logfire Python SDK, with a framework picker and auto-tracing.
+- **[TypeScript](https://pydantic.dev/docs/logfire/typescript-sdk/)**: the Logfire TypeScript SDK for Node.js, browsers, and edge runtimes.
+- **[Rust](../languages/rust.md)**: the first-party `logfire` crate.
+- **[Go](../languages/go.md)**: the standard OpenTelemetry Go SDK.
+- **[.NET](../languages/dotnet.md)**: the standard OpenTelemetry .NET SDK.
+- **[Java](../languages/java.md)**: the zero-code OpenTelemetry agent, no code changes.
+- **[Ruby](../languages/ruby.md)**: the standard OpenTelemetry Ruby SDK.
+- **[PHP](../languages/php.md)**: the standard OpenTelemetry PHP SDK.
+
+Using something else? Any OpenTelemetry-compatible client can send to Logfire: see [Alternative clients](../how-to-guides/alternative-clients.md).
+
+## Next steps
+
+Once your app is sending data:
+
+- **See it arrive** in the [Live view](../guides/web-ui/live.md).
+- **Instrument the libraries you already use** (web framework, database driver, HTTP client) with [Integrations](../integrations/index.md).
+- **New to tracing?** [Core concepts](../concepts.md) explains spans and traces and how to read them.

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -141,6 +141,9 @@ navigation:
   - section: "Instrumentation"
     slug: ""
     contents:
+      - page: "Overview"
+        path: "instrument/index.md"
+        slug: "instrument"
       - section: "Python"
         contents:
           - page: "Onboarding Checklist"


### PR DESCRIPTION
## Summary
Gives the **Instrumentation** section an overview/landing page (it had none) that orients the reader on what instrumentation is and fans out to every language on-ramp — Python, TypeScript, Rust, Go, .NET, Java, Ruby, PHP — plus the generic OpenTelemetry path. Slug `instrument`.

## Note
**Stacked on #2136** (base is `docs/instrument-ruby-php`) because the landing links to the Ruby/PHP pages added there. Retarget to `main` once #2136 merges.

## Test plan
- All landing links resolve; nav YAML valid, `instrument` slug unique.
- Renders as the section overview (same pattern as the Integrations landing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

