### PR TITLE
Handle evolving user token formats in display

### DIFF
--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -25,6 +25,7 @@ DEFAULT_FILE = HOME_LOGFIRE / 'default.toml'
 """File used to store user tokens."""
 
 
+LOGFIRE_TOKEN_REGION_PATTERN = re.compile(r'^pylf_v[0-9]+_(?P<region>[a-z]+)_')
 PYDANTIC_LOGFIRE_TOKEN_PATTERN = re.compile(
     r'^(?P<safe_part>pylf_v(?P<version>[0-9]+)_(?P<region>[a-z]+)_'
     r'(?:(?P<organization_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})_)?)'
@@ -88,14 +89,18 @@ class UserToken:
 
     def __str__(self) -> str:
         region = 'us'
-        if match := PYDANTIC_LOGFIRE_TOKEN_PATTERN.match(self.token):
-            region = match.group('region')
+        token_match = PYDANTIC_LOGFIRE_TOKEN_PATTERN.match(self.token)
+        region_match = token_match or LOGFIRE_TOKEN_REGION_PATTERN.match(self.token)
+        if region_match:
+            region = region_match.group('region')
             if region not in REGIONS:
                 region = 'us'
 
         token_repr = f'{region.upper()} ({self.base_url}) - '
-        if match:
-            token_repr += match.group('safe_part') + match.group('token')[:5]
+        if token_match:
+            token_repr += token_match.group('safe_part') + token_match.group('token')[:5]
+        elif region_match:
+            token_repr += self.token[region_match.end() : region_match.end() + 5]
         else:
             token_repr += self.token[:5]
         token_repr += '****'

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -62,7 +62,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 from typing_extensions import Self, Unpack, assert_type
 
-from logfire._internal.auth import REGIONS
+from logfire._internal.auth import LOGFIRE_TOKEN_REGION_PATTERN, REGIONS
 from logfire._internal.baggage import DirectBaggageAttributesSpanProcessor
 from logfire._internal.collect_system_info import collect_package_info
 from logfire.exceptions import LogfireConfigError
@@ -138,7 +138,6 @@ CREDENTIALS_FILENAME = 'logfire_credentials.json'
 COMMON_REQUEST_HEADERS = {'User-Agent': f'logfire/{VERSION}'}
 """Common request headers for requests to the Logfire API."""
 PROJECT_NAME_PATTERN = r'^[a-z0-9]+(?:-[a-z0-9]+)*$'
-LOGFIRE_TOKEN_REGION_PATTERN = re.compile(r'^pylf_v[0-9]+_(?P<region>[a-z]+)_')
 
 METRICS_PREFERRED_TEMPORALITY = {
     Counter: AggregationTemporality.DELTA,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -39,6 +39,11 @@ from logfire.exceptions import LogfireConfigError
             'pylf_v2_eu_9f9ba85a-b759-4181-9527-d812e03f9f7f_0kYhc414Ys2FNDRdt5vFB05xFx5NjVcbcBMy4Kp6PH0W',
             'EU (https://logfire-eu.pydantic.dev) - pylf_v2_eu_9f9ba85a-b759-4181-9527-d812e03f9f7f_0kYhc****',
         ),
+        (
+            'https://logfire-eu.pydantic.dev',
+            'pylf_v3_eu_new-token-format',
+            'EU (https://logfire-eu.pydantic.dev) - new-t****',
+        ),
     ],
 )
 def test_user_token_str(base_url: str, token: str, expected: str) -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2889,6 +2889,9 @@ def test_staging_token_regions():
         get_base_url_from_token(
             'pylf_v2_stagingeu_9F9BA85A-B759-4181-9527-D812E03F9F7F_0kYhc414Ys2FNDRdt5vFB05xFx5NjVcbcBMy4Kp6PH0W'
         )
+        == get_base_url_from_token(
+            'pylf_v2_stagingeu_9F9BA85AB759181-9527-D81^&*%*&^%*&^    2E03F9F7F_0kYhc414Ys2FNDRdt5vFBcbcBMy4Kp6PH0W'
+        )
         == 'https://logfire-eu.pydantic.info'
     )
 


### PR DESCRIPTION
## Summary

- fall back to the format-agnostic token region matcher when a user token no longer matches the strict parser
- redact evolving token formats to the first five characters after the region marker
- keep the shared region matcher available from the configuration module without duplicating it

## Why

`UserToken.__str__` depended on full validation of the current token suffix format. A future suffix change could therefore lose the correct region label and fall back to showing the beginning of the complete token. Matching the stable region prefix separately keeps the display useful and safely redacted as token formats evolve.

## Validation

- `uv run pytest tests/test_auth.py -q`
- `uv run pytest tests/test_configure.py -q -k 'staging_token_regions or token_region'`
- `uv run ruff check logfire/_internal/auth.py logfire/_internal/config.py tests/test_auth.py`
- `uv run pyright logfire/_internal/auth.py logfire/_internal/config.py tests/test_auth.py`
- pre-commit hooks run by `gcap`
