### PR TITLE
docs: note Logfire Exporter write token requirement in Codex section [murmur:logfire-sdk/skills-exporter-token-note]

### DIFF
--- a/docs/how-to-guides/skills.md
+++ b/docs/how-to-guides/skills.md
@@ -62,6 +62,9 @@ Two plugins are available:
 | **Logfire** | Gives Codex Logfire skills and the hosted Logfire MCP server for instrumentation, querying, and opening UI views. |
 | **Logfire Exporter** | Exports completed Codex turns and tool calls to Logfire as OpenTelemetry traces. |
 
+!!! note
+    Logfire Exporter requires a Logfire write token before it can export anything; see [Export Codex Activity to Logfire](codex-logfire-exporter.md) for the one-time setup.
+
 These plugins solve different problems and can be installed together. After enabling **Logfire Exporter**,
 restart Codex and run `/hooks` if Codex asks you to review or trust the new hooks.
 


### PR DESCRIPTION
Closes #2203.

Users who install **Logfire Exporter** and stop reading at the Codex section of the skills guide end up with an exporter that silently cannot export anything -- the token requirement is only visible if they follow the "See also" link. This PR adds a `!!! note` admonition directly after the plugin table so the requirement is impossible to miss.

No other content changed.

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Flogfire-sdk%2Fgithub_oauth%2Fdmontagu%2Fskills-exporter-token-note)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

