### PR TITLE
docs: describe a trace accurately (not only as a request), across getting-started and AI pages

### DIFF
--- a/docs/ai-observability.md
+++ b/docs/ai-observability.md
@@ -13,7 +13,7 @@ description: "See every agent decision, tool call, and downstream service in one
 
 <div class="agent-observability-intro__detail-copy">
 
-<p>Logfire turns an agent run into one trace (the full journey of one request, made of nested spans): the model calls, tool calls, database queries, API requests, and response your user receives.</p>
+<p>Logfire turns an agent run into one trace (the full journey of one request or agent run, made of nested spans): the model calls, tool calls, database queries, API requests, and response your user receives.</p>
 
 </div>
 

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -18,7 +18,7 @@ Along the way you'll touch three Logfire features, each covered in depth on its 
 A few terms, defined once:
 
 - A **span** is one unit of work: a single operation, with a name, a start, and a duration.
-- A **trace** is the full journey of one request, made of nested spans (the agent run, its model call, each tool call).
+- A **trace** is the full journey of one request or agent run, made of nested spans (the agent run, its model call, each tool call).
 - A **token** is the unit language models read and bill by: a few characters of text.
 - A **scorer** (also called an **evaluator**) is the thing that judges an output. Each scorer produces a **score**: one saved quality rating for an output.
 

--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -5,7 +5,7 @@ description: "Install the Logfire SDK, add a few lines to your app, and watch yo
 
 # Send your first trace
 
-Go from install to your first trace in about 5 minutes. A trace is the journey of one request, made of nested spans; a span is one operation, with a name, a start, and a duration. Logfire has native SDKs for Python, JavaScript/TypeScript, and Rust, plus any language through OpenTelemetry (OTel), the open industry standard it is built on.
+Go from install to your first trace in about 5 minutes. A trace is the full record of one request, job, task, or agent run from start to finish, made of nested spans; a span is one operation within it, with a name, a start, and a duration. Logfire has native SDKs for Python, JavaScript/TypeScript, and Rust, plus any language through OpenTelemetry (OTel), the open industry standard it is built on.
 
 ## Before you start
 

--- a/docs/get-started/for-ai-engineers.md
+++ b/docs/get-started/for-ai-engineers.md
@@ -19,7 +19,7 @@ Follow these in order. Each link says why it's here.
 
     See the full list under [LLM integrations](../integrations/llms/index.md).
 
-2. **[Understand an agent run](../ai-observability.md)**: once data is flowing, see how Logfire records the model's conversation, tool calls, tokens, cost, and the code around them. A **trace** is the full record of one request; a **span** is one step inside it.
+2. **[Understand an agent run](../ai-observability.md)**: once data is flowing, see how Logfire records the model's conversation, tool calls, tokens, cost, and the code around them. A **trace** is the full record of one agent run or request; a **span** is one step inside it.
 
 3. **[Read every LLM call, with tokens and cost](../guides/web-ui/llms.md)**: the LLMs and providers view breaks down which models you're calling, how many tokens each request used, and what it's costing you.
 

--- a/docs/get-started/for-backend-and-sre.md
+++ b/docs/get-started/for-backend-and-sre.md
@@ -11,7 +11,7 @@ Follow these in order. Each link says why it's here.
 
 ## Your path
 
-1. **[Send your first trace to Logfire](../first-trace.md)**: install Logfire and link this machine to a project. A **trace** is the full record of one request; a **span** is one step inside it (a database query, an outgoing API call). This is the five-minute foundation everything else builds on.
+1. **[Send your first trace to Logfire](../first-trace.md)**: install Logfire and link this machine to a project. A **trace** is the full record of one request or job; a **span** is one step inside it (a database query, an outgoing API call). This is the five-minute foundation everything else builds on.
 
 2. **Instrument your framework and dependencies**: one line each turns on tracing for the request path:
     - Web frameworks: [FastAPI](../integrations/web-frameworks/fastapi.md), [Django](../integrations/web-frameworks/django.md), [Flask](../integrations/web-frameworks/flask.md), [Starlette](../integrations/web-frameworks/starlette.md) (see [all web frameworks](../integrations/web-frameworks/index.md))

--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -7,7 +7,7 @@ integration: logfire
 
 See every call your app makes to Anthropic's Claude models: the full conversation, each tool call,
 how many **tokens** (the units a model reads and bills by, a few characters of text each) it used,
