### PR TITLE
fix: keep the data directory gitignored after logfire clean

### DIFF
--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -211,14 +211,24 @@ class UnexpectedResponse(RequestException):
             raise cls(response)
 
 
+DATA_DIR_FILENAMES = {'.gitignore', 'logfire_credentials.json'}
+"""The files that Logfire itself writes into a data directory."""
+
+
 def ensure_data_dir_exists(data_dir: Path) -> None:
     if data_dir.exists():
         if not data_dir.is_dir():  # pragma: no cover
             raise ValueError(f'Data directory {data_dir} exists but is not a directory')
-        return
-    data_dir.mkdir(parents=True, exist_ok=True)
+    else:
+        data_dir.mkdir(parents=True, exist_ok=True)
     gitignore = data_dir / '.gitignore'
-    gitignore.write_text('*')
+    # Seed the .gitignore for a newly created directory, and for an existing one holding nothing
+    # but the files Logfire writes itself. That covers a directory emptied by `logfire clean`, and
+    # restores the ignore rule for one left with an unignored credentials file, since this runs
+    # before that file is rewritten. Skip a directory with any other contents: `--data-dir` can
+    # point at a directory of the user's own, and a `.gitignore` of `*` there would ignore all of it.
+    if not gitignore.exists() and {path.name for path in data_dir.iterdir()} <= DATA_DIR_FILENAMES:
+        gitignore.write_text('*')
 
 
 def get_version(version: str) -> Version:

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -221,14 +221,19 @@ def ensure_data_dir_exists(data_dir: Path) -> None:
             raise ValueError(f'Data directory {data_dir} exists but is not a directory')
     else:
         data_dir.mkdir(parents=True, exist_ok=True)
-    gitignore = data_dir / '.gitignore'
     # Seed the .gitignore for a newly created directory, and for an existing one holding nothing
     # but the files Logfire writes itself. That covers a directory emptied by `logfire clean`, and
     # restores the ignore rule for one left with an unignored credentials file, since this runs
     # before that file is rewritten. Skip a directory with any other contents: `--data-dir` can
     # point at a directory of the user's own, and a `.gitignore` of `*` there would ignore all of it.
-    if not gitignore.exists() and {path.name for path in data_dir.iterdir()} <= DATA_DIR_FILENAMES:
-        gitignore.write_text('*')
+    if {path.name for path in data_dir.iterdir()} <= DATA_DIR_FILENAMES:
+        try:
+            # Exclusive creation, so an existing .gitignore keeps its rules, and a symlink planted
+            # in a data directory that arrived from elsewhere is refused rather than followed.
+            with (data_dir / '.gitignore').open('x') as gitignore:
+                gitignore.write('*')
+        except FileExistsError:
+            pass
 
 
 def get_version(version: str) -> Version:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -258,6 +258,47 @@ def test_clean(
     ]
 
 
