### PR TITLE
Add instrument default message template customization

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -231,14 +231,23 @@ class AdvancedOptions:
 
     ```python
     import logfire
+    from logfire.types import InstrumentMessageTemplateHelper
+
+    def simple_function_name(helper: InstrumentMessageTemplateHelper) -> str:
+        return helper.name
 
     logfire.configure(
-        advanced=logfire.AdvancedOptions(instrument_default_msg_template=lambda helper: helper.name)
+        advanced=logfire.AdvancedOptions(instrument_default_msg_template=simple_function_name)
     )
     ```
 
     The callback receives an instance of
     [`InstrumentMessageTemplateHelper`][logfire.types.InstrumentMessageTemplateHelper].
+
+    When using `ProcessPoolExecutor`, define the callback at module level, not as a lambda or local function,
+    so it can be pickled and sent to child processes. See the
+    [distributed tracing guide](https://logfire.pydantic.dev/docs/how-to-guides/distributed-tracing/#thread-and-pool-executors)
+    for details.
 
     This is experimental and may be modified or removed.
     """

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -228,7 +228,11 @@ class AdvancedOptions:
     Called with the instrumented function and should return the message template to use, e.g:
 
     ```python
-    AdvancedOptions(instrument_default_span_name=lambda func: func.__name__)
+    import logfire
+
+    logfire.configure(
+        advanced=logfire.AdvancedOptions(instrument_default_span_name=lambda func: func.__name__)
+    )
     ```
 
     Defaults to `None`, which keeps the existing `f'Calling {module_name}.{qualname}'` format.

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -72,7 +72,7 @@ from logfire.variables.abstract import NoOpVariableProvider, VariableProvider
 from logfire.version import VERSION
 
 from ..propagate import NoExtractTraceContextPropagator, WarnOnExtractTraceContextPropagator
-from ..types import ExceptionCallback
+from ..types import ExceptionCallback, InstrumentMessageTemplateHelper
 from .client import InvalidProjectName, LogfireClient, ProjectAlreadyExists
 from .config_params import ParamManager, PydanticPluginRecordValues, normalize_token
 from .constants import (
@@ -222,22 +222,23 @@ class AdvancedOptions:
     This log and configuration is experimental and may be modified or removed.
     """
 
-    instrument_default_span_name: Callable[[Callable[..., Any]], str] | None = None
-    """Customize the default span name/message used by `@logfire.instrument` when no `msg_template` is given.
+    instrument_default_msg_template: Callable[[InstrumentMessageTemplateHelper], str] = (
+        InstrumentMessageTemplateHelper.default_template
+    )
+    """Customize the default message template used by `@logfire.instrument` when no `msg_template` is given.
 
-    Called with the instrumented function and should return the message template to use, e.g:
+    Example usage to only use the simple unqualified function name:
 
     ```python
     import logfire
 
     logfire.configure(
-        advanced=logfire.AdvancedOptions(instrument_default_span_name=lambda func: func.__name__)
+        advanced=logfire.AdvancedOptions(instrument_default_msg_template=lambda helper: helper.name)
     )
     ```
 
-    Defaults to `None`, which keeps the existing `f'Calling {module_name}.{qualname}'` format.
-    Changing the default behavior globally would be a breaking change for existing queries that
-    rely on the current format, hence this being opt-in.
+    The callback receives an instance of
+    [`InstrumentMessageTemplateHelper`][logfire.types.InstrumentMessageTemplateHelper].
 
     This is experimental and may be modified or removed.
     """

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -243,8 +243,9 @@ class AdvancedOptions:
 
     The callback receives an instance of
     [`InstrumentMessageTemplateHelper`][logfire.types.InstrumentMessageTemplateHelper].
-    It is evaluated on the first execution of each instrumented function, after configuration,
-    and the resulting template is cached for subsequent executions.
+    It is evaluated when each instrumented function is first executed after configuration,
+    and the resulting template is cached until `logfire.configure()` is called again.
+    After reconfiguration, it is evaluated again on the function's next execution.
 
     When using `ProcessPoolExecutor`, define the callback at module level, not as a lambda or local function,
     so it can be pickled and sent to child processes. See the
@@ -1057,6 +1058,7 @@ class LogfireConfig(_LogfireConfigData):
         # This ensures that we only call OTEL's global set_tracer_provider once to avoid warnings.
         self._has_set_providers = False
         self._initialized = False
+        self._instrument_default_msg_template_revision = uuid4().hex
         self._lock = RLock()
 
     def configure(
@@ -1109,6 +1111,7 @@ class LogfireConfig(_LogfireConfigData):
                 advanced,
             )
             self.initialize()
+            self._instrument_default_msg_template_revision = uuid4().hex
 
     def initialize(self) -> None:
         """Configure internals to start exporting traces and metrics."""

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -222,6 +222,22 @@ class AdvancedOptions:
     This log and configuration is experimental and may be modified or removed.
     """
 
+    instrument_default_span_name: Callable[[Callable[..., Any]], str] | None = None
+    """Customize the default span name/message used by `@logfire.instrument` when no `msg_template` is given.
+
+    Called with the instrumented function and should return the message template to use, e.g:
+
+    ```python
+    AdvancedOptions(instrument_default_span_name=lambda func: func.__name__)
+    ```
+
+    Defaults to `None`, which keeps the existing `f'Calling {module_name}.{qualname}'` format.
+    Changing the default behavior globally would be a breaking change for existing queries that
+    rely on the current format, hence this being opt-in.
+
+    This is experimental and may be modified or removed.
+    """
+
     server_response_hook: ServerResponseCallback | None = None
     """Optional callback invoked for every HTTP response received from the Logfire API.
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -243,6 +243,8 @@ class AdvancedOptions:
 
     The callback receives an instance of
     [`InstrumentMessageTemplateHelper`][logfire.types.InstrumentMessageTemplateHelper].
+    It is evaluated on the first execution of each instrumented function, after configuration,
+    and the resulting template is cached for subsequent executions.
 
     When using `ProcessPoolExecutor`, define the callback at module level, not as a lambda or local function,
     so it can be pickled and sent to child processes. See the

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -244,8 +244,8 @@ class AdvancedOptions:
     The callback receives an instance of
     [`InstrumentMessageTemplateHelper`][logfire.types.InstrumentMessageTemplateHelper].
     It is evaluated when each instrumented function is first executed after configuration,
-    and the resulting template is cached until `logfire.configure()` is called again.
-    After reconfiguration, it is evaluated again on the function's next execution.
+    and the resulting template is cached until `logfire.configure()` changes this callback.
+    After such a change, it is evaluated again on the function's next execution.
 
     When using `ProcessPoolExecutor`, define the callback at module level, not as a lambda or local function,
     so it can be pickled and sent to child processes. See the
@@ -1058,6 +1058,7 @@ class LogfireConfig(_LogfireConfigData):
         # This ensures that we only call OTEL's global set_tracer_provider once to avoid warnings.
         self._has_set_providers = False
         self._initialized = False
+        self._instrument_default_msg_template_callback = self.advanced.instrument_default_msg_template
         self._instrument_default_msg_template_revision = uuid4().hex
         self._lock = RLock()
 
@@ -1111,7 +1112,10 @@ class LogfireConfig(_LogfireConfigData):
                 advanced,
             )
             self.initialize()
-            self._instrument_default_msg_template_revision = uuid4().hex
+            instrument_default_msg_template_callback = self.advanced.instrument_default_msg_template
+            if instrument_default_msg_template_callback is not self._instrument_default_msg_template_callback:
+                self._instrument_default_msg_template_callback = instrument_default_msg_template_callback
+                self._instrument_default_msg_template_revision = uuid4().hex
 
     def initialize(self) -> None:
         """Configure internals to start exporting traces and metrics."""

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 P = ParamSpec('P')
 R = TypeVar('R')
+_PreparedExtractArgs = tuple[inspect.Signature, Sequence[str] | None] | None
 
 
 @contextmanager
@@ -70,8 +71,9 @@ def instrument(
                 stacklevel=2,
             )
 
+        prepared_extract_args = _prepare_extract_args(func, extract_args)
         attributes = get_attributes(func, msg_template, tags, logfire.config.advanced.instrument_default_msg_template)
-        open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, level=level)
+        open_span = get_open_span(logfire, attributes, span_name, prepared_extract_args, func, new_trace, level=level)
 
         if inspect.isgeneratorfunction(func):
             if not allow_generator:
@@ -127,7 +129,7 @@ def get_open_span(
     logfire: Logfire,
     attributes: dict[str, otel_types.AttributeValue],
     span_name: str | None,
-    extract_args: bool | Iterable[str],
+    extract_args: _PreparedExtractArgs,
     func: Callable[P, R],
     new_trace: bool,
     level: LevelName | int | None = None,
@@ -177,28 +179,34 @@ def get_open_span(
             return NoopSpan()
         return get_logfire()._fast_span(final_span_name, attributes, **extra_span_kwargs())  # pyright: ignore[reportPrivateUsage]
 
+    if extract_args:
+        sig, extract_args_final = extract_args
+
+        def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
+            if level_num is not None and level_num < get_logfire().config.min_level:
+                return NoopSpan()
+            bound = sig.bind(*func_args, **func_kwargs)
+            bound.apply_defaults()
+            args_dict = bound.arguments
+            if extract_args_final is not None:
+                args_dict = {key: args_dict[key] for key in extract_args_final}
+
+            return get_logfire()._instrument_span_with_args(  # pyright: ignore[reportPrivateUsage]
+                final_span_name, attributes, args_dict, **extra_span_kwargs()
+            )
+
+    return open_span
+
+
+def _prepare_extract_args(func: Callable[..., Any], extract_args: bool | Iterable[str]) -> _PreparedExtractArgs:
     if extract_args is True:
         sig = inspect.signature(func)
-        if sig.parameters:  # only extract args if there are any
-
-            def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
-                if level_num is not None and level_num < get_logfire().config.min_level:
-                    return NoopSpan()
-                bound = sig.bind(*func_args, **func_kwargs)
-                bound.apply_defaults()
-                args_dict = bound.arguments
-                return get_logfire()._instrument_span_with_args(  # pyright: ignore[reportPrivateUsage]
-                    final_span_name, attributes, args_dict, **extra_span_kwargs()
-                )
-
-        return open_span
-
-    if extract_args:  # i.e. extract_args should be an iterable of argument names
+        if sig.parameters:
+            return sig, None
+    elif extract_args:
         sig = inspect.signature(func)
-
         if isinstance(extract_args, str):
             extract_args = [extract_args]
-
         extract_args_final = uniquify_sequence(list(extract_args))
         missing = set(extract_args_final) - set(sig.parameters)
         if missing:
@@ -207,24 +215,9 @@ def get_open_span(
                 f'Ignoring missing arguments to extract: {", ".join(sorted(missing))}',
                 stacklevel=3,
             )
-
-        if extract_args_final:  # check that there are still arguments to extract
-
-            def open_span(*func_args: P.args, **func_kwargs: P.kwargs):
-                if level_num is not None and level_num < get_logfire().config.min_level:
-                    return NoopSpan()
-                bound = sig.bind(*func_args, **func_kwargs)
-                bound.apply_defaults()
-                args_dict = bound.arguments
-
-                # This line is the only difference from the extract_args=True case
-                args_dict = {k: args_dict[k] for k in extract_args_final}
-
-                return get_logfire()._instrument_span_with_args(  # pyright: ignore[reportPrivateUsage]
-                    final_span_name, attributes, args_dict, **extra_span_kwargs()
-                )
-
-    return open_span
+        if extract_args_final:
+            return sig, extract_args_final
+    return None
 
 
 def get_attributes(

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -20,7 +20,7 @@ from .constants import (
     log_level_attributes,
 )
 from .stack_info import get_filepath_attribute
-from .utils import safe_repr, uniquify_sequence
+from .utils import handle_internal_errors, safe_repr, uniquify_sequence
 
 if TYPE_CHECKING:
     from .main import Logfire
@@ -69,7 +69,7 @@ def instrument(
                 stacklevel=2,
             )
 
-        attributes = get_attributes(func, msg_template, tags)
+        attributes = get_attributes(func, msg_template, tags, logfire.config.advanced.instrument_default_span_name)
         open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, level=level)
 
         if inspect.isgeneratorfunction(func):
@@ -227,7 +227,10 @@ def get_open_span(
 
 
 def get_attributes(
-    func: Any, msg_template: str | None, tags: Sequence[str] | None
+    func: Any,
+    msg_template: str | None,
+    tags: Sequence[str] | None,
+    default_span_name: Callable[[Callable[..., Any]], str] | None = None,
 ) -> dict[str, otel_types.AttributeValue]:
     func = inspect.unwrap(func)
     if not inspect.isfunction(func) and hasattr(func, '__call__'):
@@ -235,10 +238,14 @@ def get_attributes(
         func = inspect.unwrap(func)
     func_name = getattr(func, '__qualname__', getattr(func, '__name__', safe_repr(func)))
     if not msg_template:
-        try:
-            msg_template = f'Calling {inspect.getmodule(func).__name__}.{func_name}'  # pyright: ignore[reportOptionalMemberAccess]
-        except Exception:  # pragma: no cover
-            msg_template = f'Calling {func_name}'
+        if default_span_name is not None:
+            with handle_internal_errors:
+                msg_template = default_span_name(func)
+        if not msg_template:
+            try:
+                msg_template = f'Calling {inspect.getmodule(func).__name__}.{func_name}'  # pyright: ignore[reportOptionalMemberAccess]
+            except Exception:  # pragma: no cover
+                msg_template = f'Calling {func_name}'
     attributes: dict[str, otel_types.AttributeValue] = {
         'code.function': func_name,
         ATTRIBUTES_MESSAGE_TEMPLATE_KEY: msg_template,

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -97,6 +97,7 @@ def instrument(
             )
         else:
             cached_open_span: Callable[P, AbstractContextManager[Any]] | None = None
+            cached_config_revision: str | None = None
             initialization_lock = _InstrumentInitializationLock()
 
             def get_logfire():
@@ -112,11 +113,14 @@ def instrument(
                     return logfire
 
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs) -> AbstractContextManager[Any]:
-                nonlocal cached_open_span
-                if cached_open_span is None:
+                nonlocal cached_config_revision, cached_open_span
+                current_logfire = get_logfire()
+                config_revision = current_logfire.config._instrument_default_msg_template_revision  # pyright: ignore[reportPrivateUsage]
+                if cached_config_revision != config_revision:
                     with initialization_lock:
-                        if cached_open_span is None:
-                            current_logfire = get_logfire()
+                        current_logfire = get_logfire()
+                        config_revision = current_logfire.config._instrument_default_msg_template_revision  # pyright: ignore[reportPrivateUsage]
+                        if cached_config_revision != config_revision:
                             attributes = get_attributes(
                                 func,
                                 msg_template,
@@ -132,6 +136,8 @@ def instrument(
                                 new_trace,
                                 level=level,
                             )
+                            cached_config_revision = config_revision
+                assert cached_open_span is not None
                 return cached_open_span(*func_args, **func_kwargs)
 
         if inspect.isgeneratorfunction(func):

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -12,6 +12,7 @@ from opentelemetry import trace
 from opentelemetry.util import types as otel_types
 from typing_extensions import LiteralString, ParamSpec
 
+from ..types import InstrumentMessageTemplateHelper
 from .constants import (
     ATTRIBUTES_LOG_LEVEL_NUM_KEY,
     ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
@@ -20,7 +21,7 @@ from .constants import (
     log_level_attributes,
 )
 from .stack_info import get_filepath_attribute
-from .utils import handle_internal_errors, safe_repr, uniquify_sequence
+from .utils import handle_internal_errors, uniquify_sequence
 
 if TYPE_CHECKING:
     from .main import Logfire
@@ -69,7 +70,7 @@ def instrument(
                 stacklevel=2,
             )
 
-        attributes = get_attributes(func, msg_template, tags, logfire.config.advanced.instrument_default_span_name)
+        attributes = get_attributes(func, msg_template, tags, logfire.config.advanced.instrument_default_msg_template)
         open_span = get_open_span(logfire, attributes, span_name, extract_args, func, new_trace, level=level)
 
         if inspect.isgeneratorfunction(func):
@@ -230,22 +231,16 @@ def get_attributes(
     func: Any,
     msg_template: str | None,
     tags: Sequence[str] | None,
-    default_span_name: Callable[[Callable[..., Any]], str] | None = None,
+    default_msg_template: Callable[[InstrumentMessageTemplateHelper], str],
 ) -> dict[str, otel_types.AttributeValue]:
-    func = inspect.unwrap(func)
-    if not inspect.isfunction(func) and hasattr(func, '__call__'):
-        func = func.__call__
-        func = inspect.unwrap(func)
-    func_name = getattr(func, '__qualname__', getattr(func, '__name__', safe_repr(func)))
+    helper = InstrumentMessageTemplateHelper(func)
+    func = helper.callable
+    func_name = helper.qualname
     if not msg_template:
-        if default_span_name is not None:
-            with handle_internal_errors:
-                msg_template = default_span_name(func)
+        with handle_internal_errors:
+            msg_template = default_msg_template(helper)
         if not msg_template:
-            try:
-                msg_template = f'Calling {inspect.getmodule(func).__name__}.{func_name}'  # pyright: ignore[reportOptionalMemberAccess]
-            except Exception:  # pragma: no cover
-                msg_template = f'Calling {func_name}'
+            msg_template = helper.default_template()
     attributes: dict[str, otel_types.AttributeValue] = {
         'code.function': func_name,
         ATTRIBUTES_MESSAGE_TEMPLATE_KEY: msg_template,

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import functools
 import inspect
+import threading
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import AbstractContextManager, asynccontextmanager, contextmanager
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 P = ParamSpec('P')
 R = TypeVar('R')
 _PreparedExtractArgs = tuple[inspect.Signature, Sequence[str] | None] | None
+_INSTRUMENT_INITIALIZATION_LOCK = threading.RLock()
 
 
 @contextmanager
@@ -40,6 +42,12 @@ def _cm():  # pragma: no cover
 @asynccontextmanager
 async def _acm():  # pragma: no cover
     yield
+
+
+@contextmanager
+def _instrument_initialization_lock():
+    with _INSTRUMENT_INITIALIZATION_LOCK:
+        yield
 
 
 CONTEXTMANAGER_HELPER_CODE = getattr(_cm, '__code__', None)
@@ -95,22 +103,24 @@ def instrument(
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs) -> AbstractContextManager[Any]:
                 nonlocal cached_open_span
                 if cached_open_span is None:
-                    current_logfire = get_logfire()
-                    attributes = get_attributes(
-                        func,
-                        msg_template,
-                        tags,
-                        current_logfire.config.advanced.instrument_default_msg_template,
-                    )
-                    cached_open_span = get_open_span(
-                        current_logfire,
-                        attributes,
-                        span_name,
-                        prepared_extract_args,
-                        func,
-                        new_trace,
-                        level=level,
-                    )
+                    with _instrument_initialization_lock():
+                        if cached_open_span is None:
+                            current_logfire = get_logfire()
+                            attributes = get_attributes(
+                                func,
+                                msg_template,
+                                tags,
+                                current_logfire.config.advanced.instrument_default_msg_template,
+                            )
+                            cached_open_span = get_open_span(
+                                current_logfire,
+                                attributes,
+                                span_name,
+                                prepared_extract_args,
+                                func,
+                                new_trace,
+                                level=level,
+                            )
                 return cached_open_span(*func_args, **func_kwargs)
 
         if inspect.isgeneratorfunction(func):

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -31,7 +31,23 @@ if TYPE_CHECKING:
 P = ParamSpec('P')
 R = TypeVar('R')
 _PreparedExtractArgs = tuple[inspect.Signature, Sequence[str] | None] | None
-_INSTRUMENT_INITIALIZATION_LOCK = threading.RLock()
+
+
+class _InstrumentInitializationLock:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+
+    def __enter__(self) -> None:
+        self._lock.acquire()
+
+    def __exit__(self, *_args: Any) -> None:
+        self._lock.release()
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {}
+
+    def __setstate__(self, _state: dict[str, Any]) -> None:
+        self.__init__()
 
 
 @contextmanager
@@ -42,12 +58,6 @@ def _cm():  # pragma: no cover
 @asynccontextmanager
 async def _acm():  # pragma: no cover
     yield
-
-
-@contextmanager
-def _instrument_initialization_lock():
-    with _INSTRUMENT_INITIALIZATION_LOCK:
-        yield
 
 
 CONTEXTMANAGER_HELPER_CODE = getattr(_cm, '__code__', None)
@@ -87,6 +97,7 @@ def instrument(
             )
         else:
             cached_open_span: Callable[P, AbstractContextManager[Any]] | None = None
+            initialization_lock = _InstrumentInitializationLock()
 
             def get_logfire():
                 # Avoid capturing the global instance, which would make the instrumented function
@@ -103,7 +114,7 @@ def instrument(
             def open_span(*func_args: P.args, **func_kwargs: P.kwargs) -> AbstractContextManager[Any]:
                 nonlocal cached_open_span
                 if cached_open_span is None:
-                    with _instrument_initialization_lock():
+                    with initialization_lock:
                         if cached_open_span is None:
                             current_logfire = get_logfire()
                             attributes = get_attributes(

--- a/logfire/_internal/instrument.py
+++ b/logfire/_internal/instrument.py
@@ -72,8 +72,46 @@ def instrument(
             )
 
         prepared_extract_args = _prepare_extract_args(func, extract_args)
-        attributes = get_attributes(func, msg_template, tags, logfire.config.advanced.instrument_default_msg_template)
-        open_span = get_open_span(logfire, attributes, span_name, prepared_extract_args, func, new_trace, level=level)
+        if msg_template:
+            attributes = get_attributes(func, msg_template, tags, InstrumentMessageTemplateHelper.default_template)
+            open_span = get_open_span(
+                logfire, attributes, span_name, prepared_extract_args, func, new_trace, level=level
+            )
+        else:
+            cached_open_span: Callable[P, AbstractContextManager[Any]] | None = None
+
+            def get_logfire():
+                # Avoid capturing the global instance, which would make the instrumented function
+                # unpicklable with cloudpickle.
+                from logfire import DEFAULT_LOGFIRE_INSTANCE
+
+                return DEFAULT_LOGFIRE_INSTANCE
+
+            if get_logfire() != logfire:
+
+                def get_logfire():
+                    return logfire
+
+            def open_span(*func_args: P.args, **func_kwargs: P.kwargs) -> AbstractContextManager[Any]:
+                nonlocal cached_open_span
+                if cached_open_span is None:
+                    current_logfire = get_logfire()
+                    attributes = get_attributes(
+                        func,
+                        msg_template,
+                        tags,
+                        current_logfire.config.advanced.instrument_default_msg_template,
+                    )
+                    cached_open_span = get_open_span(
+                        current_logfire,
+                        attributes,
+                        span_name,
+                        prepared_extract_args,
+                        func,
+                        new_trace,
+                        level=level,
+                    )
+                return cached_open_span(*func_args, **func_kwargs)
 
         if inspect.isgeneratorfunction(func):
             if not allow_generator:

--- a/logfire/types.py
+++ b/logfire/types.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 
 import requests
@@ -15,7 +17,7 @@ from logfire._internal.constants import (
 )
 from logfire._internal.stack_info import warn_at_user_stacklevel
 from logfire._internal.tracer import get_parent_span
-from logfire._internal.utils import canonicalize_exception_traceback
+from logfire._internal.utils import canonicalize_exception_traceback, safe_repr
 from logfire.exceptions import LogfireServerWarning
 
 if TYPE_CHECKING:
@@ -301,3 +303,60 @@ ServerResponseCallback = Callable[[ServerResponseCallbackHelper], None]
 
 This is experimental and may change significantly in future releases.
 """
+
+
+@dataclass
+class InstrumentMessageTemplateHelper:
+    """Helper object passed to AdvancedOptions.instrument_default_msg_template.
+
+    This is experimental and may change significantly in future releases.
+    """
+
+    raw_callable: Callable[..., Any]
+    """The original callable passed to `logfire.instrument`."""
+
+    @cached_property
+    def callable(self) -> Callable[..., Any]:
+        """A callable that's more likely than `raw_callable` to be the real function you want to inspect.
+
+        Unwraps decorators and handles callable non-functions.
+        """
+        func: Callable[..., Any] = inspect.unwrap(self.raw_callable)
+        if not inspect.isfunction(func) and hasattr(func, '__call__'):
+            func = func.__call__
+            func = inspect.unwrap(func)
+        return func
+
+    @cached_property
+    def name(self) -> str:
+        """The simple name of the callable, or a safe representation if it has no `__name__` attribute."""
+        func = self.callable
+        return getattr(func, '__name__', '') or safe_repr(func)
+
+    @cached_property
+    def qualname(self) -> str:
+        """The qualified name of the callable, falling back to the simple name if it has no `__qualname__` attribute."""
+        return getattr(self.callable, '__qualname__', '') or self.name
+
+    @cached_property
+    def module_name(self) -> str:
+        """The name of the module the callable is defined in, or an empty string if it can't be determined."""
+        try:
+            module = inspect.getmodule(self.callable)
+            if module:
+                return module.__name__
+        except Exception:  # pragma: no cover
+            pass
+        return ''
+
+    @cached_property
+    def _module_qualified_name(self) -> str:
+        result = self.qualname
+        module_name = self.module_name
+        if module_name:
+            result = f'{module_name}.{result}'
+        return result
+
+    def default_template(self) -> str:
+        """The default message template for this callable."""
+        return f'Calling {self._module_qualified_name}'

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -85,9 +85,14 @@ from logfire.exceptions import LogfireConfigError
 from logfire.integrations.pydantic import get_pydantic_plugin_config
 from logfire.propagate import NoExtractTraceContextPropagator, WarnOnExtractTraceContextPropagator
 from logfire.testing import TestExporter
+from logfire.types import InstrumentMessageTemplateHelper
 from logfire.version import VERSION
 
 PROCESS_RUNTIME_VERSION_REGEX = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
+
+
+def _instrument_default_msg_template(helper: InstrumentMessageTemplateHelper) -> str:
+    return helper.name
 
 
 @pytest.fixture(autouse=True)
@@ -1283,7 +1288,10 @@ def test_config_serializable():
                 block_before_first_resolve=False,
                 include_baggage_in_context=False,
             ),
