### PR TITLE
docs: unify Python onboarding into one spine (first-trace as the single entry)

### DIFF
--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -141,6 +141,7 @@ Each integration ships as an extra, so install the matching one first: `pip inst
 ## Next steps
 
 - **New to tracing?** [Core concepts](concepts.md) explains spans and traces and how to read them.
+- **Want the full Python walkthrough?** The [Python onboarding guide](guides/onboarding-checklist/index.md) adds manual tracing, auto-tracing, and metrics, step by step.
 - **Already using a framework?** [Integrations](integrations/index.md) add rich tracing to FastAPI, Django, SQLAlchemy, HTTPX, and many more with one line.
 - **Building with AI?** [AI & LLM Observability](ai-observability.md) shows the requests, tool calls, tokens, and cost behind your model-powered features.
 - **Not sure where to focus?** [Choose your path](get-started/choose-your-path.md) gives a short, ordered route for your role.

--- a/docs/get-started/for-backend-and-sre.md
+++ b/docs/get-started/for-backend-and-sre.md
@@ -11,7 +11,7 @@ Follow these in order. Each link says why it's here.
 
 ## Your path
 
-1. **[Send your first trace to Logfire](../index.md)**: install Logfire and link this machine to a project. A **trace** is the full record of one request; a **span** is one step inside it (a database query, an outgoing API call). This is the five-minute foundation everything else builds on.
+1. **[Send your first trace to Logfire](../first-trace.md)**: install Logfire and link this machine to a project. A **trace** is the full record of one request; a **span** is one step inside it (a database query, an outgoing API call). This is the five-minute foundation everything else builds on.
 
 2. **Instrument your framework and dependencies**: one line each turns on tracing for the request path:
     - Web frameworks: [FastAPI](../integrations/web-frameworks/fastapi.md), [Django](../integrations/web-frameworks/django.md), [Flask](../integrations/web-frameworks/flask.md), [Starlette](../integrations/web-frameworks/starlette.md) (see [all web frameworks](../integrations/web-frameworks/index.md))

--- a/docs/get-started/solo-builder.md
+++ b/docs/get-started/solo-builder.md
@@ -9,7 +9,7 @@ It's just you and your app, and you want to see what it's doing without wading t
 
 ## Your path
 
-1. **[Send your first trace to Logfire](../index.md)**: about five minutes. You install Logfire, sign in through your browser (no secret key to copy and paste), and run a small program. A **trace** is the record of what your code did on one run (the steps it took and how long each one took) and you'll see one appear on screen.
+1. **[Send your first trace to Logfire](../first-trace.md)**: about five minutes. You install Logfire, sign in through your browser (no secret key to copy and paste), and run a small program. A **trace** is the record of what your code did on one run (the steps it took and how long each one took) and you'll see one appear on screen.
 
 2. **Turn on tracing for what you already use**: pick the one that matches your app and add its single line of setup:
     - Building with an LLM (the AI that generates text)? [OpenAI](../integrations/llms/openai.md), [Anthropic](../integrations/llms/anthropic.md), or an [agent framework](../integrations/llms/pydanticai.md).

--- a/docs/guides/onboarding-checklist/add-auto-tracing.md
+++ b/docs/guides/onboarding-checklist/add-auto-tracing.md
@@ -107,3 +107,7 @@ Renaming/aliasing either the function or module won't work.
 Neither will calling this indirectly via another function.
 
 This decorator simply returns the argument unchanged, so there is zero runtime overhead.
+
+## Next step
+
+**[Add metrics](add-metrics.md)**: record counts, sizes, and gauges to measure your app's behavior over time.

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -314,3 +314,7 @@ import logfire
 
 logfire.configure(console=logfire.ConsoleOptions(min_log_level='debug'))
 ```
