### PR TITLE
ci: run pytest with xdist (-n logical) in the test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,7 +125,7 @@ jobs:
           uv pip install 'opentelemetry-exporter-otlp-proto-http==${{ matrix.otel-version }}.*'
 
       - run: mkdir coverage
-      - run: uv run --no-sync coverage run -m pytest --junitxml=coverage/test-results.xml
+      - run: uv run --no-sync coverage run -m pytest -n logical --dist=loadgroup --junitxml=coverage/test-results.xml
         env:
           COVERAGE_FILE: coverage/.coverage.${{ runner.os }}-py${{ matrix.python-version }}-pydantic-${{ matrix.pydantic-version }}-otel-${{ matrix.otel-version }}
       - name: store coverage files

--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import os
+from collections.abc import Iterator
 from unittest import mock
 
 import pydantic
@@ -15,6 +17,18 @@ if get_version(pydantic.__version__) < get_version('2.5.0'):
     pytest.skip('DSPy/LiteLLM requires Pydantic >= 2.5 for Discriminator import', allow_module_level=True)
 
 
+@pytest.fixture
+def close_litellm_event_loop() -> Iterator[None]:
+    """Close the event loop LiteLLM's synchronous service hook creates on Python 3.10."""
+    yield
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        return
+    loop.close()
+    asyncio.set_event_loop(None)
+
+
 def test_missing_openinference_dependency() -> None:
     with mock.patch.dict('sys.modules', {'openinference.instrumentation.dspy': None}):
         with pytest.raises(RuntimeError) as exc_info:
@@ -27,7 +41,7 @@ You can install this with:
 
 
 @pytest.mark.vcr()
-def test_dspy_instrumentation(exporter: TestExporter) -> None:
+def test_dspy_instrumentation(exporter: TestExporter, close_litellm_event_loop: None) -> None:
     # Skip test if dspy can't be imported due to compatibility issues
     dspy = pytest.importorskip('dspy', reason='DSPy import failed due to environment incompatibility')
 


### PR DESCRIPTION
The pytest step is 96% of each paid test-matrix job's wall time (~312s of ~324s), running single-process on a 4-core runner. Run it with xdist instead, mirroring the Makefile's `testcov` target exactly (`coverage run -m pytest -n logical --dist=loadgroup`), which the suite already uses for every local run:

- `-n logical` uses all vCPUs (Ubicloud vCPUs are hyperthreaded, so `-n auto` would only use half; `psutil` is already in the dependency tree).
- `--dist=loadgroup` preserves the `xdist_group` co-scheduling the local runs rely on.
- Coverage already collects from xdist workers via `patch = ["subprocess"]` in `pyproject.toml`, and the combine job merges the per-leg parallel data files unchanged.

This should substantially cut both merge-queue latency and paid runner minutes per CI round.

Previously parked as draft behind #2179: the suite had cross-test interference under xdist that is now fixed on main (#2194, #2195, #2196). Eight consecutive full-suite `-n logical --dist=loadgroup` runs on this branch pass locally (2291 passed, 0 failed).