### PR TITLE
docs: make Core Concepts the canonical span/trace explainer + de-market the funnel

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,36 +1,38 @@
 ---
-title: "Logfire Concepts: Spans, Traces, Metrics & Logs"
+title: "Core concepts: traces, spans, metrics, and logs"
 description: "Explore how Logfire handles spans, traces, metrics, and event data to help you monitor, debug, and optimize your application."
 ---
 ## Overview
 
-Understanding the core building blocks of observability helps you monitor, debug, and optimize your applications. The four key concepts work together to give you complete insight into your application's behavior: spans and traces show you what's happening and how long it takes, metrics reveal trends and performance over time, and logs capture specific events and details.
+Observability is the practice of understanding what your running software is doing from the outside, from the data it emits. That data is called **telemetry**. Logfire is built on four kinds of telemetry that work together: **spans** and **traces** show you what happened and how long it took, **metrics** reveal trends over time, and **logs** capture individual events. This page explains each one.
 
-New to observability? Another great resource is the [OpenTelemetry primer](https://opentelemetry.io/docs/concepts/observability-primer/).
+New to observability? The [OpenTelemetry primer](https://opentelemetry.io/docs/concepts/observability-primer/) is another good introduction.
 
 ## Concepts
 
-| Concept | Description                                                     |
-| ------- | --------------------------------------------------------------- |
-| Span    | Atomic unit of telemetry data                                   |
-| Trace   | Contains spans, tree structure shows parent/child relationships |
-| Metric  | Values calculated using telemetry data                          |
-| Log     | No duration, timestamped, emitted by services/loggers           |
+| Concept | What it is |
+| ------- | ---------- |
+| Span    | One unit of work: a single operation, with a name, a start, and a duration |
+| Trace   | A tree of spans showing the parent/child path of one request |
+| Metric  | A value measured over time, such as latency, CPU load, or queue length |
+| Log     | A timestamped record of a single event, with no duration |
 
 ## What is a Span?
 
-A **span** is the building block of a trace. You might also think of spans as logs with extra functionality: a single row in our live view.
+A **span** records one unit of work: a single operation, with a name, a start, and a duration (for example, "count the files in this directory" or "read this file"). Spans are the building block of a trace, and each one appears as a single row in the Live view.
+
+If you've used logging before, think of a span as a log with a duration and structure: as well as recording that something happened, it measures how long that something took, and it can contain other spans nested inside it.
 
 !!! info
-    Spans let you **add context** to your logs and **measure code execution time**. Multiple spans combine to form a trace, providing a complete picture of an operation's journey through your system.
+    Spans let you **add context** to your logs and **measure how long code takes to run**. Multiple spans combine to form a trace, giving a complete picture of an operation's journey through your system.
 
 ![Spans](images/concepts/spans.png)
 
 ## What is a Trace?
 
-A trace is a tree structure of spans which shows the path of any client request, LLM run, API call through your application.
+A trace is a tree of spans that shows the path of one request (a client request, an LLM run, an API call) through your application.
 
-Spans are ordered and nested, meaning you can think of this like a stack trace - it shows you the whole history of all services touched and all responses returned.
+Spans are ordered and nested: a span can contain other spans, so a trace reads like an outline of everything that happened, in order, with each step's duration. It shows the whole history of the services touched and the responses returned.
 
 !!! info
     Traces are not limited to a single service. They can be propagated to completely different and isolated services. For example, a single trace could contain http requests to both a Python API and a SQL database.
@@ -97,9 +99,9 @@ with logfire.span('Asking the user for their {question}', question='birthday'): 
 
 ---
 
-By instrumenting your code with traces and spans, you can see how long operations take, identify bottlenecks,
-and get a high-level view of request flows in your system: all invaluable for maintaining the performance and
-reliability of your applications.
+By instrumenting your code (adding a few lines so Logfire can record what it does) with traces and spans, you can see
+how long operations take, identify bottlenecks, and get a high-level view of request flows in your system: all
+invaluable for maintaining the performance and reliability of your applications.
 
 ## What is a Metric?
 
@@ -150,4 +152,10 @@ see the [adding metrics guide](guides/onboarding-checklist/add-metrics.md).
 
 Logs record something which happened in your application. Importantly, they do not have a duration, compared to spans and traces.
 
-A log is a timestamped text record, either structured (recommended) or unstructured, with optional metadata. Of all telemetry signals, logs are the best known and have the largest footprint on our collective understanding. Most programming languages have built-in logging capabilities or well-known, widely used logging libraries. Most Python users are familiar with the [`logging`][] module for example.
+A log is a timestamped text record, either structured (recommended) or unstructured, with optional metadata. Of all telemetry signals, logs are the best known: most programming languages have built-in logging, and most Python users are familiar with the standard-library [`logging`](https://docs.python.org/3/library/logging.html) module, for example.
+
+## Next steps
+
+- **Send your first trace**: the [quickstart](first-trace.md) gets you from install to a trace in about five minutes.
+- **Instrument a framework**: [Integrations](integrations/index.md) record traces from FastAPI, Django, SQLAlchemy, HTTPX, and many more with one line each.
+- **Read your traces**: the [Live view](guides/web-ui/live.md) is where traces arrive and where you explore them.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -27,7 +27,7 @@ Built by the Pydantic team (the same people behind Pydantic AI), Logfire provide
 Logfire is for teams building AI applications who need to actually debug them:
 
 - **AI developers** who want to understand why their AI agent failed (was it the LLM? the database? the API it called?)
-- **Teams tired of correlating** between AI monitoring and APM tools manually
+- **Teams tired of correlating** between AI monitoring and application performance monitoring (APM) tools manually
 - **Polyglot architectures** with Python AI + TypeScript frontend, etc.
 - **Developers who want SQL-based querying**, which is essential for agentic coding workflows
 - **Organizations needing enterprise features** like SOC2, HIPAA, and self-hosting
@@ -119,7 +119,7 @@ Yes. We provide a full JavaScript/TypeScript SDK.
 - Cloudflare Workers
 - Deno
 
-The JS SDK provides the same core features as Python: spans, structured logging, error tracking, and distributed tracing.
+The JS SDK provides the same core features as Python: spans, structured logging, error tracking, and distributed tracing (stitching spans from several services into one trace).
 
 [JavaScript SDK](https://pydantic.dev/docs/logfire/typescript-sdk/)
 
@@ -137,7 +137,7 @@ The JS SDK provides the same core features as Python: spans, structured logging,
 - Next.js, Express, Cloudflare Workers
 - Vercel AI SDK
 
-**Other languages:** Any framework following OpenTelemetry semantic conventions.
+**Other languages:** Any framework following OpenTelemetry semantic conventions (its standard names for common telemetry).
 
 [Full integrations list](integrations/index.md)
 
@@ -208,11 +208,11 @@ SQL is the most widely-known query language, and AI assistants are exceptionally
 This matters especially for **agentic coding workflows**:
 
 - **Coding agents can query freely:** No limitation to predefined APIs. Ask any question, get any answer.
-- **Arbitrary analysis:** JOINs, aggregations, window functions, CTEs. Full SQL power.
+- **Arbitrary analysis:** JOINs, aggregations, window functions, CTEs (common table expressions). Full SQL power.
 - **AI-native:** GPT-5, Claude, and other assistants write excellent SQL
 - **Familiar syntax:** No new query language to learn
 
-When you're iterating on AI applications with a coding agent, the agent needs to understand production behavior. With SQL, it can ask any question. With proprietary DSLs or limited APIs, it's constrained to what someone anticipated.
+When you're iterating on AI applications with a coding agent, the agent needs to understand production behavior. With SQL, it can ask any question. With a proprietary query language or limited APIs, it's constrained to what someone anticipated.
 
 *Logfire uses [Apache DataFusion](https://datafusion.apache.org/) as its query engine, with syntax designed to match PostgreSQL conventions.*
 

--- a/docs/why.md
+++ b/docs/why.md
@@ -4,21 +4,21 @@ description: "Logfire unifies metrics, tracing, and structured data logging into
 ---
 # Introducing Pydantic Logfire
 
-From the team behind Pydantic Validation, **Pydantic Logfire** is an observability platform built on the same belief as our open-source library: that the most powerful tools can be easy to use.
+From the team behind Pydantic Validation, **Pydantic Logfire** is an observability platform built on the same belief as our open-source library: that a tool can be genuinely capable and still be quick to pick up.
 
 ## What sets Logfire apart
 
 <div class="grid cards" markdown>
 
-- :rocket:{ .lg .middle } **Simplicity and Power**
+- :rocket:{ .lg .middle } **Simple to use, deep when you need it**
 
   ***
 
-  Logfire's dashboard is simple relative to the power it provides, ensuring your entire engineering team will actually use it. Time-to-first-log should be less than 5 minutes.
+  Logfire is approachable enough that your whole engineering team will actually use it, and you'll see your first data within about five minutes.
 
   [:octicons-arrow-right-24: Read more](#simplicity-and-power)
 
-- :material-robot-outline:{ .lg .middle } **The Full AI Engineering Loop**
+- :material-robot-outline:{ .lg .middle } **The full AI engineering loop**
 
   ***
 
@@ -26,7 +26,7 @@ From the team behind Pydantic Validation, **Pydantic Logfire** is an observabili
 
   [:octicons-arrow-right-24: Read more](ai-observability.md)
 
-- :material-code-braces:{ .lg .middle } **Deep Language Integration**
+- :material-code-braces:{ .lg .middle } **Deep language integration**
 
   ***
 
@@ -34,7 +34,7 @@ From the team behind Pydantic Validation, **Pydantic Logfire** is an observabili
 
   [:octicons-arrow-right-24: Read more](#deep-language-integration)
 
-- :simple-pydantic:{ .lg .middle } **Pydantic Integration**
+- :simple-pydantic:{ .lg .middle } **Pydantic integration**
 
   ***
 
@@ -50,7 +50,7 @@ From the team behind Pydantic Validation, **Pydantic Logfire** is an observabili
 
   [:octicons-arrow-right-24: Read more](#opentelemetry-under-the-hood)
 
-- :simple-instructure:{ .lg .middle } **Structured Data**
+- :simple-instructure:{ .lg .middle } **Structured data**
 
   ***
 
@@ -74,7 +74,7 @@ Pydantic Logfire was built by developers who understand real applications: from 
 
 ![Logfire FastAPI screenshot](images/index/logfire-screenshot-fastapi-200.png)
 
-## Simplicity and Power :rocket:
+## Simple to use, deep when you need it {#simplicity-and-power}
 
 Emulating the Pydantic library's philosophy, Pydantic Logfire offers an
 intuitive start for beginners while providing the depth experts desire. It's the same balance of ease, sophistication,
@@ -84,7 +84,7 @@ Within a few minutes you'll have your first logs:
 
 ![Logfire hello world screenshot](images/index/logfire-screenshot-hello-world-age.png)
 
-This might look similar to simple logging, but it's much more powerful. You get:
+This might look like ordinary logging, but it does much more. You get:
 
 - **Structured data** from your logs
 - **Nested logs &amp; traces** to contextualize what you're viewing
@@ -93,10 +93,10 @@ This might look similar to simple logging, but it's much more powerful. You get:
 
 Ready to try Logfire? [Get Started](index.md)!
 
-## Deep language integration :material-code-braces:
+## Deep language integration {#deep-language-integration}
 
-**Pydantic Logfire** automatically instruments your code for minimal manual effort, provides
-exceptional insights into async code, offers detailed performance analytics, and displays Python
+**Pydantic Logfire** automatically instruments your code for minimal manual effort, gives you clear
+visibility into async code, offers detailed performance analytics, and displays Python
 objects the same as the interpreter. Python has the deepest integration, but Logfire also has native SDKs for JavaScript/TypeScript and Rust, and works with any OpenTelemetry-compatible language.
 
 ### Rich display of Python objects
@@ -113,9 +113,9 @@ In this simple app example, you can see every interaction the user makes with th
 
 ## Pydantic integration
 
-**Logfire** has an out-of-the-box **Pydantic** integration that lets you understand the data
+**Logfire** has a built-in **Pydantic** integration that lets you understand the data
 passing through your Pydantic models and get analytics on validations. For existing Pydantic users,
-it delivers unparalleled insights into your usage of Pydantic models.
+it shows you exactly how your Pydantic models are being used.
 
 We can record Pydantic models directly:
 
@@ -174,7 +174,7 @@ Learn more about the [Pydantic Plugin here](integrations/pydantic.md).
 
 ![Logfire pydantic plugin screenshot](images/index/logfire-screenshot-pydantic-plugin.png)
 
-## OpenTelemetry under the hood :telescope:
+## OpenTelemetry under the hood {#opentelemetry-under-the-hood}
 
 Because **Pydantic Logfire** is built on [OpenTelemetry](https://opentelemetry.io/), you can
 use a wealth of existing tooling and infrastructure, including
@@ -230,9 +230,9 @@ And, importantly, details of failed input validations:
 
 ![Logfire FastAPI 422 response screenshot](images/index/logfire-screenshot-fastapi-422.png)
 
-In the example above, we can see the FastAPI arguments failing (`user` is null when it should always be populated). This demonstrates type-checking from Pydantic used out-of-the-box in FastAPI.
+In the example above, we can see the FastAPI arguments failing (`user` is null when it should always be populated). This demonstrates type-checking from Pydantic used built-in with FastAPI.
 
-## Structured Data and SQL :abacus: {#sql}
+## Structured data and SQL {#sql}
 
 Query your data with SQL using familiar PostgreSQL-compatible syntax: all the control and (for many) nothing new to learn.
 


### PR DESCRIPTION
Funnel-clarity fixes from a persona-journey docs audit (the newcomer-to-AI-tooling reader).

## Core Concepts (`concepts.md`)
This is the page readers are sent to for spans and traces, but it was the *weakest* explainer of them. Rewritten to teach in plain language:
- Span was defined as **"Atomic unit of telemetry data"** — the exact phrase the style guide bans — and explained via "log" before "log" was defined. Now: *a span is one unit of work: a single operation, with a name, a start, and a duration.*
- Glossed **telemetry** and **instrument** on first use; replaced the "think of it like a stack trace" analogy (assumes prior knowledge) with a plain nesting description.
- Fixed an empty `[logging][]` link, and added a **Next steps** fan-out (the page previously dead-ended).

## `why.md`
Removed the banned marketing vocabulary ("most powerful", "much more powerful", "exceptional insights", "unparalleled insights", "out-of-the-box"), sentence-cased the Title-Case card titles and section headings (anchors preserved with explicit `{#…}`), and reframed the "time-to-first-log" internal target as a reader outcome.

## `faq.md`
Spelled out acronyms on first use (**APM**, **CTE**) and glossed **distributed tracing**, **semantic conventions**, and **proprietary DSLs**.

### Deliberately deferred
`why.md`'s deeper narrative rewrite and `faq.md`'s competitive/battlecard framing ("AI-only tools have tied one hand behind their back", naming Langfuse/Arize/Datadog in-page) are positioning calls left for the team to own.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

