### PR TITLE
Speed up default scrubbing pattern matching

### DIFF
--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -63,6 +63,12 @@ DEFAULT_PATTERNS = [
     ],
 ]
 
+# Every default pattern starts matching at one of these characters. Checking this
+# inexpensive character class first avoids trying every alternative at every
+# position in large strings. Custom patterns are not constrained by this prefix.
+_DEFAULT_PATTERN_START_CHARS = 'pmsacljx_'
+_DEFAULT_PATTERN = rf'(?=[{_DEFAULT_PATTERN_START_CHARS}])(?:{"|".join(DEFAULT_PATTERNS)})'
+
 JsonPath: typing_extensions.TypeAlias = 'tuple[str | int, ...]'
 
 
@@ -204,7 +210,7 @@ class Scrubber(BaseScrubber):
 
     def __init__(self, patterns: Sequence[str] | None, callback: ScrubCallback | None = None):
         # See ScrubbingOptions for more info on these parameters.
-        patterns = [*DEFAULT_PATTERNS, *(patterns or [])]
+        patterns = [_DEFAULT_PATTERN, *(patterns or [])]
         self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
         self._callback = callback
 

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -14,8 +14,75 @@ from opentelemetry.sdk.environment_variables import OTEL_RESOURCE_ATTRIBUTES
 from opentelemetry.trace.propagation import get_current_span
 
 import logfire
-from logfire._internal.scrubbing import NoopScrubber
+from logfire._internal.scrubbing import DEFAULT_PATTERNS, NoopScrubber, Scrubber
 from logfire.testing import TestExporter, TestLogExporter
+
+DEFAULT_PATTERN_EXAMPLES = {
+    'password': 'has_password_value',
+    'passwd': 'has_passwd_value',
+    'mysql_pwd': 'has_mysql_pwd_value',
+    'secret': 'has_secret_value',
+    r'auth(?!ors?\b)': 'has_authorization_value',
+    'credential': 'has_credential_value',
+    'private[._ -]?key': 'has_private-key_value',
+    'api[._ -]?key': 'has_api.key_value',
+    'session': 'has_session_value',
+    'cookie': 'has_cookie_value',
+    'social[._ -]?security': 'has_social security_value',
+    'credit[._ -]?card': 'has_credit_card_value',
+    'logfire[._ -]?token': 'has_logfire-token_value',
+    r'pylf_v\d+_': 'has_pylf_v12_token',
+    r'(?:\b|_)csrf(?:\b|_)': 'has csrf value',
+    r'(?:\b|_)xsrf(?:\b|_)': 'has xsrf value',
+    r'(?:\b|_)jwt(?:\b|_)': 'has jwt value',
+    r'(?:\b|_)ssn(?:\b|_)': 'has ssn value',
+}
+
+
+def test_optimized_default_patterns_match_naive_pattern():
+    """The optimized prefilter must not change which default pattern matches first."""
+    assert DEFAULT_PATTERN_EXAMPLES.keys() == set(DEFAULT_PATTERNS)
+    naive_pattern = re.compile('|'.join(DEFAULT_PATTERNS), re.IGNORECASE | re.DOTALL)
+
+    for value in [*DEFAULT_PATTERN_EXAMPLES.values(), 'has ſecret value', 'has credentıal value']:
+        expected = naive_pattern.search(value)
+        assert expected is not None
+
+        scrub_matches: list[logfire.ScrubMatch] = []
+
+        def callback(match: logfire.ScrubMatch):
+            scrub_matches.append(match)
+            return match.value
+
+        result, scrubbed_notes = Scrubber(None, callback).scrub_value(('attributes', 'value'), value)
+
+        assert result == value
+        assert scrubbed_notes == []
+        assert len(scrub_matches) == 1
+        actual = scrub_matches[0].pattern_match
+        assert (actual.span(), actual.group(0)) == (expected.span(), expected.group(0))
+
+
+@pytest.mark.parametrize(
+    ('extra_pattern', 'value', 'expected_match'),
+    [
+        ('custom', 'custom before password', 'custom'),
+        ('pass', 'passwords', 'password'),
+        (r'\d+', '123 before password', '123'),
+    ],
+)
+def test_optimized_default_patterns_preserve_extra_pattern_order(extra_pattern: str, value: str, expected_match: str):
+    matches: list[str] = []
+
+    def callback(match: logfire.ScrubMatch):
+        matches.append(match.pattern_match.group(0))
+        return match.value
+
+    result, scrubbed_notes = Scrubber([extra_pattern], callback).scrub_value(('attributes', 'value'), value)
+
+    assert result == value
+    assert scrubbed_notes == []
+    assert matches == [expected_match]
 
 
 def test_scrub_attribute(exporter: TestExporter):

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -44,7 +44,7 @@ def test_optimized_default_patterns_match_naive_pattern():
     assert DEFAULT_PATTERN_EXAMPLES.keys() == set(DEFAULT_PATTERNS)
     naive_pattern = re.compile('|'.join(DEFAULT_PATTERNS), re.IGNORECASE | re.DOTALL)
 
-    for value in [*DEFAULT_PATTERN_EXAMPLES.values(), 'has ſecret value', 'has credentıal value']:
+    for value in [*DEFAULT_PATTERN_EXAMPLES.values(), 'has \u017fecret value', 'has credent\u0131al value']:
         expected = naive_pattern.search(value)
         assert expected is not None
 
