### PR TITLE
docs: point EU/self-hosted plugin users at a plugin update, not a manual MCP entry

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -35,15 +35,18 @@ querying, and more) in one step:
         region or a self-hosted instance, set `LOGFIRE_MCP_URL` in the shell where you launch Claude
         Code, e.g. `export LOGFIRE_MCP_URL=https://logfire-eu.pydantic.dev/mcp`.
 
-        The variable requires plugin version 0.1.4 or later (`claude plugin list` shows the
-        installed version). Update an older install with:
+        The variable requires plugin version 0.1.4 or later. Run `claude plugin list` to see the
+        installed version and the marketplace it came from, then update an older install with:
 
         ```bash
         claude plugin marketplace update claude-plugins-official
         claude plugin update logfire@claude-plugins-official
         ```
 
-        Restart Claude Code afterwards for the update to take effect.
+        Restart Claude Code afterwards for the update to take effect. If you installed from the
+        `pydantic-skills` marketplace instead (see [Coding Agent Skills](skills.md)), substitute
+        that name in both commands; `claude-plugins-official` pins a specific commit of the plugin
+        repository, so a release can take longer to appear there.
 
 === "Codex"
 

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -49,10 +49,13 @@ querying, and more) in one step:
 
         `claude-plugins-official` pins a specific commit of the plugin repository, so a new release
         can take a day to appear there. If the update reports that you are already on the latest
-        version but that version is below 0.1.4, install from `pydantic-skills`, which tracks the
-        latest commit:
+        version but that version is below 0.1.4, switch to `pydantic-skills`, which tracks the
+        latest commit. Uninstall the official copy first: both marketplaces provide the same
+        `logfire` MCP server, so leaving both installed means whichever was installed last wins,
+        and an older copy hardcodes the US endpoint.
 
         ```bash
+        claude plugin remove logfire@claude-plugins-official
         claude plugin marketplace add pydantic/skills
         claude plugin install logfire@pydantic-skills
         ```

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -35,9 +35,15 @@ querying, and more) in one step:
         region or a self-hosted instance, set `LOGFIRE_MCP_URL` in the shell where you launch Claude
         Code, e.g. `export LOGFIRE_MCP_URL=https://logfire-eu.pydantic.dev/mcp`.
 
-        If your installed plugin predates version 0.1.4, the variable has no effect. Add the endpoint
-        manually instead with
-        `claude mcp add --transport http logfire https://logfire-eu.pydantic.dev/mcp`.
+        The variable requires plugin version 0.1.4 or later (`claude plugin list` shows the
+        installed version). Update an older install with:
+
+        ```bash
+        claude plugin marketplace update claude-plugins-official
+        claude plugin update logfire@claude-plugins-official
+        ```
+
+        Restart Claude Code afterwards for the update to take effect.
 
 === "Codex"
 

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -45,8 +45,17 @@ querying, and more) in one step:
 
         Restart Claude Code afterwards for the update to take effect. If you installed from the
         `pydantic-skills` marketplace instead (see [Coding Agent Skills](skills.md)), substitute
-        that name in both commands; `claude-plugins-official` pins a specific commit of the plugin
-        repository, so a release can take longer to appear there.
+        that name in both commands.
+
+        `claude-plugins-official` pins a specific commit of the plugin repository, so a new release
+        can take a day to appear there. If the update reports that you are already on the latest
+        version but that version is below 0.1.4, install from `pydantic-skills`, which tracks the
+        latest commit:
+
+        ```bash
+        claude plugin marketplace add pydantic/skills
+        claude plugin install logfire@pydantic-skills
+        ```
 
 === "Codex"
 

--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -43,9 +43,9 @@ querying, and more) in one step:
         claude plugin update logfire@claude-plugins-official
         ```
 
-        Restart Claude Code afterwards for the update to take effect. If you installed from the
-        `pydantic-skills` marketplace instead (see [Coding Agent Skills](skills.md)), substitute
-        that name in both commands.
+        Run `/reload-plugins` in Claude Code, or restart Claude Code, for the update to take effect.
+        If you installed from the `pydantic-skills` marketplace instead (see
+        [Coding Agent Skills](skills.md)), substitute that name in both commands.
 
         `claude-plugins-official` pins a specific commit of the plugin repository, so a new release
         can take a day to appear there. If the update reports that you are already on the latest
@@ -59,6 +59,8 @@ querying, and more) in one step:
         claude plugin marketplace add pydantic/skills
         claude plugin install logfire@pydantic-skills
         ```
+
+        Run `/reload-plugins` in Claude Code, or restart Claude Code, after switching marketplaces.
 
 === "Codex"
 


### PR DESCRIPTION
Follow-up to #2208.

The `LOGFIRE_MCP_URL` note told anyone on an older plugin to bypass the plugin and register the MCP server by hand (`claude mcp add ...`), which leaves them with a duplicate, unmanaged server entry and no plugin skills. Tell them how to update the plugin instead.

Verified `claude plugin marketplace update` / `claude plugin update <plugin>@<marketplace>` are the real commands (`claude plugin update --help`), and that `claude plugin list` reports the installed version.

Note the `LOGFIRE_MCP_URL` support itself is still pending in pydantic/skills#48 (latest published plugin is 0.1.3), so this note becomes accurate for everyone once that merges and the official marketplace picks it up.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

