### PR TITLE
Add ETag/304 support and SSE-triggered follow-up refresh [murmur:platform/logfire-py-variables-sse-hardening]

### DIFF
--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 import threading
+import time
 import warnings
 import weakref
 from collections.abc import Mapping
@@ -97,12 +98,16 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._last_fetched_at: datetime | None = None
 
         self._config: VariablesConfig | None = None
+        self._etag: str | None = None  # ETag from last successful response for conditional GETs
 
         self._shutdown = False
         self._shutdown_timeout_exceeded = False
         self._refresh_lock = threading.Lock()
         self._worker_awaken = threading.Event()
         self._force_refresh_event = threading.Event()  # Set by SSE listener to force immediate refresh
+        # Monotonic timestamp after which the worker should do a follow-up forced refresh (gap 5).
+        # Set after an SSE-triggered refresh to catch the 1s server-side cache window.
+        self._followup_refresh_at: float | None = None
 
         # SSE listener for real-time updates
         self._sse_connected = False
@@ -132,6 +137,9 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._force_refresh_event = threading.Event()
         # Only restart threads if we were started before the fork
         if self._started and not was_shutdown:
+            # Clear the follow-up timer before the child worker starts so that an inherited
+            # elapsed timer cannot fire before we have a chance to reset it.
+            self._followup_refresh_at = None
             self._worker_thread = threading.Thread(
                 name='LogfireRemoteProvider',
                 target=self._worker,
@@ -314,10 +322,23 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
             self.refresh(force=force)
 
+            # Gap 5: after an SSE-event-triggered forced refresh, schedule a single follow-up
+            # refresh ~2s later.  The server-side in-memory cache (platform PR #28877) has a 1s
+            # per-pod TTL, so the immediate refetch can race and return the pre-update config.
+            # One debounced follow-up guarantees convergence without adding new threads.
+            if force:
+                self._followup_refresh_at = time.monotonic() + 2.0
+
             # Gap 3: add uniform +/-10% jitter to the wait so that fleets deployed
             # simultaneously don't poll in lockstep.
             base_interval = self._polling_interval.total_seconds()
             wait_timeout = base_interval * random.uniform(0.9, 1.1)
+
+            # If a follow-up refresh is pending, shorten the wait accordingly.
+            followup_at = self._followup_refresh_at
+            if followup_at is not None:
+                followup_remaining = max(0.0, followup_at - time.monotonic())
+                wait_timeout = min(wait_timeout, followup_remaining)
 
             # Use wait(timeout) then clear() to avoid lost wakeups:
             # If SSE sets the event during refresh(), wait() returns immediately
@@ -325,8 +346,18 @@ class LogfireRemoteVariableProvider(VariableProvider):
             awakened = self._worker_awaken.wait(wait_timeout)
             if awakened:  # pragma: no branch
                 self._worker_awaken.clear()
-            if self._shutdown:  # pragma: no branch
+
+            # Do not fire the follow-up refresh if shutdown has begun -- the request
+            # would be unnecessary and could exceed the shutdown timeout budget.
+            if self._shutdown:
                 break
+
+            # Gap 5 (continued): if the follow-up window has elapsed, do a forced refresh
+            # and clear the pending timer.
+            followup_at = self._followup_refresh_at
+            if followup_at is not None and time.monotonic() >= followup_at:
+                self._followup_refresh_at = None
+                self.refresh(force=True)
 
     def refresh(self, force: bool = False):
         """Fetch the latest variable configuration from the remote API.
@@ -352,9 +383,22 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
             try:
                 with self._session_lock:
+                    # Gap 4: send a conditional GET when we have a cached ETag so the server
+                    # can respond with 304 Not Modified and skip the response body entirely.
+                    # Servers that don't support ETags (all current ones) see identical
+                    # behaviour -- they simply ignore the header.
+                    headers: dict[str, str] = {}
+                    if self._etag is not None:
+                        headers['If-None-Match'] = self._etag
                     variables_response = self._session.get(
-                        urljoin(self._base_url, '/v1/variables/'), timeout=self._timeout
+                        urljoin(self._base_url, '/v1/variables/'), timeout=self._timeout, headers=headers
                     )
+                    # Gap 4: 304 Not Modified -- config is current, just refresh the timestamp.
+                    # Do NOT call raise_for_status here (304 is outside 2xx).
+                    if variables_response.status_code == 304:
+                        self._last_fetched_at = datetime.now(tz=timezone.utc)
+                        self._has_attempted_fetch = True
+                        return
                     UnexpectedResponse.raise_for_status(variables_response)
                     variables_config_data = variables_response.json()
             except Exception as e:
@@ -367,6 +411,11 @@ class LogfireRemoteVariableProvider(VariableProvider):
                 self._has_attempted_fetch = True
                 self._log_error('Error retrieving variables', e)
                 return
+
+            # Gap 4: remember the ETag from a successful 200 response for the next request.
+            # Always update (including clearing to None) so a server that stops sending ETags
+            # doesn't leave a stale validator that causes spurious 304s on subsequent requests.
+            self._etag = variables_response.headers.get('ETag')
 
             try:
                 new_config = VariablesConfig.model_validate(variables_config_data)

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -5904,3 +5904,248 @@ class TestSSEHardening:
             finally:
                 provider._shutdown = True
                 provider.shutdown(timeout_millis=100)
+
+    # ---------- Gap 5: follow-up refresh after SSE-triggered refresh ----------
+
+    def test_worker_executes_follow_up_refresh_when_timer_elapsed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When _followup_refresh_at has already elapsed the worker fires a forced refresh and clears the timer."""
+        import time as _time
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            # Pre-set the follow-up timer to a time that has already elapsed.
+            provider._followup_refresh_at = _time.monotonic() - 1.0
+
+            wait_calls = 0
+
+            def capturing_wait(timeout: float | None = None) -> bool:
+                nonlocal wait_calls
+                wait_calls += 1
+                # Signal shutdown only on the second call so that the first iteration can
+                # fire the follow-up refresh before the worker exits.
+                if wait_calls >= 2:
+                    provider._shutdown = True
+                return False
+
+            monkeypatch.setattr(provider._worker_awaken, 'wait', capturing_wait)
+            try:
+                provider._worker()
+
+                # Timer must be cleared once the follow-up refresh fires.
+                assert provider._followup_refresh_at is None, 'Follow-up timer must be cleared after firing'
+                # Normal poll + follow-up forced refresh = at least 2 HTTP calls.
+                assert request_mocker.call_count >= 2, (
+                    f'Expected >= 2 requests (poll + follow-up), got {request_mocker.call_count}'
+                )
+            finally:
+                provider._shutdown = True
+                provider.shutdown(timeout_millis=100)
+
+    def test_worker_skips_follow_up_refresh_on_shutdown(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When shutdown begins the worker exits before firing a pending follow-up refresh."""
+        import time as _time
+
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            # Pre-set the follow-up timer to a time that has already elapsed.
+            provider._followup_refresh_at = _time.monotonic() - 1.0
+
+            def capturing_wait(timeout: float | None = None) -> bool:
+                # Signal shutdown immediately -- the worker should exit without firing the follow-up.
+                provider._shutdown = True
+                return False
+
+            monkeypatch.setattr(provider._worker_awaken, 'wait', capturing_wait)
+            try:
+                provider._worker()
+
+                # The follow-up timer must NOT have been cleared (it was not fired).
+                assert provider._followup_refresh_at is not None, 'Follow-up timer should not be cleared on shutdown'
+                # Only the initial poll request should have been made; no follow-up.
+                assert request_mocker.call_count == 1, (
+                    f'Expected exactly 1 request (no follow-up on shutdown), got {request_mocker.call_count}'
+                )
+            finally:
+                provider._shutdown = True
+                provider.shutdown(timeout_millis=100)
+
+    # ---------- Gap 4: ETag / conditional GET / 304 handling ----------
+
+    def test_304_keeps_config_and_updates_last_fetched_at(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 304 response keeps the current config and updates _last_fetched_at without logging."""
+        config_data: dict[str, Any] = {
+            'variables': {
+                'my_var': {
+                    'name': 'my_var',
+                    'labels': {'v1': {'version': 1, 'serialized_value': '"hello"'}},
+                    'rollout': {'labels': {'v1': 1.0}},
+                    'overrides': [],
+                }
+            }
+        }
+
+        request_mocker = requests_mock_module.Mocker()
+        # First call returns 200 + ETag; second returns 304.
+        request_mocker.get(
+            'http://localhost:8000/v1/variables/',
+            [
+                {'json': config_data, 'status_code': 200, 'headers': {'ETag': '"abc123"'}},
+                {'status_code': 304},
+            ],
+        )
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            # Capture any _log_error calls to verify 304 doesn't trigger one.
+            logged_errors: list[str] = []
+
+            def _capture_log_error(msg: str, exc: Exception) -> None:
+                logged_errors.append(msg)
+
+            monkeypatch.setattr(provider, '_log_error', _capture_log_error)
+
+            provider.refresh(force=True)  # 200 -- populates config and ETag
+            assert provider._config is not None
+            first_fetched_at = provider._last_fetched_at
+
+            provider.refresh(force=True)  # 304 -- must not replace config or log an error
+            assert provider._config is not None
+            assert not logged_errors, f'Unexpected errors logged on 304: {logged_errors}'
+            assert provider._last_fetched_at is not None
+            assert first_fetched_at is not None
+            assert provider._last_fetched_at >= first_fetched_at
+
+    def test_if_none_match_sent_when_etag_known(self) -> None:
+        """When a previous response set an ETag the next request must include If-None-Match."""
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get(
+            'http://localhost:8000/v1/variables/',
+            [
+                {'json': {'variables': {}}, 'status_code': 200, 'headers': {'ETag': '"deadbeef"'}},
+                {'json': {'variables': {}}, 'status_code': 200},
+            ],
+        )
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            provider.refresh(force=True)  # stores ETag
+            provider.refresh(force=True)  # sends If-None-Match
+
+            assert request_mocker.call_count == 2
+            second_request = request_mocker.request_history[1]
+            assert second_request.headers.get('If-None-Match') == '"deadbeef"'
+
+    def test_304_does_not_trip_error_logging(self) -> None:
+        """A 304 response must never cause _log_error to be called (regression guard for PR #2111)."""
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get(
+            'http://localhost:8000/v1/variables/',
+            [
+                {'json': {'variables': {}}, 'status_code': 200, 'headers': {'ETag': '"v1"'}},
+                {'status_code': 304},
+            ],
+        )
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            with warnings.catch_warnings():
+                warnings.filterwarnings('error')
+                provider.refresh(force=True)  # 200
+                provider.refresh(force=True)  # 304 -- must not warn
+
+    def test_etag_stored_from_200_response(self) -> None:
+        """A 200 response with an ETag header must store the ETag on the provider."""
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get(
+            'http://localhost:8000/v1/variables/',
+            json={'variables': {}},
+            headers={'ETag': '"deadbeef"'},
+        )
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            assert provider._etag is None
+            provider.refresh(force=True)
+            assert provider._etag == '"deadbeef"'
+
+    def test_no_etag_header_leaves_etag_none(self) -> None:
+        """A 200 response without an ETag header must leave _etag as None."""
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get('http://localhost:8000/v1/variables/', json={'variables': {}})
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            provider.refresh(force=True)
+            assert provider._etag is None
+
+    def test_200_without_etag_clears_stale_etag(self) -> None:
+        """A 200 response without ETag must clear a previously stored ETag (prevents stale validator)."""
+        request_mocker = requests_mock_module.Mocker()
+        request_mocker.get(
+            'http://localhost:8000/v1/variables/',
+            [
+                {'json': {'variables': {}}, 'status_code': 200, 'headers': {'ETag': '"v1"'}},
+                {'json': {'variables': {}}, 'status_code': 200},  # no ETag
+            ],
+        )
+        with request_mocker:
+            provider = LogfireRemoteVariableProvider(
+                base_url=REMOTE_BASE_URL,
+                token=REMOTE_TOKEN,
+                options=VariablesOptions(
+                    block_before_first_resolve=False,
+                    polling_interval=timedelta(seconds=60),
+                ),
+            )
+            provider.refresh(force=True)
+            assert provider._etag == '"v1"'
+            provider.refresh(force=True)
+            assert provider._etag is None  # cleared because 200 had no ETag


### PR DESCRIPTION
Stacked on #2144. Split from #2118 at @alexmojaki's request. Covers gaps 4-5.

## Changes

**Gap 4 -- ETag / conditional GET / 304 Not Modified**

On each poll request the provider now sends `If-None-Match: <etag>` when a cached ETag is available. A `304 Not Modified` response updates `_last_fetched_at` without replacing config or logging errors (regression guard for PR #2111). The ETag is always updated unconditionally so a server that stops sending it doesn't leave a stale validator causing spurious 304s. Current servers send no ETag, so behaviour is identical until the server is updated.

**Gap 5 -- Follow-up refresh after SSE-triggered forced refresh**

After an SSE event wakes the worker and triggers a forced refresh, a follow-up refresh is scheduled ~2 s later. The server-side per-pod cache has a 1 s TTL, so an immediate refetch can race and return pre-update config; the follow-up guarantees convergence. The follow-up is cancelled if shutdown begins before it fires (no unnecessary HTTP requests on shutdown). Also: `_at_fork_reinit` clears the timer before starting the child worker so an inherited elapsed timer cannot fire prematurely.

## Test plan
- `test_304_keeps_config_and_updates_last_fetched_at`
- `test_if_none_match_sent_when_etag_known`
- `test_304_does_not_trip_error_logging`
- `test_etag_stored_from_200_response`
- `test_no_etag_header_leaves_etag_none`
- `test_200_without_etag_clears_stale_etag`
- `test_worker_executes_follow_up_refresh_when_timer_elapsed`
- `test_worker_skips_follow_up_refresh_on_shutdown`
- `uv run coverage run -m pytest tests/test_variables.py` → 311 passed, 100% coverage on `remote.py`

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Fplatform%2Fgithub_oauth%2Fdmontagu%2Flogfire-py-variables-sse-hardening)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

