### PR TITLE
Correct released Evals and human-review docs

### DIFF
--- a/dev-docs/documentation-style-guide.md
+++ b/dev-docs/documentation-style-guide.md
@@ -296,11 +296,14 @@ append-only shared infrastructure.
   software that has no single right answer.
 - **offline eval**: running evals against a fixed dataset, like a test suite.
 - **online / live eval**: scoring real production traffic as it happens, like monitoring.
-- **scorer / evaluator**: the thing that judges an output and produces a score (code, or an LLM).
-- **score**: one saved quality rating for an output, from a human or an automated scorer.
+- **scorer / evaluator**: the thing that judges an output and produces one or more evaluator results (code, or an LLM).
+- **evaluator result**: an automated judgment about an output, represented as an assertion, numeric score, or categorical label.
+- **assertion**: a pass/fail evaluator result.
+- **score**: a numeric evaluator result whose scale and direction come from the evaluator.
+- **label**: a categorical evaluator result, such as `safe`, `unsafe`, or `needs_review`.
 - **LLM-as-a-judge**: using a language model to score another model's output.
 - **dataset**: a collection of test cases (inputs and expected outputs) you evaluate against.
-- **experiment**: one run of your AI over a dataset, producing scores you can compare across versions.
+- **experiment**: one run of your AI over a dataset, producing evaluator results you can compare across versions.
 - **session**: a group of related interactions (e.g. one multi-turn conversation).
 - **token** (LLM): the unit models read and bill by; a few characters of text. *(Disambiguate from
   "write token" when both appear.)*

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -256,7 +256,7 @@ Run `python eval.py` again. Now that the agent can't call `order_status`, it ans
 
 Look at the order rows: `✗✔`. `MentionsFact` failed, but the `LLMJudge` still **passed**. "I don't have access to your order information" reads polite and helpful, so the judge waves it through; only the deterministic scorer catches that the answer is useless. That's the judge-fooling failure mode from step 3, caught live.
 
-**What you'll see in Logfire:** open the [Evals: Datasets & Experiments](../evaluate/datasets-and-experiments.md) page, select both experiments (`support-agent-baseline` and `support-agent-no-tools`) with the checkboxes, and click **Compare**. Logfire lines the two runs up case by case and highlights the differences. You'll see the pass rate fall and can click straight into a failing case's trace to confirm the agent never called the tool.
+**What you'll see in Logfire:** open the [Evals: Datasets & Experiments](../evaluate/datasets-and-experiments.md) page and open `support-agent-no-tools` as the candidate. Select **Compare runs**, then choose `support-agent-baseline` as the baseline. Logfire lines up the two runs case by case and highlights the differences. You'll see the pass rate fall and can click straight into a failing case's trace to confirm the agent never called the tool.
 
 That comparison is the whole reason evals exist: "it feels worse" becomes "the pass rate went from 100% to 66.7% on these cases, and here's the trace showing why." Wire this eval into your continuous integration (the automated checks that run on every change), asserting on the pass rate the report gives you, so a regression like this fails the build before it reaches a user.
 

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -273,7 +273,7 @@ To review one of the support-agent runs:
 3. Find the uncertain run and select **Add annotation**.
 4. Choose **Pass**, **Neutral**, or **Fail**, explain the evidence in **Comment**, and select **Save**.
 
-For a systematic batch of reviews, use an annotation queue instead of finding each run manually. The interactions a reviewer flags as bad are strong candidates for your dataset, so future evals can test them again. See [Human review](../evaluate/human-review.md) for the full workflow.
+If your team participates in the Design Partner early-access program, use an annotation queue for a systematic batch of reviews instead of finding each run manually. The interactions a reviewer flags as bad are strong candidates for your dataset, so future evals can test them again. See [Human review](../evaluate/human-review.md) for availability and the full workflow.
 
 ## What you've got now
 

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -273,7 +273,7 @@ To review one of the support-agent runs:
 3. Find the uncertain run and select **Add annotation**.
 4. Choose **Pass**, **Neutral**, or **Fail**, explain the evidence in **Comment**, and select **Save**.
 
-If your team participates in the Design Partner early-access program, use an annotation queue for a systematic batch of reviews instead of finding each run manually. The interactions a reviewer flags as bad are strong candidates for your dataset, so future evals can test them again. See [Human review](../evaluate/human-review.md) for availability and the full workflow.
+If your team participates in the Design Partner early-access program, an annotation queue provides a systematic batch of runs to review instead of making reviewers find each run manually. The interactions a reviewer flags as bad are strong candidates for your dataset, so future evals can test them again. See [Human review](../evaluate/human-review.md) to compare the two review modes and check availability.
 
 ## What you've got now
 

