### PR TITLE
Add `log_event_loop_pauses`: detect event loop pauses on any loop implementation, including uvloop

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -129,6 +129,9 @@ except ImportError:
             def log_slow_async_callbacks(self, *args, **kwargs) -> None:  # pragma: no cover
                 return nullcontext()
 
+            def log_event_loop_pauses(self, *args, **kwargs) -> None:  # pragma: no cover
+                return nullcontext()
+
             def install_auto_tracing(self, *args, **kwargs) -> None: ...
 
             def instrument(self, msg_template=None, **kwargs):
@@ -232,6 +235,7 @@ except ImportError:
         with_settings = DEFAULT_LOGFIRE_INSTANCE.with_settings
         force_flush = DEFAULT_LOGFIRE_INSTANCE.force_flush
         log_slow_async_callbacks = DEFAULT_LOGFIRE_INSTANCE.log_slow_async_callbacks
+        log_event_loop_pauses = DEFAULT_LOGFIRE_INSTANCE.log_event_loop_pauses
         install_auto_tracing = DEFAULT_LOGFIRE_INSTANCE.install_auto_tracing
         instrument = DEFAULT_LOGFIRE_INSTANCE.instrument
         instrument_asgi = DEFAULT_LOGFIRE_INSTANCE.instrument_asgi

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -36,6 +36,7 @@ span = DEFAULT_LOGFIRE_INSTANCE.span
 instrument = DEFAULT_LOGFIRE_INSTANCE.instrument
 force_flush = DEFAULT_LOGFIRE_INSTANCE.force_flush
 log_slow_async_callbacks = DEFAULT_LOGFIRE_INSTANCE.log_slow_async_callbacks
+log_event_loop_pauses = DEFAULT_LOGFIRE_INSTANCE.log_event_loop_pauses
 install_auto_tracing = DEFAULT_LOGFIRE_INSTANCE.install_auto_tracing
 instrument_pydantic = DEFAULT_LOGFIRE_INSTANCE.instrument_pydantic
 instrument_pydantic_ai = DEFAULT_LOGFIRE_INSTANCE.instrument_pydantic_ai
