### PR TITLE
Scrub spans and logs lazily in the exporter thread

### DIFF
--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -82,6 +82,9 @@ def scrubbing_callback(match: logfire.ScrubMatch):
 logfire.configure(scrubbing=logfire.ScrubbingOptions(callback=scrubbing_callback))
 ```
 
+Scrubbing runs when a span or log is about to be sent, which usually happens on a background thread, so
+the callback shouldn't rely on the state of the thread that created the span, e.g. context variables.
+
 ## Security tips
 
 ### Use message templates

--- a/logfire/_internal/exporters/logs.py
+++ b/logfire/_internal/exporters/logs.py
@@ -4,7 +4,7 @@ from opentelemetry.sdk._logs import ReadWriteLogRecord
 
 import logfire
 from logfire._internal.exporters.wrapper import WrapperLogProcessor
-from logfire._internal.scrubbing import BaseScrubber
+from logfire._internal.scrubbing import BaseScrubber, LazilyScrubbedLogRecord
 from logfire._internal.utils import is_instrumentation_suppressed
 
 
@@ -26,5 +26,5 @@ class MainLogProcessorWrapper(WrapperLogProcessor):
     scrubber: BaseScrubber
 
     def on_emit(self, log_record: ReadWriteLogRecord):
-        log_record.log_record = self.scrubber.scrub_log(log_record.log_record)
+        log_record.log_record = LazilyScrubbedLogRecord(log_record.log_record, self.scrubber)
         return super().on_emit(log_record)

--- a/logfire/_internal/exporters/processor_wrapper.py
+++ b/logfire/_internal/exporters/processor_wrapper.py
@@ -27,7 +27,7 @@ from ..constants import (
 from ..db_statement_summary import message_from_db_statement
 from ..integrations.llm_providers.semconv import PROVIDER_NAME
 from ..json_schema import JsonSchemaProperties, attributes_json_schema
-from ..scrubbing import BaseScrubber
+from ..scrubbing import BaseScrubber, LazilyScrubbedReadableSpan
 from ..utils import (
     ReadableSpanDict,
     handle_internal_errors,
@@ -81,8 +81,7 @@ class MainSpanProcessorWrapper(WrapperSpanProcessor):
             _transform_google_genai_span(span_dict)
             _transform_litellm_span(span_dict)
             _default_gen_ai_response_model(span_dict)
-            self.scrubber.scrub_span(span_dict)
-            span = ReadableSpan(**span_dict)
+            span = LazilyScrubbedReadableSpan(span_dict, self.scrubber)
         super().on_end(span)
 
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -6,13 +6,15 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from threading import Lock
 from typing import Any, TypedDict, cast
 
 import typing_extensions
 from opentelemetry._logs import LogRecord
 from opentelemetry.attributes import BoundedAttributes
-from opentelemetry.sdk.trace import Event
+from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.trace import Link
+from opentelemetry.util import types as otel_types
 
 from .constants import (
     ATTRIBUTES_CONFIG,
@@ -33,7 +35,7 @@ from .constants import (
 )
 from .integrations.llm_providers import semconv as gen_ai_semconv
 from .stack_info import STACK_INFO_KEYS
-from .utils import ReadableSpanDict, truncate_string
+from .utils import ReadableSpanDict, handle_internal_errors, truncate_string
 
 DEFAULT_PATTERNS = [
     'password',
@@ -345,6 +347,83 @@ class SpanScrubber:
         matched_substring = match.pattern_match.group(0)
         self.scrubbed.append(ScrubbedNote(path=match.path, matched_substring=matched_substring))
         return f'[Scrubbed due to {matched_substring!r}]'
+
+
+class LazilyScrubbedReadableSpan(ReadableSpan):
+    """A span which is scrubbed the first time its contents are read.
+
+    Scrubbing is expensive, and spans end in application code (often an event loop)
+    but are read by exporters, which usually run in a background thread.
+    """
+
+    def __init__(self, span_dict: ReadableSpanDict, scrubber: BaseScrubber) -> None:
+        super().__init__(**span_dict)
+        self._span_dict = span_dict
+        self._scrubber = scrubber
+        self._scrub_lock = Lock()
+        self._scrub_done = False
+
+    def _scrub(self) -> None:
+        with self._scrub_lock:
+            if self._scrub_done:
+                return
+            self._scrub_done = True
+            with handle_internal_errors:
+                self._scrubber.scrub_span(self._span_dict)
+            self._attributes = self._span_dict['attributes']
+            self._events = self._span_dict['events']
+            self._links = self._span_dict['links']
+
+    @property
+    def attributes(self) -> otel_types.Attributes:
+        self._scrub()
+        return super().attributes
+
+    @property
+    def events(self) -> Sequence[Event]:
+        self._scrub()
+        return super().events
+
+    @property
+    def links(self) -> Sequence[Link]:
+        self._scrub()
+        return super().links
+
+    def to_json(self, indent: int | None = 4) -> str:
+        self._scrub()
+        # TODO(Marcelo): We should check if pydantic is installed, and if so use `pydantic_core.to_json()`.
+        return super().to_json(indent)
+
+
+class LazilyScrubbedLogRecord(LogRecord):
+    """A log record which is scrubbed the first time its contents are read.
+
+    See [`LazilyScrubbedReadableSpan`][logfire._internal.scrubbing.LazilyScrubbedReadableSpan].
+    """
+
+    def __init__(self, log_record: LogRecord, scrubber: BaseScrubber) -> None:
+        self._unscrubbed = log_record
+        self._scrubber = scrubber
+        self._scrub_lock = Lock()
+        self._scrubbed: LogRecord | None = None
+
+    def __getattr__(self, name: str) -> Any:
+        # Everything except the scrubbed `attributes` and `body` comes straight from the original record.
+        return getattr(self._unscrubbed, name)
+
+    def _scrub(self) -> LogRecord:
+        with self._scrub_lock:
+            if self._scrubbed is None:
+                self._scrubbed = self._scrubber.scrub_log(self._unscrubbed)
+            return self._scrubbed
+
+    @property
+    def attributes(self) -> otel_types._ExtendedAttributes | None:  # pyright: ignore[reportPrivateUsage]
+        return self._scrub().attributes
+
+    @property
+    def body(self) -> otel_types.AnyValue:
+        return self._scrub().body
 
 
 class MessageValueCleaner:

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -56,7 +56,8 @@ def test_otel_logs_supress_scopes(logs_exporter: InMemoryLogRecordExporter, conf
     with suppress_instrumentation():
         logger3.emit(record)
     [log_data] = logs_exporter.get_finished_logs()
-    assert log_data.log_record == record
+    assert log_data.log_record.body == record.body
+    assert log_data.log_record.attributes == record.attributes
     assert log_data.instrumentation_scope
     assert log_data.instrumentation_scope.name == 'scope3'
 

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -406,6 +406,37 @@ def test_disable_scrubbing(exporter: TestExporter, logs_exporter: TestLogExporte
     )
 
 
+def test_scrubbing_is_deferred_until_the_data_is_read(
+    exporter: TestExporter, logs_exporter: TestLogExporter, config_kwargs: dict[str, Any]
+):
+    """Scrubbing should happen in the exporter, not in the thread that ended the span or emitted the log."""
+    matches: list[logfire.ScrubMatch] = []
+
+    def callback(match: logfire.ScrubMatch):
+        matches.append(match)
+
+    config_kwargs['advanced'].log_record_processors = [SimpleLogRecordProcessor(logs_exporter)]
+    logfire.configure(**config_kwargs, scrubbing=logfire.ScrubbingOptions(callback=callback))
+
+    logfire.info('hi', my_password='hunter2')
+    get_logger(__name__).emit(LogRecord(attributes={'my_password': 'hunter2'}))
+    assert not matches
+
+    [span] = exporter.exported_spans
+    assert span.to_json() == IsJson(IsPartialDict(attributes=IsPartialDict(my_password="[Scrubbed due to 'password']")))
+    assert span.attributes and span.attributes['my_password'] == "[Scrubbed due to 'password']"
+
+    [log] = logs_exporter.get_finished_logs()
+    assert log.log_record.attributes == snapshot(
+        {
+            'my_password': "[Scrubbed due to 'password']",
+            'logfire.scrubbed': '[{"path": ["attributes", "my_password"], "matched_substring": "password"}]',
+        }
+    )
+
+    assert len(matches) == snapshot(2)
+
+
 def test_scrubbing_deprecated_args(config_kwargs: dict[str, Any]):
     def callback(match: logfire.ScrubMatch):  # pragma: no cover
         return str(match)


### PR DESCRIPTION
Scrubbing ran in `MainSpanProcessorWrapper.on_end` and `MainLogProcessorWrapper.on_emit`, i.e. in whichever thread ended the span or emitted the log - often an application's event loop.

Spans and log records are now wrapped in `LazilyScrubbedReadableSpan` / `LazilyScrubbedLogRecord`, which scrub on first read of their contents. That read happens inside `SpanExporter.export()`, which for the Logfire exporter runs on the batch processor's background thread. The result is cached under a lock, so it's computed once no matter how many exporters read the span. Every exporter still receives scrubbed data, including user-provided `additional_span_processors` - only the timing moved.

## Measurements

Time spent inside `logfire.info()` - the part that runs on the event loop - with a 200-item nested payload, 50 calls:

| | mean | p95 | max |
|---|---|---|---|
| before | 7.2ms | 7.8ms | 13.3ms |
| after | 2.4ms | 2.7ms | 3.8ms |

Tagging each scrubbing callback invocation with `threading.current_thread().name` confirms it moved from `MainThread` to `OtelBatchSpanRecordProcessor`.

**Caveat:** measuring event-loop heartbeat lag instead gives 12.1ms after vs 12.9ms before - essentially unchanged. Scrubbing is pure Python, so on the worker thread it still holds the GIL. What changed is that the work is now preemptible at `sys.getswitchinterval()` granularity instead of one monolithic block, and it's off the critical path of the coroutine that logged. For an app genuinely CPU-bound on scrubbing this redistributes the cost rather than eliminating it.

## Notes

- With `SimpleSpanProcessor` (the console exporter, `TestExporter`) the read still happens in the calling thread - unavoidable, since those export synchronously.
- With `sampling=SamplingOptions(tail=...)`, `TailSamplingProcessor` reads `span.attributes` to get the level, which triggers the scrub inline again. Not addressed here.
- An exporter that never reads `span.attributes` now skips scrubbing entirely. The real OTLP path serializes every attribute, so it's unaffected.
- `force_flush()` scrubs on whatever thread calls it, since the pending batch is drained there.
- The scrubbing callback now runs on a background thread, so it can't rely on the state of the thread that created the span. Documented in `docs/how-to-guides/scrubbing.md`.
- One assertion in `test_otel_logs.py` compared the log record by identity; it now compares body and attributes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

