### PR TITLE
Inline the revised agent setup prompt

### DIFF
--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -23,17 +23,50 @@ To have an AI coding agent wire this up for you, copy this prompt into Claude Co
 
 <CopyPrompt>
 
-```text
-Set up Pydantic Logfire in this project so it sends traces to Logfire. Follow the guide at https://pydantic.dev/docs/logfire/get-started/first-trace/.
+````text
+Note for the agent: This prompt was copied from the Pydantic Logfire website by the user. The user may not have read it. Briefly tell the user what you plan to do before each step.
 
-1. Install the Logfire SDK for this project's language and initialize it at startup the way the guide describes for that language (for Python and JavaScript that is logfire.configure(); other languages may use OpenTelemetry), then instrument its web framework plus any LLM and HTTP clients. Don't refactor unrelated code.
+Set up Pydantic Logfire in this project to instrument it and send OpenTelemetry signals to Logfire.
 
-2. Authenticate. If a `LOGFIRE_TOKEN` environment variable is already set, use it as-is. Otherwise, for a local Python project, install Logfire with the project's dependency manager (for example `uv add logfire`, `poetry add logfire`, or `pip install logfire`), then run `logfire auth` (or `uvx logfire auth`): this opens a browser where you sign in or create a free Logfire account (no credit card required) and a project, then links this machine. For another language, a non-interactive shell, or a deployment, ask me for a write token (the credential that lets an app send data to Logfire) from Project > Settings > Write tokens and set it as the `LOGFIRE_TOKEN` environment variable. Keep any token out of your replies: `logfire auth` saves credentials to `~/.logfire` in your home directory (outside the repo), and if you create or receive a token, put it in a gitignored `.env` rather than printing it; never commit it.
+Check if version control is being used. If so, and if there are uncommitted changes, ask the user to commit or stash them before proceeding. If things are clean, open a new branch for the Logfire setup work.
 
-3. Run the app so it sends a trace, then give me the Logfire Live view link on its own line and in bold so I can open it and confirm the trace arrived.
+Fetch reference material as text rather than using visual browser tools. Don't try using the Logfire UI.
 
-4. Once the trace is arriving, offer a few next steps and do the ones I want: run `logfire inspect` to find other dependencies Logfire can instrument and add the relevant ones; set up the Logfire MCP (Model Context Protocol) server so you can query my Logfire data going forward (https://pydantic.dev/docs/logfire/guides/mcp-server/, it logs in through the browser); or set up alerts or evals.
+If there are multiple services in this codebase, instrument them all, one by one.
+
+Check which languages and package management tools are being used and install the appropriate SDK:
+- Python: install `logfire[system-metrics]` via uv, pip, etc
+- JS/TS: install via npm, yarn, etc:
+    - Node.js: `@pydantic/logfire-node`
+    - Browser: `@pydantic/logfire-browser`
+    - Cloudflare Workers: `@pydantic/logfire-cf-workers` and `logfire`
+- Rust: `cargo add logfire`
+- Other languages: There's no dedicated Logfire SDK. Install the OpenTelemetry SDK and follow https://pydantic.dev/docs/logfire/guides/alternative-clients/ to configure it to send to the Logfire backend.
+
+Authenticate. Keep any token out of replies, logs, and committed files.
+- If `LOGFIRE_TOKEN` is already set in the environment, you don't need to do anything, the SDK will use it automatically.
+- For Python, say: """
+Run this from the project folder:
+
+```bash
+logfire auth && python -c 'import logfire; logfire.configure()'
 ```
+
+The first command will open a browser where you can sign in or create a free Logfire account (no credit card required) and link this machine to that account. The second command will link this specific folder to one new or existing project in your account. Then tell me when you're done.
+"""
+(Tweak the command to ensure the correct Python interpreter is used, e.g. with `uv run`.
+The first command will create a file `~/.logfire/default.toml`, the second will create a gitignored folder `.logfire` in the project folder containing credentials that the SDK can read. You can check these to troubleshoot but assume they exist if things go well. Don't expect them to set `LOGFIRE_TOKEN`, this is a different kind of authentication.)
+- Otherwise, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
+- If there's still problems, say "Try looking at https://logfire.pydantic.dev/-/redirect/latest-project/settings/setup or https://pydantic.dev/docs/logfire/get-started/first-trace/ for more information."
+
+Run `curl https://raw.githubusercontent.com/pydantic/logfire/refs/heads/main/logfire/.agents/skills/logfire-instrumentation/SKILL.md` and read the instructions. Then read the linked references for the applicable languages. Add a few lines of code to configure the SDK and instrument web frameworks, databases, LLMs, and HTTP clients where integrations already exist. For Python projects, add `logfire.instrument_system_metrics()`, and if they're using standard logging, add `logfire.LogfireLoggingHandler()` to the logging handlers. Do not refactor unrelated code or make extensive changes. The goal is to get some observability quickly and easily. If no integrations apply, sprinkle in up to 5 manual `logfire.span/info/instrument` calls.
+
+Run the code. It may print a Logfire project URL, e.g. https://logfire-us.pydantic.dev/myorganisationname/myprojectname. If not, try running `uvx logfire whoami` which should pick up `LOGFIRE_TOKEN` or other credentials, even if the user's project doesn't use Python. If that doesn't give a URL, go with https://logfire.pydantic.dev/-/redirect/latest-project/. If you don't see any errors about failing to send data, assume it's working. Say "Open the Live View at <URL> and confirm that you see traces.". Don't try to verify yourself.
+
+If all is well, provide the user with a link to GitHub or whatever source control where they can create a PR if appropriate.
+
+Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the approriate config files. If you don't have permission to edit directly, give a copyable command which does so.
+````
 
 </CopyPrompt>
 

