### PR TITLE
Raise the docs example timeout from 3s to 10s

### DIFF
--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -93,7 +93,7 @@ def test_skill_examples_formatting(eval_example: EvalExample):
 
 
 @pytest.mark.parametrize('example', _get_runnable_examples(), ids=str)
-@pytest.mark.timeout(3)
+@pytest.mark.timeout(10)
 def test_runnable(example: CodeExample, eval_example: EvalExample):
     """Ensure examples in documentation are runnable."""
     if 'from fastapi' in example.source and get_version(pydantic.__version__) < get_version('2.7.0'):


### PR DESCRIPTION
`make test` runs pytest with `-n logical` since #2175, so docs examples now execute while every core is busy running other tests. A 3s wall-clock cap on examples that import heavy modules (fastapi, etc.) flakes under that contention: one loaded local run produced 41 spurious `test_runnable` timeouts. 10s is still far below any real hang, which is what the per-test timeout is there to catch.

Part of making the suite reliable under parallel runs (#2179).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