-            advanced=logfire.AdvancedOptions(id_generator=SeededRandomIdGenerator(seed=42)),
+            advanced=logfire.AdvancedOptions(
+                id_generator=SeededRandomIdGenerator(seed=42),
+                instrument_default_msg_template=_instrument_default_msg_template,
+            ),
         )
 
         for field in dataclasses.fields(GLOBAL_CONFIG):
@@ -1314,6 +1322,7 @@ def test_config_serializable():
         assert isinstance(GLOBAL_CONFIG.advanced.id_generator, SeededRandomIdGenerator)
         assert isinstance(GLOBAL_CONFIG.variables, logfire.VariablesOptions)
         assert GLOBAL_CONFIG.advanced.id_generator.seed == 42
+        assert GLOBAL_CONFIG.advanced.instrument_default_msg_template is _instrument_default_msg_template
 
         # Clean up the remote variable provider to stop the background thread
         logfire.configure(send_to_logfire=False)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -46,6 +46,7 @@ from logfire._internal.tracer import record_exception
 from logfire._internal.utils import SeededRandomIdGenerator, is_instrumentation_suppressed
 from logfire.integrations.logging import LogfireLoggingHandler
 from logfire.testing import TestExporter
+from logfire.types import InstrumentMessageTemplateHelper
 from tests.test_metrics import get_collected_metrics
 
 