@@ -99,21 +99,25 @@ def test_default_pattern_start_chars_cover_each_pattern():
         (r'(?:\b|_)xsrf(?:\b|_)', 'has_xsrf_value'),
         (r'(?:\b|_)jwt(?:\b|_)', 'has_jwt_value'),
         (r'(?:\b|_)ssn(?:\b|_)', 'has_ssn_value'),
-        ('secret', 'has ſecret value'),
-        ('credential', 'has credentıal value'),
+        ('secret', 'has \u017fecret value'),
+        ('credential', 'has credent\u0131al value'),
     ]
+
+    def make_callback(bucket: list[logfire.ScrubMatch]):
+        def callback(match: logfire.ScrubMatch):
+            bucket.append(match)
+            return match.value
+
+        return callback
 
     for pattern, value in isolated_examples:
         expected = re.compile(pattern, re.IGNORECASE | re.DOTALL).search(value)
         assert expected is not None, pattern
 
         scrub_matches: list[logfire.ScrubMatch] = []
-
-        def callback(match: logfire.ScrubMatch):
-            scrub_matches.append(match)
-            return match.value
-
-        result, scrubbed_notes = Scrubber(None, callback).scrub_value(('attributes', 'value'), value)
+        result, scrubbed_notes = Scrubber(None, make_callback(scrub_matches)).scrub_value(
+            ('attributes', 'value'), value
+        )
 
         assert result == value
         assert scrubbed_notes == []

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -85,6 +85,43 @@ def test_optimized_default_patterns_preserve_extra_pattern_order(extra_pattern: 
     assert matches == [expected_match]
 
 
+def test_default_pattern_start_chars_cover_each_pattern():
+    """The prefilter must still find each default pattern's own first match.
+
+    Compare against that pattern in isolation, not the combined leftmost match,
+    so a new pattern cannot be silently disabled if its example also contains
+    an earlier default match, e.g. adding `token` with `has_secret_token_value`.
+    """
+    assert DEFAULT_PATTERN_EXAMPLES.keys() == set(DEFAULT_PATTERNS)
+    isolated_examples = [
+        *DEFAULT_PATTERN_EXAMPLES.items(),
+        (r'(?:\b|_)csrf(?:\b|_)', 'has_csrf_value'),
+        (r'(?:\b|_)xsrf(?:\b|_)', 'has_xsrf_value'),
+        (r'(?:\b|_)jwt(?:\b|_)', 'has_jwt_value'),
+        (r'(?:\b|_)ssn(?:\b|_)', 'has_ssn_value'),
+        ('secret', 'has ſecret value'),
+        ('credential', 'has credentıal value'),
+    ]
+
+    for pattern, value in isolated_examples:
+        expected = re.compile(pattern, re.IGNORECASE | re.DOTALL).search(value)
+        assert expected is not None, pattern
+
+        scrub_matches: list[logfire.ScrubMatch] = []
+
+        def callback(match: logfire.ScrubMatch):
+            scrub_matches.append(match)
+            return match.value
+
+        result, scrubbed_notes = Scrubber(None, callback).scrub_value(('attributes', 'value'), value)
+
+        assert result == value
+        assert scrubbed_notes == []
+        assert len(scrub_matches) == 1, (pattern, value)
+        actual = scrub_matches[0].pattern_match
+        assert (actual.span(), actual.group(0)) == (expected.span(), expected.group(0))
+
+
 def test_scrub_attribute(exporter: TestExporter):
     logfire.info(
         'Password: {user_password}',


### PR DESCRIPTION
## Summary

- add a cheap start-character prefilter before the default scrubbing regex
- keep custom patterns outside the prefilter so their syntax and precedence remain unchanged
- verify every documented default produces the same first match as the previous expression, including Unicode case folding and custom-pattern overlap

## Why

The previous flat alternation tried every default branch at every string position. Large attribute values, especially values without a sensitive match, spent most of their scrubbing time in `re.Pattern.search`.

The prefilter rejects positions that cannot begin a default match before evaluating the existing patterns. It does not change the default patterns themselves.

## Benchmarks

Median microseconds per `re.Pattern.search` on synthetic JSON attributes:

| Python | Matching before | Matching after | Speedup | Benign before | Benign after | Speedup |
|---|---:|---:|---:|---:|---:|---:|
| 3.10 | 383.7 | 131.5 | 2.92x | 1026.0 | 201.6 | 5.09x |
| 3.12 | 323.1 | 102.3 | 3.16x | 884.7 | 165.8 | 5.34x |
| 3.13 | 328.9 | 103.1 | 3.19x | 883.3 | 165.1 | 5.35x |
| 3.14 | 347.6 | 113.6 | 3.06x | 971.4 | 184.3 | 5.27x |

A representative whole-value scrub improved from 3.77 ms to 1.15 ms, a 3.29x speedup.

## Validation

- `uv run pytest tests/test_secret_scrubbing.py -q`: 18 passed
- `make lint`
- `make typecheck`
- pre-commit on changed files
- full suite: 2,288 passed, 9 skipped, and 2 expected failures; one unrelated Claude Agent SDK cassette snapshot failed because its recorded directory listing differs from a clean worktree, and it reproduces with the original scrubber constructor


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

