### PR TITLE
docs: drop install extras logfire does not have

### DIFF
--- a/docs/cookbook/debug-a-slow-tool-call.md
+++ b/docs/cookbook/debug-a-slow-tool-call.md
@@ -52,7 +52,7 @@ slow.
 - **Python packages**: Pydantic AI, the Psycopg 3 driver, and Logfire's instrumentation for both:
 
     ```bash
-    pip install "logfire[pydantic-ai,psycopg]" "pydantic-ai-slim[google]" "psycopg[binary]"
+    pip install "logfire[psycopg]" "pydantic-ai-slim[google]" "psycopg[binary]"
     ```
 
 Set your write token and model key so the app can send traces and call the model:

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -34,10 +34,10 @@ A few terms, defined once:
 Install the packages you need:
 
 ```bash
-pip install "logfire[pydantic-ai]" pydantic-evals "pydantic-ai-slim[google]"
+pip install logfire pydantic-evals "pydantic-ai-slim[google]"
 ```
 
-`logfire[pydantic-ai]` pulls in Logfire and Pydantic AI together; `pydantic-evals` is the evaluation library; the `[google]` extra adds the Gemini client. (Using `uv`? `uv add "logfire[pydantic-ai]" pydantic-evals "pydantic-ai-slim[google]"`.)
+Logfire needs no extra to instrument Pydantic AI; `pydantic-ai-slim` is Pydantic AI itself and its `[google]` extra adds the Gemini client; `pydantic-evals` is the evaluation library. (Using `uv`? `uv add logfire pydantic-evals "pydantic-ai-slim[google]"`.)
 
 ## Step 1: Build the agent
 

--- a/logfire/.agents/skills/logfire-instrumentation/SKILL.md
+++ b/logfire/.agents/skills/logfire-instrumentation/SKILL.md
@@ -153,12 +153,14 @@ async def handle_order(order_id: int):
 Logfire auto-instruments AI libraries to capture LLM calls, token usage, tool invocations, and agent runs.
 These spans can include prompts, model outputs, tool arguments, tool results, and user-controlled content.
 
+Pydantic AI, OpenAI and Anthropic need no Logfire extra — install the library itself:
+
 ```bash
-uv add 'logfire[pydantic-ai]'
-# or: uv add 'logfire[openai]' / uv add 'logfire[anthropic]'
+uv add logfire pydantic-ai
+# or: uv add logfire openai / uv add logfire anthropic
 ```
 
-Available AI extras: `pydantic-ai`, `openai`, `anthropic`, `litellm`, `dspy`, `google-genai`.
+Logfire's own AI extras are `litellm`, `dspy` and `google-genai`, e.g. `uv add 'logfire[dspy]'`.
 
 ```python
 import logfire


### PR DESCRIPTION
### What was broken

Three install instructions ask for Logfire extras that do not exist:

| Where | Command | Extra |
|---|---|---|
| `docs/cookbook/evaluate-an-agent.md` | `pip install "logfire[pydantic-ai]" …` | `pydantic-ai` |
| `docs/cookbook/debug-a-slow-tool-call.md` | `pip install "logfire[pydantic-ai,psycopg]" …` | `pydantic-ai` |
| `logfire/.agents/skills/logfire-instrumentation/SKILL.md` | `uv add 'logfire[pydantic-ai]'`, `'logfire[openai]'`, `'logfire[anthropic]'` | `pydantic-ai`, `openai`, `anthropic` |

None of the three are in `pyproject.toml`, and none are in the published wheel:

```
>>> importlib.metadata.metadata('logfire').get_all('Provides-Extra')
['aiohttp', 'aiohttp-client', 'aiohttp-server', 'asgi', 'asyncpg', 'aws-lambda', 'celery',
 'datasets', 'django', 'dspy', 'fastapi', 'flask', 'gateway', 'google-genai', 'httpx',
 'litellm', 'mysql', 'psycopg', 'psycopg2', 'pymongo', 'redis', 'requests', 'sqlalchemy',
 'sqlite3', 'starlette', 'system-metrics', 'variables', 'wsgi']
```

The cookbook also states the consequence as a fact: "`logfire[pydantic-ai]` pulls in Logfire and
Pydantic AI together." It does not.

The docs already say the right thing elsewhere, which is what made this look like an oversight
rather than a policy: `integrations/llms/pydanticai.md` — "there's no extra to add";
`integrations/llms/openai.md` and `anthropic.md` — "nothing extra to install".

### How I checked

Python 3.12.13, logfire 4.40.0 from PyPI.

Neither installer stops you, and only one of them says anything at the moment it happens:

```
$ pip install "logfire[pydantic-ai]"
WARNING: logfire 4.40.0 does not provide the extra 'pydantic-ai'

$ uv add 'logfire[anthropic]'
warning: The package `logfire==4.40.0` does not have an extra named `anthropic`
```

The skill's own next step is where it turns into a failure. Following it verbatim:

```
$ uv add 'logfire[openai]'
$ uv run python -c "import logfire; logfire.configure(); logfire.instrument_openai()"
ModuleNotFoundError: No module named 'openai'
```

The two cookbooks survive by luck: they install `pydantic-ai-slim[google]` on the same line, so
Pydantic AI arrives from that package instead. A reader who trusts the sentence and drops the
package that looks redundant gets `ModuleNotFoundError: No module named 'pydantic_ai'`.

Every replacement was installed and exercised, not just resolved:

```
$ pip install logfire pydantic-evals "pydantic-ai-slim[google]"     # no warnings
   pydantic_ai imports; logfire.instrument_pydantic_ai present; GoogleModel present

$ pip install "logfire[psycopg]" "pydantic-ai-slim[google]" "psycopg[binary]"   # no warnings
   logfire.instrument_psycopg and .instrument_pydantic_ai present; psycopg 3.3.4

$ uv add logfire pydantic-ai                                        # no warnings
   logfire.instrument_pydantic_ai() runs

$ uv add openai                                                     # in the same project
   logfire.instrument_openai() runs
```

### What it is now

- Both cookbooks install `logfire` plain; the sentence in `evaluate-an-agent.md` now says which
  package actually brings Pydantic AI.
- `debug-a-slow-tool-call.md` keeps `[psycopg]`, which is real.
- The agent skill states that Pydantic AI, OpenAI and Anthropic need no Logfire extra, and lists
  the three AI extras Logfire does ship (`litellm`, `dspy`, `google-genai`).

Docs-only, no code paths touched. `logfire[psycopg]`, `litellm`, `dspy` and `google-genai` were all
checked against the same `Provides-Extra` list above.

---
Assisted-by: Claude Opus 5 — this PR was drafted and verified by Anton's AI cofounder running on his
account. Per `dev-docs/documentation-style-guide.md` §7: every command above was run, and every
output is copied from a real run rather than reconstructed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

