### PR TITLE
Fix two races in Claude Agent SDK tool-use hook instrumentation

### DIFF
--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -44,6 +44,7 @@ from logfire._internal.integrations.llm_providers.semconv import (
     ToolCallPart,
     ToolCallResponsePart,
 )
+from logfire._internal.stack_info import get_user_stack_info
 from logfire._internal.utils import handle_internal_errors
 
 if TYPE_CHECKING:
@@ -197,6 +198,11 @@ async def pre_tool_use_hook(
         try:
             span_name = f'execute_tool {tool_name}'
             span = state.logfire.span(span_name)
+            # Replace the code attributes inferred from this hook task's stack with the
+            # ones captured at receive_response time; set directly on the OTLP attributes
+            # so they stay out of logfire.json_schema like other code attributes.
+            # The cast is needed because a TypedDict doesn't satisfy Mapping's value variance.
+            span._otlp_attributes.update(cast('dict[str, str | int]', state.code_attrs))  # pyright: ignore[reportPrivateUsage]
             span.set_attributes(
                 {
                     OPERATION_NAME: 'execute_tool',
@@ -450,6 +456,11 @@ class _ConversationState:
         self.announced_tool_ids: set[str] = set()
         self._tool_announced = anyio.Event()
         self.tool_announcement_timeout = 1.0
+        # Code attributes for spans created in hook tasks, whose own stacks have no
+        # meaningful user frame (the task is rooted in the event loop, so the first
+        # non-library frame varies with how the process was started, if one exists
+        # at all). Capture the user's frame here, where it's still on the stack.
+        self.code_attrs = get_user_stack_info()
 
     async def wait_for_tool_announcement(self, tool_use_id: str) -> None:
         """Wait until the assistant message announcing `tool_use_id` has been handled.

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, AsyncIterable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import TYPE_CHECKING, Any, cast
 
+import anyio
 import claude_agent_sdk
 from claude_agent_sdk import (
     AssistantMessage,
@@ -177,6 +178,8 @@ async def pre_tool_use_hook(
         state = _get_state()
         if state is None:
             return {}
+
+        await state.wait_for_tool_announcement(tool_use_id)
 
         tool_name = str(input_data.get('tool_name', 'unknown_tool'))
         tool_input = input_data.get('tool_input', {})
@@ -443,6 +446,23 @@ class _ConversationState:
         self._current_output_parts: list[MessagePart] = []
         self._system_instructions = system_instructions
         self.model: str | None = None
+        # Tool call IDs from assistant messages that have been applied to this state.
+        self.announced_tool_ids: set[str] = set()
+        self._tool_announced = anyio.Event()
+        self.tool_announcement_timeout = 1.0
+
+    async def wait_for_tool_announcement(self, tool_use_id: str) -> None:
+        """Wait until the assistant message announcing `tool_use_id` has been handled.
+
+        The CLI sends the assistant message (containing the `tool_use` block) before it
+        invokes the PreToolUse hook, but hooks run in separate anyio tasks, so the hook
+        can be scheduled before the main task has applied that message to this state.
+        Closing the chat span at that point would lose its output and model attributes.
+        The timeout is a safety valve for tool calls that are never announced.
+        """
+        with anyio.move_on_after(self.tool_announcement_timeout):
+            while tool_use_id not in self.announced_tool_ids:
+                await self._tool_announced.wait()
 
     def add_tool_result(self, tool_use_id: str, tool_name: str, result: Any) -> None:
         """Record a tool result to include in the next chat span's input messages."""
@@ -492,10 +512,20 @@ class _ConversationState:
 
     def handle_assistant_message(self, message: AssistantMessage) -> None:
         """Handle AssistantMessage: add output and usage to the current chat span."""
+        content = getattr(message, 'content', [])
+
+        new_tool_ids = {block.id for block in content if isinstance(block, ToolUseBlock)}
+        if new_tool_ids:
+            self.announced_tool_ids.update(new_tool_ids)
+            # Wake any PreToolUse hooks waiting for these tool calls, and replace the
+            # event so future waiters block until the next announcement.
+            event = self._tool_announced
+            self._tool_announced = anyio.Event()
+            event.set()
+
         if self._current_span is None:  # pragma: no cover
             return
 
-        content = getattr(message, 'content', [])
         output_messages = _content_blocks_to_output_messages(content)
         new_parts = output_messages[0]['parts'] if output_messages else []
 

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -44,7 +44,7 @@ from logfire._internal.integrations.llm_providers.semconv import (
     ToolCallPart,
     ToolCallResponsePart,
 )
-from logfire._internal.stack_info import get_user_stack_info
+from logfire._internal.stack_info import STACK_INFO_KEYS, get_user_stack_info
 from logfire._internal.utils import handle_internal_errors
 
 if TYPE_CHECKING:
@@ -199,9 +199,12 @@ async def pre_tool_use_hook(
             span_name = f'execute_tool {tool_name}'
             span = state.logfire.span(span_name)
             # Replace the code attributes inferred from this hook task's stack with the
-            # ones captured at receive_response time; set directly on the OTLP attributes
-            # so they stay out of logfire.json_schema like other code attributes.
+            # ones captured at receive_response time (dropping them entirely if no user
+            # frame was found then); set directly on the OTLP attributes so they stay out
+            # of logfire.json_schema like other code attributes.
             # The cast is needed because a TypedDict doesn't satisfy Mapping's value variance.
+            for key in STACK_INFO_KEYS:
+                span._otlp_attributes.pop(key, None)  # pyright: ignore[reportPrivateUsage]
             span._otlp_attributes.update(cast('dict[str, str | int]', state.code_attrs))  # pyright: ignore[reportPrivateUsage]
             span.set_attributes(
                 {

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -34,7 +34,6 @@ from claude_agent_sdk import (
     ToolUseBlock,
 )
 from claude_agent_sdk.types import HookContext
-from dirty_equals import IsStr
 from inline_snapshot import snapshot
 
 import logfire
@@ -765,7 +764,7 @@ async def test_tool_use_conversation_cassette(
                 'start_time': 2000000000,
                 'end_time': 3000000000,
                 'attributes': {
-                    'code.filepath': IsStr(),
+                    'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_tool_use_conversation_cassette',
                     'code.lineno': 123,
                     'gen_ai.operation.name': 'chat',
@@ -824,10 +823,11 @@ async def test_tool_use_conversation_cassette(
                 'start_time': 4000000000,
                 'end_time': 5000000000,
                 'attributes': {
-                    'code.filepath': IsStr(),
+                    'code.filepath': 'test_claude_agent_sdk.py',
                     'code.lineno': 123,
                     'logfire.msg_template': 'execute_tool Bash',
                     'gen_ai.tool.name': 'Bash',
+                    'code.function': 'test_tool_use_conversation_cassette',
                     'gen_ai.tool.call.id': 'toolu_01MRdgcFhYNo1LHvRQKvKckg',
                     'gen_ai.tool.call.arguments': {'command': 'ls', 'description': 'List files in current directory'},
                     'gen_ai.tool.call.result': {

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -21,8 +21,10 @@ from contextlib import suppress
 from pathlib import Path
 from unittest.mock import Mock
 
+import anyio
 import pytest
 from claude_agent_sdk import (
+    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
     HookMatcher,
@@ -249,6 +251,10 @@ async def test_tool_use_hooks(exporter: TestExporter) -> None:
 
     with logfire_instance.span('root') as root_span:
         state = _ConversationState(logfire=logfire_instance, root_span=root_span, input_messages=[])
+        # Normally the assistant message carrying the tool_use blocks announces the IDs
+        # before the CLI invokes the PreToolUse hooks; do the same here so the hooks
+        # don't wait for an announcement that never comes.
+        state.announced_tool_ids.update({'tool_1', 'tool_no_resp', 'tool_2'})
         _set_state(state)
         try:
             # Successful tool call
@@ -414,6 +420,7 @@ async def test_clear_orphaned_tool_spans(exporter: TestExporter) -> None:
 
     with logfire_instance.span('root') as root_span:
         state = _ConversationState(logfire=logfire_instance, root_span=root_span, input_messages=[])
+        state.announced_tool_ids.add('orphan_1')
         _set_state(state)
         try:
             # Start a tool span but never call post_tool_use_hook
@@ -476,6 +483,62 @@ async def test_clear_orphaned_tool_spans(exporter: TestExporter) -> None:
             },
         ]
     )
+
+
+@pytest.mark.anyio
+async def test_pre_hook_waits_for_tool_announcement() -> None:
+    """A PreToolUse hook scheduled before the assistant message blocks until it's applied."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+
+    with logfire_instance.span('root') as root_span:
+        state = _ConversationState(logfire=logfire_instance, root_span=root_span, input_messages=[])
+        _set_state(state)
+        try:
+            async with anyio.create_task_group() as tg:
+
+                async def call_hook() -> None:
+                    await pre_tool_use_hook(
+                        {'tool_name': 'Bash', 'tool_input': {'command': 'ls'}, 'tool_use_id': 'tool_1'},
+                        'tool_1',
+                        {'signal': None},
+                    )
+
+                tg.start_soon(call_hook)
+                await anyio.sleep(0.01)
+                # The hook is waiting for the announcement; no span has been created yet.
+                assert 'tool_1' not in state.active_tool_spans
+                state.handle_assistant_message(
+                    AssistantMessage(
+                        content=[ToolUseBlock(id='tool_1', name='Bash', input={'command': 'ls'})],
+                        model='claude-sonnet-4-6',
+                    )
+                )
+            # The announcement woke the hook, which then created the span.
+            assert 'tool_1' in state.active_tool_spans
+            state.close()
+        finally:
+            _clear_state()
+
+
+@pytest.mark.anyio
+async def test_pre_hook_announcement_timeout() -> None:
+    """A tool call that is never announced still gets a span after the safety-valve timeout."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+
+    with logfire_instance.span('root') as root_span:
+        state = _ConversationState(logfire=logfire_instance, root_span=root_span, input_messages=[])
+        state.tool_announcement_timeout = 0.01
+        _set_state(state)
+        try:
+            await pre_tool_use_hook(
+                {'tool_name': 'Bash', 'tool_input': {'command': 'ls'}, 'tool_use_id': 'tool_never'},
+                'tool_never',
+                {'signal': None},
+            )
+            assert 'tool_never' in state.active_tool_spans
+            state.close()
+        finally:
+            _clear_state()
 
 
 @pytest.mark.anyio
@@ -663,16 +726,29 @@ async def test_basic_conversation_cassette(
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize('consumer_delay', [0, 0.05])
 async def test_tool_use_conversation_cassette(
-    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter, consumer_delay: float
 ) -> None:
-    """Tool use conversation: assistant calls Bash, gets result, then responds."""
+    """Tool use conversation: assistant calls Bash, gets result, then responds.
+
+    The delayed-consumer variant slows down message processing so the SDK's spawned
+    hook tasks are scheduled before the main task applies the assistant message,
+    exercising `wait_for_tool_announcement`. The spans must be identical either way.
+    """
     record = request.config.getoption('--record-claude-cassettes', default=False)
+    if record and consumer_delay:
+        pytest.skip('Only record the cassette once')
     client = _make_client('tool_use_conversation.json', monkeypatch=monkeypatch, record=bool(record))
     try:
         await client.connect()
         await client.query('List files in the current directory')
-        collected = [msg async for msg in client.receive_response()]
+        collected: list[object] = []
+        async for msg in client.receive_response():
+            if consumer_delay:
+                # Delay processing of the next message so hook tasks run first.
+                await anyio.sleep(consumer_delay)
+            collected.append(msg)
     finally:
         await _close_sdk_streams(client)
         await client.disconnect()


### PR DESCRIPTION
Two fixes for spans created by the Claude Agent SDK integration's tool-use hooks, which run in separate anyio tasks:

1. **PreToolUse hooks raced with assistant message processing.** The CLI sends the assistant message (containing the `tool_use` block) before invoking the PreToolUse hook, but the hook runs in its own task and could be scheduled first. When that happened, the hook closed the current chat span before the main task had applied the assistant message, so the chat span lost its output messages, model attributes, and name, and the conversation history fed to later chat spans was missing the assistant turn. The hook now waits (with a 1s safety-valve timeout) until the assistant message announcing its `tool_use_id` has been handled.

2. **Tool span code attributes were environment-dependent junk.** Spans created inside hook tasks inferred `code.filepath`/`code.lineno` from the hook task's stack, which bottoms out in the event loop; the first non-library frame is whatever launched the process (e.g. a console script's `<module>` frame), and in some environments there is no such frame at all. Tool spans now use the user's frame captured when `receive_response` is entered.

Both were exposed by running the test suite under pytest-xdist (#2179): the cassette test's span snapshots flipped depending on task scheduling and process launch context. The cassette test now also runs a delayed-consumer variant that deterministically exercises the hook-waits-for-announcement path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

