### PR TITLE
Preserve event loop state in DSPy test

### DIFF
--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -67,6 +67,7 @@ def test_isolated_litellm_event_loop_preserves_existing_loop() -> None:
                 assert isolated_loop is not existing_loop
 
             assert isolated_loop.is_closed()
+            assert asyncio.get_event_loop_policy() is existing_policy  # pyright: ignore[reportDeprecated]
             assert asyncio.get_event_loop() is existing_loop
             assert not existing_loop.is_closed()
         finally:

--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -32,11 +32,30 @@ def _event_loop_policy(policy: asyncio.AbstractEventLoopPolicy) -> Generator[Non
 
 
 @contextmanager
+def _current_event_loop(loop: asyncio.AbstractEventLoop) -> Generator[None, None, None]:
+    """Temporarily set a loop on Python 3.14+, where get_event_loop() never creates one."""
+    try:
+        previous_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        previous_loop = None
+
+    asyncio.set_event_loop(loop)
+    try:
+        yield
+    finally:
+        asyncio.set_event_loop(previous_loop)
+
+
+@contextmanager
 def _isolated_litellm_event_loop() -> Generator[None, None, None]:
     """Give LiteLLM a loop owned by this test without disturbing an existing loop."""
     if sys.version_info >= (3, 14):
-        # get_event_loop() raises when no loop is set, so LiteLLM uses asyncio.run().
-        yield
+        loop = asyncio.new_event_loop()
+        try:
+            with _current_event_loop(loop):
+                yield
+        finally:
+            loop.close()
         return
 
     test_policy = asyncio.DefaultEventLoopPolicy()
@@ -55,23 +74,30 @@ def isolated_litellm_event_loop() -> Iterator[None]:
         yield
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 14), reason='Event loop policies are deprecated on Python 3.14')
-def test_isolated_litellm_event_loop_preserves_existing_loop() -> None:
-    existing_policy = asyncio.DefaultEventLoopPolicy()
-    with _event_loop_policy(existing_policy):
-        existing_loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(existing_loop)
-        try:
-            with _isolated_litellm_event_loop():
-                isolated_loop = asyncio.get_event_loop()
-                assert isolated_loop is not existing_loop
+def _assert_litellm_event_loop_is_isolated(existing_loop: asyncio.AbstractEventLoop) -> None:
+    with _isolated_litellm_event_loop():
+        isolated_loop = asyncio.get_event_loop()
+        assert isolated_loop is not existing_loop
 
-            assert isolated_loop.is_closed()
-            assert asyncio.get_event_loop_policy() is existing_policy  # pyright: ignore[reportDeprecated]
-            assert asyncio.get_event_loop() is existing_loop
-            assert not existing_loop.is_closed()
-        finally:
-            existing_loop.close()
+    assert isolated_loop.is_closed()
+    assert asyncio.get_event_loop() is existing_loop
+    assert not existing_loop.is_closed()
+
+
+def test_isolated_litellm_event_loop_preserves_existing_loop() -> None:
+    existing_loop = asyncio.new_event_loop()
+    try:
+        if sys.version_info >= (3, 14):
+            with _current_event_loop(existing_loop):
+                _assert_litellm_event_loop_is_isolated(existing_loop)
+        else:
+            existing_policy = asyncio.DefaultEventLoopPolicy()
+            with _event_loop_policy(existing_policy):
+                asyncio.set_event_loop(existing_loop)
+                _assert_litellm_event_loop_is_isolated(existing_loop)
+                assert asyncio.get_event_loop_policy() is existing_policy  # pyright: ignore[reportDeprecated]
+    finally:
+        existing_loop.close()
 
 
 def test_missing_openinference_dependency() -> None:

--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import logging
 import os
-from collections.abc import Iterator
+import sys
+from collections.abc import Generator, Iterator
+from contextlib import contextmanager
 from unittest import mock
 
 import pydantic
@@ -17,16 +21,56 @@ if get_version(pydantic.__version__) < get_version('2.5.0'):
     pytest.skip('DSPy/LiteLLM requires Pydantic >= 2.5 for Discriminator import', allow_module_level=True)
 
 
