### PR TITLE
fix(auth,client): add timeout to outbound HTTP session requests

### DIFF
--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -24,6 +24,14 @@ HOME_LOGFIRE = Path.home() / '.logfire'
 DEFAULT_FILE = HOME_LOGFIRE / 'default.toml'
 """File used to store user tokens."""
 
+DEVICE_FLOW_TIMEOUT = 15
+"""Timeout (in seconds) for both requests in the device authorization flow.
+
+The `wait` endpoint blocks server-side for ~10 seconds while it waits for the user to
+authenticate, so this is a snug bound around that rather than a general-purpose HTTP timeout.
+Both halves of the flow use it so they can't drift apart.
+"""
+
 
 LOGFIRE_TOKEN_REGION_PATTERN = re.compile(r'^pylf_v[0-9]+_(?P<region>[a-z]+)_')
 PYDANTIC_LOGFIRE_TOKEN_PATTERN = re.compile(
@@ -250,7 +258,7 @@ def request_device_code(session: requests.Session, base_api_url: str) -> tuple[s
     machine_name = platform.uname()[1]
     device_auth_endpoint = urljoin(base_api_url, '/v1/device-auth/new/')
     try:
-        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=15)
+        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=DEVICE_FLOW_TIMEOUT)
         UnexpectedResponse.raise_for_status(res)
     except requests.RequestException as e:  # pragma: no cover
         raise LogfireConfigError('Failed to request a device code.') from e
