### PR TITLE
Fix global instrumentation leak from test_logfire_api's test_runtime

### DIFF
--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -10,11 +10,39 @@ from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from pydantic import __version__ as pydantic_version
 
 from logfire._internal.utils import get_version
 
 pydantic_pre_2_5 = get_version(pydantic_version) < get_version('2.5.0')
+
+
+@pytest.fixture(autouse=True)
+def uninstrument_global_instrumentors():
+    """Undo global instrumentation applied by calling every `instrument_*` method.
+
+    `test_runtime`'s `with_logfire` variant really calls methods like
+    `instrument_requests()`, which patch shared libraries via `BaseInstrumentor`
+    singletons. Left instrumented, they poison tests that run later in the same
+    process, e.g. by making `logfire.instrument_requests()` a warning no-op bound
+    to this test's long-gone configuration.
+    """
+    yield
+    to_visit = [BaseInstrumentor]
+    while to_visit:
+        cls = to_visit.pop()
+        to_visit.extend(cls.__subclasses__())
+        # The singleton is stored on each subclass that has been instantiated.
+        instance = cls.__dict__.get('_instance')
+        if isinstance(instance, BaseInstrumentor) and instance.is_instrumented_by_opentelemetry:
+            try:
+                instance.uninstrument()
+            except Exception:
+                # Some instrumentors can't uninstrument what the test set up, e.g.
+                # AwsLambdaInstrumentor given a MagicMock handler is marked instrumented
+                # without the internal state uninstrument expects.
+                pass
 
 
 def logfire_dunder_all() -> set[str]:

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -10,9 +10,6 @@ from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
-from mcp.client.session import ClientSession
-from mcp.server import Server
-from mcp.shared.session import BaseSession
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from pydantic import __version__ as pydantic_version
 
@@ -34,13 +31,21 @@ def uninstrument_global_instrumentors():
     span gets nested in a duplicate span from the leaked wrapper.
     """
     # The attributes instrument_mcp patches, saved here and restored afterwards.
-    mcp_patched = [
-        (BaseSession, 'send_request'),
-        (BaseSession, 'send_notification'),
-        (ClientSession, '_received_notification'),
-        (ClientSession, '_received_request'),
-        (Server, '_handle_request'),
-    ]
+    # mcp itself is unimportable on old pydantic versions, matching test_runtime's guard.
+    try:
+        from mcp.client.session import ClientSession
+        from mcp.server import Server
+        from mcp.shared.session import BaseSession
+    except ImportError:
+        mcp_patched = []
+    else:
+        mcp_patched = [
+            (BaseSession, 'send_request'),
+            (BaseSession, 'send_notification'),
+            (ClientSession, '_received_notification'),
+            (ClientSession, '_received_request'),
+            (Server, '_handle_request'),
+        ]
     saved = [(cls, name, getattr(cls, name)) for cls, name in mcp_patched]
 
     yield

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -47,9 +47,14 @@ def uninstrument_global_instrumentors():
             (Server, '_handle_request'),
         ]
     saved = [(cls, name, getattr(cls, name)) for cls, name in mcp_patched]
+    # install_auto_tracing(modules=['all']) adds an import hook that would rewrite
+    # every module imported later in this process; drop it with any other finders
+    # added during the test.
+    original_meta_path = list(sys.meta_path)
 
     yield
 
+    sys.meta_path[:] = original_meta_path
     for cls, name, value in saved:
         setattr(cls, name, value)
 
@@ -111,7 +116,9 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire__all__.remove('Logfire')
 
     assert hasattr(logfire_api, 'configure')
-    logfire_api.configure(send_to_logfire=False, console=False)
+    # inspect_arguments=False: f-string introspection has dedicated coverage elsewhere,
+    # and `executing` can sporadically fail to match a node under a heavily loaded machine.
+    logfire_api.configure(send_to_logfire=False, console=False, inspect_arguments=False)
     logfire__all__.remove('configure')
 
     assert hasattr(logfire_api, 'VERSION')

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -13,6 +13,7 @@ import pytest
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from pydantic import __version__ as pydantic_version
 
+from logfire._internal.auto_trace.import_hook import LogfireFinder
 from logfire._internal.utils import get_version
 
 pydantic_pre_2_5 = get_version(pydantic_version) < get_version('2.5.0')
@@ -47,14 +48,14 @@ def uninstrument_global_instrumentors():
             (Server, '_handle_request'),
         ]
     saved = [(cls, name, getattr(cls, name)) for cls, name in mcp_patched]
-    # install_auto_tracing(modules=['all']) adds an import hook that would rewrite
-    # every module imported later in this process; drop it with any other finders
-    # added during the test.
-    original_meta_path = list(sys.meta_path)
 
     yield
 
-    sys.meta_path[:] = original_meta_path
+    # install_auto_tracing() adds an import hook that would stay active for every
+    # module imported later in this process; drop it. Only LogfireFinder is removed:
+    # imports during the test add unrelated finders (e.g. six._SixMetaPathImporter)
+    # that later imports still need.
+    sys.meta_path[:] = [finder for finder in sys.meta_path if not isinstance(finder, LogfireFinder)]
     for cls, name, value in saved:
         setattr(cls, name, value)
 

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -10,6 +10,9 @@ from types import ModuleType
 from unittest.mock import MagicMock
 
 import pytest
+from mcp.client.session import ClientSession
+from mcp.server import Server
+from mcp.shared.session import BaseSession
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from pydantic import __version__ as pydantic_version
 
@@ -24,11 +27,27 @@ def uninstrument_global_instrumentors():
 
     `test_runtime`'s `with_logfire` variant really calls methods like
     `instrument_requests()`, which patch shared libraries via `BaseInstrumentor`
-    singletons. Left instrumented, they poison tests that run later in the same
-    process, e.g. by making `logfire.instrument_requests()` a warning no-op bound
-    to this test's long-gone configuration.
+    singletons, and `instrument_mcp()`, which wraps methods of MCP session classes
+    without any already-instrumented guard. Left in place, these poison tests that
+    run later in the same process: `logfire.instrument_requests()` becomes a
+    warning no-op bound to this test's long-gone configuration, and every MCP
+    span gets nested in a duplicate span from the leaked wrapper.
     """
