### PR TITLE
Fix race in test_disk_retryer_close_during_retry

### DIFF
--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import textwrap
+import threading
 import weakref
 from pathlib import Path
 from typing import Any
@@ -240,21 +241,26 @@ def test_disk_retryer_close_during_retry(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(retryer.session, 'send', failing_send)
 
     # After a few sleeps, call close() so the retry loop checks self.closed and returns.
+    # close() runs on the retry thread and sets retryer.thread to None, and with time.sleep
+    # mocked the retry loop can get there before add_task even returns in the main thread,
+    # so hold off until the main thread has captured the thread reference.
+    thread_captured = threading.Event()
     sleep_count = 0
 
     def mock_sleep(seconds: float) -> None:
         nonlocal sleep_count
         sleep_count += 1
         if sleep_count >= 3:
+            thread_captured.wait(timeout=5)
             retryer.close()
 
     monkeypatch.setattr('time.sleep', mock_sleep)
 
     retryer.add_task(b'123', {'url': 'http://example.com/'})
 
-    # Capture thread reference before it can be set to None by close().
     thread = retryer.thread
     assert thread is not None
+    thread_captured.set()
     thread.join(timeout=5)
 
     assert sleep_count >= 3


### PR DESCRIPTION
The test's mocked `time.sleep` lets the retry thread burn through its loop and call `close()` (which sets `retryer.thread = None`) before the main thread returns from `add_task` and reads `retryer.thread`, failing the not-None assertion. Rare on an idle machine, but it failed 2 of 7 CI legs under xdist load on #2177, and inserting a 0.2s delay before the read reproduces it deterministically.

Fix: gate `close()` in the mocked sleep on a `threading.Event` the main thread sets after capturing the thread reference. The same delay probe passes with the fix.

Part of #2179.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

