### PR TITLE
docs: make the AI Engineering section cohere (surface the Gateway, split instrument vs gateway)

### DIFF
--- a/docs/ai-observability.md
+++ b/docs/ai-observability.md
@@ -81,3 +81,7 @@ Both failures look like a bad answer to the user. They need different fixes. Log
 Start with a one-line integration for [Pydantic AI](integrations/llms/pydanticai.md), [OpenAI](integrations/llms/openai.md), [Anthropic](integrations/llms/anthropic.md), [LangChain](integrations/llms/langchain.md), or another supported framework. Logfire also accepts [OpenTelemetry (OTel), the open industry standard for collecting traces, metrics, and logs](how-to-guides/alternative-clients.md), so a TypeScript frontend, Python agent service, and Go backend can all appear in the same trace.
 
 [See all integrations →](integrations/index.md)
+
+## Control cost and routing (optional)
+
+To cap what your app can spend on models, fail over between providers, or keep one API key for many models, route your calls through the [AI Gateway](reference/advanced/gateway/index.md). This is optional: the instrumentation above is all you need to trace and debug your agents.

--- a/docs/get-started/for-ai-engineers.md
+++ b/docs/get-started/for-ai-engineers.md
@@ -17,7 +17,7 @@ Follow these in order. Each link says why it's here.
     - [Pydantic AI](../integrations/llms/pydanticai.md) (for agents)
     - [LangChain](../integrations/llms/langchain.md), [LlamaIndex](../integrations/llms/llamaindex.md), [LiteLLM](../integrations/llms/litellm.md), [Google GenAI](../integrations/llms/google-genai.md)
 
-    See the full list under [LLM integrations](../integrations/index.md).
+    See the full list under [LLM integrations](../integrations/llms/index.md).
 
 2. **[Understand an agent run](../ai-observability.md)**: once data is flowing, see how Logfire records the model's conversation, tool calls, tokens, cost, and the code around them. A **trace** is the full record of one request; a **span** is one step inside it.
 

--- a/docs/integrations/llms/index.md
+++ b/docs/integrations/llms/index.md
@@ -7,6 +7,9 @@ description: "Instrument the LLM SDK or agent framework you already use and see 
 
 Trace the model calls, agent steps, and tool calls in your AI app. Instrument the SDK or agent framework you already use with a few lines, and the resulting spans show up in Logfire, with prompts, tokens, cost, and latency where the integration captures them.
 
+!!! note "Instrument vs. gateway"
+    These pages **instrument** the calls you already make, so you can see them in Logfire. To instead **route** your calls through Logfire for spending caps and provider failover, see [Connect an agent to the AI Gateway](../../reference/advanced/gateway/integrations/index.md).
+
 <div class="integration-grid">
   <a class="integration-card" href="pydanticai.md">
     <span class="integration-logo integration-logo--glyph" style="-webkit-mask: url(../../images/integrations/llms/pydantic-ai.svg) center/contain no-repeat; mask: url(../../images/integrations/llms/pydantic-ai.svg) center/contain no-repeat"></span>

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -7,6 +7,9 @@ description: "Route LLM calls through a single Logfire-managed endpoint with bui
 
 The Logfire AI Gateway lets you route LLM calls through a single endpoint with built-in spending limits, fallbacks, and usage tracking. Instead of scattering provider API keys across your applications, you point your existing SDKs (OpenAI, Anthropic, Google GenAI, Pydantic AI, or plain HTTP) at the gateway and authenticate with a gateway API key that you manage in Logfire.
 
+!!! note
+    The gateway is for **routing** your model calls. If you only want to **see and debug** the calls you already make, you don't need it: [instrument a framework](../../../integrations/llms/index.md) instead.
+
 The gateway gives you:
 
 - **One endpoint, many providers**: call OpenAI, Anthropic, Google, AWS Bedrock, Groq, Mistral, and more through provider-compatible endpoints, using the SDKs you already have.

--- a/docs/reference/advanced/gateway/integrations/index.md
+++ b/docs/reference/advanced/gateway/integrations/index.md
@@ -7,6 +7,9 @@ description: "Use the Logfire AI Gateway with agent frameworks and model SDKs."
 
 Connect the framework, prompts, tools, and agent workflow you already use to the Logfire AI Gateway.
 
+!!! note "Gateway vs. instrument"
+    These guides **route** your model calls through the gateway for spending caps, failover, and shared keys. If you only want to **see and debug** the calls you already make, you don't need the gateway: [instrument a framework](../../../../integrations/llms/index.md) instead.
+
 Each guide shows the two client settings you need to change: the API key and gateway URL. You can point them at one model provider or at a [routing group](../index.md#routing-groups), which can fail over to another provider or distribute requests across several providers.
 
 ## Before you start


### PR DESCRIPTION
Coherence fixes for the consolidated AI Engineering section, from a persona-journey docs audit.

## Two problems
1. **The Overview skipped a whole subsection.** `ai-observability.md` fanned out to Instrument, Observe, Evals, and Prompts — but **never mentioned the AI Gateway**, so a reader who lands in the Gateway nav has no mental model for what it is or when to use it.
2. **The same frameworks appear twice, unexplained.** Pydantic AI, OpenAI, LangChain, and LlamaIndex are listed under both *Instrument a framework* and *AI Gateway → Connect an agent*, with nothing saying how they differ — readers can't tell which page to open.

## The fix — one mental model
Instrument (see the calls you already make) → Observe → Evaluate / Prompts, with the **Gateway as the optional "route calls through Logfire for spend and routing control" branch**.

- Overview gains a short **"Control cost and routing (optional)"** section that routes to the Gateway and states plain instrumentation is all you need to trace/debug agents.
- A reciprocal **instrument-vs-gateway note** on both catalog pages and the gateway overview, cross-linking each other, so the double-listing is explained rather than confusing.
- Fixed the for-ai-engineers "LLM integrations" link, which said *LLM integrations* but pointed at the general integrations index.

### Deliberately deferred (flagged, not smuggled in)
Trimming the over-long `evaluate/overview.md` and restyling `guides/web-ui/llm-panels.md` to the current writing bar are page-quality follow-ups, out of scope for this section-coherence PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

