### PR TITLE
Fix metric resource PID after fork

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -982,47 +982,30 @@ def _register_at_fork_resource_updates(
 
         pid_resource = Resource({'process.pid': os.getpid()})
 
-        # This callback is registered before the OpenTelemetry providers' callbacks, so reset their locks before
-        # calling their lock-taking resource updaters. Their later callbacks can safely repeat the reset.
+        # This callback runs before OpenTelemetry resets its locks, so update the same backing state as its
+        # lock-taking `_update_resource` methods without acquiring inherited locks. Tests snapshot those methods
+        # so that changes to these private implementation details are caught when OpenTelemetry is upgraded.
         tracer_provider = proxy_tracer_provider.provider
         if isinstance(tracer_provider, SDKTracerProvider):
-            handle_fork = getattr(tracer_provider, '_handle_fork', None)
-            update_resource = getattr(tracer_provider, '_update_resource', None)
-            if handle_fork and update_resource:
-                handle_fork()
-                update_resource(pid_resource)
-            else:
-                new_resource = tracer_provider.resource.merge(pid_resource)
-                tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_tracer in proxy_tracer_provider.tracers:
-                    if isinstance(proxy_tracer.tracer, SDKTracer):
-                        proxy_tracer.tracer.resource = new_resource
+            new_resource = tracer_provider.resource.merge(pid_resource)
+            tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+            for proxy_tracer in proxy_tracer_provider.tracers:
+                if isinstance(proxy_tracer.tracer, SDKTracer):
+                    proxy_tracer.tracer.resource = new_resource
 
         meter_provider = proxy_meter_provider.provider
         if isinstance(meter_provider, MeterProvider):
-            handle_fork = getattr(meter_provider, '_handle_fork', None)
-            update_resource = getattr(meter_provider, '_update_resource', None)
-            if handle_fork and update_resource:
-                handle_fork()
-                update_resource(pid_resource)
-            else:
-                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                    pid_resource
-                )
+            meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                pid_resource
+            )
 
         logger_provider = proxy_logger_provider.provider
         if isinstance(logger_provider, SDKLoggerProvider):
