### PR TITLE
ci: switch maintainer/merge-queue CI from Depot to Ubicloud runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,14 +66,12 @@ jobs:
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
     # Use Ubicloud premium 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
-    # Use 'ci:slow' label to force standard GitHub runners on a PR; merge queue runs have no
-    # labels, so during a runner-provider outage set the FAST_RUNNERS_DISABLED repository
-    # variable to 'true' to force standard GitHub runners everywhere
+    # During a runner-provider outage, set the FAST_RUNNERS_DISABLED repository variable to
+    # 'true' to force standard GitHub runners everywhere
     # Use 'ci:fast' label to opt-in fork PRs to Ubicloud runners
     runs-on: >-
       ${{
         vars.FAST_RUNNERS_DISABLED != 'true'
-        && !contains(github.event.pull_request.labels.*.name, 'ci:slow')
         && (
           github.event_name == 'merge_group'
           || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,17 +65,16 @@ jobs:
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
-    # Use Ubicloud premium 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
+    # Use Ubicloud premium 4-core runners for maintainer PRs and merge queue runs (faster
+    # CPUs/more cores); fork PRs run on standard GitHub runners
     # During a runner-provider outage, set the FAST_RUNNERS_DISABLED repository variable to
     # 'true' to force standard GitHub runners everywhere
-    # Use 'ci:fast' label to opt-in fork PRs to Ubicloud runners
     runs-on: >-
       ${{
         vars.FAST_RUNNERS_DISABLED != 'true'
         && (
           github.event_name == 'merge_group'
           || github.event.pull_request.head.repo.full_name == github.repository
-          || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
         && 'ubicloud-premium-4'
         || 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,11 +65,11 @@ jobs:
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
-    # Use Depot 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
+    # Use Ubicloud premium 4-core runners for maintainer PRs and merge queue runs (faster CPUs/more cores)
     # Use 'ci:slow' label to force standard GitHub runners on a PR; merge queue runs have no
     # labels, so during a runner-provider outage set the FAST_RUNNERS_DISABLED repository
     # variable to 'true' to force standard GitHub runners everywhere
-    # Use 'ci:fast' label to opt-in fork PRs to Depot runners
+    # Use 'ci:fast' label to opt-in fork PRs to Ubicloud runners
     runs-on: >-
       ${{
         vars.FAST_RUNNERS_DISABLED != 'true'
@@ -79,7 +79,7 @@ jobs:
           || github.event.pull_request.head.repo.full_name == github.repository
           || contains(github.event.pull_request.labels.*.name, 'ci:fast')
         )
-        && 'depot-ubuntu-24.04-4'
+        && 'ubicloud-premium-4'
         || 'ubuntu-latest'
       }}
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ typecheck:
 
 .PHONY: test  # Run the tests
 test:
-	uv run --no-sync pytest -n auto --dist=loadgroup
+	uv run --no-sync pytest -n logical --dist=loadgroup
 
 .PHONY: test-update-examples  # Update the examples in the documentation
 test-update-examples:
@@ -47,7 +47,7 @@ generate-stubs:
 
 .PHONY: testcov  # Run tests and generate a coverage report
 testcov:
-	uv run --no-sync coverage run -m pytest -n auto --dist=loadgroup
+	uv run --no-sync coverage run -m pytest -n logical --dist=loadgroup
 	uv run coverage combine
 	@echo "building coverage html"
 	uv run coverage html --show-contexts


### PR DESCRIPTION
Swap the paid CI runner for the `test` job from `depot-ubuntu-24.04-4` to `ubicloud-premium-4` (~60% cheaper per minute, and benchmarked faster on pydantic-ai's identical workload in pydantic/pydantic-ai#6000). Fork PRs continue to run on free `ubuntu-latest`.

Also:

- Drop the `ci:slow` / `ci:fast` label checks. Neither label was ever created on the repo (the #1714 conditions referenced labels that don't exist, so they were unusable dead code). For runner-provider outages, the `FAST_RUNNERS_DISABLED` repository variable covers all run types including merge-queue runs (set it to `'true'`, unset when the outage ends).
- Switch pytest-xdist from `-n auto` to `-n logical` in the Makefile `test` / `testcov` targets: Ubicloud vCPUs are hyperthreaded and `-n auto` counts physical cores, so it would only spawn half the workers on the new runners (see pydantic/pydantic-ai#6001, -39% wall time from the same change). `psutil` (required for `-n logical`) is already in the dependency tree via `opentelemetry-instrumentation-system-metrics`. On macOS dev machines physical == logical, so this is a no-op locally.