-@pytest.fixture
-def close_litellm_event_loop() -> Iterator[None]:
-    """Close the event loop LiteLLM's synchronous service hook creates on Python 3.10."""
-    yield
+@contextmanager
+def _event_loop_policy(policy: asyncio.AbstractEventLoopPolicy) -> Generator[None, None, None]:
+    previous_policy = asyncio.get_event_loop_policy()  # pyright: ignore[reportDeprecated]
+    asyncio.set_event_loop_policy(policy)  # pyright: ignore[reportDeprecated]
     try:
-        loop = asyncio.get_event_loop()
-    except RuntimeError:
+        yield
+    finally:
+        asyncio.set_event_loop_policy(previous_policy)  # pyright: ignore[reportDeprecated]
+
+
+@contextmanager
+def _isolated_litellm_event_loop() -> Generator[None, None, None]:
+    """Give LiteLLM a loop owned by this test without disturbing an existing loop."""
+    if sys.version_info >= (3, 14):
+        # get_event_loop() raises when no loop is set, so LiteLLM uses asyncio.run().
+        yield
         return
-    loop.close()
-    asyncio.set_event_loop(None)
+
+    test_policy = asyncio.DefaultEventLoopPolicy()
+    with _event_loop_policy(test_policy):
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            yield
+        finally:
+            loop.close()
+
+
+@pytest.fixture
+def isolated_litellm_event_loop() -> Iterator[None]:
+    with _isolated_litellm_event_loop():
+        yield
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 14), reason='Event loop policies are deprecated on Python 3.14')
+def test_isolated_litellm_event_loop_preserves_existing_loop() -> None:
+    existing_policy = asyncio.DefaultEventLoopPolicy()
+    with _event_loop_policy(existing_policy):
+        existing_loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(existing_loop)
+        try:
+            with _isolated_litellm_event_loop():
+                isolated_loop = asyncio.get_event_loop()
+                assert isolated_loop is not existing_loop
+
+            assert isolated_loop.is_closed()
+            assert asyncio.get_event_loop() is existing_loop
+            assert not existing_loop.is_closed()
+        finally:
+            existing_loop.close()
 
 
 def test_missing_openinference_dependency() -> None:
@@ -41,7 +85,7 @@ You can install this with:
 
 
 @pytest.mark.vcr()
-def test_dspy_instrumentation(exporter: TestExporter, close_litellm_event_loop: None) -> None:
+def test_dspy_instrumentation(exporter: TestExporter, isolated_litellm_event_loop: None) -> None:
     # Skip test if dspy can't be imported due to compatibility issues
     dspy = pytest.importorskip('dspy', reason='DSPy import failed due to environment incompatibility')
 


### PR DESCRIPTION
## Summary

- isolate LiteLLM's synchronous service-hook loop from any pre-existing test loop
- restore the prior event-loop policy after the DSPy integration test
- add a regression proving the temporary loop is closed while an existing loop remains active

## Root cause

This follows up on the unresolved automated-review findings from #2177. The cleanup fixture added there called `asyncio.get_event_loop()` during teardown and then closed and cleared whichever loop it returned. That could close a loop owned by another fixture or disturb worker state when DSPy skipped before LiteLLM ran.

Python 3.10–3.13 still allow LiteLLM's synchronous hook to obtain an implicitly managed loop, so the test now installs a test-owned policy and loop only on those versions. On Python 3.14, `get_event_loop()` raises when no loop is configured and LiteLLM already falls back to `asyncio.run()`.

## Impact

This is test-only. It removes a source of cross-test event-loop interference without changing SDK behavior.

## Validation

- full xdist suite: 2,292 passed, 9 skipped, 2 xfailed
- focused DSPy tests on Python 3.10 and Python 3.12, both serial and with xdist
- focused runs with `ResourceWarning` promoted to an error
- repository commit hooks: Ruff, Ruff Format, and Pyright


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