-            handle_fork = getattr(logger_provider, '_handle_fork', None)
-            update_resource = getattr(logger_provider, '_update_resource', None)
-            if handle_fork and update_resource:
-                handle_fork()
-                update_resource(pid_resource)
-            else:
-                new_resource = logger_provider.resource.merge(pid_resource)
-                logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_logger in proxy_logger_provider.loggers:
-                    if isinstance(proxy_logger.logger, SDKLogger):
-                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+            new_resource = logger_provider.resource.merge(pid_resource)
+            logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+            for proxy_logger in proxy_logger_provider.loggers:
+                if isinstance(proxy_logger.logger, SDKLogger):
+                    proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
     os.register_at_fork(after_in_child=fix_pid)
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -982,9 +982,14 @@ def _register_at_fork_resource_updates(
 
             pid_resource = Resource({'process.pid': os.getpid()})
 
+            # This callback is registered before the OpenTelemetry providers' callbacks, so reset their locks before
+            # calling their lock-taking resource updaters. Their later callbacks can safely repeat the reset.
             tracer_provider = proxy_tracer_provider.provider
             if isinstance(tracer_provider, SDKTracerProvider):
-                if update_resource := getattr(tracer_provider, '_update_resource', None):
+                handle_fork = getattr(tracer_provider, '_handle_fork', None)
+                update_resource = getattr(tracer_provider, '_update_resource', None)
+                if handle_fork and update_resource:
+                    handle_fork()
                     update_resource(pid_resource)
                 else:
                     new_resource = tracer_provider.resource.merge(pid_resource)
@@ -995,7 +1000,10 @@ def _register_at_fork_resource_updates(
 
             meter_provider = proxy_meter_provider.provider
             if isinstance(meter_provider, MeterProvider):
-                if update_resource := getattr(meter_provider, '_update_resource', None):
+                handle_fork = getattr(meter_provider, '_handle_fork', None)
+                update_resource = getattr(meter_provider, '_update_resource', None)
+                if handle_fork and update_resource:
+                    handle_fork()
                     update_resource(pid_resource)
                 else:
                     meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
@@ -1004,7 +1012,10 @@ def _register_at_fork_resource_updates(
 
             logger_provider = proxy_logger_provider.provider
             if isinstance(logger_provider, SDKLoggerProvider):
-                if update_resource := getattr(logger_provider, '_update_resource', None):
+                handle_fork = getattr(logger_provider, '_handle_fork', None)
+                update_resource = getattr(logger_provider, '_update_resource', None)
+                if handle_fork and update_resource:
+                    handle_fork()
                     update_resource(pid_resource)
                 else:
                     new_resource = logger_provider.resource.merge(pid_resource)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -972,57 +972,57 @@ def _register_at_fork_resource_updates(
     proxy_meter_provider_ref = weakref.ref(proxy_meter_provider)
     proxy_logger_provider_ref = weakref.ref(proxy_logger_provider)
 
+    @handle_internal_errors
     def fix_pid():
-        with handle_internal_errors:
-            proxy_tracer_provider = proxy_tracer_provider_ref()
-            proxy_meter_provider = proxy_meter_provider_ref()
-            proxy_logger_provider = proxy_logger_provider_ref()
-            if not proxy_tracer_provider or not proxy_meter_provider or not proxy_logger_provider:
-                return
+        proxy_tracer_provider = proxy_tracer_provider_ref()
+        proxy_meter_provider = proxy_meter_provider_ref()
+        proxy_logger_provider = proxy_logger_provider_ref()
+        if not proxy_tracer_provider or not proxy_meter_provider or not proxy_logger_provider:
+            return
 
-            pid_resource = Resource({'process.pid': os.getpid()})
+        pid_resource = Resource({'process.pid': os.getpid()})
 
-            # This callback is registered before the OpenTelemetry providers' callbacks, so reset their locks before
-            # calling their lock-taking resource updaters. Their later callbacks can safely repeat the reset.
-            tracer_provider = proxy_tracer_provider.provider
-            if isinstance(tracer_provider, SDKTracerProvider):
-                handle_fork = getattr(tracer_provider, '_handle_fork', None)
-                update_resource = getattr(tracer_provider, '_update_resource', None)
-                if handle_fork and update_resource:
-                    handle_fork()
-                    update_resource(pid_resource)
-                else:
-                    new_resource = tracer_provider.resource.merge(pid_resource)
-                    tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                    for proxy_tracer in proxy_tracer_provider.tracers:
-                        if isinstance(proxy_tracer.tracer, SDKTracer):
-                            proxy_tracer.tracer.resource = new_resource
+        # This callback is registered before the OpenTelemetry providers' callbacks, so reset their locks before
+        # calling their lock-taking resource updaters. Their later callbacks can safely repeat the reset.
+        tracer_provider = proxy_tracer_provider.provider
+        if isinstance(tracer_provider, SDKTracerProvider):
+            handle_fork = getattr(tracer_provider, '_handle_fork', None)
+            update_resource = getattr(tracer_provider, '_update_resource', None)
+            if handle_fork and update_resource:
+                handle_fork()
+                update_resource(pid_resource)
+            else:
+                new_resource = tracer_provider.resource.merge(pid_resource)
+                tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                for proxy_tracer in proxy_tracer_provider.tracers:
+                    if isinstance(proxy_tracer.tracer, SDKTracer):
+                        proxy_tracer.tracer.resource = new_resource
 
-            meter_provider = proxy_meter_provider.provider
-            if isinstance(meter_provider, MeterProvider):
-                handle_fork = getattr(meter_provider, '_handle_fork', None)
-                update_resource = getattr(meter_provider, '_update_resource', None)
-                if handle_fork and update_resource:
-                    handle_fork()
-                    update_resource(pid_resource)
-                else:
-                    meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                        pid_resource
-                    )
+        meter_provider = proxy_meter_provider.provider
+        if isinstance(meter_provider, MeterProvider):
+            handle_fork = getattr(meter_provider, '_handle_fork', None)
+            update_resource = getattr(meter_provider, '_update_resource', None)
+            if handle_fork and update_resource:
+                handle_fork()
+                update_resource(pid_resource)
+            else:
+                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                    pid_resource
+                )
 
-            logger_provider = proxy_logger_provider.provider
-            if isinstance(logger_provider, SDKLoggerProvider):
-                handle_fork = getattr(logger_provider, '_handle_fork', None)
-                update_resource = getattr(logger_provider, '_update_resource', None)
-                if handle_fork and update_resource:
-                    handle_fork()
-                    update_resource(pid_resource)
-                else:
-                    new_resource = logger_provider.resource.merge(pid_resource)
-                    logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                    for proxy_logger in proxy_logger_provider.loggers:
-                        if isinstance(proxy_logger.logger, SDKLogger):
-                            proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+        logger_provider = proxy_logger_provider.provider
+        if isinstance(logger_provider, SDKLoggerProvider):
+            handle_fork = getattr(logger_provider, '_handle_fork', None)
+            update_resource = getattr(logger_provider, '_update_resource', None)
+            if handle_fork and update_resource:
+                handle_fork()
+                update_resource(pid_resource)
+            else:
+                new_resource = logger_provider.resource.merge(pid_resource)
+                logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                for proxy_logger in proxy_logger_provider.loggers:
+                    if isinstance(proxy_logger.logger, SDKLogger):
+                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
     os.register_at_fork(after_in_child=fix_pid)
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -960,6 +960,49 @@ class _LogfireConfigData:
         self.metrics = metrics
 
 
+def _register_at_fork_resource_updates(
+    tracer_provider: SDKTracerProvider,
+    meter_provider: MeterProvider | NoOpMeterProvider,
+    logger_provider: SDKLoggerProvider,
+    proxy_tracer_provider: ProxyTracerProvider,
+    proxy_logger_provider: ProxyLoggerProvider,
+) -> None:
+    if not hasattr(os, 'register_at_fork'):  # pragma: no cover
+        return
+
+    def fix_pid():  # pragma: no cover
+        with handle_internal_errors:
+            pid_resource = Resource({'process.pid': os.getpid()})
+
+            if update_resource := getattr(tracer_provider, '_update_resource', None):
+                update_resource(pid_resource)
+            else:
+                new_resource = tracer_provider.resource.merge(pid_resource)
+                tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                for proxy_tracer in proxy_tracer_provider.tracers:
+                    if isinstance(proxy_tracer.tracer, SDKTracer):
+                        proxy_tracer.tracer.resource = new_resource
+
+            if isinstance(meter_provider, MeterProvider):
+                if update_resource := getattr(meter_provider, '_update_resource', None):
+                    update_resource(pid_resource)
+                else:
+                    meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                        pid_resource
+                    )
+
+            if update_resource := getattr(logger_provider, '_update_resource', None):
+                update_resource(pid_resource)
+            else:
+                new_resource = logger_provider.resource.merge(pid_resource)
+                logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                for proxy_logger in proxy_logger_provider.loggers:
+                    if isinstance(proxy_logger.logger, SDKLogger):
+                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+
+    os.register_at_fork(after_in_child=fix_pid)
+
+
 class LogfireConfig(_LogfireConfigData):
     def __init__(
         self,
@@ -1494,39 +1537,13 @@ class LogfireConfig(_LogfireConfigData):
             logger_provider = SDKLoggerProvider(resource)
             logger_provider.add_log_record_processor(root_log_processor)
 
-            if hasattr(os, 'register_at_fork'):  # pragma: no branch
-
-                def fix_pid():  # pragma: no cover
-                    with handle_internal_errors:
-                        pid_resource = Resource({'process.pid': os.getpid()})
-
-                        if update_resource := getattr(tracer_provider, '_update_resource', None):
-                            update_resource(pid_resource)
-                        else:
-                            new_resource = tracer_provider.resource.merge(pid_resource)
-                            tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                            for proxy_tracer in self._tracer_provider.tracers:
-                                if isinstance(proxy_tracer.tracer, SDKTracer):
-                                    proxy_tracer.tracer.resource = new_resource
-
-                        if isinstance(meter_provider, MeterProvider):
-                            if update_resource := getattr(meter_provider, '_update_resource', None):
-                                update_resource(pid_resource)
-                            else:
-                                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                                    pid_resource
-                                )
-
-                        if update_resource := getattr(logger_provider, '_update_resource', None):
-                            update_resource(pid_resource)
-                        else:
-                            new_resource = logger_provider.resource.merge(pid_resource)
-                            logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                            for proxy_logger in self._logger_provider.loggers:
-                                if isinstance(proxy_logger.logger, SDKLogger):
-                                    proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-
-                os.register_at_fork(after_in_child=fix_pid)
+            _register_at_fork_resource_updates(
+                tracer_provider,
+                meter_provider,
+                logger_provider,
+                self._tracer_provider,
+                self._logger_provider,
+            )
 
             self._logger_provider.shutdown()
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -961,49 +961,48 @@ class _LogfireConfigData:
 
 
 def _register_at_fork_resource_updates(
-    tracer_provider: SDKTracerProvider,
-    meter_provider: MeterProvider | NoOpMeterProvider,
-    logger_provider: SDKLoggerProvider,
     proxy_tracer_provider: ProxyTracerProvider,
+    proxy_meter_provider: ProxyMeterProvider,
     proxy_logger_provider: ProxyLoggerProvider,
 ) -> None:
     if not hasattr(os, 'register_at_fork'):  # pragma: no cover
         return
 
     proxy_tracer_provider_ref = weakref.ref(proxy_tracer_provider)
+    proxy_meter_provider_ref = weakref.ref(proxy_meter_provider)
     proxy_logger_provider_ref = weakref.ref(proxy_logger_provider)
 
     def fix_pid():
         with handle_internal_errors:
+            proxy_tracer_provider = proxy_tracer_provider_ref()
+            proxy_meter_provider = proxy_meter_provider_ref()
+            proxy_logger_provider = proxy_logger_provider_ref()
+            if not proxy_tracer_provider or not proxy_meter_provider or not proxy_logger_provider:
+                return
+
             pid_resource = Resource({'process.pid': os.getpid()})
 
-            if update_resource := getattr(tracer_provider, '_update_resource', None):
-                update_resource(pid_resource)
-            else:
+            tracer_provider = proxy_tracer_provider.provider
+            if isinstance(tracer_provider, SDKTracerProvider):
                 new_resource = tracer_provider.resource.merge(pid_resource)
                 tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                if proxy_tracer_provider := proxy_tracer_provider_ref():  # pragma: no branch
-                    for proxy_tracer in proxy_tracer_provider.tracers:
-                        if isinstance(proxy_tracer.tracer, SDKTracer):
-                            proxy_tracer.tracer.resource = new_resource
+                for proxy_tracer in proxy_tracer_provider.tracers:
+                    if isinstance(proxy_tracer.tracer, SDKTracer):
+                        proxy_tracer.tracer.resource = new_resource
 
+            meter_provider = proxy_meter_provider.provider
             if isinstance(meter_provider, MeterProvider):
-                if update_resource := getattr(meter_provider, '_update_resource', None):
-                    update_resource(pid_resource)
-                else:
-                    meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                        pid_resource
-                    )
+                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                    pid_resource
+                )
 