-how long it took, and any errors, as a **trace** (the full journey of one request, made of nested
+how long it took, and any errors, as a **trace** (the full journey of one request or agent run, made of nested
 **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
 
 ## What you'll capture

--- a/docs/integrations/llms/google-genai.md
+++ b/docs/integrations/llms/google-genai.md
@@ -8,7 +8,7 @@ integration: logfire
 See every call your app makes to Google's Gemini models through the
 [Google Gen AI SDK (`google-genai`)](https://googleapis.github.io/python-genai/): the full
 conversation, how many **tokens** (the units a model reads and bills by, a few characters of text
-each) it used, how long it took, and any errors, as a **trace** (the full journey of one request,
+each) it used, how long it took, and any errors, as a **trace** (the full journey of one request or agent run,
 made of nested **spans**, where each span is one unit of work with a name, a start, and a duration)
 in Logfire.
 

--- a/docs/integrations/llms/langchain.md
+++ b/docs/integrations/llms/langchain.md
@@ -8,7 +8,7 @@ integration: "built-in"
 See every step your [LangChain](https://www.langchain.com/) chains and
 [LangGraph](https://www.langchain.com/langgraph) agents take: the model calls, tool calls, how many
 **tokens** (the units a model reads and bills by, a few characters of text each) they used, how long
-they took, and any errors, as a **trace** (the full journey of one request, made of nested
+they took, and any errors, as a **trace** (the full journey of one request or agent run, made of nested
 **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
 
 LangChain has built-in tracing through LangSmith that speaks OpenTelemetry (the open standard Logfire

--- a/docs/integrations/llms/litellm.md
+++ b/docs/integrations/llms/litellm.md
@@ -7,7 +7,7 @@ integration: logfire
 
 See every call your app makes through [LiteLLM](https://docs.litellm.ai/): the full conversation,
 how many **tokens** (the units a model reads and bills by, a few characters of text each) it used,
-how long it took, and any errors, as a **trace** (the full journey of one request, made of nested
+how long it took, and any errors, as a **trace** (the full journey of one request or agent run, made of nested
 **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
 LiteLLM gives you one interface to many model providers, and this integration records every call
 regardless of which provider handles it.

--- a/docs/integrations/llms/llamaindex.md
+++ b/docs/integrations/llms/llamaindex.md
@@ -7,7 +7,7 @@ integration: otel
 
 See every step your [LlamaIndex](https://www.llamaindex.ai/) query pipeline takes (loading and
 indexing documents, retrieving context, and calling the model), how long each took, and any errors,
-as a **trace** (the full journey of one request, made of nested **spans**, where each span is one unit
+as a **trace** (the full journey of one request or agent run, made of nested **spans**, where each span is one unit
 of work with a name, a start, and a duration) in Logfire.
 
 We recommend instrumenting LlamaIndex with the OpenTelemetry instrumentation from

--- a/docs/integrations/llms/magentic.md
+++ b/docs/integrations/llms/magentic.md
@@ -5,7 +5,7 @@ integration: "third-party"
 ---
 # Magentic
 
-See what [Magentic](https://github.com/jackmpcollins/magentic) does when it turns a model's reply into structured output: the prompt it built, each retry it needed, and the tool or function calls it made, as a **trace** (the full journey of one request, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
+See what [Magentic](https://github.com/jackmpcollins/magentic) does when it turns a model's reply into structured output: the prompt it built, each retry it needed, and the tool or function calls it made, as a **trace** (the full journey of one request or agent run, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
 
 Magentic is a library for getting structured output from models, built around standard Python type annotations and Pydantic. It emits its own spans as soon as Logfire is configured; there's no separate Magentic instrument call.
 

--- a/docs/integrations/llms/mcp.md
+++ b/docs/integrations/llms/mcp.md
@@ -5,7 +5,7 @@ integration: logfire
 ---
 # Model Context Protocol (MCP)
 
-See the calls flowing between your Model Context Protocol (MCP) client and server (the tool a client asked for, the arguments it sent, and the result the server returned) joined into one **trace** (the full journey of one request, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire, even though the client and server run in separate processes.
+See the calls flowing between your Model Context Protocol (MCP) client and server (the tool a client asked for, the arguments it sent, and the result the server returned) joined into one **trace** (the full journey of one request or agent run, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire, even though the client and server run in separate processes.
 
 The Model Context Protocol is a standard way for an AI application to call tools and fetch data from a separate server. Instrumenting both sides lets Logfire stitch their spans into a single distributed trace: one trace that spans more than one process.
 

--- a/docs/integrations/llms/mirascope.md
+++ b/docs/integrations/llms/mirascope.md
@@ -5,7 +5,7 @@ integration: "third-party"
 ---
 # Mirascope
 
-See what your [Mirascope][mirascope-repo] functions do: the prompt template they built, the conversation with the model, and the tokens each call used, as a **trace** (the full journey of one request, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
+See what your [Mirascope][mirascope-repo] functions do: the prompt template they built, the conversation with the model, and the tokens each call used, as a **trace** (the full journey of one request or agent run, made of nested **spans**, where each span is one unit of work with a name, a start, and a duration) in Logfire.
 
 Mirascope is a library for building with models. It adds this instrumentation through its own [`@with_logfire`][mirascope-logfire] decorator, which works with every [model provider it supports][mirascope-supported-providers].
 

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -6,7 +6,7 @@ integration: logfire
 # OpenAI
 
 See every call your app makes to OpenAI: the full conversation, each tool call, how many tokens it
-used, how long it took, and any errors, as a **trace** (the full journey of one request, made of
+used, how long it took, and any errors, as a **trace** (the full journey of one request or agent run, made of
 nested **spans**, where each span is one unit of work with a name, a start, and a duration) in
 Logfire.
 


### PR DESCRIPTION
A trace isn't always an HTTP request — it's any top-level operation: a background job, a scheduled task, or an **agent run**. Several pages glossed a trace as "one request" / "the journey of one request," which is inaccurate (an agent run isn't a request), and a few were even self-contradictory (e.g. the AI observability overview said "turns an agent run into one trace (the full journey of one request…)").

## Changes
- **Getting-started definitions**: `first-trace.md`, `for-ai-engineers.md`, `for-backend-and-sre.md` — reworded to name jobs / tasks / agent runs, not just requests.
- **AI/agent pages** (11): the AI observability overview, the evaluate-an-agent cookbook, and the LLM integration pages (`openai`, `anthropic`, `google-genai`, `langchain`, `litellm`, `llamaindex`, `magentic`, `mcp`, `mirascope`) — the shared gloss now reads "one request or agent run."

## Scope note
The same "full journey of one request" gloss also appears on the **web-framework / database / HTTP** integration pages, but those pages are specifically about request-handling code, so "one request" is contextually accurate there and is intentionally left unchanged.