### PR TITLE
fix: deduplicate InspectArgumentsFailedWarning per call site (Fixes #2223)

### DIFF
--- a/logfire/_internal/ast_utils.py
+++ b/logfire/_internal/ast_utils.py
@@ -144,6 +144,12 @@ class BaseTransformer(ast.NodeTransformer):
         return span_name, attributes
 
 
+# Call sites `(filename, lineno)` that have already been warned about missing source code.
+# Once a call site's source is unavailable it will stay unavailable for the whole process,
+# so we deduplicate the warning to avoid repeating it for every span created from that site.
+_warned_source_unavailable_callsites: set[tuple[str, int]] = set()
+
+
 class CallNodeFinder(ABC):
     """Base class for finding the `ast.Call` node corresponding to a function call in a given frame.
 
@@ -172,11 +178,18 @@ class CallNodeFinder(ABC):
             # This is a very likely cause.
             # There's nothing we could possibly do to make magic work here,
             # and it's a clear case where the user should turn the magic off.
-            self.warn_inspect_arguments(
-                'No source code available. '
-                'This happens when running in an interactive shell, '
-                'using exec(), or running .pyc files without the source .py files.',
-            )
+            # Once we know source is unavailable for a given call site it will stay that
+            # way for the whole process (interactive shell, exec(), .pyc without source),
+            # so only warn once per call site instead of once per span. Otherwise a single
+            # call site that creates many spans floods the output with the same warning.
+            callsite = (self.frame.f_code.co_filename, self.frame.f_lineno)
+            if callsite not in _warned_source_unavailable_callsites:
+                _warned_source_unavailable_callsites.add(callsite)
+                self.warn_inspect_arguments(
+                    'No source code available. '
+                    'This happens when running in an interactive shell, '
+                    'using exec(), or running .pyc files without the source .py files.',
+                )
             return None
 
         msg = '`executing` failed to find a node.'

--- a/tests/test_source_code_extraction.py
+++ b/tests/test_source_code_extraction.py
@@ -231,3 +231,27 @@ def test_get_node_source_text_falls_back_to_unparse(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(ast, 'get_source_segment', get_source_segment)
 
     assert ast_utils.get_node_source_text(node, Source()) == 'x'
+
+
+def test_source_code_extraction_warning_not_repeated_per_span(exporter: TestExporter) -> None:
+    """Repeated spans from the same call site should not each emit `InspectArgumentsFailedWarning`.
+
+    Regression test for https://github.com/pydantic/logfire/issues/2223.
+    When the caller's source is unavailable (e.g. running .pyc files without the source .py
+    files, or exec()'d code) but the message template is a plain literal with explicit
+    keyword values, the warning should only be emitted once per call site/process, not once
+    per span.
+    """
+    code = """\
+import logfire
+
+def make_span(test_name: str) -> None:
+    with logfire.span('wc-test {test_name}', test_name=test_name):
+        pass
+
+for i in range(3):
+    make_span(f'test-{i}')
+"""
+    with pytest.warns(InspectArgumentsFailedWarning, match='No source code available') as record:
+        exec(code)
+    assert len(record) == 1


### PR DESCRIPTION
## Description

Fix repeated `InspectArgumentsFailedWarning` warnings when source code is unavailable. Previously, `warn_inspect_arguments()` fired on every span creation from a source-less call site. Now it warns once per unique call site (filename + line number).

## Root Cause

`CallNodeFinder._get_call_node()` in `logfire/_internal/ast_utils.py` calls `warn_inspect_arguments("No source code available...")` unconditionally when `executing.Source` has no source text. Nothing deduplicates across spans from the same call site, so N spans produce N identical warnings — cluttering test output and logfire logs.

## Fix

Module-level `_warned_source_unavailable_callsites: set[tuple[str, int]]` tracks call sites by `(frame.f_code.co_filename, frame.f_lineno)`. The warning is emitted once per unique call site; subsequent calls fall through silently.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #2223

## Testing

- [x] **RED**: `test_source_code_extraction_warning_not_repeated_per_span` — 3 warnings instead of 1 without fix
- [x] **GREEN**: 1 warning with fix (1 passed)
- [x] **REGRESSION**: 1863 passed, 9 skipped, 2 xfailed — identical to baseline
- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright` on `ast_utils.py`: 0 errors

## Additional Notes

The fix implements the issue's own suggestion #2 (deduplicate per call site/process) and preserves the existing `inspect_arguments=False` escape hatch for users who want to suppress the warning entirely. Frame identity was verified empirically: `self.frame` is stable across repeated calls from the same call site.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

