### PR TITLE
docs: fix grid links + convert the LLM catalog to theme-adaptive logos

### DIFF
--- a/docs/instrument/index.md
+++ b/docs/instrument/index.md
@@ -14,15 +14,15 @@ Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open 
 These wrap OpenTelemetry in an idiomatic API for each language, with streamlined setup and extra features. Each guide takes you from install to your first trace in a few minutes:
 
 <div class="integration-grid">
-  <a class="integration-card" href="onboarding-checklist/">
+  <a class="integration-card" href="../guides/onboarding-checklist/index.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/python.svg)"></span>
     <span class="integration-name">Python</span>
   </a>
-  <a class="integration-card" href="../typescript-sdk/">
+  <a class="integration-card" href="https://pydantic.dev/docs/logfire/typescript-sdk/">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/typescript.svg)"></span>
     <span class="integration-name">JavaScript / TypeScript</span>
   </a>
-  <a class="integration-card" href="rust/">
+  <a class="integration-card" href="../languages/rust.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/rust.svg)"></span>
     <span class="integration-name">Rust</span>
   </a>
@@ -33,27 +33,27 @@ These wrap OpenTelemetry in an idiomatic API for each language, with streamlined
 For a language without a dedicated SDK, send data with the standard OpenTelemetry SDK. We have setup guides for:
 
 <div class="integration-grid">
-  <a class="integration-card" href="go/">
+  <a class="integration-card" href="../languages/go.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/go.svg)"></span>
     <span class="integration-name">Go</span>
   </a>
-  <a class="integration-card" href="dotnet/">
+  <a class="integration-card" href="../languages/dotnet.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/dotnet.svg)"></span>
     <span class="integration-name">.NET</span>
   </a>
-  <a class="integration-card" href="java/">
+  <a class="integration-card" href="../languages/java.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/java.svg)"></span>
     <span class="integration-name">Java</span>
   </a>
-  <a class="integration-card" href="ruby/">
+  <a class="integration-card" href="../languages/ruby.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/ruby.svg)"></span>
     <span class="integration-name">Ruby</span>
   </a>
-  <a class="integration-card" href="php/">
+  <a class="integration-card" href="../languages/php.md">
     <span class="integration-logo integration-logo--glyph" style="--glyph: url(../images/languages/php.svg)"></span>
     <span class="integration-name">PHP</span>
   </a>
-  <a class="integration-card" href="../guides/alternative-clients/">
+  <a class="integration-card" href="../how-to-guides/alternative-clients.md">
     <span class="integration-logo integration-logo--plainmark">+</span>
     <span class="integration-name">Any other language</span>
   </a>

--- a/docs/integrations/llms/index.md
+++ b/docs/integrations/llms/index.md
@@ -8,52 +8,52 @@ description: "Instrument the LLM SDK or agent framework you already use and see 
 Trace the model calls, agent steps, and tool calls in your AI app. Instrument the SDK or agent framework you already use with a few lines, and the resulting spans show up in Logfire, with prompts, tokens, cost, and latency where the integration captures them.
 
 <div class="integration-grid">
-  <a class="integration-card" href="pydanticai/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/pydantic-ai.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="pydanticai.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/pydantic-ai.svg)"></span>
     <span class="integration-name">Pydantic AI</span>
   </a>
-  <a class="integration-card" href="openai/">
-    <span class="integration-logo integration-logo--mark">O</span>
+  <a class="integration-card" href="openai.md">
+    <span class="integration-logo integration-logo--plainmark">O</span>
     <span class="integration-name">OpenAI</span>
   </a>
-  <a class="integration-card" href="google-genai/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/google-gemini.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="google-genai.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/google-gemini.svg)"></span>
     <span class="integration-name">Google Gen AI</span>
   </a>
-  <a class="integration-card" href="anthropic/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/anthropic.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="anthropic.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/anthropic.svg)"></span>
     <span class="integration-name">Anthropic</span>
   </a>
-  <a class="integration-card" href="langchain/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/langchain.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="langchain.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/langchain.svg)"></span>
     <span class="integration-name">LangChain</span>
   </a>
-  <a class="integration-card" href="litellm/">
-    <span class="integration-logo integration-logo--mark">Li</span>
+  <a class="integration-card" href="litellm.md">
+    <span class="integration-logo integration-logo--plainmark">Li</span>
     <span class="integration-name">LiteLLM</span>
   </a>
-  <a class="integration-card" href="dspy/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/dspy.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="dspy.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/dspy.svg)"></span>
     <span class="integration-name">DSPy</span>
   </a>
-  <a class="integration-card" href="mcp/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/mcp.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="mcp.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/mcp.svg)"></span>
     <span class="integration-name">MCP</span>
   </a>
-  <a class="integration-card" href="claude-agent-sdk/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/claude-agent-sdk.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="claude-agent-sdk.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/claude-agent-sdk.svg)"></span>
     <span class="integration-name">Claude Agent SDK</span>
   </a>
-  <a class="integration-card" href="llamaindex/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/llamaindex.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="llamaindex.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/llamaindex.svg)"></span>
     <span class="integration-name">LlamaIndex</span>
   </a>
-  <a class="integration-card" href="mirascope/">
-    <span class="integration-logo"><img src="../../images/integrations/llms/mirascope.svg" alt="" loading="lazy"></span>
+  <a class="integration-card" href="mirascope.md">
+    <span class="integration-logo integration-logo--glyph" style="--glyph: url(../../images/integrations/llms/mirascope.svg)"></span>
     <span class="integration-name">Mirascope</span>
   </a>
-  <a class="integration-card" href="magentic/">
-    <span class="integration-logo integration-logo--mark">Ma</span>
+  <a class="integration-card" href="magentic.md">
+    <span class="integration-logo integration-logo--plainmark">Ma</span>
     <span class="integration-name">Magentic</span>
   </a>
 </div>


### PR DESCRIPTION
Fixes the unified-docs built-link-checker errors from the instrument overview and the LLM integrations catalog. Both grids used rendered route paths (and the catalog used `<img>` logos), which the checker flags because it resolves them against the flattened `.md` export.

- **Card hrefs → source-relative `.md`** on both grids, which the link transform rewrites to real routes. (TypeScript keeps its full URL — no `.md` source in this repo.)
- **Catalog logos → the glyph (CSS mask) treatment** already used by the instrument grid: theme-adaptive silhouettes, no `<img>`, so the export has no unresolved image paths and both grids look consistent.

## Depends on

[pydantic/unified-docs#145](https://github.com/pydantic/unified-docs/pull/145) (rewrites `.md` hrefs in raw HTML anchors) — **merge that first**.

## Verified

Full unified-docs build + lychee, with both PRs applied: the checker goes from **32 broken links → 2**. The instrument (9) and catalog (21: routes + images) errors are all gone. The remaining 2 are a dead `harness/skills` link in the pydantic-ai-harness repo (unrelated).