--- a/docs/cookbook/evaluate-an-agent.md
+++ b/docs/cookbook/evaluate-an-agent.md
@@ -20,7 +20,7 @@ A few terms, defined once:
 - A **span** is one unit of work: a single operation, with a name, a start, and a duration.
 - A **trace** is the full journey of one request or agent run, made of nested spans (the agent run, its model call, each tool call).
 - A **token** is the unit language models read and bill by: a few characters of text.
-- A **scorer** (also called an **evaluator**) is the thing that judges an output. Each scorer produces a **score**: one saved quality rating for an output.
+- A **scorer** (also called an **evaluator**) is the thing that judges an output. Each scorer produces evaluator results, such as pass/fail assertions or numeric scores.
 
 ## Prerequisites
 
@@ -29,7 +29,7 @@ A few terms, defined once:
 - **A Google Gemini API key**, from [Google AI Studio](https://aistudio.google.com/apikey), set as the `GEMINI_API_KEY` environment variable. The agent below uses `google:gemini-flash-lite-latest`; any [model Pydantic AI supports](https://pydantic.dev/docs/ai/models/) works the same way: swap the model string and set that provider's key instead.
 
 !!! note "Consequence: this sends data, and some of it costs money"
-    Running the agent and the eval sends traces, inputs, outputs, and scores to your Logfire project, where they're stored and visible to your team. Every model call (the agent's own answers *and* the LLM-as-a-judge scorer you'll add in step 3) is a real, billed API call to your provider. A dozen cases with one judge is a few dozen calls; keep that in mind before you point this at a 500-case dataset.
+    Running the agent and the eval sends traces, inputs, outputs, and evaluator results to your Logfire project, where they're stored and visible to your team. Every model call (the agent's own answers *and* the LLM-as-a-judge scorer you'll add in step 3) is a real, billed API call to your provider. A dozen cases with one judge is a few dozen calls; keep that in mind before you point this at a 500-case dataset.
 
 Install the packages you need:
 
@@ -264,33 +264,16 @@ Now change the prompt back so you're on the good version again.
 
 ## Step 5: Send the uncertain cases to a human
 
-Some answers can't be settled by code or by a model: *was this reply actually the right call?* When the judge is unsure, or a real user reacts, route that answer to a person. Their judgment lands as the **same kind of score** as your automated ones, so it sits next to the code and LLM scores on the same output and rolls up into the same numbers.
+Some answers can't be settled by code or by a model: *was this reply actually the right call?* When the judge is unsure, route that agent run to a person. A run annotation records an editable human verdict and supporting evidence. It remains separate from the automated evaluator results in the experiment.
 
-The most direct path in your own product: capture a signal (a thumbs-up/down on the answer) and attach it to the span with `record_feedback`. Save the span's **traceparent** (a short string that identifies the span) when you answer, then reference it when the user reacts:
+To review one of the support-agent runs:
 
-```python skip-run="true" skip-reason="external-connection"
-import logfire
-from logfire.experimental.annotations import get_traceparent, record_feedback
+1. Open **Annotations** under **AI Evaluations** in Logfire.
+2. Select the support agent, then select **Proceed to annotate**.
+3. Find the uncertain run and select **Add annotation**.
+4. Choose **Pass**, **Neutral**, or **Fail**, explain the evidence in **Comment**, and select **Save**.
 
-logfire.configure()
-
-with logfire.span('answer support question') as span:
-    traceparent = get_traceparent(span)  # save this alongside the reply you return
-    ...  # run the agent, return the answer
-
-# later, when the user clicks thumbs-up in your product:
-record_feedback(
-    traceparent,
-    'helpful',  # the feedback's name
-    True,  # bool = pass/fail, number = score, string = label
-    comment='User clicked thumbs up',
-)
-```
-
-The interactions a human flags as bad are exactly the cases you want to fold back into your dataset, so every future eval re-tests them. See [Human review](../evaluate/human-review.md) for annotating traces by hand, working an annotation queue, and the full `record_feedback` API.
-
-!!! note "Experimental API"
-    `record_feedback` and `get_traceparent` live in `logfire.experimental.annotations`; the interface may change in a future release.
+For a systematic batch of reviews, use an annotation queue instead of finding each run manually. The interactions a reviewer flags as bad are strong candidates for your dataset, so future evals can test them again. See [Human review](../evaluate/human-review.md) for the full workflow.
 
 ## What you've got now
 
@@ -299,9 +282,9 @@ Starting from a handful of lines of agent code, you now have:
 - **Every agent run traced**: model calls, tokens, cost, and tool calls, readable as a transcript, so a wrong answer is something you can *see* rather than guess at.
 - **A repeatable quality measure**: a dataset and two scorers that turn "seems fine" into a pass rate you can defend.
 - **A regression caught on purpose**: proof that comparing experiments tells you which direction a change moved quality, before a user finds out.
-- **A path to human judgment**: user feedback and hand review landing as the same scores as your automated ones.
+- **A path to human judgment**: editable run annotations that reviewers can use to identify new regression cases.
 
-The insight the journey produces: observability and evaluation aren't separate tools. The trace tells you *what happened*; the eval tells you *whether it was good*; the human tells you *when the machine wasn't sure*. All three attach to the same run, so you can move from a bad score straight to the trace that explains it.
+The insight the journey produces: observability and evaluation aren't separate tools. The trace tells you *what happened*; the eval measures selected behavior; the human records context that automated checks missed. Together they help you turn a production failure into a repeatable regression case.
 
 ## Troubleshooting
 
@@ -311,7 +294,7 @@ The insight the journey produces: observability and evaluation aren't separate t
 ## What's next
 
 - [AI observability](../ai-observability.md): the full picture of what Logfire captures from your agent, and why seeing the whole stack (not just the model) matters.
-- [Evaluate your AI](../evaluate/overview.md): the concepts behind datasets, scorers, scores, and experiments, plus best practices for LLM judges.
+- [Evaluate your AI](../evaluate/overview.md): the concepts behind datasets, evaluators, results, and experiments, plus best practices for LLM judges.
 - [Run an evaluation](../evaluate/evals-in-code.md): the offline eval path in full, including hosted datasets shared with your team.
-- [Human review](../evaluate/human-review.md): annotate traces, work an annotation queue, and capture user feedback as scores.
+- [Human review](../evaluate/human-review.md): annotate agent runs directly or work through an annotation queue.
 - [Live Evaluations](../evaluate/live-evals.md): score real production traffic automatically, then send the uncertain cases here to human review.

--- a/docs/evaluate/annotate-agent-runs.md
+++ b/docs/evaluate/annotate-agent-runs.md
@@ -7,13 +7,13 @@ description: "Review an agent interaction and record a pass, neutral, or fail ve
 
 Review an agent interaction in context, then save a verdict, comment, and tags that explain what it got right or wrong.
 
-An agent **run** is one end-to-end invocation of your agent, including its messages, model calls, and tool calls. Annotate a run when you need a human judgment that automated checks cannot provide, such as whether an answer was helpful, safe, or on-topic. The result is a [score](human-review.md), one saved quality rating for an output, that you can compare with your automated evaluations.
+An agent **run** is one end-to-end invocation of your agent, including its messages, model calls, and tool calls. Annotate a run when you need a human judgment that automated checks cannot provide, such as whether an answer was helpful, safe, or on-topic. The result is an editable [run annotation](human-review.md) that remains separate from automated evaluator results.
 
-Use this direct workflow when you are investigating one run or a small sample in context. For a systematic batch of reviews, use an [annotation queue](human-review.md#work-an-annotation-queue) to give reviewers a curated list of interactions.
+Use this direct workflow when you are investigating one run or a small sample in context. For a systematic batch of reviews, use an [annotation queue](human-review.md#work-through-an-annotation-queue) to give reviewers a curated list of interactions.
 
 !!! note "Run annotations are in Beta"
 
-    Run-level annotations are behind the `run_annotations` feature flag and may change. Span annotations are generally available.
+    Run annotations are available in every project, but the workflow may change while it is in Beta.
 
 !!! note "Review data is stored in Logfire"
 
@@ -57,10 +57,10 @@ The agent needs recorded runs in the selected time range. Send or wait for an ag
 
 ### I do not see the annotation controls
 
-Run annotations require the `run_annotations` feature flag. Ask a project administrator to enable it for your project.
+Open the interaction from **Agents** > **Runs**. Run annotations are attached to complete agent runs and are not available from the generic Live view.
 
 ## Next steps
 
-- [Human review](human-review.md): understand how annotations, queues, and end-user feedback become scores.
+- [Human review](human-review.md): understand how direct review and annotation queues support evaluation work.
 - [Run an evaluation](evals-in-code.md): compare a fixed dataset against your scoring criteria.
 - [Live Evaluations](live-evals.md): score production traffic automatically, then use annotations for the cases that need human review.

--- a/docs/evaluate/annotate-agent-runs.md
+++ b/docs/evaluate/annotate-agent-runs.md
@@ -9,7 +9,7 @@ Review an agent interaction in context, then save a verdict, comment, and tags t
 
 An agent **run** is one end-to-end invocation of your agent, including its messages, model calls, and tool calls. Annotate a run when you need a human judgment that automated checks cannot provide, such as whether an answer was helpful, safe, or on-topic. The result is an editable [run annotation](human-review.md) that remains separate from automated evaluator results.
 
-Use this direct workflow when you are investigating one run or a small sample in context. For a systematic batch of reviews, use an [annotation queue](human-review.md#work-through-an-annotation-queue) to give reviewers a curated list of interactions.
+Use this direct workflow when you are investigating one run or a small sample in context. Design Partner customers participating in early access can use an [annotation queue](human-review.md#work-through-an-annotation-queue) for a systematic batch of interactions.
 
 !!! note "Run annotations are in Beta"
 

--- a/docs/evaluate/human-review.md
+++ b/docs/evaluate/human-review.md
@@ -1,93 +1,59 @@
 ---
-title: "Human review: score AI outputs by hand"
-description: "Add human judgment to your AI evaluations in Pydantic Logfire: annotate spans and runs, work an annotation queue, and capture user feedback as scores."
+title: "Review AI outputs by hand"
+description: "Add human judgment to agent runs in Pydantic Logfire by reviewing runs directly or working through an annotation queue."
 ---
 
-# Human review
+# Review AI outputs by hand
 
-Some questions about an AI's output can't be answered by code or by another model: was this support reply actually helpful? was the tone right? did the agent do the sensible thing? **Human review** is how a person looks at a real interaction and records a judgment. That judgment lands as a **score** (one saved quality rating for an output), the same kind of score your automated evaluations produce, so human ratings sit next to code and LLM-as-a-judge ratings on the same output and roll up into the same numbers.
+Review an agent run when code and model-based evaluators cannot decide whether the result was helpful, safe, or appropriate.
 
-If you're new to scores and evaluations, read the [evals overview](overview.md) first. This page assumes those terms.
+A **run annotation** is editable reviewer feedback attached to one end-to-end agent invocation. It can record a pass, neutral, or fail verdict, plus a comment and tags that explain the decision. Run annotations are human-review evidence, not automated evaluator results, and they do not roll into experiment or Live Evaluation aggregates.
 
-## When you'd do this
+## When to use human review
 
-- You need a ground-truth label a machine can't produce: "was this answer genuinely helpful?"
-- You're building the ~20–100 hand-labeled cases you need to [benchmark an LLM judge](overview.md#best-practices-with-the-reason-attached) before trusting it.
-- You want to curate real production interactions into a [dataset](datasets-and-experiments.md) of good and bad examples.
-- You want to hear directly from your end users: a thumbs-up/down on an answer, in your own product.
+- Build a hand-labeled set for checking whether an LLM judge agrees with your reviewers.
+- Investigate production interactions where automated signals are missing or ambiguous.
+- Identify failures worth preserving as cases in a repeatable [dataset](datasets-and-experiments.md).
+- Apply a shared review criterion across a sample of agent runs.
 
-## Three ways to do one job
+## Choose direct review or a queue
 
-Human review shows up in three places in Logfire. They differ in *who* does the reviewing and *how* the work is dispatched, but all three produce the same thing: **scores attached to an output**.
+### Review one run
 
-### Annotate a span or a run
-
-The most direct form: open a **span** (one unit of work: a single operation, with a name, a start, and a duration) or a whole **run** in the [live view](../guides/web-ui/live.md), and record your judgment on it directly: a pass/fail flag, a label, a numeric rating, or a free-text note. Reach for this when you're already looking at a trace and want to capture what you see.
-
-For the agent-run workflow in the web UI, see [Annotate an agent run](annotate-agent-runs.md).
-
-- **Span annotation**: rate a single operation: this one LLM call, this one tool call.
-- **Run annotation** (Beta): rate a whole run of your AI (an end-to-end agent invocation across many spans) as one unit, rather than a single span inside it. Enable it with the `run_annotations` feature flag.
+Use direct review when you are investigating one run or a small sample. Open the run, inspect its messages, model calls, tool calls, and output, then save your judgment. Follow [Annotate an agent run](annotate-agent-runs.md) for the complete workflow.
 
 !!! note "Run annotations are in Beta"
 
-    Run-level annotations are behind the `run_annotations` feature flag and may change. Span annotations are generally available.
+    Run annotations are available in every project, but the workflow may change while it is in Beta.
 
-### Work an annotation queue
+### Work through an annotation queue
 
-When review needs to be systematic rather than opportunistic (a reviewer sitting down to label 100 interactions in a row), an **annotation queue** is a curated list of interactions lined up for review, so a reviewer works through them one after another instead of hunting for traces to rate. Fill a queue from production traffic (for example, every low-scoring call, or a random sample), then a human works down the list, and each judgment is saved as a score on that interaction.
+Use an **annotation queue** when review needs to be systematic. A queue gives reviewers a curated list of agent runs to inspect one after another instead of asking them to find runs manually. Teams can use queues for a random quality sample or for interactions selected by another signal.
 
 !!! note "Annotation queues are a Design Partner feature"
 
-    Annotation queues are available to Design Partner customers (teams on our early-access program).
+    Annotation queues are available to Design Partner customers participating in the early-access program.
 
-### Capture user feedback
+## Make the judgment reusable
 
-The reviewer doesn't have to be on your team: it can be your end user. Capture a signal from inside your own product (a thumbs-up/down, a star rating, a "this didn't help" click) and attach it to the interaction that produced it. That feedback is stored as a score on the same output, so real-user judgment sits alongside your internal reviews and your automated scorers.
+Agree on one sentence that defines the criterion before reviewing. For example: "The answer resolves the customer's question without inventing details."
 
-Attach feedback to a span with `record_feedback`. When you handle the request, save the span's **traceparent** (a short string that identifies the span); later, when the user reacts, reference it to record their rating:
+For each run:
 
-```python
-import logfire
-from logfire.experimental.annotations import get_traceparent, record_feedback
+1. Choose **Pass**, **Neutral**, or **Fail** using that criterion.
+2. Add a comment that identifies the evidence behind the verdict.
+3. Add tags such as `hallucination`, `tone`, or `tool-error` when they will help reviewers find related cases.
 
-logfire.configure()
-
-with logfire.span('answer question') as span:
-    traceparent = get_traceparent(span)  # save this alongside the response you return
-    ...  # produce the answer
-
-# later, when the user reacts in your product:
-record_feedback(
-    traceparent,
-    'helpful',  # the name of the feedback
-    True,  # the type sets the score's shape: bool = pass/fail, number = numeric, string = label
-    comment='User clicked thumbs up',
-)
-```
-
-The value's type sets the score's **shape** (a **bool** records a pass/fail, a **string** records a label, a **number** records a numeric rating) and any `comment` is saved as the reason. Open that trace in the Live view and you'll see the `helpful` score on the span, next to any scores from your automated evaluators.
-
-!!! note "Experimental API"
-
-    `record_feedback` and `get_traceparent` live in `logfire.experimental.annotations`; the interface may change in a future release.
-
-## Why these feed your evals
-
-Because all three produce scores, human review isn't a separate island:
-
-- **Ground truth for judges.** Hand-labeled scores are what you [benchmark an LLM judge against](overview.md#best-practices-with-the-reason-attached). If the judge disagrees with your humans a third of the time, you know its automated scores aren't trustworthy yet.
-- **Seeds for datasets.** An interaction a human flagged as bad is exactly the case you want in your [dataset](datasets-and-experiments.md), so your offline evals re-test it on every future version.
-- **One picture of quality.** On any given output, you can see the code scorer, the LLM judge, the human reviewer, and the end user's feedback together, not four disconnected tools.
+Use the resulting annotations as calibration data for automated evaluators or as leads for new dataset cases. Adding a failing production interaction to a dataset lets future offline experiments check that behavior again.
 
 ## Consequences to know
 
-- **Annotations and feedback are stored in Logfire.** A score you record (and any free-text note attached to it) is sent to and stored in your Logfire project, visible to your team.
-- **User feedback carries whatever you attach.** If you send free-text feedback from your product, treat it like any other user data: it may contain personally identifiable information (PII), so [redact sensitive data](../how-to-guides/scrubbing.md) before it leaves your machine if that's a concern.
+- **Run annotations are stored in Logfire.** A saved verdict, comment, and tags are sent to your Logfire project and remain visible to your team.
+- **Comments can contain user data.** Treat comments like other production data. Do not copy sensitive information into them.
 
 ## Next steps
 
-- [Evals overview](overview.md): how scores, scorers, and experiments fit together.
-- [Datasets](datasets-and-experiments.md): turn the interactions you reviewed into re-runnable test cases.
-- [Run an evaluation](evals-in-code.md): score a whole dataset offline.
-- [Live Evaluations](live-evals.md): score production traffic automatically, then send the uncertain cases to human review.
+- [Annotate an agent run](annotate-agent-runs.md): review one interaction and save a verdict.
+- [Manage datasets](manage-datasets.md): preserve reviewed failures as repeatable test cases.
+- [Run an evaluation](evals-in-code.md): measure a fixed dataset with automated evaluators.
+- [Live Evaluations](live-evals.md): monitor automated evaluator results from production traffic.

--- a/docs/evaluate/overview.md
+++ b/docs/evaluate/overview.md
@@ -1,29 +1,29 @@
 ---
 title: "Evaluate your AI: measure output quality"
-description: "Learn how evaluations work in Pydantic Logfire (datasets, scorers, scores, and experiments) and how to measure AI output quality offline and in production."
+description: "Learn how evaluations work in Pydantic Logfire (datasets, evaluators, results, and experiments) and how to measure AI output quality offline and in production."
 ---
 
 # Evaluate your AI
 
 Know whether your AI system is getting better or worse, with numbers, not vibes. When you change a prompt, swap a model, or refactor an agent, an evaluation tells you if answer quality went up or down before your users find out.
 
-An **evaluation (eval)** is a repeatable test of an AI system's output quality, like a test suite for software, except the output has no single right answer. Instead of `assertEqual`, an eval attaches a **scorer** (also called an **evaluator**: the thing that judges an output and produces a score) to each answer, and each scorer produces a **score** (one saved quality rating for an output). Collect those scores over a set of test cases and you can compare versions instead of guessing.
+An **evaluation (eval)** is a repeatable test of an AI system's output quality, like a test suite for software, except the output has no single right answer. Instead of `assertEqual`, an eval attaches a **scorer** (also called an **evaluator**: the thing that judges an output) to each answer. An evaluator can produce a pass/fail assertion, a numeric score, or a categorical label. Collect those results over a set of test cases and you can compare versions instead of guessing.
 
 ## The stakes
 
 Without evals, "did that prompt change help?" is answered by re-reading a handful of outputs and forming an impression. That impression doesn't survive a teammate, a week, or a model upgrade. A regression that only shows up on 1 in 20 inputs is invisible to spot-checking and obvious to an eval. Evals turn "it feels better" into "the pass rate went from 82% to 91% on our 200-case set."
 
-## The scaffold: dataset → task → scorers → score → experiment
+## The scaffold: dataset → task → evaluators → results → experiment
 
-Every offline eval in Logfire is built from the same five pieces (online evals reuse only the **scorer** and **score** pieces, applied to live traffic instead of a dataset). Learn them once:
+Every offline eval in Logfire is built from the same five pieces (online evals reuse only the **evaluator** and **evaluator result** pieces, applied to live traffic instead of a dataset). Learn them once:
 
 1. **Dataset**: a collection of test cases (inputs and, optionally, expected outputs) you evaluate against.
 2. **Task**: your AI system under test: a function that takes a case's input and returns an output (an LLM call, a Pydantic AI agent, your own API).
-3. **Scorers (evaluators)**: one or more judges attached to the task. Each looks at an output and produces a score. A scorer can be plain code (exact match, "contains no personally identifiable information (PII)"), an **LLM-as-a-judge** (using a language model to score another model's output), or a human.
-4. **Score**: the rating each scorer produces for each output, saved so you can compare and aggregate.
-5. **Experiment**: one run of your task over the whole dataset, producing a table of scores you can compare across versions.
+3. **Scorers (evaluators)**: one or more judges attached to the task. Each looks at an output and produces one or more evaluator results. A scorer can be plain code (exact match, "contains no personally identifiable information (PII)") or an **LLM-as-a-judge** (using a language model to evaluate another model's output).
+4. **Evaluator result**: an assertion, numeric score, or categorical label produced for an output and saved so you can compare and aggregate it appropriately.
+5. **Experiment**: one run of your task over the whole dataset, producing evaluator results you can compare across versions.
 
-In prose, the flow is: the **dataset** feeds each case into your **task**; each output is handed to your **scorers**; each scorer emits a **score**; and the whole pass over the dataset is one **experiment** you can line up against the last one.
+In prose, the flow is: the **dataset** feeds each case into your **task**; each output is handed to your **scorers**; each scorer emits evaluator results; and the whole pass over the dataset is one **experiment** you can line up against the last one.
 
 ## Two ways to hold a dataset
 
@@ -43,11 +43,9 @@ The two modes use these pieces differently, and the easiest way to hold them apa
 
 Offline is your test suite; online is your production monitoring. Most teams need both: the test suite proves a change is safe to ship, monitoring proves it stayed good once real traffic hit it.
 
-## The score: one primitive for every kind of judgment
+## Choose the evaluator result that matches the question
 
-A **score** is the unifying primitive. Whether the rating came from an LLM-as-a-judge, a code check, a human reviewer, or a thumbs-up from an end user, it lands as the same kind of saved score, so all four show up together on the same output and roll up into the same numbers. That means [human review](human-review.md) and user feedback aren't a separate system bolted on the side; they produce scores that sit next to your automated ones.
-
-When you design a scorer, the score's *shape* is the real decision. Reach for the shape that matches the question:
+When you design a scorer, choose the result type that matches the judgment:
 
 - **Pass/fail (boolean)**: for checks with a clear yes/no: "did it hallucinate?", "does the output contain PII?", "is it valid JSON?" This is the shape to prefer whenever you can express the judgment as a yes/no.
 - **Categorical (a label)**: for a small set of known outcomes: `refused` / `answered` / `deflected`, or `low` / `medium` / `high` severity. Use when the answer is one of a few named buckets.
@@ -69,7 +67,7 @@ When you design a scorer, the score's *shape* is the real decision. Reach for th
 
 ## Consequences to know
 
-- **Sending eval results to Logfire stores them.** With `logfire.configure()`, an eval run (inputs, outputs, and scores) is sent to and stored in your Logfire project, visible to your team. Run without it to keep results local.
+- **Sending eval results to Logfire stores them.** With `logfire.configure()`, an eval run (inputs, outputs, and evaluator results) is sent to and stored in your Logfire project, visible to your team. Run without it to keep results local.
 - **LLM-as-a-judge scorers cost money.** Each judged output is another model call. A 500-case dataset with two LLM judges is 1,000 extra model calls per experiment.
 
 ## Next steps
@@ -79,4 +77,4 @@ When you design a scorer, the score's *shape* is the real decision. Reach for th
 - **[Evals SDK](datasets-sdk.md)**: manage datasets and evaluations programmatically.
 - **[Review experiments](review-experiments.md)**: diagnose failed cases and compare a candidate with a baseline.
 - **[Live Evaluations](live-evals.md)**: score real production traffic as it happens.
-- **[Human review](human-review.md)**: turn human judgment and user feedback into scores that sit next to your automated ones.
+- **[Human review](human-review.md)**: record editable judgments on agent runs and turn useful failures into regression cases.

--- a/docs/get-started/for-ai-engineers.md
+++ b/docs/get-started/for-ai-engineers.md
@@ -23,7 +23,7 @@ Follow these in order. Each link says why it's here.
 
 3. **[Read every LLM call, with tokens and cost](../guides/web-ui/llms.md)**: the LLMs and providers view breaks down which models you're calling, how many tokens each request used, and what it's costing you.
 
-4. **[Evaluate your AI: measure output quality](../evaluate/overview.md)**: move from "it looks fine" to a number. An **evaluation** runs your AI over a set of test cases and scores the output. A **scorer** is the rule that produces a **score**: one saved rating from a human, your own code, or an LLM acting as judge.
+4. **[Evaluate your AI: measure output quality](../evaluate/overview.md)**: move from "it looks fine" to evidence. An **evaluation** runs your AI over a set of test cases. A **scorer** judges each output and produces results such as pass/fail assertions, numeric scores, or categorical labels.
 
 5. **[Change a prompt without shipping code](../reference/advanced/prompt-management/index.md)**: version your prompts outside your codebase so you can test a new wording, promote it to production, and roll it back, all without a redeploy.
 

--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -56,7 +56,7 @@ If a run failed, a banner at the top of the Summary tab surfaces the exception t
 
 ## Annotating a run
 
-From a run's detail panel you can record a human judgment of its quality: a verdict, category, tags, and a comment. See [Annotate an agent run](../../evaluate/annotate-agent-runs.md) for the full workflow. Those ratings are the same [scores](../../evaluate/human-review.md) that power your [evaluations](../../evaluate/overview.md). Run-level annotations are in Beta (the `run_annotations` feature flag).
+From a run's detail panel you can record a human judgment of its quality: a verdict, category, tags, and a comment. See [Annotate an agent run](../../evaluate/annotate-agent-runs.md) for the full workflow. These editable [run annotations](../../evaluate/human-review.md) remain separate from automated [evaluation results](../../evaluate/overview.md). Run annotations are in Beta.
 
 ## Next steps
 

--- a/docs/reference/api/datasets.md
+++ b/docs/reference/api/datasets.md
@@ -18,16 +18,14 @@ For usage examples, see the [SDK Guide](../../evaluate/datasets-sdk.md).
 | `list_datasets()` | List all datasets in the project. |
 | `get_dataset(id_or_name, input_type, output_type, metadata_type, *, include_cases)` | Get a dataset, optionally as a typed [`pydantic_evals.Dataset`][pydantic_evals.Dataset]. Pass `include_cases=False` to get metadata only. |
 | `push_dataset(dataset, *, name, description, on_case_conflict)` | Publish a local [`pydantic_evals.Dataset`][pydantic_evals.Dataset] to hosted storage. Creates or updates the hosted dataset, infers schemas from typed `Dataset[...]` generics when available, uploads all cases, and returns metadata only. |
-| `create_dataset(name, *, input_type, output_type, metadata_type, description)` | Create a new dataset. Types are converted to JSON schemas automatically. |
-| `update_dataset(id_or_name, *, name, input_type, output_type, metadata_type, description)` | Update a dataset's metadata or schemas. |
+| `create_dataset(name, *, input_type, output_type, metadata_type, description, evaluators, report_evaluators)` | Create a new dataset. Types are converted to JSON schemas automatically. |
+| `update_dataset(id_or_name, *, name, input_type, output_type, metadata_type, description, evaluators, report_evaluators)` | Update a dataset's metadata, schemas, or evaluators. |
 | `delete_dataset(id_or_name)` | Delete a dataset and all its cases. |
 | `list_cases(dataset_id_or_name)` | List all cases in a dataset. |
 | `get_case(dataset_id_or_name, case_id)` | Get a specific case. |
 | `add_cases(dataset_id_or_name, cases, *, on_conflict)` | Add cases to a dataset. Accepts [`pydantic_evals.Case`][pydantic_evals.Case] objects or plain dicts. Uses upsert by default (`on_conflict='update'`): cases with matching names are updated. Set `on_conflict='error'` to fail on conflicts. |
 | `update_case(dataset_id_or_name, case_id, *, name, inputs, expected_output, metadata, evaluators)` | Update an existing case. |
 | `delete_case(dataset_id_or_name, case_id)` | Delete a case. |
-
-`push_dataset(...)` rejects dataset-level `evaluators` and `report_evaluators` for now, because hosted datasets do not store them yet. Case-level evaluators are still uploaded with their cases.
 
 An async version, `AsyncLogfireAPIClient`, provides the same methods as async coroutines.
 


### PR DESCRIPTION
## Summary

- remove public span-annotation and `record_feedback` workflows from the Evals overview, human-review guide, and agent-evaluation cookbook
- document the released human-review paths: editable agent-run annotations and annotation queues
- state explicitly that run annotations remain separate from automated experiment and Live Evaluation aggregates
- document experiment comparison as one candidate and one baseline, matching the released flow
- remove stale references to the nonexistent `run_annotations` feature flag
- align evaluator-result terminology and correct the stale hosted-dataset API reference

## Validation

- `make lint`
- `uv run pytest -k test_docs` (131 passed)
- `git diff --check`
- repository-wide search confirms no remaining public documentation references to span annotations, `record_feedback`, `get_traceparent`, `run_annotations`, or multi-run selection

## Authoring note

Drafted with Codex, then checked against current platform routes, feature flags, walkthroughs, the released comparison UI, and the shipped Logfire dataset client.