+    # The attributes instrument_mcp patches, saved here and restored afterwards.
+    mcp_patched = [
+        (BaseSession, 'send_request'),
+        (BaseSession, 'send_notification'),
+        (ClientSession, '_received_notification'),
+        (ClientSession, '_received_request'),
+        (Server, '_handle_request'),
+    ]
+    saved = [(cls, name, getattr(cls, name)) for cls, name in mcp_patched]
+
     yield
+
+    for cls, name, value in saved:
+        setattr(cls, name, value)
+
     to_visit = [BaseInstrumentor]
     while to_visit:
         cls = to_visit.pop()


### PR DESCRIPTION
`test_runtime[with_logfire]` calls every `instrument_*` method for real, and several of them patch shared global state that the test never undid:

- Methods like `instrument_requests()` and `instrument_httpx()` instrument via `BaseInstrumentor` singletons. Leaked, they turn a later test's `logfire.instrument_requests()` into an "Attempting to instrument while already instrumented" no-op bound to this test's long-gone configuration, so that test's spans silently vanish. This is what broke `test_variables.py::TestLogfireRemoteVariableProviderInstrumentation::test_user_requests_are_still_instrumented` under pytest-xdist (#2179).
- `instrument_mcp()` wraps `BaseSession`/`ClientSession`/`Server` methods with no already-instrumented guard, so the leaked wrapper nested every MCP span created by later tests in a duplicate span. This is what broke `test_pydantic_ai_mcp.py::test_pydantic_ai_mcp_sampling`.

Sequentially the leaks happened to be masked (e.g. a sibling test's teardown uninstruments requests), but xdist scheduling can put a victim downstream of `test_runtime` on the same worker. Both are reproducible on main without xdist:

```
pytest "tests/test_logfire_api.py::test_runtime" "tests/test_variables.py::TestLogfireRemoteVariableProviderInstrumentation::test_user_requests_are_still_instrumented"
pytest "tests/test_logfire_api.py::test_runtime" "tests/otel_integrations/test_pydantic_ai_mcp.py::test_pydantic_ai_mcp_sampling"
```

The fix is an autouse fixture in `test_logfire_api.py` that restores the MCP session methods and walks `BaseInstrumentor` subclasses to uninstrument any singleton left instrumented. Found by temporarily adding a suite-wide tripwire fixture that fails any test leaving `RequestsInstrumentor` instrumented at teardown.