-            if update_resource := getattr(logger_provider, '_update_resource', None):
-                update_resource(pid_resource)
-            else:
+            logger_provider = proxy_logger_provider.provider
+            if isinstance(logger_provider, SDKLoggerProvider):
                 new_resource = logger_provider.resource.merge(pid_resource)
                 logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                if proxy_logger_provider := proxy_logger_provider_ref():  # pragma: no branch
-                    for proxy_logger in proxy_logger_provider.loggers:
-                        if isinstance(proxy_logger.logger, SDKLogger):
-                            proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                for proxy_logger in proxy_logger_provider.loggers:
+                    if isinstance(proxy_logger.logger, SDKLogger):
+                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
     os.register_at_fork(after_in_child=fix_pid)
 
@@ -1072,6 +1071,7 @@ class LogfireConfig(_LogfireConfigData):
         self._meter_provider = ProxyMeterProvider(NoOpMeterProvider())
         self._variable_provider: VariableProvider = NoOpVariableProvider()
         self._logger_provider = ProxyLoggerProvider(NoOpLoggerProvider())
+        _register_at_fork_resource_updates(self._tracer_provider, self._meter_provider, self._logger_provider)
         self._otlp_forwarding = OTLPForwardingManager([])
         self._variables: dict[str, Variable[Any] | TemplateVariable[Any, Any]] = {}
         # This ensures that we only call OTEL's global set_tracer_provider once to avoid warnings.
@@ -1541,14 +1541,6 @@ class LogfireConfig(_LogfireConfigData):
             )
             logger_provider = SDKLoggerProvider(resource)
             logger_provider.add_log_record_processor(root_log_processor)
-
-            _register_at_fork_resource_updates(
-                tracer_provider,
-                meter_provider,
-                logger_provider,
-                self._tracer_provider,
-                self._logger_provider,
-            )
 
             self._logger_provider.shutdown()
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -970,7 +970,7 @@ def _register_at_fork_resource_updates(
     if not hasattr(os, 'register_at_fork'):  # pragma: no cover
         return
 
-    def fix_pid():  # pragma: no cover
+    def fix_pid():
         with handle_internal_errors:
             pid_resource = Resource({'process.pid': os.getpid()})
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1510,9 +1510,12 @@ class LogfireConfig(_LogfireConfigData):
                                     proxy_tracer.tracer.resource = new_resource
 
                         if isinstance(meter_provider, MeterProvider):
-                            meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                                pid_resource
-                            )
+                            if update_resource := getattr(meter_provider, '_update_resource', None):
+                                update_resource(pid_resource)
+                            else:
+                                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                                    pid_resource
+                                )
 
                         if update_resource := getattr(logger_provider, '_update_resource', None):
                             update_resource(pid_resource)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1452,9 +1452,13 @@ class LogfireConfig(_LogfireConfigData):
 
                 def fix_pid():  # pragma: no cover
                     with handle_internal_errors:
