### PR TITLE
docs: add Rust tab to first-trace.md by-hand section [murmur:logfire-sdk/first-trace-rust-tab]

### DIFF
--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -39,7 +39,7 @@ Set up Pydantic Logfire in this project so it sends traces to Logfire. Follow th
 
 ## Or do it by hand
 
-Pick your language below; the Python and JavaScript/TypeScript tabs are complete, runnable examples.
+Pick your language below; the Python, JavaScript/TypeScript, and Rust tabs are complete, runnable examples.
 
 === "Python"
 
@@ -112,9 +112,43 @@ Pick your language below; the Python and JavaScript/TypeScript tabs are complete
 
     For browsers, Cloudflare Workers, and frameworks, see [Language support](instrument/index.md).
 
+=== "Rust"
+
+    **1. Install and connect**
+
+    Copy a write token (the credential your app uses to send data to a Logfire project) from **Project → Settings → Write tokens**, then add the SDK to your project and set the token:
+
+    ```bash
+    cargo add logfire
+    export LOGFIRE_TOKEN="your-write-token"
+    ```
+
+    **2. Add Logfire to your app**
+
+    ```rust title="src/main.rs"
+    fn main() -> Result<(), Box<dyn std::error::Error>> {
+        let logfire = logfire::configure().finish()?;
+        let _guard = logfire.shutdown_guard();
+
+        logfire::span!("greeting").in_scope(|| {
+            logfire::info!("Hello, world!");
+        });
+
+        Ok(())
+    }
+    ```
+
+    `configure()` connects your app to Logfire. `span!()` records one operation, and the `info!()` inside it is a log nested in that span, so together they make your first trace. `shutdown_guard()` flushes any buffered data when it is dropped at the end of `main`.
+
+    **3. Run it**
+
+    ```bash
+    cargo run
+    ```
+
 === "Any other language"
 
-    Logfire works with any language that supports OpenTelemetry (OTel), the open standard it is built on. See [Language support](instrument/index.md) for Go, Rust, Java, .NET, and more.
+    Logfire works with any language that supports OpenTelemetry (OTel), the open standard it is built on. See [Language support](instrument/index.md) for Go, Java, .NET, and more.
 
 ## See it in the Live view
 


### PR DESCRIPTION
## Summary

- Adds a `=== "Rust"` tab to the "Or do it by hand" section of `docs/first-trace.md`, giving Rust first-class treatment alongside Python and JavaScript/TypeScript
- Tab covers: `cargo add logfire` + `LOGFIRE_TOKEN` setup, a minimal runnable example (configure, span with info inside, shutdown_guard), and `cargo run` step
- API verified against the [pydantic/logfire-rust README](https://github.com/pydantic/logfire-rust) and [docs.rs/logfire](https://docs.rs/logfire/latest/logfire/)
- Updates the intro sentence to name Rust as a complete, runnable example
- Removes "Rust" from the "Any other language" tab since it now has its own dedicated tab

Closes #2200

## Test plan

- [ ] Verify the rendered docs show four tabs: Python, JavaScript/TypeScript, Rust, Any other language
- [ ] Confirm the Rust code snippet compiles: `cargo add logfire && cargo run` with a valid `LOGFIRE_TOKEN`
- [ ] Confirm "Any other language" tab no longer mentions Rust

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Flogfire-sdk%2Fgithub_oauth%2Fdmontagu%2Ffirst-trace-rust-tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

