### PR TITLE
docs: fix silent OTLP data loss for non-Python clients + wrong Get Help description

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -1,6 +1,6 @@
 ---
 title: "Get Help with Pydantic Logfire: Docs, Support & GitHub"
-description: "Need to send alerts to Slack from Logfire? This guide shows how to create a Slack webhook and define SQL-based alert criteria for your Slack alert system."
+description: "Where to get help with Pydantic Logfire: the community Slack, GitHub issues, documentation, and email support."
 hide:
 ---
 # Getting help with Pydantic Logfire

--- a/docs/how-to-guides/alternative-clients.md
+++ b/docs/how-to-guides/alternative-clients.md
@@ -11,12 +11,17 @@ in many languages to export to the **Logfire** backend, including those outside 
 [first-class supported languages](../instrument/index.md). Depending on your SDK, you may need to set only
 these [environment variables](https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/):
 
-- `OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev` for both traces and metrics, or:
+- `OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev` for traces, metrics, and logs, or set one signal at a time:
     - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://logfire-us.pydantic.dev/v1/traces` for just traces
     - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://logfire-us.pydantic.dev/v1/metrics` for just metrics
     - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logfire-us.pydantic.dev/v1/logs` for just logs
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` so the SDK exports over HTTP (see the warning below).
 - `OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` - see [Create Write Tokens](./create-write-tokens.md)
   to obtain a write token and replace `your-write-token` with it.
+- `OTEL_SERVICE_NAME=your-service-name` to set the name your service is grouped under in Logfire. Without it, your data appears under `(unknown)` in the [Services](../guides/web-ui/services.md) view.
+
+!!! warning "Set the protocol to `http/protobuf`"
+    Logfire receives OpenTelemetry data over HTTP, but many SDKs (for example Java, .NET, and anything using a gRPC exporter) default to gRPC. When an SDK exports over gRPC, it sends nothing to Logfire, often with only a connection error, or no error at all. Setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or the equivalent in code) is the most common fix when data never arrives.
 
 !!! note
     This page shows `https://logfire-us.pydantic.dev` as the base URL which is for the US [region](../reference/data-regions.md).
@@ -30,6 +35,7 @@ First, run these commands:
 pip install opentelemetry-exporter-otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
 export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=my-service
 ```
 
 Then run this script with `python`:
@@ -106,6 +112,7 @@ First, set up a new Cargo project:
 cargo new --bin otel-example && cd otel-example
 export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
 export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=my-service
 ```
 
 Update the `Cargo.toml` and `main.rs` files with the following contents:
@@ -164,3 +171,16 @@ fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 ```
 
 Finally, use `cargo run` to execute.
+
+## Verify
+
+Run your program, then open the [Live view](../guides/web-ui/live.md) for your project. You should see a trace with a single span named `Hello World`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| Nothing arrives, with a connection error or no error at all | The SDK is exporting over its default gRPC protocol | Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or the equivalent in code). Logfire receives data over HTTP only. |
+| Requests rejected with `401` or `403` | Missing or invalid write token | Set `OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` with a valid [write token](./create-write-tokens.md). |
+| Data appears under `(unknown)` in the [Services](../guides/web-ui/services.md) view | No service name set | Set `OTEL_SERVICE_NAME=your-service-name`. |
+| Connection or TLS errors | The endpoint points at the wrong region | Use `https://logfire-us.pydantic.dev` (US) or `https://logfire-eu.pydantic.dev` (EU). |


### PR DESCRIPTION
Two fixes surfaced by a persona-journey docs audit.

## Alternative clients (any-language OpenTelemetry path)
The generic env-var recipe omitted `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`. Logfire receives OpenTelemetry data over HTTP only, but many SDKs (Java, .NET, anything using a gRPC exporter) default to gRPC — so they send **nothing, usually with no error**, and a user following this page had no way to know why. This is the catch-all page for languages without a dedicated guide, so it was the most likely place to hit the problem and the least equipped to explain it.

- Add `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` with a warning explaining the gRPC-default failure mode.
- Add `OTEL_SERVICE_NAME` (without it, data lands under `(unknown)` in the Services view).
- Add **Verify** and **Troubleshooting** sections to match the dedicated language pages.

## Get Help page
Its meta description was copy-pasted from a Slack-alerts page and described completely different content. Rewritten to match the page.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

