### PR TITLE
test(logfire-api): add test for __all__ export consistency

### DIFF
--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -403,8 +403,9 @@ def test_override_init_pyi() -> None:  # pragma: no cover
     (Path(__file__).parent.parent / 'logfire-api' / 'logfire_api' / '__init__.pyi').write_text(new_init_pyi)
     pytest.fail('The __init__.pyi file was updated.')
 
-def test_logfire_api_dunder_all_consistency() -> None: # check the __all__ consistency
+
+def test_logfire_api_dunder_all_consistency() -> None:  # check the __all__ consistency
     import logfire_api
-    
+
     for member in logfire_api.__all__:
         assert hasattr(logfire_api, member), f"'{member}' listed in logfire_api.__all__ but doesn't exist!"

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -405,7 +405,7 @@ def test_override_init_pyi() -> None:  # pragma: no cover
 
 
 def test_logfire_api_dunder_all_consistency() -> None:  # check the __all__ consistency
-    import logfire_api
+    logfire_api = import_logfire_api_without_logfire()
 
     for member in logfire_api.__all__:
         assert hasattr(logfire_api, member), f"'{member}' listed in logfire_api.__all__ but doesn't exist!"

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -405,7 +405,8 @@ def test_override_init_pyi() -> None:  # pragma: no cover
 
 
 def test_logfire_api_dunder_all_consistency() -> None:  # check the __all__ consistency
-    logfire_api = import_logfire_api_without_logfire()
+    import logfire_api
 
-    for member in logfire_api.__all__:
-        assert hasattr(logfire_api, member), f"'{member}' listed in logfire_api.__all__ but doesn't exist!"
+    if hasattr(logfire_api, '__all__'):
+        for member in logfire_api.__all__:
+            assert hasattr(logfire_api, member), f"'{member}' listed in logfire_api.__all__ but doesn't exist!"

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -402,3 +402,9 @@ def test_override_init_pyi() -> None:  # pragma: no cover
         pytest.skip('No changes were made to the __init__.pyi file.')
     (Path(__file__).parent.parent / 'logfire-api' / 'logfire_api' / '__init__.pyi').write_text(new_init_pyi)
     pytest.fail('The __init__.pyi file was updated.')
+
+def test_logfire_api_dunder_all_consistency() -> None: # check the __all__ consistency
+    import logfire_api
+    
+    for member in logfire_api.__all__:
+        assert hasattr(logfire_api, member), f"'{member}' listed in logfire_api.__all__ but doesn't exist!"


### PR DESCRIPTION
Fixes **#335.** 
Adds _test_logfire_api_dunder_all_consistency_ to ensure every attribute in _logfire_api.__all___ actually exists on the module.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

