### PR TITLE
Document AI Gateway audio transcriptions

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -629,6 +629,9 @@ navigation:
           - page: "Embeddings"
             path: "reference/advanced/gateway/embeddings.md"
             slug: "manage/ai-gateway/embeddings"
+          - page: "Audio Transcriptions"
+            path: "reference/advanced/gateway/transcriptions.md"
+            slug: "manage/ai-gateway/transcriptions"
           - section: "Connect an agent"
             contents:
               - page: "Overview"

--- a/docs/reference/advanced/gateway/transcriptions.md
+++ b/docs/reference/advanced/gateway/transcriptions.md
@@ -5,28 +5,30 @@ description: "Transcribe audio through the Logfire AI Gateway with OpenAI-compat
 
 # Audio Transcriptions
 
-The AI Gateway proxies audio transcription requests the same way it proxies chat: point an OpenAI-compatible client at a gateway route and call its `/audio/transcriptions` endpoint. The request is the standard OpenAI `multipart/form-data` upload (the audio file rides along with the form fields), so `client.audio.transcriptions.create` works unchanged. Usage is recorded for every transcription call; estimated cost is tracked when pricing data is available for the model, and where the charge lands depends on the provider type: built-in provider usage draws from your prepaid gateway balance, while bring-your-own-key (BYOK) usage is billed directly by the upstream provider (see [Providers](index.md#providers)).
+The AI Gateway proxies audio transcription requests the same way it proxies chat: point an OpenAI-compatible client at a gateway route and call its `/audio/transcriptions` endpoint. The request is the standard OpenAI `multipart/form-data` upload (the audio file rides along with the form fields), so `client.audio.transcriptions.create` works unchanged. Usage is recorded for every transcription call, and estimated cost is tracked when pricing data is available for the model.
+
+Transcriptions currently require a bring-your-own-key (BYOK) provider — the upstream provider bills your own credential directly, and requests routed to a Logfire built-in provider are refused for now (see [Providers](index.md#providers)).
 
 ## Which providers can serve transcriptions
 
-Transcriptions are available for provider types whose `/audio/transcriptions` endpoint the gateway proxies as an OpenAI-compatible request: **OpenAI**, **Azure Foundry**, **Mistral** (voxtral models), **Ollama**, and **custom** OpenAI-compatible providers.
+Transcriptions are available for provider types whose `/audio/transcriptions` endpoint the gateway proxies as an OpenAI-compatible request: **OpenAI**, **Azure Foundry**, **Groq** (whisper models), **Mistral** (voxtral models), **Ollama**, and **custom** OpenAI-compatible providers.
 
 ## Models and response formats
 
 Two kinds of transcription models are metered differently:
 
-- **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog. These work on both built-in and BYOK providers.
-- **Duration-priced models** (`whisper-1`, Mistral's `voxtral-mini-latest`): the response reports the audio duration, which the gateway records as usage. These are BYOK-only for now.
+- **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog.
+- **Duration-priced models** (`whisper-1`, Mistral's `voxtral-mini-latest`, Groq's `whisper-large-v3` and `whisper-large-v3-turbo`): the response reports the audio duration, which the gateway records as usage. Groq's responses carry no usage object at all, so request `response_format: verbose_json` there — the gateway meters the duration that format reports.
 
-On a **built-in** provider, use a token-priced model with the default `json` response format; other combinations are refused up front because their responses carry no usage the gateway can bill. On **BYOK** providers all response formats work (`json`, `verbose_json`, `text`, `srt`, `vtt`); if the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
+All response formats work (`json`, `verbose_json`, `text`, `srt`, `vtt`); if the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
 
 Streaming transcription and `audio/translations` are not supported through the gateway yet.
 
 ## Sending a transcription request
 
-Address the request to `<gateway-base-url>/<route>/audio/transcriptions` as `multipart/form-data` with a `file` and a `model` field (plus the optional OpenAI fields: `language`, `prompt`, `temperature`, `response_format`). Uploads are capped at 25MB, matching OpenAI's limit.
+Address the request to `<gateway-base-url>/<route>/audio/transcriptions` as `multipart/form-data` with a `file` and a `model` field (plus the optional OpenAI fields: `language`, `prompt`, `temperature`, `response_format`). The gateway caps the request body at 30MB, slightly above the 25MB audio file limit OpenAI and Groq document, so a maximal upload plus its form fields still fits.
 
-The examples below use the `openai` route in the US region; see the [gateway base URLs](index.md#connect-an-sdk) for other regions.
+The examples below use an `openai` route in the US region pointing at your own OpenAI provider credential; see the [gateway base URLs](index.md#connect-an-sdk) for other regions.
 
 === "curl"
 

--- a/docs/reference/advanced/gateway/transcriptions.md
+++ b/docs/reference/advanced/gateway/transcriptions.md
@@ -1,0 +1,84 @@
+---
+title: "Audio Transcriptions"
+description: "Transcribe audio through the Logfire AI Gateway with OpenAI-compatible audio/transcriptions requests."
+---
+
+# Audio Transcriptions
+
+The AI Gateway proxies audio transcription requests the same way it proxies chat: point an OpenAI-compatible client at a gateway route and call its `/audio/transcriptions` endpoint. The request is the standard OpenAI `multipart/form-data` upload (the audio file rides along with the form fields), so `client.audio.transcriptions.create` works unchanged. Usage is recorded for every transcription call; estimated cost is tracked when pricing data is available for the model, and where the charge lands depends on the provider type: built-in provider usage draws from your prepaid gateway balance, while bring-your-own-key (BYOK) usage is billed directly by the upstream provider (see [Providers](index.md#providers)).
+
+## Which providers can serve transcriptions
+
+Transcriptions are available for provider types whose `/audio/transcriptions` endpoint the gateway proxies as an OpenAI-compatible request: **OpenAI**, **Azure Foundry**, **Ollama**, and **custom** OpenAI-compatible providers.
+
+## Models and response formats
+
+Two kinds of transcription models are metered differently:
+
+- **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog. These work on both built-in and BYOK providers.
+- **Duration-priced models** (`whisper-1`): the response reports the audio duration in seconds, which the gateway records as usage. These are BYOK-only for now.
+
+On a **built-in** provider, use a token-priced model with the default `json` response format; other combinations are refused up front because their responses carry no usage the gateway can bill. On **BYOK** providers all response formats work (`json`, `verbose_json`, `text`, `srt`, `vtt`); if the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
+
+Streaming transcription and `audio/translations` are not supported through the gateway yet.
+
+## Sending a transcription request
+
+Address the request to `<gateway-base-url>/<route>/audio/transcriptions` as `multipart/form-data` with a `file` and a `model` field (plus the optional OpenAI fields: `language`, `prompt`, `temperature`, `response_format`). Uploads are capped at 25MB, matching OpenAI's limit.
+
+The examples below use the `openai` route in the US region; see the [gateway base URLs](index.md#connect-an-sdk) for other regions.
+
+=== "curl"
+
+    ```bash
+    curl https://gateway-us.pydantic.dev/proxy/openai/audio/transcriptions \
+      -H "Authorization: Bearer <YOUR_GATEWAY_API_KEY>" \
+      -F file=@recording.wav \
+      -F model=gpt-4o-mini-transcribe
+    ```
+
+=== "Python (OpenAI SDK)"
+
+    ```python skip-run="true" skip-reason="external-connection"
+    from openai import OpenAI
+
+    client = OpenAI(
+        api_key='<YOUR_GATEWAY_API_KEY>',
+        base_url='https://gateway-us.pydantic.dev/proxy/openai',
+    )
+
+    with open('recording.wav', 'rb') as audio_file:
+        transcription = client.audio.transcriptions.create(
+            file=audio_file,
+            model='gpt-4o-mini-transcribe',
+        )
+    print(transcription.text)
+    ```
+
+=== "TypeScript (OpenAI SDK)"
+
+    ```typescript
+    import fs from 'node:fs'
+
+    import OpenAI from 'openai'
+
+    const client = new OpenAI({
+      apiKey: '<YOUR_GATEWAY_API_KEY>',
+      baseURL: 'https://gateway-us.pydantic.dev/proxy/openai',
+    })
+
+    const transcription = await client.audio.transcriptions.create({
+      file: fs.createReadStream('recording.wav'),
+      model: 'gpt-4o-mini-transcribe',
+    })
+    console.log(transcription.text)
+    ```
+
+Usage is recorded on every transcription request like any other gateway call (and estimated cost too, when pricing data is available for the model), so transcriptions show up in your **Spending** analytics and (when telemetry is enabled) as traces alongside the rest of your LLM traffic, with the transcript as the response text. The audio content itself never enters your telemetry: traces carry a summary of the form fields (model, filename, size), not the file bytes.
+
+The `prompt` form field (context you give the model about the audio) goes through the gateway's input guardrails like any chat message; the audio content itself is not inspected.
+
+## See also
+
+- [AI Gateway](index.md): enabling the gateway, providers, routing, and connecting SDKs.
+- [Embeddings](embeddings.md): the same pattern for embedding requests.

--- a/docs/reference/advanced/gateway/transcriptions.md
+++ b/docs/reference/advanced/gateway/transcriptions.md
@@ -20,7 +20,7 @@ Two kinds of transcription models are metered differently:
 - **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog.
 - **Duration-priced models** (`whisper-1`, Mistral's `voxtral-mini-latest`, Groq's `whisper-large-v3` and `whisper-large-v3-turbo`): the response reports the audio duration, which the gateway records as usage. Groq's responses carry no usage object at all, so request `response_format: verbose_json` there — the gateway meters the duration that format reports.
 
-All response formats work (`json`, `verbose_json`, `text`, `srt`, `vtt`); if the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
+The `response_format` field passes through to the provider, so the model must support the format you request: `whisper-1` accepts all the OpenAI formats (`json`, `verbose_json`, `text`, `srt`, `vtt`), while the token-priced `gpt-4o-transcribe` family accepts only `json` and `text` — check your provider's own documentation for other models. If the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
 
 Streaming transcription and `audio/translations` are not supported through the gateway yet.
 
@@ -76,7 +76,7 @@ The examples below use an `openai` route in the US region pointing at your own O
     console.log(transcription.text)
     ```
 
-Usage is recorded on every transcription request like any other gateway call (and estimated cost too, when pricing data is available for the model), so transcriptions show up in your **Spending** analytics and (when telemetry is enabled) as traces alongside the rest of your LLM traffic, with the transcript as the response text. The audio content itself never enters your telemetry: traces carry a summary of the form fields (model, filename, size), not the file bytes.
+Usage is recorded on every transcription request like any other gateway call (and estimated cost too, when pricing data is available for the model), so transcriptions show up in your **Spending** analytics and (when telemetry is enabled) as traces alongside the rest of your LLM traffic, with the transcript as the response text. The raw audio never enters your telemetry — traces carry a summary of the form fields (model, filename, size), not the file bytes — but the transcript text itself is recorded as the response message, just like a chat completion's output. Keep that in mind if your recordings contain sensitive content.
 
 The `prompt` form field (context you give the model about the audio) goes through the gateway's input guardrails like any chat message; the audio content itself is not inspected.
 

--- a/docs/reference/advanced/gateway/transcriptions.md
+++ b/docs/reference/advanced/gateway/transcriptions.md
@@ -20,7 +20,7 @@ Two kinds of transcription models are metered differently:
 - **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog.
 - **Duration-priced models** (`whisper-1`, Mistral's `voxtral-mini-latest`, Groq's `whisper-large-v3` and `whisper-large-v3-turbo`): the response reports the audio duration, which the gateway records as usage. Groq's responses carry no usage object at all, so request `response_format: verbose_json` there — the gateway meters the duration that format reports.
 
-The `response_format` field passes through to the provider, so the model must support the format you request: `whisper-1` accepts all the OpenAI formats (`json`, `verbose_json`, `text`, `srt`, `vtt`), while the token-priced `gpt-4o-transcribe` family accepts only `json` and `text` — check your provider's own documentation for other models. If the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
+The `response_format` field passes through to the provider, so the model must support the format you request: `whisper-1` accepts all the OpenAI formats (`json`, `verbose_json`, `text`, `srt`, `vtt`), while the token-priced models above accept only `json` (`gpt-4o-transcribe-diarize` also documents `text`) — check your provider's own documentation for other models. If the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
 
 Streaming transcription and `audio/translations` are not supported through the gateway yet.
 

--- a/docs/reference/advanced/gateway/transcriptions.md
+++ b/docs/reference/advanced/gateway/transcriptions.md
@@ -9,14 +9,14 @@ The AI Gateway proxies audio transcription requests the same way it proxies chat
 
 ## Which providers can serve transcriptions
 
-Transcriptions are available for provider types whose `/audio/transcriptions` endpoint the gateway proxies as an OpenAI-compatible request: **OpenAI**, **Azure Foundry**, **Ollama**, and **custom** OpenAI-compatible providers.
+Transcriptions are available for provider types whose `/audio/transcriptions` endpoint the gateway proxies as an OpenAI-compatible request: **OpenAI**, **Azure Foundry**, **Mistral** (voxtral models), **Ollama**, and **custom** OpenAI-compatible providers.
 
 ## Models and response formats
 
 Two kinds of transcription models are metered differently:
 
 - **Token-priced models** (`gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-transcribe`): the JSON response carries a usage object with audio and text token counts, and the gateway prices them from its model catalog. These work on both built-in and BYOK providers.
-- **Duration-priced models** (`whisper-1`): the response reports the audio duration in seconds, which the gateway records as usage. These are BYOK-only for now.
+- **Duration-priced models** (`whisper-1`, Mistral's `voxtral-mini-latest`): the response reports the audio duration, which the gateway records as usage. These are BYOK-only for now.
 
 On a **built-in** provider, use a token-priced model with the default `json` response format; other combinations are refused up front because their responses carry no usage the gateway can bill. On **BYOK** providers all response formats work (`json`, `verbose_json`, `text`, `srt`, `vtt`); if the provider has **Require cost data** enabled, formats that produce no usage (`text`/`srt`/`vtt`) are refused up front.
 


### PR DESCRIPTION
## Summary

Adds `reference/advanced/gateway/transcriptions.md` (and its navigation entry): the AI Gateway now proxies OpenAI-compatible `POST /proxy/<route>/audio/transcriptions` requests, so this documents which provider types serve it (OpenAI, Azure Foundry, Groq, Mistral, Ollama, custom), how token-priced vs duration-priced models are metered, the current BYOK-only restriction and response-format constraints, and curl / Python / TypeScript examples, mirroring the structure of the Embeddings page.

The gateway feature this documents has shipped in the platform.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
