### PR TITLE
Fix pytest-plugin xdist tests under an outer xdist run

### DIFF
--- a/tests/otel_integrations/test_pytest_plugin.py
+++ b/tests/otel_integrations/test_pytest_plugin.py
@@ -59,6 +59,11 @@ def logfire_pytester(pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch,
     monkeypatch.delenv('LOGFIRE_TOKEN', raising=False)
     monkeypatch.delenv('TRACEPARENT', raising=False)
     monkeypatch.delenv('TRACESTATE', raising=False)
+    # The outer suite may itself run under xdist; don't leak its worker env vars into
+    # the inner pytest runs, where the plugin would detect them as xdist mode.
+    monkeypatch.delenv('PYTEST_XDIST_WORKER', raising=False)
+    monkeypatch.delenv('PYTEST_XDIST_WORKER_COUNT', raising=False)
+    monkeypatch.delenv('PYTEST_XDIST_TESTRUNUID', raising=False)
 
     # Create a conftest that captures spans to a JSON file
     # NOTE: We use trylast=True so this runs AFTER the logfire pytest plugin configures


### PR DESCRIPTION
The two xdist tests in `test_pytest_plugin.py` spawn inner pytest runs via `runpytest_subprocess`, which inherit `PYTEST_XDIST_WORKER` / `PYTEST_XDIST_WORKER_COUNT` from the environment when the outer suite itself runs under xdist. The plugin detects xdist purely from those env vars (`integrations/pytest.py`), so the inner runs misclassify: a non-xdist inner run grows worker attributes, and an inner controller thinks it is a worker and emits no controller session span.

This is why `make test` (which uses `-n`) currently fails these two tests locally while serial CI passes them. Sanitize the xdist env vars in the `logfire_pytester` fixture alongside the existing env sanitization. Verified both tests pass under `-n 4` locally with this change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

