### PR TITLE
ci: run CI on merge_group events to support GitHub merge queue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
     tags:
       - "**"
   pull_request: { }
+  merge_group: { }
 
 env:
   CI: true
@@ -64,14 +65,15 @@ jobs:
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
-    # Use Depot 4-core runners for maintainer PRs (faster CPUs/more cores)
+    # Use Depot 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
     # Use 'ci:slow' label to force standard GitHub runners (e.g. during Depot outages)
     # Use 'ci:fast' label to opt-in fork PRs to Depot runners
     runs-on: >-
       ${{
         !contains(github.event.pull_request.labels.*.name, 'ci:slow')
         && (
-          github.event.pull_request.head.repo.full_name == github.repository
+          github.event_name == 'merge_group'
+          || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
         && 'depot-ubuntu-24.04-4'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,11 +66,14 @@ jobs:
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
     # Use Depot 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
-    # Use 'ci:slow' label to force standard GitHub runners (e.g. during Depot outages)
+    # Use 'ci:slow' label to force standard GitHub runners on a PR; merge queue runs have no
+    # labels, so during a runner-provider outage set the FAST_RUNNERS_DISABLED repository
+    # variable to 'true' to force standard GitHub runners everywhere
     # Use 'ci:fast' label to opt-in fork PRs to Depot runners
     runs-on: >-
       ${{
-        !contains(github.event.pull_request.labels.*.name, 'ci:slow')
+        vars.FAST_RUNNERS_DISABLED != 'true'
+        && !contains(github.event.pull_request.labels.*.name, 'ci:slow')
         && (
           github.event_name == 'merge_group'
           || github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
Prerequisite for enabling a GitHub merge queue on `main`.

- Add `merge_group` to the CI workflow triggers so the required `check` status is reported on merge-queue group branches. Without this, queued PRs would wait forever for a check that never runs.
- Treat `merge_group` runs like maintainer PRs in the `test` job's runner selection (Depot 4-core). Merge-group refs are always repo-internal, and on `merge_group` events `github.event.pull_request` is empty, so without this the queue runs would silently fall back to `ubuntu-latest`.

Once this is on `main`, the merge queue can be enabled in branch protection; merging then goes through "Merge when ready" instead of auto-merge, so multiple PRs can be queued without each merge invalidating the others' auto-merge.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