@@ -277,7 +285,7 @@ def poll_for_token(session: requests.Session, device_code: str, base_api_url: st
     errors = 0
     while True:
         try:
-            res = session.get(auth_endpoint, timeout=15)
+            res = session.get(auth_endpoint, timeout=DEVICE_FLOW_TIMEOUT)
             UnexpectedResponse.raise_for_status(res)
         except requests.RequestException as e:
             errors += 1

--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -250,7 +250,7 @@ def request_device_code(session: requests.Session, base_api_url: str) -> tuple[s
     machine_name = platform.uname()[1]
     device_auth_endpoint = urljoin(base_api_url, '/v1/device-auth/new/')
     try:
-        res = session.post(device_auth_endpoint, params={'machine_name': machine_name})
+        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=15)
         UnexpectedResponse.raise_for_status(res)
     except requests.RequestException as e:  # pragma: no cover
         raise LogfireConfigError('Failed to request a device code.') from e

--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -24,7 +24,7 @@ HOME_LOGFIRE = Path.home() / '.logfire'
 DEFAULT_FILE = HOME_LOGFIRE / 'default.toml'
 """File used to store user tokens."""
 
-DEVICE_FLOW_TIMEOUT = 15
+_DEVICE_FLOW_TIMEOUT = 15
 """Timeout (in seconds) for both requests in the device authorization flow.
 
 The `wait` endpoint blocks server-side for ~10 seconds while it waits for the user to
@@ -258,7 +258,7 @@ def request_device_code(session: requests.Session, base_api_url: str) -> tuple[s
     machine_name = platform.uname()[1]
     device_auth_endpoint = urljoin(base_api_url, '/v1/device-auth/new/')
     try:
-        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=DEVICE_FLOW_TIMEOUT)
+        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=_DEVICE_FLOW_TIMEOUT)
         UnexpectedResponse.raise_for_status(res)
     except requests.RequestException as e:  # pragma: no cover
         raise LogfireConfigError('Failed to request a device code.') from e
@@ -285,7 +285,7 @@ def poll_for_token(session: requests.Session, device_code: str, base_api_url: st
     errors = 0
     while True:
         try:
-            res = session.get(auth_endpoint, timeout=DEVICE_FLOW_TIMEOUT)
+            res = session.get(auth_endpoint, timeout=_DEVICE_FLOW_TIMEOUT)
             UnexpectedResponse.raise_for_status(res)
         except requests.RequestException as e:
             errors += 1

--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -14,6 +14,7 @@ from .server_response import ServerResponseCallback, install_logfire_response_ho
 from .utils import UnexpectedResponse
 
 UA_HEADER = f'logfire/{VERSION}'
+_REQUEST_TIMEOUT = 30
 
 
 class ProjectAlreadyExists(Exception):
@@ -69,7 +70,7 @@ class LogfireClient:
         )
 
     def _get_raw(self, endpoint: str, params: dict[str, Any] | None = None) -> Response:
-        response = self._session.get(urljoin(self.base_url, endpoint), params=params)
+        response = self._session.get(urljoin(self.base_url, endpoint), params=params, timeout=_REQUEST_TIMEOUT)
         UnexpectedResponse.raise_for_status(response)
         return response
 
@@ -80,12 +81,12 @@ class LogfireClient:
             raise LogfireConfigError(error_message) from e
 
     def _post_raw(self, endpoint: str, body: Any | None = None) -> Response:
-        response = self._session.post(urljoin(self.base_url, endpoint), json=body)
+        response = self._session.post(urljoin(self.base_url, endpoint), json=body, timeout=_REQUEST_TIMEOUT)
         UnexpectedResponse.raise_for_status(response)
         return response
 
     def _put_raw(self, endpoint: str, body: Any | None = None) -> Response:  # pragma: no cover
-        response = self._session.put(urljoin(self.base_url, endpoint), json=body)
+        response = self._session.put(urljoin(self.base_url, endpoint), json=body, timeout=_REQUEST_TIMEOUT)
         UnexpectedResponse.raise_for_status(response)
         return response
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,7 @@ import requests
 import requests_mock
 from inline_snapshot import snapshot
 
-from logfire._internal.auth import UserToken, UserTokenCollection, request_device_code
+from logfire._internal.auth import DEVICE_FLOW_TIMEOUT, UserToken, UserTokenCollection, request_device_code
 from logfire.exceptions import LogfireConfigError
 
 
@@ -195,5 +195,5 @@ def test_request_device_code_sends_a_timeout() -> None:
 
         assert result == ('device-code', 'https://logfire-us.pydantic.dev/auth/device-code')
         assert m.last_request is not None
-        # Matches the timeout used by `poll_for_token` for the other half of the device flow.
-        assert m.last_request.timeout == 15
+        # Both halves of the device flow share this timeout.
+        assert m.last_request.timeout == DEVICE_FLOW_TIMEOUT

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,7 +9,7 @@ import requests
 import requests_mock
 from inline_snapshot import snapshot
 
-from logfire._internal.auth import DEVICE_FLOW_TIMEOUT, UserToken, UserTokenCollection, request_device_code
+from logfire._internal.auth import UserToken, UserTokenCollection, request_device_code
 from logfire.exceptions import LogfireConfigError
 
 
@@ -196,4 +196,4 @@ def test_request_device_code_sends_a_timeout() -> None:
         assert result == ('device-code', 'https://logfire-us.pydantic.dev/auth/device-code')
         assert m.last_request is not None
         # Both halves of the device flow share this timeout.
-        assert m.last_request.timeout == DEVICE_FLOW_TIMEOUT
+        assert m.last_request.timeout == 15

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 
 import inline_snapshot.extra
 import pytest
+import requests
+import requests_mock
 from inline_snapshot import snapshot
 
-from logfire._internal.auth import UserToken, UserTokenCollection
+from logfire._internal.auth import UserToken, UserTokenCollection, request_device_code
 from logfire.exceptions import LogfireConfigError
 
 
@@ -177,3 +179,21 @@ def test_logout_all_multiple_regions(multiple_credentials: Path) -> None:
     removed = token_collection.logout()
     assert removed == ['https://logfire-us.pydantic.dev', 'https://logfire-eu.pydantic.dev']
     assert multiple_credentials.read_text() == ''
+
+
+def test_request_device_code_sends_a_timeout() -> None:
+    """The device code request must carry a timeout, otherwise `logfire auth` hangs on an unresponsive server."""
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        result = request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert result == ('device-code', 'https://logfire-us.pydantic.dev/auth/device-code')
+        assert m.last_request is not None
+        # Matches the timeout used by `poll_for_token` for the other half of the device flow.
+        assert m.last_request.timeout == 15

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,10 +4,7 @@ import pytest
 import requests_mock
 
 from logfire._internal.auth import UserToken
-from logfire._internal.client import (
-    _REQUEST_TIMEOUT,  # pyright: ignore[reportPrivateUsage]
-    LogfireClient,
-)
+from logfire._internal.client import LogfireClient
 
 
 def test_client_expired_token() -> None:
@@ -32,7 +29,7 @@ def test_requests_send_a_timeout() -> None:
         client._put_raw('/v1/anything', body={})  # pyright: ignore[reportPrivateUsage]
 
     assert [(request.method, request.timeout) for request in m.request_history] == [
-        ('GET', _REQUEST_TIMEOUT),
-        ('POST', _REQUEST_TIMEOUT),
-        ('PUT', _REQUEST_TIMEOUT),
+        ('GET', 30),
+        ('POST', 30),
+        ('PUT', 30),
     ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,38 @@
 from __future__ import annotations
 
 import pytest
+import requests_mock
 
 from logfire._internal.auth import UserToken
-from logfire._internal.client import LogfireClient
+from logfire._internal.client import (
+    _REQUEST_TIMEOUT,  # pyright: ignore[reportPrivateUsage]
+    LogfireClient,
+)
 
 
 def test_client_expired_token() -> None:
     with pytest.raises(RuntimeError):
         LogfireClient(user_token=UserToken(token='abc', base_url='http://localhost', expiration='1970-01-01T00:00:00'))
+
+
+def test_requests_send_a_timeout() -> None:
+    """Every request the client makes must carry a timeout, otherwise an unresponsive server hangs the CLI."""
+    client = LogfireClient(
+        user_token=UserToken(token='abc', base_url='http://localhost', expiration='2099-12-31T23:59:59')
+    )
+
+    with requests_mock.Mocker() as m:
+        m.get('http://localhost/v1/account/me', json={'name': 'me'})
+        m.post('http://localhost/v1/organizations/my-org/projects/my-project/write-tokens/', json={'token': 'abc'})
+        m.put('http://localhost/v1/anything', json={})
+
+        client.get_user_information()
+        client.create_write_token('my-org', 'my-project')
+        # `_put_raw` has no public caller yet, so exercise the PUT path directly.
+        client._put_raw('/v1/anything', body={})  # pyright: ignore[reportPrivateUsage]
+
+    assert [(request.method, request.timeout) for request in m.request_history] == [
+        ('GET', _REQUEST_TIMEOUT),
+        ('POST', _REQUEST_TIMEOUT),
+        ('PUT', _REQUEST_TIMEOUT),
+    ]


### PR DESCRIPTION
auth.py already uses timeout=15 on the poll_for_token request but the preceding device_auth POST has no timeout. client.py makes GET, POST, and PUT calls through the session with no timeout set. A slow or unresponsive logfire backend will hang these calls indefinitely. Added timeout=15 in auth.py to match the existing pattern, and a shared timeout constant in client.py applied to all three request methods.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