+
+## Next step
+
+**[Add auto-tracing](add-auto-tracing.md)**: instrument whole modules automatically, without adding a span to every function by hand.

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -260,6 +260,17 @@ logfire.metric_up_down_counter_callback(
 
 You can read more about the Up-Down Counter metric in the [OpenTelemetry documentation][up-down-counter-callback-metric].
 
+## You're done
+
+You've integrated Logfire, added manual and automatic tracing, and started recording metrics. Your Python app is now
+sending the data you need to monitor performance, find bugs, and understand behavior.
+
+From here:
+
+- **Watch it live**: open the [Live view](../web-ui/live.md) and use your app.
+- **Instrument the libraries you use**: [Integrations](../../integrations/index.md) add rich tracing to your web framework, database, and HTTP clients with one line each.
+- **Build dashboards and alerts**: turn the questions you check often into [Dashboards](../web-ui/dashboards.md), and get told about problems with [Alerts](../web-ui/alerts.md).
+
 [counter-metric]: https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
 [histogram-metric]: https://opentelemetry.io/docs/specs/otel/metrics/api/#histogram
 [up-down-counter-metric]: https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter

--- a/docs/guides/onboarding-checklist/index.md
+++ b/docs/guides/onboarding-checklist/index.md
@@ -2,12 +2,12 @@
 title: "Get started with Logfire in Python"
 description: "Instrument your Python app with Logfire: initial integration, tracing setup (manual and auto), and collecting metrics."
 ---
-Instrument your **Python** app with Logfire. Whether you're starting a new project or integrating Logfire with an
-existing application, this guide helps you quickly instrument your code and start sending as much data to
-Logfire with as little development effort as possible.
+You've already [sent your first trace](../../first-trace.md). Now go deeper: this guide takes your **Python** app from that
+first trace to full instrumentation: integrating Logfire with your logging, adding manual and automatic tracing, and
+recording metrics.
 
-Once you've worked through these steps, you'll be collecting all the data necessary to monitor performance, identify and
-fix bugs, analyze user behavior, and make data-driven decisions.
+Once you've worked through these steps, you'll be collecting all the data you need to monitor performance, find and
+fix bugs, understand behavior, and make data-driven decisions.
 
 !!! note
     If you aren't familiar with traces and spans, start with the [Tracing with Spans](../../concepts.md) page.
@@ -33,4 +33,4 @@ introduction to the Logfire Web UI and show you how to interact with the data yo
 !!! note
     For a more comprehensive walkthrough of the Logfire Web UI and its features, you may be interested in our [Logfire Web UI Guide](../web-ui/live.md).
 
-Let's get started! :rocket:
+Let's get started!

--- a/docs/guides/onboarding-checklist/integrate.md
+++ b/docs/guides/onboarding-checklist/integrate.md
@@ -2,13 +2,14 @@
 title: "Logfire Onboarding: OpenTelemetry & Logging Setup"
 description: "This guide shows how to integrate Logfire using OpenTelemetry instrumentation. Get set up with Python's standard logging, Loguru, or Structlog quickly."
 ---
-In this section, we'll focus on integrating **Logfire** with your application.
+This step assumes you've already [sent your first trace](../../first-trace.md), which installs the SDK and calls
+`logfire.configure()`. Here we integrate **Logfire** more fully with your application: the instrumentation packages for
+the libraries you already use, and your existing logging.
 
 ## OpenTelemetry Instrumentation
 
-Harnessing the power of [OpenTelemetry], **Logfire** not only offers broad compatibility with any [OpenTelemetry]
-instrumentation package, but also includes a CLI command that highlights any
-missing components in your project.
+**Logfire** works with any [OpenTelemetry] instrumentation package (a plug-in that automatically traces a specific
+library or framework), and includes a CLI command that highlights instrumentation your project is missing.
 
 To inspect your project, run the following command:
 
@@ -16,7 +17,7 @@ To inspect your project, run the following command:
 logfire inspect
 ```
 
-This will output the projects you need to install to have optimal OpenTelemetry instrumentation:
+This lists the packages you need to install for OpenTelemetry instrumentation:
 
 ![Logfire inspect command](../../images/cli/terminal-screenshot-inspect.png)
 
@@ -77,8 +78,6 @@ If you go to the link, you will see the `"Hello Fred!"` log in the Web UI:
 
 ![Logfire Web UI with logs](../../images/guide/browser-integrate.png)
 
-It is simple as that! Cool, right? 🤘
-
 ### Loguru
 
 To integrate with Loguru, check out the [Loguru] page.
@@ -86,6 +85,10 @@ To integrate with Loguru, check out the [Loguru] page.
 ### Structlog
 
 To integrate with Structlog, check out the [Structlog] page.
+
+## Next step
+
+**[Add manual tracing](add-manual-tracing.md)**: create your own spans and logs to record exactly the operations you care about.
 
 [inspect-command]: ../../reference/cli.md#inspect-inspect
 [integrations]: ../../integrations/index.md

--- a/docs/instrument/index.md
+++ b/docs/instrument/index.md
@@ -14,7 +14,7 @@ Logfire is built on [OpenTelemetry (OTel)](https://opentelemetry.io/), the open 
 These wrap OpenTelemetry in an idiomatic API for each language, with streamlined setup and extra features. Each guide takes you from install to your first trace in a few minutes:
 
 <div class="integration-grid">
-  <a class="integration-card" href="../guides/onboarding-checklist/index.md">
+  <a class="integration-card" href="../first-trace.md">
     <span class="integration-logo integration-logo--glyph" style="-webkit-mask: url(../images/languages/python.svg) center/contain no-repeat; mask: url(../images/languages/python.svg) center/contain no-repeat"></span>
     <span class="integration-name">Python</span>
   </a>


### PR DESCRIPTION
The Python onboarding had **two competing front doors**, surfaced by a persona-journey audit.

## The problem
The Instrumentation grid's Python card and two persona pages routed readers into the onboarding **checklist**, whose first step opens with `logfire inspect` — as if the SDK were already installed and configured. The checklist never covers install, sign-up, auth, or `logfire.configure()`. Meanwhile `first-trace.md` is the real quickstart (install → auth → configure → verified trace). A first-time Python dev who took the grid path hit a wall.

## The fix — `first-trace.md` becomes the single entry
- **Grid Python card** → `first-trace.md` (was the checklist's second overview).
- **Persona links**: the "Send your first trace" links on the backend/SRE and solo-builder pages pointed at the Get Started hub, not the quickstart — now fixed (the AI-engineer page already pointed correctly).
- **Checklist reframed as "go deeper"**: it now names `first-trace.md` as its prerequisite, and `first-trace.md` links back to it, so the two pages complement instead of compete.
- **Steps now chain**: integrate → manual → auto → metrics each link to the next, and the last ends with a completion + fan-out to Live view / Integrations / dashboards / alerts. Previously every step dead-ended.
- Dropped the hype opener, a "projects" vs "packages" slip, and emoji filler on the integrate page.

No slugs change, so no redirects needed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