+def test_clean_then_write_creds_file_restores_gitignore(
+    tmp_dir_cwd: Path,
+    logfire_credentials: LogfireCredentials,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(sys, 'stdin', io.StringIO('y'))
+    data_dir = tmp_dir_cwd / '.logfire'
+
+    logfire_credentials.write_creds_file(data_dir)
+    assert (data_dir / '.gitignore').read_text() == '*'
+
+    main(shlex.split(f'clean --data-dir {str(data_dir)}'))
+    assert not (data_dir / '.gitignore').exists()
+
+    logfire_credentials.write_creds_file(data_dir)
+    assert (data_dir / '.gitignore').read_text() == '*'
+
+
+@pytest.mark.parametrize(
+    'existing_files,gitignored',
+    [
+        ([], True),
+        (['logfire_credentials.json'], True),
+        (['main.py'], False),
+    ],
+)
+def test_write_creds_file_gitignores_existing_data_dir(
+    tmp_dir_cwd: Path,
+    logfire_credentials: LogfireCredentials,
+    existing_files: list[str],
+    gitignored: bool,
+) -> None:
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    for name in existing_files:
+        (data_dir / name).touch()
+
+    logfire_credentials.write_creds_file(data_dir)
+    assert (data_dir / '.gitignore').exists() is gitignored
+
+
 def test_clean_default_dir_does_not_exist(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as exc:
         main(shlex.split('clean --data-dir potato'))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -276,6 +276,27 @@ def test_clean_then_write_creds_file_restores_gitignore(
     assert (data_dir / '.gitignore').read_text() == '*'
 
 
+def test_write_creds_file_keeps_existing_gitignore(tmp_dir_cwd: Path, logfire_credentials: LogfireCredentials) -> None:
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    (data_dir / '.gitignore').write_text('logfire_credentials.json\n')
+
+    logfire_credentials.write_creds_file(data_dir)
+    assert (data_dir / '.gitignore').read_text() == 'logfire_credentials.json\n'
+
+
+def test_write_creds_file_does_not_follow_gitignore_symlink(
+    tmp_dir_cwd: Path, logfire_credentials: LogfireCredentials
+) -> None:
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    outside = tmp_dir_cwd / 'outside'
+    (data_dir / '.gitignore').symlink_to(outside)
+
+    logfire_credentials.write_creds_file(data_dir)
+    assert not outside.exists()
+
+
 @pytest.mark.parametrize(
     'existing_files,gitignored',
     [


### PR DESCRIPTION
Closes #2172.

## What

`ensure_data_dir_exists` writes `.gitignore` only in the branch that creates the data directory, and returns early when the directory already exists. Any later credentials write into an existing directory therefore leaves `logfire_credentials.json` with nothing ignoring it. Two ways to get there:

- `logfire clean` deletes `.gitignore` and `logfire_credentials.json` but leaves the directory, so the next `logfire projects use`, or `logfire.configure()` on first run, writes a token into a directory git has stopped ignoring.
- `mkdir .logfire` before a first-ever `logfire projects use` skips the seeding the same way, with no `clean` involved.

## Fix

Write the `.gitignore` whenever it is missing, restricted to directories holding nothing but the files Logfire writes itself.

Key properties:

- **Existing ignore rules are never clobbered.** The comment on `ensureDataDir` in logfire-js gives that as the reason the seeding is create-only. Writing only when the file is absent preserves it.
- **A populated directory is never ignored wholesale.** `--data-dir` accepts any path, so seeding unconditionally would let `logfire projects use --data-dir .` drop a `.gitignore` of `*` into a directory of the user's own. The subset check against `DATA_DIR_FILENAMES` is what prevents that.
- **A directory already left unignored is fixed by the next write.** `write_creds_file` calls `ensure_data_dir_exists` before rewriting the credentials, so an unignored `logfire_credentials.json` is still there at this point. Matching `DATA_DIR_FILENAMES` rather than requiring an empty directory is what restores the ignore rule for anyone already in that state.

I can switch to either narrower fix if you prefer: seeding only into an empty directory reads more simply but leaves those users leaking, and not deleting `.gitignore` in `parse_clean` is a one-liner but leaves the `mkdir` case unfixed.

## Changes

- `logfire/_internal/utils.py`: `ensure_data_dir_exists` seeds a missing `.gitignore`; add `DATA_DIR_FILENAMES`. `parse_clean` still lists the two filenames inline, since reusing the constant there would reorder the output its test asserts.
- `tests/test_cli.py`: two tests next to `test_clean`, four cases.

## Test plan

- `test_clean_then_write_creds_file_restores_gitignore`: the reported round trip of write, `clean`, write again. Fails on main with `FileNotFoundError` on the missing `.gitignore`.
- `test_write_creds_file_gitignores_existing_data_dir`, parametrized over what the directory already holds:
  - empty, the `mkdir .logfire` case. Fails on main.
  - a stale `logfire_credentials.json`, the already-unignored case. Fails on main, and is also what the empty-directory alternative fails.
  - a file of the user's, the guard. Passes on main too, and would catch an unconditional seed.
- Walked the issue's reproduction against real git. On main, `git check-ignore` exits 1 after the second write and `git status --porcelain -uall` reports `?? .logfire/logfire_credentials.json`. Here it exits 0 with a clean status, and the `mkdir .logfire` path matches. The tests stop at asserting the `.gitignore` is written, since whether git honors a file of `*` is git's contract.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