-                        new_resource = resource.merge(Resource({'process.pid': os.getpid()}))
+                        pid_resource = Resource({'process.pid': os.getpid()})
+                        new_resource = resource.merge(pid_resource)
                         tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                        meter_provider._resource = new_resource  # pyright: ignore[reportAttributeAccessIssue]
+                        if isinstance(meter_provider, MeterProvider):
+                            meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                                pid_resource
+                            )
                         logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
                 os.register_at_fork(after_in_child=fix_pid)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -33,7 +33,7 @@ from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExp
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.metrics import NoOpMeterProvider, set_meter_provider
 from opentelemetry.propagate import get_global_textmap, set_global_textmap
-from opentelemetry.sdk._logs import LoggerProvider as SDKLoggerProvider, LogRecordProcessor
+from opentelemetry.sdk._logs import Logger as SDKLogger, LoggerProvider as SDKLoggerProvider, LogRecordProcessor
 from opentelemetry.sdk._logs._internal import SynchronousMultiLogRecordProcessor
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, SimpleLogRecordProcessor
 from opentelemetry.sdk.environment_variables import (
@@ -54,7 +54,12 @@ from opentelemetry.sdk.metrics import (
 from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricReader, PeriodicExportingMetricReader
 from opentelemetry.sdk.metrics.view import DropAggregation, ExponentialBucketHistogramAggregation, View
 from opentelemetry.sdk.resources import OsResourceDetector, Resource, ResourceDetector, get_aggregated_resources
-from opentelemetry.sdk.trace import SpanProcessor, SynchronousMultiSpanProcessor, TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace import (
+    SpanProcessor,
+    SynchronousMultiSpanProcessor,
+    Tracer as SDKTracer,
+    TracerProvider as SDKTracerProvider,
+)
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio, Sampler
@@ -1448,21 +1453,6 @@ class LogfireConfig(_LogfireConfigData):
             else:
                 meter_provider = NoOpMeterProvider()
 
-            if hasattr(os, 'register_at_fork'):  # pragma: no branch
-
-                def fix_pid():  # pragma: no cover
-                    with handle_internal_errors:
-                        pid_resource = Resource({'process.pid': os.getpid()})
-                        new_resource = resource.merge(pid_resource)
-                        tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                        if isinstance(meter_provider, MeterProvider):
-                            meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                                pid_resource
-                            )
-                        logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-
-                os.register_at_fork(after_in_child=fix_pid)
-
             # we need to shut down any existing providers to avoid leaking resources (like threads)
             # but if this takes longer than 100ms you should call `logfire.shutdown` before reconfiguring
             self._meter_provider.shutdown(
@@ -1503,6 +1493,38 @@ class LogfireConfig(_LogfireConfigData):
             )
             logger_provider = SDKLoggerProvider(resource)
             logger_provider.add_log_record_processor(root_log_processor)
+
+            if hasattr(os, 'register_at_fork'):  # pragma: no branch
+
+                def fix_pid():  # pragma: no cover
+                    with handle_internal_errors:
+                        pid_resource = Resource({'process.pid': os.getpid()})
+
+                        if update_resource := getattr(tracer_provider, '_update_resource', None):
+                            update_resource(pid_resource)
+                        else:
+                            new_resource = tracer_provider.resource.merge(pid_resource)
+                            tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                            for proxy_tracer in self._tracer_provider.tracers:
+                                if isinstance(proxy_tracer.tracer, SDKTracer):
+                                    proxy_tracer.tracer.resource = new_resource
+
+                        if isinstance(meter_provider, MeterProvider):
+                            meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                                pid_resource
+                            )
+
+                        if update_resource := getattr(logger_provider, '_update_resource', None):
+                            update_resource(pid_resource)
+                        else:
+                            new_resource = logger_provider.resource.merge(pid_resource)
+                            logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                            for proxy_logger in self._logger_provider.loggers:
+                                if isinstance(proxy_logger.logger, SDKLogger):
+                                    proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+
+                os.register_at_fork(after_in_child=fix_pid)
+
             self._logger_provider.shutdown()
 
             self._logger_provider.set_provider(logger_provider)

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -984,25 +984,34 @@ def _register_at_fork_resource_updates(
 
             tracer_provider = proxy_tracer_provider.provider
             if isinstance(tracer_provider, SDKTracerProvider):
-                new_resource = tracer_provider.resource.merge(pid_resource)
-                tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_tracer in proxy_tracer_provider.tracers:
-                    if isinstance(proxy_tracer.tracer, SDKTracer):
-                        proxy_tracer.tracer.resource = new_resource
+                if update_resource := getattr(tracer_provider, '_update_resource', None):
+                    update_resource(pid_resource)
+                else:
+                    new_resource = tracer_provider.resource.merge(pid_resource)
+                    tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                    for proxy_tracer in proxy_tracer_provider.tracers:
+                        if isinstance(proxy_tracer.tracer, SDKTracer):
+                            proxy_tracer.tracer.resource = new_resource
 
             meter_provider = proxy_meter_provider.provider
             if isinstance(meter_provider, MeterProvider):
-                meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
-                    pid_resource
-                )
+                if update_resource := getattr(meter_provider, '_update_resource', None):
+                    update_resource(pid_resource)
+                else:
+                    meter_provider._sdk_config.resource = meter_provider._sdk_config.resource.merge(  # pyright: ignore[reportPrivateUsage]
+                        pid_resource
+                    )
 
             logger_provider = proxy_logger_provider.provider
             if isinstance(logger_provider, SDKLoggerProvider):
