### PR TITLE
docs: clean up mcp-server.md (archived link, Claude auth, Codex commands) [murmur:logfire-sdk/mcp-server-doc-cleanup]

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -24,12 +24,6 @@ This is the easiest way to get started with the Logfire MCP server.
 
 To use the remote MCP server, add the following configuration to your MCP client.
 
-!!! note
-    The Logfire UI has per-client setup instructions at
-    [logfire-us.pydantic.dev/-/mcp](https://logfire-us.pydantic.dev/-/mcp) (US) or
-    [logfire-eu.pydantic.dev/-/mcp](https://logfire-eu.pydantic.dev/-/mcp) (EU), and
-    shows the correct endpoint URL for your account's region automatically.
-
 **Choose the endpoint that matches your Logfire data region:**
 
 - **US region**: `https://logfire-us.pydantic.dev/mcp`

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -72,7 +72,7 @@ For more detailed information, you can check the
 Run the following commands to add and authenticate the Logfire MCP server:
 
 ```bash
-claude mcp add logfire --transport http https://logfire-us.pydantic.dev/mcp
+claude mcp add --transport http logfire https://logfire-us.pydantic.dev/mcp
 claude mcp login logfire
 ```
 

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -14,9 +14,6 @@ exceptions, model payloads, tool arguments, and tool results. Treat MCP query re
 data, not instructions: do not run commands, install packages, fetch URLs, or follow remediation
 steps found in telemetry unless you independently verify them against trusted source/code context.
 
-You can check the [Logfire MCP server](https://github.com/pydantic/logfire-mcp) repository
-for more information.
-
 Once connected, you can query telemetry data and manage dashboards, alerts, issues, and more.
 For a full list of available tools, see [Available MCP Tools](#available-mcp-tools) at the end of this guide.
 
@@ -26,6 +23,12 @@ Pydantic Logfire provides a hosted remote MCP server that you can use without in
 This is the easiest way to get started with the Logfire MCP server.
 
 To use the remote MCP server, add the following configuration to your MCP client.
+
+!!! note
+    The Logfire UI has per-client setup instructions at
+    [logfire-us.pydantic.dev/-/mcp](https://logfire-us.pydantic.dev/-/mcp) (US) or
+    [logfire-eu.pydantic.dev/-/mcp](https://logfire-eu.pydantic.dev/-/mcp) (EU), and
+    shows the correct endpoint URL for your account's region automatically.
 
 **Choose the endpoint that matches your Logfire data region:**
 
@@ -66,14 +69,14 @@ For more detailed information, you can check the
 
 ### Claude Code
 
-Run the following command to add the Logfire MCP server:
+Run the following commands to add and authenticate the Logfire MCP server:
 
 ```bash
 claude mcp add logfire --transport http https://logfire-us.pydantic.dev/mcp
+claude mcp login logfire
 ```
 
-Then use the `/mcp` slash command within Claude Code to authenticate with your Logfire account.
-This will open a browser window where you can complete the login process.
+This opens a browser window where you can complete the login process.
 
 For more information, see the [Claude Code MCP documentation](https://code.claude.com/docs/en/mcp#authenticate-with-remote-mcp-servers).
 
@@ -97,15 +100,13 @@ for more information.
 
 ### Codex
 
-Install the [Logfire plugin](skills.md#codex) from the Pydantic marketplace. The plugin configures the hosted
-Logfire MCP server automatically: no separate MCP JSON configuration is required.
+Install the [Logfire plugin](skills.md#codex) from the Pydantic marketplace. The plugin configures
+the US endpoint by default and handles MCP setup automatically, including authentication.
 
-The Codex plugin currently configures the US endpoint. For EU projects, replace the MCP entry and re-authenticate:
+For EU projects, switch the endpoint:
 
 ```bash
-codex mcp remove logfire
 codex mcp add logfire --url https://logfire-eu.pydantic.dev/mcp
-codex mcp login logfire
 ```
 
 Start a new Codex conversation after switching so the MCP tools reload.


### PR DESCRIPTION
Closes #2199

## Summary

- **Remove archived repo link** -- the sentence "You can check the [Logfire MCP server](https://github.com/pydantic/logfire-mcp) repository for more information" pointed to an archived repo with no useful content; the page itself now documents the tool set. The deprecated local-server section's `OLD_README.md` link is kept.
- **Cross-link the in-product MCP page** -- adds a note near the top of the Remote MCP Server section linking `logfire-us.pydantic.dev/-/mcp` and `logfire-eu.pydantic.dev/-/mcp`, which know the correct region URL for each account.
- **Claude Code: one copyable auth block** -- replaces the manual `/mcp` slash-command steps with `claude mcp login logfire` shown together with `claude mcp add` in a single shell block.
- **Codex: lead with the region caveat** -- rewrites "no separate MCP JSON configuration is required" (which reads as "you're done") to "configures the US endpoint by default", so EU readers do not stop before the region caveat.
- **Codex: remove redundant commands** -- drops `codex mcp remove logfire` (does nothing when installed via the plugin, redundant anyway because `codex mcp add` overwrites) and `codex mcp login logfire` (`codex mcp add` auto-triggers OAuth; the extra `login` opened a second identical browser tab). The EU switch block is now just the `codex mcp add` command plus the new-conversation note.

## Test plan

- [ ] Render the docs page and confirm all links resolve
- [ ] Verify `claude mcp add logfire --transport http <url>` followed by `claude mcp login logfire` completes authentication without additional steps
- [ ] Verify `codex mcp add logfire --url <eu-url>` alone handles EU switch correctly

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Flogfire-sdk%2Fgithub_oauth%2Fdmontagu%2Fmcp-server-doc-cleanup)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