@@ -263,16 +264,16 @@ def test_instrument_with_no_parameters(exporter: TestExporter) -> None:
     )
 
 
-def _default_span_name_from_func_name(func: Callable[..., Any]) -> str:
-    return getattr(func, '__name__', '')
+def _default_msg_template_from_function_name(helper: InstrumentMessageTemplateHelper) -> str:
+    return helper.name
 
 
-def _raising_default_span_name(func: Callable[..., Any]) -> str:
+def _raising_default_msg_template(_helper: InstrumentMessageTemplateHelper) -> str:
     raise ValueError('boom')
 
 
-def test_instrument_default_span_name_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
-    config_kwargs['advanced'].instrument_default_span_name = _default_span_name_from_func_name
+def test_instrument_default_msg_template_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['advanced'].instrument_default_msg_template = _default_msg_template_from_function_name
     logfire.configure(**config_kwargs)
 
     @logfire.instrument()
@@ -291,7 +292,7 @@ def test_instrument_default_span_name_customized(exporter: TestExporter, config_
                 'attributes': {
                     'code.filepath': 'test_logfire.py',
                     'code.lineno': 123,
-                    'code.function': 'test_instrument_default_span_name_customized.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_customized.<locals>.foo',
                     'logfire.msg_template': 'foo',
                     'logfire.span_type': 'span',
                     'logfire.msg': 'foo',
@@ -303,10 +304,10 @@ def test_instrument_default_span_name_customized(exporter: TestExporter, config_
     )
 
 
-def test_instrument_default_span_name_ignored_when_msg_template_given(
+def test_instrument_default_msg_template_ignored_when_msg_template_given(
     exporter: TestExporter, config_kwargs: dict[str, Any]
 ) -> None:
-    config_kwargs['advanced'].instrument_default_span_name = _default_span_name_from_func_name
+    config_kwargs['advanced'].instrument_default_msg_template = _default_msg_template_from_function_name
     logfire.configure(**config_kwargs)
 
     @logfire.instrument('explicit template')
@@ -325,7 +326,7 @@ def test_instrument_default_span_name_ignored_when_msg_template_given(
                 'attributes': {
                     'code.filepath': 'test_logfire.py',
                     'code.lineno': 123,
-                    'code.function': 'test_instrument_default_span_name_ignored_when_msg_template_given.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_ignored_when_msg_template_given.<locals>.foo',
                     'logfire.msg_template': 'explicit template',
                     'logfire.span_type': 'span',
                     'logfire.msg': 'explicit template',
@@ -337,11 +338,11 @@ def test_instrument_default_span_name_ignored_when_msg_template_given(
     )
 
 
-def test_internal_exception_in_instrument_default_span_name_falls_back_to_default(
+def test_internal_exception_in_instrument_default_msg_template_falls_back_to_default(
     exporter: TestExporter, config_kwargs: dict[str, Any]
 ) -> None:
     # Name must contain "test_internal_exception" so log_internal_error swallows instead of re-raising here.
-    config_kwargs['advanced'].instrument_default_span_name = _raising_default_span_name
+    config_kwargs['advanced'].instrument_default_msg_template = _raising_default_msg_template
     logfire.configure(**config_kwargs)
 
     @logfire.instrument()
@@ -352,7 +353,7 @@ def test_internal_exception_in_instrument_default_span_name_falls_back_to_defaul
     [span] = exporter.exported_spans_as_dict(_strip_function_qualname=False)
     assert span['attributes']['logfire.msg_template'] == (
         'Calling tests.test_logfire.'
-        'test_internal_exception_in_instrument_default_span_name_falls_back_to_default.<locals>.foo'
+        'test_internal_exception_in_instrument_default_msg_template_falls_back_to_default.<locals>.foo'
     )
 
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -272,6 +272,65 @@ def _raising_default_msg_template(_helper: InstrumentMessageTemplateHelper) -> s
     raise ValueError('boom')
 
 
+def _changed_default_msg_template(_helper: InstrumentMessageTemplateHelper) -> str:
+    return 'changed'
+
+
+def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
+    exporter: TestExporter, config_kwargs: dict[str, Any]
+) -> None:
+    @logfire.instrument()
+    def foo(x: int):
+        return x * 2
+
+    config_kwargs['advanced'].instrument_default_msg_template = _default_msg_template_from_function_name
+    logfire.configure(**config_kwargs)
+    assert foo(2) == 4
+    foo = cloudpickle.loads(cloudpickle.dumps(foo))  # type: ignore
+
+    config_kwargs['advanced'].instrument_default_msg_template = _changed_default_msg_template
+    assert foo(3) == 6
+
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False, parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'foo',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.function': 'test_instrument_default_msg_template_resolved_and_cached_on_first_call.<locals>.foo',
+                    'logfire.msg_template': 'foo',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.msg': 'foo',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
+                    'x': 2,
+                    'logfire.span_type': 'span',
+                },
+            },
+            {
+                'name': 'foo',
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'parent': None,
+                'start_time': 3000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'code.function': 'test_instrument_default_msg_template_resolved_and_cached_on_first_call.<locals>.foo',
+                    'logfire.msg_template': 'foo',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.msg': 'foo',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
+                    'x': 3,
+                    'logfire.span_type': 'span',
+                },
+            },
+        ]
+    )
+
+
 def test_instrument_default_msg_template_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
     config_kwargs['advanced'].instrument_default_msg_template = _default_msg_template_from_function_name
     logfire.configure(**config_kwargs)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -364,11 +364,13 @@ def test_instrument_default_msg_template_initialized_once_concurrently(config_kw
 def test_instrument_default_msg_template_initializes_functions_independently(config_kwargs: dict[str, Any]) -> None:
     foo_initializing = threading.Event()
     bar_initialized = threading.Event()
+    foo_saw_bar_initialized = False
 
     def default_msg_template(helper: InstrumentMessageTemplateHelper) -> str:
+        nonlocal foo_saw_bar_initialized
         if helper.name == 'foo':
             foo_initializing.set()
-            assert bar_initialized.wait(timeout=5)
+            foo_saw_bar_initialized = bar_initialized.wait(timeout=5)
         else:
             bar_initialized.set()
         return helper.name
@@ -390,6 +392,7 @@ def test_instrument_default_msg_template_initializes_functions_independently(con
         bar_future = executor.submit(bar)
         assert foo_future.result() == 1
         assert bar_future.result() == 2
+    assert foo_saw_bar_initialized
 
 
 def test_instrument_default_msg_template_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -278,7 +278,7 @@ def _changed_default_msg_template(_helper: InstrumentMessageTemplateHelper) -> s
     return 'changed'
 
 
-def test_instrument_default_msg_template_cached_until_reconfigured(
+def test_instrument_default_msg_template_cached_until_callback_changes(
     exporter: TestExporter, config_kwargs: dict[str, Any]
 ) -> None:
     @logfire.instrument()
@@ -304,7 +304,7 @@ def test_instrument_default_msg_template_cached_until_reconfigured(
                 'start_time': 1000000000,
                 'end_time': 2000000000,
                 'attributes': {
-                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_cached_until_callback_changes.<locals>.foo',
                     'logfire.msg_template': 'foo',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -321,7 +321,7 @@ def test_instrument_default_msg_template_cached_until_reconfigured(
                 'start_time': 3000000000,
                 'end_time': 4000000000,
                 'attributes': {
-                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_cached_until_callback_changes.<locals>.foo',
                     'logfire.msg_template': 'foo',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -338,7 +338,7 @@ def test_instrument_default_msg_template_cached_until_reconfigured(
                 'start_time': 5000000000,
                 'end_time': 6000000000,
                 'attributes': {
-                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_cached_until_callback_changes.<locals>.foo',
                     'logfire.msg_template': 'changed',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -382,7 +382,7 @@ def test_instrument_default_msg_template_initialized_once_concurrently(config_kw
     assert callback_calls == 1
     logfire.configure(**config_kwargs)
     call_concurrently()
-    assert callback_calls == 2
+    assert callback_calls == 1
 
 
 def test_instrument_default_msg_template_initializes_functions_independently(config_kwargs: dict[str, Any]) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -267,6 +267,10 @@ def _default_span_name_from_func_name(func: Callable[..., Any]) -> str:
     return getattr(func, '__name__', '')
 
 
+def _raising_default_span_name(func: Callable[..., Any]) -> str:
+    raise ValueError('boom')
+
+
 def test_instrument_default_span_name_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
     config_kwargs['advanced'].instrument_default_span_name = _default_span_name_from_func_name
     logfire.configure(**config_kwargs)
@@ -330,6 +334,25 @@ def test_instrument_default_span_name_ignored_when_msg_template_given(
                 },
             }
         ]
+    )
+
+
+def test_internal_exception_in_instrument_default_span_name_falls_back_to_default(
+    exporter: TestExporter, config_kwargs: dict[str, Any]
+) -> None:
+    # Name must contain "test_internal_exception" so log_internal_error swallows instead of re-raising here.
+    config_kwargs['advanced'].instrument_default_span_name = _raising_default_span_name
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument()
+    def foo(x: int):
+        return x * 2
+
+    assert foo(2) == 4
+    [span] = exporter.exported_spans_as_dict(_strip_function_qualname=False)
+    assert span['attributes']['logfire.msg_template'] == (
+        'Calling tests.test_logfire.'
+        'test_internal_exception_in_instrument_default_span_name_falls_back_to_default.<locals>.foo'
     )
 
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -361,6 +361,37 @@ def test_instrument_default_msg_template_initialized_once_concurrently(config_kw
     assert callback_calls == 1
 
 
+def test_instrument_default_msg_template_initializes_functions_independently(config_kwargs: dict[str, Any]) -> None:
+    foo_initializing = threading.Event()
+    bar_initialized = threading.Event()
+
+    def default_msg_template(helper: InstrumentMessageTemplateHelper) -> str:
+        if helper.name == 'foo':
+            foo_initializing.set()
+            assert bar_initialized.wait(timeout=5)
+        else:
+            bar_initialized.set()
+        return helper.name
+
+    config_kwargs['advanced'].instrument_default_msg_template = default_msg_template
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument(extract_args=False)
+    def foo() -> int:
+        return 1
+
+    @logfire.instrument(extract_args=False)
+    def bar() -> int:
+        return 2
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        foo_future = executor.submit(foo)
+        assert foo_initializing.wait(timeout=5)
+        bar_future = executor.submit(bar)
+        assert foo_future.result() == 1
+        assert bar_future.result() == 2
+
+
 def test_instrument_default_msg_template_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
     config_kwargs['advanced'].instrument_default_msg_template = _default_msg_template_from_function_name
     logfire.configure(**config_kwargs)

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -263,8 +263,12 @@ def test_instrument_with_no_parameters(exporter: TestExporter) -> None:
     )
 
 
+def _default_span_name_from_func_name(func: Callable[..., Any]) -> str:
+    return getattr(func, '__name__', '')
+
+
 def test_instrument_default_span_name_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
-    config_kwargs['advanced'].instrument_default_span_name = lambda func: func.__name__
+    config_kwargs['advanced'].instrument_default_span_name = _default_span_name_from_func_name
     logfire.configure(**config_kwargs)
 
     @logfire.instrument()
@@ -272,7 +276,7 @@ def test_instrument_default_span_name_customized(exporter: TestExporter, config_
         return x * 2
 
     assert foo(2) == 4
-    assert exporter.exported_spans_as_dict(_strip_function_qualname=False) == snapshot(
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False, parse_json_attributes=True) == snapshot(
         [
             {
                 'name': 'foo',
@@ -288,7 +292,7 @@ def test_instrument_default_span_name_customized(exporter: TestExporter, config_
                     'logfire.span_type': 'span',
                     'logfire.msg': 'foo',
                     'x': 2,
-                    'logfire.json_schema': '{"type":"object","properties":{"x":{}}}',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
                 },
             }
         ]
@@ -298,7 +302,7 @@ def test_instrument_default_span_name_customized(exporter: TestExporter, config_
 def test_instrument_default_span_name_ignored_when_msg_template_given(
     exporter: TestExporter, config_kwargs: dict[str, Any]
 ) -> None:
-    config_kwargs['advanced'].instrument_default_span_name = lambda func: func.__name__
+    config_kwargs['advanced'].instrument_default_span_name = _default_span_name_from_func_name
     logfire.configure(**config_kwargs)
 
     @logfire.instrument('explicit template')
@@ -306,8 +310,27 @@ def test_instrument_default_span_name_ignored_when_msg_template_given(
         return x * 2
 
     assert foo(2) == 4
-    [span] = exporter.exported_spans_as_dict(_strip_function_qualname=False)
-    assert span['attributes']['logfire.msg_template'] == 'explicit template'
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False, parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'explicit template',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.lineno': 123,
+                    'code.function': 'test_instrument_default_span_name_ignored_when_msg_template_given.<locals>.foo',
+                    'logfire.msg_template': 'explicit template',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'explicit template',
+                    'x': 2,
+                    'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
+                },
+            }
+        ]
+    )
 
 
 def test_instrument_func_with_no_params(exporter: TestExporter) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -4,6 +4,8 @@ import inspect
 import os
 import re
 import sys
+import threading
+import time
 import warnings
 from collections.abc import Callable
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
@@ -329,6 +331,34 @@ def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
             },
         ]
     )
+
+
+def test_instrument_default_msg_template_initialized_once_concurrently(config_kwargs: dict[str, Any]) -> None:
+    callback_calls = 0
+    barrier = threading.Barrier(10)
+
+    def default_msg_template(helper: InstrumentMessageTemplateHelper) -> str:
+        nonlocal callback_calls
+        callback_calls += 1
+        time.sleep(0.05)
+        return helper.name
+
+    config_kwargs['advanced'].instrument_default_msg_template = default_msg_template
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument(extract_args=False)
+    def foo() -> int:
+        return 4
+
+    def call_foo() -> int:
+        barrier.wait()
+        return foo()
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        futures = [executor.submit(call_foo) for _ in range(10)]
+        assert [future.result() for future in futures] == [4] * 10
+
+    assert callback_calls == 1
 
 
 def test_instrument_default_msg_template_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -278,7 +278,7 @@ def _changed_default_msg_template(_helper: InstrumentMessageTemplateHelper) -> s
     return 'changed'
 
 
-def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
+def test_instrument_default_msg_template_cached_until_reconfigured(
     exporter: TestExporter, config_kwargs: dict[str, Any]
 ) -> None:
     @logfire.instrument()
@@ -289,9 +289,11 @@ def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
     logfire.configure(**config_kwargs)
     assert foo(2) == 4
     foo = cloudpickle.loads(cloudpickle.dumps(foo))  # type: ignore
+    assert foo(3) == 6
 
     config_kwargs['advanced'].instrument_default_msg_template = _changed_default_msg_template
-    assert foo(3) == 6
+    logfire.configure(**config_kwargs)
+    assert foo(4) == 8
 
     assert exporter.exported_spans_as_dict(_strip_function_qualname=False, parse_json_attributes=True) == snapshot(
         [
@@ -302,7 +304,7 @@ def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
                 'start_time': 1000000000,
                 'end_time': 2000000000,
                 'attributes': {
-                    'code.function': 'test_instrument_default_msg_template_resolved_and_cached_on_first_call.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
                     'logfire.msg_template': 'foo',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
@@ -319,13 +321,30 @@ def test_instrument_default_msg_template_resolved_and_cached_on_first_call(
                 'start_time': 3000000000,
                 'end_time': 4000000000,
                 'attributes': {
-                    'code.function': 'test_instrument_default_msg_template_resolved_and_cached_on_first_call.<locals>.foo',
+                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
                     'logfire.msg_template': 'foo',
                     'code.lineno': 123,
                     'code.filepath': 'test_logfire.py',
                     'logfire.msg': 'foo',
                     'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
                     'x': 3,
+                    'logfire.span_type': 'span',
+                },
+            },
+            {
+                'name': 'changed',
+                'context': {'trace_id': 3, 'span_id': 5, 'is_remote': False},
+                'parent': None,
+                'start_time': 5000000000,
+                'end_time': 6000000000,
+                'attributes': {
+                    'code.function': 'test_instrument_default_msg_template_cached_until_reconfigured.<locals>.foo',
+                    'logfire.msg_template': 'changed',
+                    'code.lineno': 123,
+                    'code.filepath': 'test_logfire.py',
+                    'logfire.msg': 'changed',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'x': {}}},
+                    'x': 4,
                     'logfire.span_type': 'span',
                 },
             },
@@ -354,11 +373,16 @@ def test_instrument_default_msg_template_initialized_once_concurrently(config_kw
         barrier.wait()
         return foo()
 
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(call_foo) for _ in range(10)]
-        assert [future.result() for future in futures] == [4] * 10
+    def call_concurrently() -> None:
+        with ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(call_foo) for _ in range(10)]
+            assert [future.result() for future in futures] == [4] * 10
 
+    call_concurrently()
     assert callback_calls == 1
+    logfire.configure(**config_kwargs)
+    call_concurrently()
+    assert callback_calls == 2
 
 
 def test_instrument_default_msg_template_initializes_functions_independently(config_kwargs: dict[str, Any]) -> None:

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -263,6 +263,53 @@ def test_instrument_with_no_parameters(exporter: TestExporter) -> None:
     )
 
 
+def test_instrument_default_span_name_customized(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
+    config_kwargs['advanced'].instrument_default_span_name = lambda func: func.__name__
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument()
+    def foo(x: int):
+        return x * 2
+
+    assert foo(2) == 4
+    assert exporter.exported_spans_as_dict(_strip_function_qualname=False) == snapshot(
+        [
+            {
+                'name': 'foo',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.lineno': 123,
+                    'code.function': 'test_instrument_default_span_name_customized.<locals>.foo',
+                    'logfire.msg_template': 'foo',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'foo',
+                    'x': 2,
+                    'logfire.json_schema': '{"type":"object","properties":{"x":{}}}',
+                },
+            }
+        ]
+    )
+
+
+def test_instrument_default_span_name_ignored_when_msg_template_given(
+    exporter: TestExporter, config_kwargs: dict[str, Any]
+) -> None:
+    config_kwargs['advanced'].instrument_default_span_name = lambda func: func.__name__
+    logfire.configure(**config_kwargs)
+
+    @logfire.instrument('explicit template')
+    def foo(x: int):
+        return x * 2
+
+    assert foo(2) == 4
+    [span] = exporter.exported_spans_as_dict(_strip_function_qualname=False)
+    assert span['attributes']['logfire.msg_template'] == 'explicit template'
+
+
 def test_instrument_func_with_no_params(exporter: TestExporter) -> None:
     @logfire.instrument()
     def foo():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,26 @@
+from functools import wraps
+from unittest.mock import patch
+
+from logfire.types import InstrumentMessageTemplateHelper
+
+
+def test_instrument_message_template_helper() -> None:
+    def foo() -> None:
+        pass
+
+    @wraps(foo)
+    def decorated() -> None:
+        foo()
+
+    helper = InstrumentMessageTemplateHelper(decorated)
+    assert helper.raw_callable is decorated
+    assert helper.callable is foo
+    assert helper.name == 'foo'
+    assert helper.qualname == 'test_instrument_message_template_helper.<locals>.foo'
+    assert helper.module_name == 'tests.test_types'
+    assert helper.default_template() == 'Calling tests.test_types.test_instrument_message_template_helper.<locals>.foo'
+
+    with patch('logfire.types.inspect.getmodule', return_value=None):
+        helper = InstrumentMessageTemplateHelper(foo)
+        assert helper.module_name == ''
+        assert helper.default_template() == 'Calling test_instrument_message_template_helper.<locals>.foo'


### PR DESCRIPTION
## Summary

Fixes #1508.

`@logfire.instrument` currently generates `Calling {module}.{qualname}` whenever no explicit `msg_template` is provided. That default is useful, but projects cannot change it globally to match their tracing conventions without repeating a template at every call site.

This adds `AdvancedOptions.instrument_default_msg_template`, a callback for generating the default message template:

```python
import logfire
from logfire.types import InstrumentMessageTemplateHelper


def simple_function_name(helper: InstrumentMessageTemplateHelper) -> str:
    return helper.name


logfire.configure(
    advanced=logfire.AdvancedOptions(
        instrument_default_msg_template=simple_function_name,
    )
)


@logfire.instrument
def foo_bar():
    ...


# span name and message template are now "foo_bar"
```

The callback receives an `InstrumentMessageTemplateHelper` with access to the original callable, an unwrapped callable, its simple and qualified names, its module name, and `default_template()` for the standard `Calling {module}.{qualname}` behavior.

For functions without an explicit `msg_template`, the callback is resolved on first execution after configuration and the resulting span factory is cached. Functions may therefore be decorated or imported before `logfire.configure()` and still use the application configuration when first called. Reconfiguration that changes this callback invalidates the cache, so existing instrumented functions use the new callback on their next execution; unrelated calls to `configure()` leave the cached factory intact. Explicit templates remain eager and unaffected.

The default callback and module-level custom callbacks are picklable when configuration is passed to process executors. Lambdas and local functions should not be used when `ProcessPoolExecutor` configuration propagation is required.

Existing behavior is preserved when the option is not customized. An explicit `msg_template` still takes precedence, and a callback that raises or returns an empty string falls back to the standard template.

## Test plan

- [x] `uv run pytest tests/test_logfire.py tests/test_configure.py tests/test_types.py -q` — 224 passed, 1 skipped
- [x] `uv run pytest tests/test_docs.py -q` — 125 passed
- [x] Focused Ruff and Pyright checks — clean
- [x] Pre-commit Ruff, formatting, and Pyright checks — clean