--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -45,7 +45,7 @@ Check which languages and package management tools are being used and install th
 
 Authenticate. Keep any token out of replies, logs, and committed files.
 - If `LOGFIRE_TOKEN` is already set in the environment, you don't need to do anything, the SDK will use it automatically.
-- For Python, say: """
+- Otherwise, for a local interactive Python project, say: """
 Run this from the project folder:
 
 ```bash
@@ -56,7 +56,7 @@ The first command will open a browser where you can sign in or create a free Log
 """
 (Tweak the command to ensure the correct Python interpreter is used, e.g. with `uv run`.
 The first command will create a file `~/.logfire/default.toml`, the second will create a gitignored folder `.logfire` in the project folder containing credentials that the SDK can read. You can check these to troubleshoot but assume they exist if things go well. Don't expect them to set `LOGFIRE_TOKEN`, this is a different kind of authentication.)
-- Otherwise, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
+- For another language, a non-interactive shell, or a deployment, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
 - If there's still problems, say "Try looking at https://logfire.pydantic.dev/-/redirect/latest-project/settings/setup or https://pydantic.dev/docs/logfire/get-started/first-trace/ for more information."
 
 Run `curl https://raw.githubusercontent.com/pydantic/logfire/refs/heads/main/logfire/.agents/skills/logfire-instrumentation/SKILL.md` and read the instructions. Then read the linked references for the applicable languages. Add a few lines of code to configure the SDK and instrument web frameworks, databases, LLMs, and HTTP clients where integrations already exist. For Python projects, add `logfire.instrument_system_metrics()`, and if they're using standard logging, add `logfire.LogfireLoggingHandler()` to the logging handlers. Do not refactor unrelated code or make extensive changes. The goal is to get some observability quickly and easily. If no integrations apply, sprinkle in up to 5 manual `logfire.span/info/instrument` calls.

--- a/docs/first-trace.md
+++ b/docs/first-trace.md
@@ -65,7 +65,7 @@ Run the code. It may print a Logfire project URL, e.g. https://logfire-us.pydant
 
 If all is well, provide the user with a link to GitHub or whatever source control where they can create a PR if appropriate.
 
-Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the approriate config files. If you don't have permission to edit directly, give a copyable command which does so.
+Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the appropriate config files. If you don't have permission to edit directly, give a copyable command which does so.
 ````
 
 </CopyPrompt>

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Check which languages and package management tools are being used and install th
 
 Authenticate. Keep any token out of replies, logs, and committed files.
 - If `LOGFIRE_TOKEN` is already set in the environment, you don't need to do anything, the SDK will use it automatically.
-- For Python, say: """
+- Otherwise, for a local interactive Python project, say: """
 Run this from the project folder:
 
 ```bash
@@ -46,7 +46,7 @@ The first command will open a browser where you can sign in or create a free Log
 """
 (Tweak the command to ensure the correct Python interpreter is used, e.g. with `uv run`.
 The first command will create a file `~/.logfire/default.toml`, the second will create a gitignored folder `.logfire` in the project folder containing credentials that the SDK can read. You can check these to troubleshoot but assume they exist if things go well. Don't expect them to set `LOGFIRE_TOKEN`, this is a different kind of authentication.)
-- Otherwise, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
+- For another language, a non-interactive shell, or a deployment, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
 - If there's still problems, say "Try looking at https://logfire.pydantic.dev/-/redirect/latest-project/settings/setup or https://pydantic.dev/docs/logfire/get-started/first-trace/ for more information."
 
 Run `curl https://raw.githubusercontent.com/pydantic/logfire/refs/heads/main/logfire/.agents/skills/logfire-instrumentation/SKILL.md` and read the instructions. Then read the linked references for the applicable languages. Add a few lines of code to configure the SDK and instrument web frameworks, databases, LLMs, and HTTP clients where integrations already exist. For Python projects, add `logfire.instrument_system_metrics()`, and if they're using standard logging, add `logfire.LogfireLoggingHandler()` to the logging handlers. Do not refactor unrelated code or make extensive changes. The goal is to get some observability quickly and easily. If no integrations apply, sprinkle in up to 5 manual `logfire.span/info/instrument` calls.

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,7 @@ Run the code. It may print a Logfire project URL, e.g. https://logfire-us.pydant
 
 If all is well, provide the user with a link to GitHub or whatever source control where they can create a PR if appropriate.
 
-Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the approriate config files. If you don't have permission to edit directly, give a copyable command which does so.
+Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the appropriate config files. If you don't have permission to edit directly, give a copyable command which does so.
 ````
 
 </AgentSetup>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,17 +13,50 @@ New here? [Create a free account](https://logfire.pydantic.dev/login), then pick
 
 <AgentSetup>
 
-```text
-Set up Pydantic Logfire in this project so it sends traces to Logfire. Follow the guide at https://pydantic.dev/docs/logfire/get-started/first-trace/.
+````text
+Note for the agent: This prompt was copied from the Pydantic Logfire website by the user. The user may not have read it. Briefly tell the user what you plan to do before each step.
 
-1. Install the Logfire SDK for this project's language and initialize it at startup the way the guide describes for that language (for Python and JavaScript that is logfire.configure(); other languages may use OpenTelemetry), then instrument its web framework plus any LLM and HTTP clients. Don't refactor unrelated code.
+Set up Pydantic Logfire in this project to instrument it and send OpenTelemetry signals to Logfire.
 
-2. Authenticate. If a `LOGFIRE_TOKEN` environment variable is already set, use it as-is. Otherwise, for a local Python project, install Logfire with the project's dependency manager (for example `uv add logfire`, `poetry add logfire`, or `pip install logfire`), then run `logfire auth` (or `uvx logfire auth`): this opens a browser where you sign in or create a free Logfire account (no credit card required) and a project, then links this machine. For another language, a non-interactive shell, or a deployment, ask me for a write token (the credential that lets an app send data to Logfire) from Project > Settings > Write tokens and set it as the `LOGFIRE_TOKEN` environment variable. Keep any token out of your replies: `logfire auth` saves credentials to `~/.logfire` in your home directory (outside the repo), and if you create or receive a token, put it in a gitignored `.env` rather than printing it; never commit it.
+Check if version control is being used. If so, and if there are uncommitted changes, ask the user to commit or stash them before proceeding. If things are clean, open a new branch for the Logfire setup work.
 
-3. Run the app so it sends a trace, then give me the Logfire Live view link on its own line and in bold so I can open it and confirm the trace arrived.
+Fetch reference material as text rather than using visual browser tools. Don't try using the Logfire UI.
 
-4. Once the trace is arriving, offer a few next steps and do the ones I want: run `logfire inspect` to find other dependencies Logfire can instrument and add the relevant ones; set up the Logfire MCP (Model Context Protocol) server so you can query my Logfire data going forward (https://pydantic.dev/docs/logfire/guides/mcp-server/, it logs in through the browser); or set up alerts or evals.
+If there are multiple services in this codebase, instrument them all, one by one.
+
+Check which languages and package management tools are being used and install the appropriate SDK:
+- Python: install `logfire[system-metrics]` via uv, pip, etc
+- JS/TS: install via npm, yarn, etc:
+    - Node.js: `@pydantic/logfire-node`
+    - Browser: `@pydantic/logfire-browser`
+    - Cloudflare Workers: `@pydantic/logfire-cf-workers` and `logfire`
+- Rust: `cargo add logfire`
+- Other languages: There's no dedicated Logfire SDK. Install the OpenTelemetry SDK and follow https://pydantic.dev/docs/logfire/guides/alternative-clients/ to configure it to send to the Logfire backend.
+
+Authenticate. Keep any token out of replies, logs, and committed files.
+- If `LOGFIRE_TOKEN` is already set in the environment, you don't need to do anything, the SDK will use it automatically.
+- For Python, say: """
+Run this from the project folder:
+
+```bash
+logfire auth && python -c 'import logfire; logfire.configure()'
 ```
+
+The first command will open a browser where you can sign in or create a free Logfire account (no credit card required) and link this machine to that account. The second command will link this specific folder to one new or existing project in your account. Then tell me when you're done.
+"""
+(Tweak the command to ensure the correct Python interpreter is used, e.g. with `uv run`.
+The first command will create a file `~/.logfire/default.toml`, the second will create a gitignored folder `.logfire` in the project folder containing credentials that the SDK can read. You can check these to troubleshoot but assume they exist if things go well. Don't expect them to set `LOGFIRE_TOKEN`, this is a different kind of authentication.)
+- Otherwise, ask them to open https://logfire.pydantic.dev/-/redirect/latest-project/settings/write-tokens to create a write token. Set it as `LOGFIRE_TOKEN` in the shell environment the app runs in (e.g. `export LOGFIRE_TOKEN=...` in the terminal, or via the deployment platform's secret manager). If the project already loads a `.env` file at startup, you may store it there instead, but confirm dotenv loading is in place and the file is gitignored first. Never commit the token or print it in a reply or log output.
+- If there's still problems, say "Try looking at https://logfire.pydantic.dev/-/redirect/latest-project/settings/setup or https://pydantic.dev/docs/logfire/get-started/first-trace/ for more information."
+
+Run `curl https://raw.githubusercontent.com/pydantic/logfire/refs/heads/main/logfire/.agents/skills/logfire-instrumentation/SKILL.md` and read the instructions. Then read the linked references for the applicable languages. Add a few lines of code to configure the SDK and instrument web frameworks, databases, LLMs, and HTTP clients where integrations already exist. For Python projects, add `logfire.instrument_system_metrics()`, and if they're using standard logging, add `logfire.LogfireLoggingHandler()` to the logging handlers. Do not refactor unrelated code or make extensive changes. The goal is to get some observability quickly and easily. If no integrations apply, sprinkle in up to 5 manual `logfire.span/info/instrument` calls.
+
+Run the code. It may print a Logfire project URL, e.g. https://logfire-us.pydantic.dev/myorganisationname/myprojectname. If not, try running `uvx logfire whoami` which should pick up `LOGFIRE_TOKEN` or other credentials, even if the user's project doesn't use Python. If that doesn't give a URL, go with https://logfire.pydantic.dev/-/redirect/latest-project/. If you don't see any errors about failing to send data, assume it's working. Say "Open the Live View at <URL> and confirm that you see traces.". Don't try to verify yourself.
+
+If all is well, provide the user with a link to GitHub or whatever source control where they can create a PR if appropriate.
+
+Read https://pydantic.dev/docs/logfire/guides/mcp-server/. Offer to install the plugins, skills, and MCP server matching this coding agent. For Claude Code and Codex, give the appropriate commands to copy and run in a `bash` triple backtick fenced code block. For other agents, edit the approriate config files. If you don't have permission to edit directly, give a copyable command which does so.
+````
 
 </AgentSetup>
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -18,6 +18,10 @@ def extract_agent_setup_prompt(path: Path, component: str) -> str:
     assert len(fence) >= 3 and set(fence) == {'`'}
     assert lines[-1] == fence
 
+    embedded_fence_lengths = [len(line) - len(line.lstrip('`')) for line in lines[1:-1] if line.startswith('`')]
+    assert embedded_fence_lengths
+    assert len(fence) > max(embedded_fence_lengths)
+
     prompt = '\n'.join(lines[1:-1])
     assert prompt
     return prompt

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def extract_agent_setup_prompt(path: Path, component: str) -> str:
+    content = path.read_text(encoding='utf-8')
+    opening_tag = f'<{component}>'
+    closing_tag = f'</{component}>'
+    assert content.count(opening_tag) == 1
+    assert content.count(closing_tag) == 1
+
+    component_content = content.split(opening_tag, 1)[1].split(closing_tag, 1)[0]
+    lines = component_content.strip().splitlines()
+    opening_fence = lines[0]
+    assert opening_fence.endswith('text')
+    fence = opening_fence.removesuffix('text')
+    assert len(fence) >= 3 and set(fence) == {'`'}
+    assert lines[-1] == fence
+
+    prompt = '\n'.join(lines[1:-1])
+    assert prompt
+    return prompt
+
+
+def test_agent_setup_prompts_match() -> None:
+    index_prompt = extract_agent_setup_prompt(REPO_ROOT / 'docs' / 'index.md', 'AgentSetup')
+    first_trace_prompt = extract_agent_setup_prompt(REPO_ROOT / 'docs' / 'first-trace.md', 'CopyPrompt')
+
+    assert index_prompt == first_trace_prompt


### PR DESCRIPTION
## Context

Logfire shows the same ready-to-copy prompt for coding agents in two places:

- the **Onboard with your coding agent** button on the Logfire landing page
- the **Prompt for your coding agent** card in the first-trace guide

An earlier change (https://github.com/pydantic/logfire/pull/2226) tried to keep that prompt in one text file and replace `{{ agent_setup_prompt() }}` during the docs build. That replacement was added to Logfire's old MkDocs plugin, but the published documentation is now built by Unified Docs and does not run that plugin. As a result, readers saw the placeholder itself instead of the setup instructions.

## What this PR changes

- puts the revised setup prompt directly in `docs/index.md` and `docs/first-trace.md`
- removes any dependency on a docs plugin or build-time substitution for this prompt
- uses a four-backtick outer code fence so the prompt can contain its own fenced `bash` command without breaking Markdown rendering
- adds a test that extracts the prompt from both page components and fails if the two copies differ or either copy is empty

The duplication is intentional. Both pages remain self-contained for Unified Docs, while the test provides a clear guard against editing only one copy later.

## Reader impact

Both entry points now display and copy the complete revised prompt. The prompt guides a coding agent through repository safety, SDK selection, authentication, instrumentation, verification, and optional follow-up setup.

## Validation

- `uv run pytest tests/test_agent_setup_prompt.py`
- repository pre-commit checks, including Ruff, Ruff Format, and pyright
- local Unified Docs preview of both pages, including the prompt's embedded `bash` fence

## AI assistance

Codex applied the requested prompt copy and test. The rendered result was checked in a local Unified Docs preview.
