### PR TITLE
Make sqlalchemy/sqlite3 tests xdist-safe

### DIFF
--- a/tests/otel_integrations/test_sqlalchemy.py
+++ b/tests/otel_integrations/test_sqlalchemy.py
@@ -22,6 +22,26 @@ import logfire
 import logfire._internal.integrations.sqlalchemy
 from logfire.testing import TestExporter
 
+# The tests in this module share on-disk sqlite files in the working directory, so they must not
+# run concurrently in different xdist workers (`--dist=loadgroup` schedules a group sequentially
+# on one worker).
+pytestmark = pytest.mark.xdist_group('sqlalchemy')
+
+
+@pytest.fixture(autouse=True)
+def uninstrument_after_test() -> Generator[None]:
+    """Clean up global instrumentation even when a test fails partway through.
+
+    A test that fails before reaching its uninstrument calls would otherwise leave sqlalchemy
+    and sqlite3 globally instrumented, sending phantom spans into every later test in the same
+    process through the proxy tracer provider.
+    """
+    yield
+    if SQLAlchemyInstrumentor().is_instrumented_by_opentelemetry:
+        SQLAlchemyInstrumentor().uninstrument()
+    if SQLite3Instrumentor().is_instrumented_by_opentelemetry:
+        SQLite3Instrumentor().uninstrument()
+
 
 class Base(DeclarativeBase):
     pass
@@ -44,7 +64,7 @@ def sqlite_engine(path: Path) -> Generator[Engine]:
         yield engine
     finally:
         engine.dispose()
-        path.unlink()
+        path.unlink(missing_ok=True)
 
 
 def test_sqlalchemy_instrumentation(exporter: TestExporter):
@@ -216,8 +236,6 @@ CREATE TABLE auth_records ( id INTEGER … t VARCHAR NOT NULL, PRIMARY KEY (id)
         ]
     )
 
-    SQLAlchemyInstrumentor().uninstrument()
-
 
 @pytest.mark.parametrize('parameter', ['engine', 'engines'])
 def test_sqlalchemy_instrumentation_commenter(parameter: str, exporter: TestExporter):
@@ -379,9 +397,6 @@ CREATE TABLE auth_records (
             },
         ]
     )
-
-    SQLAlchemyInstrumentor().uninstrument()
-    SQLite3Instrumentor().uninstrument()
 
 
 @contextmanager
@@ -572,8 +587,6 @@ SELECT auth_records.id AS auth_records_id, auth_records.number AS auth_records_n
             },
         ]
     )
-
-    SQLAlchemyInstrumentor().uninstrument()
 
 
 def test_missing_opentelemetry_dependency() -> None:

--- a/tests/otel_integrations/test_sqlite3.py
+++ b/tests/otel_integrations/test_sqlite3.py
@@ -11,6 +11,19 @@ import logfire._internal.integrations.sqlite3
 from logfire.testing import TestExporter
 
 
+@pytest.fixture(autouse=True)
+def uninstrument_after_test():
+    """Clean up global instrumentation even when a test fails partway through.
+
+    A test that fails before reaching its uninstrument call would otherwise leave sqlite3
+    globally instrumented, sending phantom spans into every later test in the same process
+    through the proxy tracer provider.
+    """
+    yield
+    if SQLite3Instrumentor().is_instrumented_by_opentelemetry:
+        SQLite3Instrumentor().uninstrument()
+
+
 def test_sqlite3_instrumentation(exporter: TestExporter):
     logfire.instrument_sqlite3()
 
@@ -80,7 +93,6 @@ def test_sqlite3_instrumentation(exporter: TestExporter):
         )
 
     conn.close()
-    SQLite3Instrumentor().uninstrument()
 
 
 def test_instrument_sqlite3_connection(exporter: TestExporter):


### PR DESCRIPTION
Fixes the two remaining xdist failures seen on #2177's CI (Python 3.10 leg):

1. **`test_sqlalchemy_instrumentation_commenter` `FileNotFoundError`**: both parametrizations use the same cwd-relative `example3.db`, so when xdist schedules them concurrently on different workers, the loser's teardown `unlink()` finds the file already deleted. Reproduces locally on the first `-n 4` run of the module.
2. **`test_sqlalchemy_async_instrumentation` snapshot mismatch (extra `PRAGMA read_uncommitted` span)**: a cascade of (1). The commenter test's `uninstrument()` calls sit after the `with` block, so the teardown crash skips them, leaving `SQLAlchemyInstrumentor` and `SQLite3Instrumentor` globally instrumented on that worker. Through the proxy tracer provider, the leaked instrumentation emits phantom spans into later tests' exporters; the extra span is `SQLiteDialect.get_isolation_level`'s raw-cursor query, invisible to engine-level instrumentation but captured by the leaked sqlite3 one.

Changes:
- `pytest.mark.xdist_group('sqlalchemy')` on the module so its tests co-schedule sequentially on one worker (`--dist=loadgroup` is how the suite is run).
- Teardown `unlink(missing_ok=True)` in `sqlite_engine`.
- Global uninstrumentation moved into crash-safe autouse fixtures in both `test_sqlalchemy.py` and `test_sqlite3.py` (which had the same leak hazard), replacing the end-of-test calls a failure could skip.

Verified: the module previously failed on the first local `-n 4 --dist=loadgroup` run; with the fix, 30 consecutive runs pass.

Part of #2179.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