-                new_resource = logger_provider.resource.merge(pid_resource)
-                logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_logger in proxy_logger_provider.loggers:
-                    if isinstance(proxy_logger.logger, SDKLogger):
-                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                if update_resource := getattr(logger_provider, '_update_resource', None):
+                    update_resource(pid_resource)
+                else:
+                    new_resource = logger_provider.resource.merge(pid_resource)
+                    logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                    for proxy_logger in proxy_logger_provider.loggers:
+                        if isinstance(proxy_logger.logger, SDKLogger):
+                            proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
     os.register_at_fork(after_in_child=fix_pid)
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -970,6 +970,9 @@ def _register_at_fork_resource_updates(
     if not hasattr(os, 'register_at_fork'):  # pragma: no cover
         return
 
+    proxy_tracer_provider_ref = weakref.ref(proxy_tracer_provider)
+    proxy_logger_provider_ref = weakref.ref(proxy_logger_provider)
+
     def fix_pid():
         with handle_internal_errors:
             pid_resource = Resource({'process.pid': os.getpid()})
@@ -979,9 +982,10 @@ def _register_at_fork_resource_updates(
             else:
                 new_resource = tracer_provider.resource.merge(pid_resource)
                 tracer_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_tracer in proxy_tracer_provider.tracers:
-                    if isinstance(proxy_tracer.tracer, SDKTracer):
-                        proxy_tracer.tracer.resource = new_resource
+                if proxy_tracer_provider := proxy_tracer_provider_ref():  # pragma: no branch
+                    for proxy_tracer in proxy_tracer_provider.tracers:
+                        if isinstance(proxy_tracer.tracer, SDKTracer):
+                            proxy_tracer.tracer.resource = new_resource
 
             if isinstance(meter_provider, MeterProvider):
                 if update_resource := getattr(meter_provider, '_update_resource', None):
@@ -996,9 +1000,10 @@ def _register_at_fork_resource_updates(
             else:
                 new_resource = logger_provider.resource.merge(pid_resource)
                 logger_provider._resource = new_resource  # pyright: ignore[reportPrivateUsage]
-                for proxy_logger in proxy_logger_provider.loggers:
-                    if isinstance(proxy_logger.logger, SDKLogger):
-                        proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
+                if proxy_logger_provider := proxy_logger_provider_ref():  # pragma: no branch
+                    for proxy_logger in proxy_logger_provider.loggers:
+                        if isinstance(proxy_logger.logger, SDKLogger):
+                            proxy_logger.logger._resource = new_resource  # pyright: ignore[reportPrivateUsage]
 
     os.register_at_fork(after_in_child=fix_pid)
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1371,17 +1371,16 @@ def test_resource_process_pid_updated_after_fork(
         for lock in provider_locks:
             lock.acquire()
 
-    parent_pid = os.getpid()
     signal.alarm(10)
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=DeprecationWarning, message='.*fork.*')
             child_pid = os.fork()
-    finally:
+    except BaseException:
         signal.alarm(0)
-        if os.getpid() == parent_pid:
-            for lock in provider_locks:
-                lock.release()
+        for lock in provider_locks:
+            lock.release()
+        raise
 
     if child_pid == 0:  # pragma: no cover
         os.close(read_fd)
@@ -1405,12 +1404,25 @@ def test_resource_process_pid_updated_after_fork(
             exit_code = 1
         os.write(write_fd, result.encode())
         os.close(write_fd)
+        signal.alarm(0)
         os._exit(exit_code)
 
+    for lock in provider_locks:
+        lock.release()
     os.close(write_fd)
-    with os.fdopen(read_fd) as read_file:
-        result = read_file.read()
-    _, status = os.waitpid(child_pid, 0)
+
+    def raise_fork_timeout(*_: object) -> None:
+        raise TimeoutError('forked child process timed out')
+
+    previous_alarm_handler = signal.signal(signal.SIGALRM, raise_fork_timeout)
+    signal.alarm(10)
+    try:
+        with os.fdopen(read_fd) as read_file:
+            result = read_file.read()
+        _, status = os.waitpid(child_pid, 0)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, previous_alarm_handler)
 
     assert os.waitstatus_to_exitcode(status) == 0, result
     assert json.loads(result) == {'metric': child_pid, 'span': child_pid, 'log': child_pid}

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1262,10 +1262,8 @@ def test_register_at_fork_resource_updates(
     logs_exporter.clear()
 
     config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
-        tracer_provider,
-        meter_provider,
-        logger_provider,
         proxy_tracer_provider,
+        proxy_meter_provider,
         proxy_logger_provider,
     )
     [callback] = callbacks
@@ -1287,17 +1285,38 @@ def test_register_at_fork_resource_updates(
     suppressed_tracer = proxy_tracer_provider.get_tracer(suppressed_scope)
     suppressed_logger = proxy_logger_provider.get_logger(suppressed_scope)
     callbacks.clear()
+    noop_proxy_meter_provider = config_module.ProxyMeterProvider(NoOpMeterProvider())
     config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
-        tracer_provider,
-        NoOpMeterProvider(),
-        logger_provider,
         proxy_tracer_provider,
+        noop_proxy_meter_provider,
         proxy_logger_provider,
     )
     [callback] = callbacks
     callback()
     assert suppressed_tracer.instrumenting_module_name == suppressed_scope
     assert suppressed_logger
+
+    callbacks.clear()
+    noop_proxy_tracer_provider = config_module.ProxyTracerProvider(
+        config_module.trace.NoOpTracerProvider(), GLOBAL_CONFIG
+    )
+    noop_proxy_logger_provider = config_module.ProxyLoggerProvider(config_module.NoOpLoggerProvider())
+    config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
+        noop_proxy_tracer_provider,
+        noop_proxy_meter_provider,
+        noop_proxy_logger_provider,
+    )
+    [callback] = callbacks
+    callback()
+
+    callbacks.clear()
+    config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
+        config_module.ProxyTracerProvider(config_module.trace.NoOpTracerProvider(), GLOBAL_CONFIG),
+        config_module.ProxyMeterProvider(NoOpMeterProvider()),
+        config_module.ProxyLoggerProvider(config_module.NoOpLoggerProvider()),
+    )
+    [callback] = callbacks
+    callback()
 
 
 @pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1240,6 +1240,8 @@ def test_resource_process_pid_updated_after_fork(
     metrics_data = metrics_reader.get_metrics_data()
     assert metrics_data is not None
     assert metrics_data.resource_metrics[0].resource.attributes['process.pid'] == os.getpid()
+    assert exporter.exported_spans[-1].resource.attributes['process.pid'] == os.getpid()
+    assert logs_exporter.get_finished_logs()[-1].resource.attributes['process.pid'] == os.getpid()
     exporter.clear()
     logs_exporter.clear()
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1281,6 +1281,24 @@ def test_register_at_fork_resource_updates(
     assert exporter.exported_spans[-1].resource.attributes['process.pid'] == 42
     assert logs_exporter.get_finished_logs()[-1].resource.attributes['process.pid'] == 42
 
+    suppressed_scope = 'fork.callback.suppressed'
+    proxy_tracer_provider.suppress_scopes(suppressed_scope)
+    proxy_logger_provider.suppress_scopes(suppressed_scope)
+    suppressed_tracer = proxy_tracer_provider.get_tracer(suppressed_scope)
+    suppressed_logger = proxy_logger_provider.get_logger(suppressed_scope)
+    callbacks.clear()
+    config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
+        tracer_provider,
+        NoOpMeterProvider(),
+        logger_provider,
+        proxy_tracer_provider,
+        proxy_logger_provider,
+    )
+    [callback] = callbacks
+    callback()
+    assert suppressed_tracer.instrumenting_module_name == suppressed_scope
+    assert suppressed_logger
+
 
 @pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')
 def test_resource_process_pid_updated_after_fork(

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -8,6 +8,7 @@ import pickle
 import subprocess
 import sys
 import threading
+import warnings
 from collections.abc import Iterable, Sequence
 from contextlib import ExitStack
 from io import StringIO
@@ -1223,6 +1224,44 @@ def test_host_and_os_resource_attributes_populated_by_default(
     assert resource_attrs['os.version'] == (
         platform.version() if platform.system().lower() in ('windows', 'sunos') else platform.release()
     )
+
+
+@pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')
+def test_metric_resource_process_pid_updated_after_fork(metrics_reader: InMemoryMetricReader) -> None:
+    counter = logfire.metric_counter('fork.counter')
+    counter.add(1)
+
+    metrics_data = metrics_reader.get_metrics_data()
+    assert metrics_data is not None
+    assert metrics_data.resource_metrics[0].resource.attributes['process.pid'] == os.getpid()
+
+    read_fd, write_fd = os.pipe()
+    with warnings.catch_warnings():
+        warnings.filterwarnings('ignore', category=DeprecationWarning, message='.*fork.*')
+        child_pid = os.fork()
+
+    if child_pid == 0:  # pragma: no cover
+        os.close(read_fd)
+        try:
+            counter.add(1)
+            metrics_data = metrics_reader.get_metrics_data()
+            assert metrics_data is not None
+            result = str(metrics_data.resource_metrics[0].resource.attributes['process.pid'])
+            exit_code = 0
+        except BaseException as error:
+            result = repr(error)
+            exit_code = 1
+        os.write(write_fd, result.encode())
+        os.close(write_fd)
+        os._exit(exit_code)
+
+    os.close(write_fd)
+    with os.fdopen(read_fd) as read_file:
+        result = read_file.read()
+    _, status = os.waitpid(child_pid, 0)
+
+    assert os.waitstatus_to_exitcode(status) == 0, result
+    assert int(result) == child_pid
 
 
 def test_otel_resource_attributes_env_var_overrides_host_and_os_defaults(

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -24,7 +24,7 @@ import requests.exceptions
 import requests_mock
 from dirty_equals import IsPartialDict, IsStr
 from inline_snapshot import snapshot
-from opentelemetry._logs import get_logger_provider
+from opentelemetry._logs import LogRecord, get_logger, get_logger_provider
 from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -85,7 +85,7 @@ from logfire._internal.utils import SeededRandomIdGenerator, get_version
 from logfire.exceptions import LogfireConfigError
 from logfire.integrations.pydantic import get_pydantic_plugin_config
 from logfire.propagate import NoExtractTraceContextPropagator, WarnOnExtractTraceContextPropagator
-from logfire.testing import TestExporter
+from logfire.testing import TestExporter, TestLogExporter
 from logfire.version import VERSION
 
 PROCESS_RUNTIME_VERSION_REGEX = r'(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
@@ -1227,13 +1227,21 @@ def test_host_and_os_resource_attributes_populated_by_default(
 
 
 @pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')
-def test_metric_resource_process_pid_updated_after_fork(metrics_reader: InMemoryMetricReader) -> None:
+def test_resource_process_pid_updated_after_fork(
+    exporter: TestExporter, logs_exporter: TestLogExporter, metrics_reader: InMemoryMetricReader
+) -> None:
     counter = logfire.metric_counter('fork.counter')
     counter.add(1)
+    logger = get_logger('fork.logger')
+    logger.emit(LogRecord(body='parent'))
+    with logfire.span('parent'):
+        pass
 
     metrics_data = metrics_reader.get_metrics_data()
     assert metrics_data is not None
     assert metrics_data.resource_metrics[0].resource.attributes['process.pid'] == os.getpid()
+    exporter.clear()
+    logs_exporter.clear()
 
     read_fd, write_fd = os.pipe()
     with warnings.catch_warnings():
@@ -1244,9 +1252,18 @@ def test_metric_resource_process_pid_updated_after_fork(metrics_reader: InMemory
         os.close(read_fd)
         try:
             counter.add(1)
+            logger.emit(LogRecord(body='child'))
+            with logfire.span('child'):
+                pass
             metrics_data = metrics_reader.get_metrics_data()
             assert metrics_data is not None
-            result = str(metrics_data.resource_metrics[0].resource.attributes['process.pid'])
+            result = json.dumps(
+                {
+                    'metric': metrics_data.resource_metrics[0].resource.attributes['process.pid'],
+                    'span': exporter.exported_spans[-1].resource.attributes['process.pid'],
+                    'log': logs_exporter.get_finished_logs()[-1].resource.attributes['process.pid'],
+                }
+            )
             exit_code = 0
         except BaseException as error:
             result = repr(error)
@@ -1261,7 +1278,7 @@ def test_metric_resource_process_pid_updated_after_fork(metrics_reader: InMemory
     _, status = os.waitpid(child_pid, 0)
 
     assert os.waitstatus_to_exitcode(status) == 0, result
-    assert int(result) == child_pid
+    assert json.loads(result) == {'metric': child_pid, 'span': child_pid, 'log': child_pid}
 
 
 def test_otel_resource_attributes_env_var_overrides_host_and_os_defaults(

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -5,6 +5,7 @@ import getpass
 import json
 import os
 import pickle
+import signal
 import subprocess
 import sys
 import threading
@@ -1253,7 +1254,11 @@ def test_register_at_fork_resource_updates(
     assert isinstance(meter_provider, config_module.MeterProvider)
     assert isinstance(logger_provider, config_module.SDKLoggerProvider)
 
-    if not use_otel_resource_updaters:
+    otel_handles_resource_fork = use_otel_resource_updaters and all(
+        hasattr(provider, '_handle_fork') and hasattr(provider, '_update_resource')
+        for provider in (tracer_provider, meter_provider, logger_provider)
+    )
+    if not otel_handles_resource_fork:
         monkeypatch.delattr(config_module.SDKTracerProvider, '_update_resource', raising=False)
         monkeypatch.delattr(config_module.MeterProvider, '_update_resource', raising=False)
         monkeypatch.delattr(config_module.SDKLoggerProvider, '_update_resource', raising=False)
@@ -1330,6 +1335,13 @@ def test_register_at_fork_resource_updates(
 def test_resource_process_pid_updated_after_fork(
     exporter: TestExporter, logs_exporter: TestLogExporter, metrics_reader: InMemoryMetricReader
 ) -> None:
+    tracer_provider = GLOBAL_CONFIG.get_tracer_provider().provider
+    meter_provider = GLOBAL_CONFIG.get_meter_provider().provider
+    logger_provider = GLOBAL_CONFIG.get_logger_provider().provider
+    assert isinstance(tracer_provider, config_module.SDKTracerProvider)
+    assert isinstance(meter_provider, config_module.MeterProvider)
+    assert isinstance(logger_provider, config_module.SDKLoggerProvider)
+
     counter = logfire.metric_counter('fork.counter')
     counter.add(1)
     logger = get_logger('fork.logger')
@@ -1346,9 +1358,30 @@ def test_resource_process_pid_updated_after_fork(
     logs_exporter.clear()
 
     read_fd, write_fd = os.pipe()
-    with warnings.catch_warnings():
-        warnings.filterwarnings('ignore', category=DeprecationWarning, message='.*fork.*')
-        child_pid = os.fork()
+    provider_locks = []
+    if all(
+        hasattr(provider, '_handle_fork') and hasattr(provider, '_update_resource')
+        for provider in (tracer_provider, meter_provider, logger_provider)
+    ):
+        provider_locks = [
+            tracer_provider._tracers_lock,  # pyright: ignore[reportPrivateUsage]
+            meter_provider._meter_lock,  # pyright: ignore[reportPrivateUsage]
+            logger_provider._active_loggers_lock,  # pyright: ignore[reportPrivateUsage]
+        ]
+        for lock in provider_locks:
+            lock.acquire()
+
+    parent_pid = os.getpid()
+    signal.alarm(10)
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', category=DeprecationWarning, message='.*fork.*')
+            child_pid = os.fork()
+    finally:
+        signal.alarm(0)
+        if os.getpid() == parent_pid:
+            for lock in provider_locks:
+                lock.release()
 
     if child_pid == 0:  # pragma: no cover
         os.close(read_fd)

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1227,11 +1227,13 @@ def test_host_and_os_resource_attributes_populated_by_default(
 
 
 @pytest.mark.skipif(not hasattr(os, 'register_at_fork'), reason='os.register_at_fork is not available')
+@pytest.mark.parametrize('use_otel_resource_updaters', [True, False])
 def test_register_at_fork_resource_updates(
     monkeypatch: pytest.MonkeyPatch,
     exporter: TestExporter,
     logs_exporter: TestLogExporter,
     metrics_reader: InMemoryMetricReader,
+    use_otel_resource_updaters: bool,
 ) -> None:
     callbacks: list[Callable[[], None]] = []
 
@@ -1250,6 +1252,11 @@ def test_register_at_fork_resource_updates(
     assert isinstance(tracer_provider, config_module.SDKTracerProvider)
     assert isinstance(meter_provider, config_module.MeterProvider)
     assert isinstance(logger_provider, config_module.SDKLoggerProvider)
+
+    if not use_otel_resource_updaters:
+        monkeypatch.delattr(config_module.SDKTracerProvider, '_update_resource', raising=False)
+        monkeypatch.delattr(config_module.MeterProvider, '_update_resource', raising=False)
+        monkeypatch.delattr(config_module.SDKLoggerProvider, '_update_resource', raising=False)
 
     counter = logfire.metric_counter('fork.callback.counter')
     counter.add(1)

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import threading
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack
 from io import StringIO
 from pathlib import Path
@@ -1224,6 +1224,62 @@ def test_host_and_os_resource_attributes_populated_by_default(
     assert resource_attrs['os.version'] == (
         platform.version() if platform.system().lower() in ('windows', 'sunos') else platform.release()
     )
+
+
+@pytest.mark.skipif(not hasattr(os, 'register_at_fork'), reason='os.register_at_fork is not available')
+def test_register_at_fork_resource_updates(
+    monkeypatch: pytest.MonkeyPatch,
+    exporter: TestExporter,
+    logs_exporter: TestLogExporter,
+    metrics_reader: InMemoryMetricReader,
+) -> None:
+    callbacks: list[Callable[[], None]] = []
+
+    def register_at_fork(*, after_in_child: Callable[[], None]) -> None:
+        callbacks.append(after_in_child)
+
+    monkeypatch.setattr(config_module.os, 'register_at_fork', register_at_fork)
+    monkeypatch.setattr(config_module.os, 'getpid', lambda: 42)
+
+    proxy_tracer_provider = GLOBAL_CONFIG.get_tracer_provider()
+    proxy_meter_provider = GLOBAL_CONFIG.get_meter_provider()
+    proxy_logger_provider = GLOBAL_CONFIG.get_logger_provider()
+    tracer_provider = proxy_tracer_provider.provider
+    meter_provider = proxy_meter_provider.provider
+    logger_provider = proxy_logger_provider.provider
+    assert isinstance(tracer_provider, config_module.SDKTracerProvider)
+    assert isinstance(meter_provider, config_module.MeterProvider)
+    assert isinstance(logger_provider, config_module.SDKLoggerProvider)
+
+    counter = logfire.metric_counter('fork.callback.counter')
+    counter.add(1)
+    logger = get_logger('fork.callback.logger')
+    logger.emit(LogRecord(body='before callback'))
+    with logfire.span('before callback'):
+        pass
+    metrics_reader.get_metrics_data()
+    exporter.clear()
+    logs_exporter.clear()
+
+    config_module._register_at_fork_resource_updates(  # pyright: ignore[reportPrivateUsage]
+        tracer_provider,
+        meter_provider,
+        logger_provider,
+        proxy_tracer_provider,
+        proxy_logger_provider,
+    )
+    [callback] = callbacks
+    callback()
+
+    counter.add(1)
+    logger.emit(LogRecord(body='after callback'))
+    with logfire.span('after callback'):
+        pass
+    metrics_data = metrics_reader.get_metrics_data()
+    assert metrics_data is not None
+    assert metrics_data.resource_metrics[0].resource.attributes['process.pid'] == 42
+    assert exporter.exported_spans[-1].resource.attributes['process.pid'] == 42
+    assert logs_exporter.get_finished_logs()[-1].resource.attributes['process.pid'] == 42
 
 
 @pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import getpass
+import inspect
 import json
 import os
 import pickle
@@ -1228,13 +1229,11 @@ def test_host_and_os_resource_attributes_populated_by_default(
 
 
 @pytest.mark.skipif(not hasattr(os, 'register_at_fork'), reason='os.register_at_fork is not available')
-@pytest.mark.parametrize('use_otel_resource_updaters', [True, False])
 def test_register_at_fork_resource_updates(
     monkeypatch: pytest.MonkeyPatch,
     exporter: TestExporter,
     logs_exporter: TestLogExporter,
     metrics_reader: InMemoryMetricReader,
-    use_otel_resource_updaters: bool,
 ) -> None:
     callbacks: list[Callable[[], None]] = []
 
@@ -1253,15 +1252,6 @@ def test_register_at_fork_resource_updates(
     assert isinstance(tracer_provider, config_module.SDKTracerProvider)
     assert isinstance(meter_provider, config_module.MeterProvider)
     assert isinstance(logger_provider, config_module.SDKLoggerProvider)
-
-    otel_handles_resource_fork = use_otel_resource_updaters and all(
-        hasattr(provider, '_handle_fork') and hasattr(provider, '_update_resource')
-        for provider in (tracer_provider, meter_provider, logger_provider)
-    )
-    if not otel_handles_resource_fork:
-        monkeypatch.delattr(config_module.SDKTracerProvider, '_update_resource', raising=False)
-        monkeypatch.delattr(config_module.MeterProvider, '_update_resource', raising=False)
-        monkeypatch.delattr(config_module.SDKLoggerProvider, '_update_resource', raising=False)
 
     counter = logfire.metric_counter('fork.callback.counter')
     counter.add(1)
@@ -1329,6 +1319,48 @@ def test_register_at_fork_resource_updates(
     )
     [callback] = callbacks
     callback()
+
+
+def test_otel_resource_updater_sources() -> None:
+    provider_classes = {
+        'traces': config_module.SDKTracerProvider,
+        'metrics': config_module.MeterProvider,
+        'logs': config_module.SDKLoggerProvider,
+    }
+    if not all(hasattr(provider_class, '_update_resource') for provider_class in provider_classes.values()):
+        pytest.skip('OpenTelemetry resource updaters were added in version 1.44')
+
+    # The fork callback manually performs the lock-free equivalent of these private methods. Fail loudly if an
+    # OpenTelemetry upgrade changes the state that needs updating.
+    assert {
+        name: inspect.getsource(getattr(provider_class, '_update_resource'))
+        for name, provider_class in provider_classes.items()
+    } == snapshot(
+        {
+            'traces': """\
+    def _update_resource(self, resource: Resource) -> None:
+        with self._tracers_lock:
+            self._resource = self._resource.merge(resource)
+            for tracer in self._tracers.values():
+                tracer._set_resource(self._resource)  # pylint: disable=protected-access
+""",
+            'metrics': """\
+    def _update_resource(self, resource: Resource) -> None:
+        with self._meter_lock:
+            self._sdk_config.resource = self._sdk_config.resource.merge(
+                resource
+            )
+""",
+            'logs': """\
+    def _update_resource(self, resource: Resource) -> None:
+        with self._active_loggers_lock:
+            self._resource = self._resource.merge(resource)
+            for logger in list(self._active_loggers):
+                # pylint: disable-next=protected-access
+                logger._set_resource(self._resource)
+""",
+        }
+    )
 
 
 @pytest.mark.skipif(not hasattr(os, 'fork'), reason='os.fork is not available')


### PR DESCRIPTION
## Summary

- update metric, span, and log resources with the child PID after `os.fork()`
- perform the updates without taking OpenTelemetry locks or rerunning its process-dependent resource detectors
- snapshot OpenTelemetry's private resource updater implementations so dependency drift fails loudly
- cover parent and child resource PIDs end to end, including a fork while provider locks are held

## Root cause

`MeterProvider` stores the resource used during collection in `_sdk_config.resource`. Assigning `meter_provider._resource` created an unused attribute, so child metrics continued to export the parent process PID. Cached SDK tracer and logger instances also retain their original resource and need to be updated after the fork.

Logfire's child callback runs before OpenTelemetry resets inherited provider locks. It therefore updates the same backing state as OpenTelemetry's private `_update_resource()` methods without calling those lock-taking methods or `_handle_fork()`, which also reruns resource detection.

## Validation

- `uv run pytest tests/test_configure.py` — 106 passed
- focused regression tests with OpenTelemetry SDK 1.44.0 — 3 passed
- focused regression tests with the minimum supported OpenTelemetry SDK 1.39.0 — 2 passed, 1 expected skip
- `uv run pyright logfire/_internal/config.py tests/test_configure.py`
- Ruff formatting and lint checks