@@ -147,6 +148,7 @@ __all__ = (
     'fatal',
     'force_flush',
     'log_slow_async_callbacks',
+    'log_event_loop_pauses',
     'install_auto_tracing',
     'instrument_asgi',
     'instrument_wsgi',

--- a/logfire/_internal/async_.py
+++ b/logfire/_internal/async_.py
@@ -4,6 +4,9 @@ import asyncio
 import asyncio.events
 import asyncio.tasks
 import inspect
+import sys
+import threading
+import time
 from contextlib import AbstractContextManager, contextmanager
 from pathlib import Path
 from types import CoroutineType
@@ -120,3 +123,119 @@ def _callback_attributes(callback: Any) -> _CallbackAttributes:
     name = name or safe_repr(callback)
     result['name'] = f'callback {name}'
     return result
+
+
+def log_event_loop_pauses(
+    logfire: Logfire, slow_duration: float, check_interval: float | None
+) -> AbstractContextManager[None]:
+    """Log a warning whenever the current event loop is unresponsive for too long.
+
+    See Logfire.log_event_loop_pauses.
+    """
+    loop = asyncio.get_running_loop()
+    if check_interval is None:
+        check_interval = slow_duration / 4
+    logfire = logfire.with_settings(custom_scope_suffix='asyncio')
+    watchdog = _EventLoopWatchdog(logfire, loop, slow_duration, check_interval)
+    watchdog.start()
+
+    @contextmanager
+    def stop_context():
+        # The user isn't required to use this context manager,
+        # monitoring has already started before this point.
+        try:
+            yield
+        finally:
+            watchdog.stop()
+
+    return stop_context()
+
+
+class _EventLoopWatchdog:
+    """Detects event loop pauses with a heartbeat scheduled on the loop and a thread watching it.
+
+    A `call_later` chain on the event loop records the time of each beat.
+    A daemon thread checks how overdue the next beat is: if the loop doesn't run the heartbeat
+    for `slow_duration` beyond its schedule, the loop is considered blocked, and the thread
+    samples the loop thread's stack right away to see what is blocking it.
+    Once the loop recovers, a warning is logged with the measured pause duration and that stack.
+
+    Unlike `log_slow_callbacks` this doesn't depend on `asyncio.events.Handle._run`,
+    so it works with any event loop implementation, including uvloop.
+    """
+
+    def __init__(self, logfire: Logfire, loop: asyncio.AbstractEventLoop, slow_duration: float, check_interval: float):
+        self.logfire = logfire
+        self.loop = loop
+        self.slow_duration = slow_duration
+        self.check_interval = check_interval
+        # `log_event_loop_pauses` requires a running loop, so the current thread is the loop's thread.
+        self.loop_thread_id = threading.get_ident()
+        self.last_beat = time.monotonic()
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(target=self._watch, name='logfire-event-loop-watchdog', daemon=True)
+
+    def start(self) -> None:
+        self._beat()
+        self.thread.start()
+
+    def stop(self) -> None:
+        self.stop_event.set()
+
+    def _beat(self) -> None:
+        # Runs on the event loop: record that the loop is responsive and schedule the next beat.
+        self.last_beat = time.monotonic()
+        if not self.stop_event.is_set():
+            self.loop.call_later(self.check_interval, self._beat)
+
+    def _watch(self) -> None:
+        # Runs on the watchdog thread.
+        while not self.stop_event.wait(self.check_interval):
+            if self.loop.is_closed():
+                return
+            beat = self.last_beat
+            # The next beat was due `check_interval` after the last one; anything beyond that is a pause.
+            if time.monotonic() - beat - self.check_interval < self.slow_duration:
+                continue
+            # The loop is blocked right now. Sample its thread's stack to see what's blocking it,
+            # then wait for the loop to recover to measure the total pause.
+            stack = self._sample_stack()
+            while self.last_beat == beat and not self.loop.is_closed():
+                if self.stop_event.wait(self.check_interval):
+                    # Stopped while the loop was still blocked; the pause's duration is unknown.
+                    return
+            if self.last_beat == beat:  # pragma: no cover
+                return  # The loop closed while blocked.
+            duration = self.last_beat - beat - self.check_interval
+            self._log_pause(duration, stack)
+
+    def _sample_stack(self) -> list[StackInfo]:
+        frame = sys._current_frames().get(self.loop_thread_id)  # pyright: ignore[reportPrivateUsage]
+        stack: list[StackInfo] = []
+        while frame is not None:
+            stack_info = get_stack_info_from_frame(frame)
+            # Ignore frames from the stdlib asyncio
+            if not stack_info.get('code.filepath', '').startswith(ASYNCIO_PATH):
+                stack.append(stack_info)
+            frame = frame.f_back
+        # Match the order of the 'stack' in `_callback_attributes`: outermost frame first.
+        stack.reverse()
+        return stack
+
+    def _log_pause(self, duration: float, stack: list[StackInfo]) -> None:
+        try:
+            attributes: _CallbackAttributes = {'stack': stack}
+            if stack:  # pragma: no branch
+                # The innermost frame is where the loop thread was blocked when sampled.
+                attributes = {**stack[-1], **attributes}
+            self.logfire.warn(
+                'Event loop blocked for {duration:.3f} seconds',
+                duration=duration,
+                **attributes,
+            )
+        except Exception:  # pragma: no cover
+            # Don't crash the watchdog thread for this.
+            try:
+                self.logfire.exception('Error in log_event_loop_pauses')
+            except Exception:
+                pass

--- a/logfire/_internal/async_.py
+++ b/logfire/_internal/async_.py
@@ -132,6 +132,10 @@ def log_event_loop_pauses(
 
     See Logfire.log_event_loop_pauses.
     """
+    if slow_duration <= 0:
+        raise ValueError('slow_duration must be positive')
+    if check_interval is not None and check_interval <= 0:
+        raise ValueError('check_interval must be positive')
     loop = asyncio.get_running_loop()
     if check_interval is None:
         check_interval = slow_duration / 4

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -953,6 +953,42 @@ class Logfire:
         """
         return async_.log_slow_callbacks(self, slow_duration)
 
+    def log_event_loop_pauses(
+        self, slow_duration: float = 0.1, check_interval: float | None = None
+    ) -> AbstractContextManager[None]:
+        """Log a warning whenever the current event loop is unresponsive for too long.
+
+        This must be called while the event loop to monitor is running.
+        It schedules a repeating heartbeat callback on the loop and starts a daemon thread which
+        watches it. When the heartbeat falls more than `slow_duration` behind schedule, the thread
+        samples the loop thread's stack to capture what is blocking it, and once the loop recovers
+        it logs a warning with the measured pause duration and the sampled stack.
+
+        Compared to `log_slow_async_callbacks` this works with any event loop implementation.
+        In particular, `log_slow_async_callbacks` silently detects nothing under uvloop
+        (which never calls the patched `asyncio.events.Handle._run`), whereas this works there too.
+        It also catches pauses which aren't caused by a single slow callback, such as garbage
+        collection or other threads holding the GIL. On the other hand, the blame it assigns is
+        a best-effort sample taken while the loop is blocked rather than exact callback timings,
+        so on a stock asyncio event loop `log_slow_async_callbacks` gives better attribution.
+
+        Only the loop running in the calling thread is monitored, and a pause is only logged once
+        the loop has recovered from it, so a permanently blocked loop logs nothing.
+
+        Args:
+            slow_duration: the threshold in seconds for when a pause is considered slow.
+            check_interval: how often (in seconds) the heartbeat runs and the watchdog thread checks it.
+                Defaults to a quarter of `slow_duration`. Measured pause durations are accurate
+                to within roughly this value.
+
+        Returns:
+            A context manager that stops the monitoring when exited.
+                Calling this method will immediately start monitoring
+                without waiting for the context manager to be opened,
+                i.e. it's not necessary to use this as a context manager.
+        """
+        return async_.log_event_loop_pauses(self, slow_duration, check_interval)
+
     def install_auto_tracing(
         self,
         modules: Sequence[str] | Callable[[AutoTraceModule], bool],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ dev = [
     "Flask >= 3.0.3",
     "django >= 4.2.16",
     "dirty-equals >= 0.8.0",
+    "uvloop >= 0.21.0; sys_platform != 'win32'",
     "pytest >= 8.3.4",
     "pytest-django >= 4.6.0",
     "pytest-pretty >= 1.2.0",

--- a/tests/test_event_loop_pauses.py
+++ b/tests/test_event_loop_pauses.py
@@ -1,0 +1,136 @@
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+from dirty_equals import IsFloat, IsInt, IsStr
+from inline_snapshot import snapshot
+
+import logfire
+from logfire.testing import TestExporter
+
+
+def watchdog_threads() -> set[threading.Thread]:
+    return {t for t in threading.enumerate() if t.name == 'logfire-event-loop-watchdog'}
+
+
+@pytest.mark.anyio
+async def test_log_event_loop_pauses(exporter: TestExporter) -> None:
+    with logfire.log_event_loop_pauses(slow_duration=0.1, check_interval=0.01):
+        await asyncio.sleep(0.02)  # let the heartbeat get going
+        time.sleep(0.4)  # block the event loop
+        # The warning is logged from the watchdog thread shortly after the loop recovers.
+        for _ in range(500):
+            if exporter.exported_spans:
+                break
+            await asyncio.sleep(0.01)
+
+    assert exporter.exported_spans[0].instrumentation_scope.name == 'logfire.asyncio'  # type: ignore
+
+    [span] = exporter.exported_spans_as_dict()
+    # The loop thread was blocked in `time.sleep` above when the stack was sampled,
+    # so the innermost frame of the sampled stack is this test function.
+    stack = json.loads(span['attributes'].pop('stack'))
+    assert stack[-1]['code.function'] == 'test_log_event_loop_pauses'
+    assert span == snapshot(
+        {
+            'name': 'Event loop blocked for {duration:.3f} seconds',
+            'context': {'trace_id': IsInt, 'span_id': IsInt, 'is_remote': False},
+            'parent': None,
+            'start_time': IsInt,
+            'end_time': IsInt,
+            'attributes': {
+                'logfire.span_type': 'log',
+                'logfire.level_num': 13,
+                'logfire.msg_template': 'Event loop blocked for {duration:.3f} seconds',
+                'logfire.msg': IsStr(regex=r'Event loop blocked for 0\.\d{3} seconds'),
+                'code.filepath': 'test_event_loop_pauses.py',
+                'code.function': 'test_log_event_loop_pauses',
+                'code.lineno': 123,
+                'duration': IsFloat(gt=0.3, lt=10),
+                'logfire.json_schema': '{"type":"object","properties":{"duration":{},"stack":{"type":"array"}}}',
+            },
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_no_warning_for_responsive_loop(exporter: TestExporter) -> None:
+    with logfire.log_event_loop_pauses(slow_duration=1, check_interval=0.01):
+        for _ in range(10):
+            await asyncio.sleep(0.001)
+            time.sleep(0.005)  # brief blocking, well under the threshold
+    assert not exporter.exported_spans
+
+
+@pytest.mark.anyio
+async def test_context_manager_stops_watchdog(exporter: TestExporter) -> None:
+    threads_before = watchdog_threads()
+    with logfire.log_event_loop_pauses():
+        [thread] = watchdog_threads() - threads_before
+        assert thread.is_alive()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    # Let the last scheduled heartbeat fire and see that it doesn't reschedule itself.
+    await asyncio.sleep(0.1)
+    assert not exporter.exported_spans
+
+
+@pytest.mark.anyio
+async def test_stop_while_loop_blocked(exporter: TestExporter) -> None:
+    context = logfire.log_event_loop_pauses(slow_duration=0.05, check_interval=0.01)
+    context.__enter__()
+    # Stop the watchdog from another thread while the event loop is still blocked.
+    timer = threading.Timer(0.2, context.__exit__, (None, None, None))
+    timer.start()
+    await asyncio.sleep(0.02)
+    time.sleep(0.6)  # block the event loop for well over the timer above
+    timer.join()
+    await asyncio.sleep(0.1)
+    # The pause was still in progress when the watchdog was stopped,
+    # so its duration is unknown and nothing is logged.
+    assert not exporter.exported_spans
+
+
+def test_watchdog_exits_when_loop_closes(exporter: TestExporter) -> None:
+    threads_before = watchdog_threads()
+
+    async def main():
+        logfire.log_event_loop_pauses(slow_duration=0.1, check_interval=0.01)
+
+    asyncio.run(main())
+    [thread] = watchdog_threads() - threads_before
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+    assert not exporter.exported_spans
+
+
+def test_requires_running_loop() -> None:
+    with pytest.raises(RuntimeError):
+        logfire.log_event_loop_pauses()
+
+
+def test_log_event_loop_pauses_uvloop(exporter: TestExporter) -> None:
+    # `log_slow_async_callbacks` can't detect anything under uvloop, whose callback handles
+    # are implemented in Cython and never call the patched `asyncio.events.Handle._run`.
+    # The heartbeat watchdog doesn't care about the event loop implementation.
+    uvloop = pytest.importorskip('uvloop')
+
+    async def main():
+        with logfire.log_event_loop_pauses(slow_duration=0.1, check_interval=0.01):
+            await asyncio.sleep(0.02)
+            time.sleep(0.4)  # block the event loop
+            for _ in range(500):
+                if exporter.exported_spans:
+                    break
+                await asyncio.sleep(0.01)
+
+    uvloop.run(main())
+
+    [span] = exporter.exported_spans_as_dict()
+    assert span['name'] == 'Event loop blocked for {duration:.3f} seconds'
+    assert span['attributes']['code.function'] == 'main'
+    duration = span['attributes']['duration']
+    assert isinstance(duration, float)
+    assert 0.3 < duration < 10

--- a/tests/test_event_loop_pauses.py
+++ b/tests/test_event_loop_pauses.py
@@ -111,6 +111,14 @@ def test_requires_running_loop() -> None:
         logfire.log_event_loop_pauses()
 
 
+def test_requires_positive_durations() -> None:
+    # Non-positive values would make the heartbeat and the watchdog thread spin in a busy loop.
+    with pytest.raises(ValueError, match='slow_duration must be positive'):
+        logfire.log_event_loop_pauses(slow_duration=0)
+    with pytest.raises(ValueError, match='check_interval must be positive'):
+        logfire.log_event_loop_pauses(check_interval=-1)
+
+
 def test_log_event_loop_pauses_uvloop(exporter: TestExporter) -> None:
     # `log_slow_async_callbacks` can't detect anything under uvloop, whose callback handles
     # are implemented in Cython and never call the patched `asyncio.events.Handle._run`.

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -158,6 +158,10 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     # NOTE: We don't call the log_slow_async_callbacks, to not give side effect to the test suite.
     logfire__all__.remove('log_slow_async_callbacks')
 
+    assert hasattr(logfire_api, 'log_event_loop_pauses')
+    # NOTE: We don't call log_event_loop_pauses either, for the same reason.
+    logfire__all__.remove('log_event_loop_pauses')
+
     assert hasattr(logfire_api, 'install_auto_tracing')
     logfire_api.install_auto_tracing(modules=['all'], min_duration=0)
     logfire__all__.remove('install_auto_tracing')

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version < '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -76,7 +76,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio", marker = "python_full_version >= '3.11'" },
+    { name = "caio" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/41/2fea7e193e061ce54eacc3b7bc0e6a99e4fcff43c78cf0a76dd781ed8334/aiofile-3.11.1.tar.gz", hash = "sha256:1f91912c6643d2a4e49ca4ae3514f0bf3867ce948a36d99a6411b8f4755f4cf9", size = 19342, upload-time = "2026-05-16T08:18:33.538Z" }
 wheels = [
@@ -1165,9 +1165,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version < '3.12'" },
-    { name = "sqlparse", marker = "python_full_version < '3.12'" },
-    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
 wheels = [
@@ -1193,9 +1193,9 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version >= '3.12'" },
-    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
-    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
@@ -2712,6 +2712,7 @@ dev = [
     { name = "testcontainers" },
     { name = "types-requests" },
     { name = "uvicorn" },
+    { name = "uvloop", marker = "sys_platform != 'win32'" },
     { name = "vcrpy" },
 ]
 
@@ -2861,6 +2862,7 @@ dev = [
     { name = "testcontainers", specifier = "<4.13" },
     { name = "types-requests" },
     { name = "uvicorn", specifier = ">=0.30.6" },
+    { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.21.0" },
     { name = "vcrpy", specifier = ">=8.2.1" },
 ]
 
@@ -4227,10 +4229,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4305,10 +4307,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -5995,8 +5997,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6544,6 +6546,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/c8/2d307868453a4bca6e64fa3581d122ae0748a0869c53f159339def179c7c/uvicorn-0.52.0.tar.gz", hash = "sha256:ca8876ad6c1983f394157c168b39d52f6dd56dabf5602fa0982751cffc2293ae", size = 97504, upload-time = "2026-07-29T08:45:34.065Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/e6/b5c0630ace9757232aec07112be8146b812787db52141ff9d50674aa7634/uvicorn-0.52.0-py3-none-any.whl", hash = "sha256:3d887809810b89ed33501bcf0a9aba469b06ecd608158efce04bd6b48d8c9b08", size = 79058, upload-time = "2026-07-29T08:45:32.492Z" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`logfire.log_slow_async_callbacks()` works by patching `asyncio.events.Handle._run`, which uvloop never calls (its callback handles are implemented in Cython), so under uvloop it silently detects nothing.

This adds `logfire.log_event_loop_pauses(slow_duration=0.1, check_interval=None)`, which detects event loop pauses without depending on the loop implementation:

- A repeating heartbeat callback on the loop records when it last ran.
- A daemon thread watches the heartbeat. When it falls more than `slow_duration` behind schedule, the loop is blocked right now, and the thread samples the loop thread's stack (via `sys._current_frames()`) to capture what is blocking it.
- Once the loop recovers, a warning is logged with the measured pause duration and the sampled stack, in the same `logfire.asyncio` scope as `log_slow_async_callbacks`:

  > Event loop blocked for 0.532 seconds

Because it measures loop responsiveness rather than timing each callback, it also catches pauses that aren't caused by a single slow callback: garbage collection, other threads holding the GIL, CPU starvation. The trade-off is that attribution is a best-effort stack sample rather than exact callback timings, so on a stock asyncio loop `log_slow_async_callbacks` still gives better attribution; the two compose fine and use the same default threshold.

Notes:

- It must be called while the loop to monitor is running (it needs the loop to schedule the heartbeat on) and monitors only that loop. Calling it with no running loop raises `RuntimeError`.
- A pause is logged once the loop recovers from it, so a permanently blocked loop logs nothing. If that case matters we could also log "blocked for at least X seconds" while still blocked; left out for now to keep this simple.
- Overhead is one timer callback plus one watchdog thread wake per `check_interval` (default `slow_duration / 4`, i.e. 40/s at the default threshold).
- uvloop is added as a dev dependency (non-Windows only) so the test suite covers the uvloop case with a real uvloop event loop.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

