### PR TITLE
Warn when a token's region is unrecognised instead of silently defaulting to US

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1740,7 +1740,13 @@ class LogfireConfig(_LogfireConfigData):
     def _initialize_credentials_from_token(self, token: str) -> LogfireCredentials | None:
         session = requests.Session()
         install_logfire_response_hook(session, self.advanced.server_response_hook)
-        return LogfireCredentials.from_token(token, session, self.advanced.generate_base_url(token))
+        # This runs in the background `check_logfire_token` thread, where a warning would be
+        # attributed to the thread rather than to the user's `configure()` call and so wouldn't
+        # be deduplicated against it. The synchronous exporter setup already warns for every
+        # token in the same list, so stay silent here.
+        return LogfireCredentials.from_token(
+            token, session, self.advanced.generate_base_url(token, warn_unknown_region=False)
+        )
 
     def _ensure_flush_after_aws_lambda(self):
         """Ensure that `force_flush` is called after an AWS Lambda invocation.

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -2253,6 +2253,11 @@ def get_base_url_from_token(token: str) -> str:
             return 'https://logfire-eu.pydantic.info'
 
         if region not in REGIONS:
+            warn_at_user_stacklevel(
+                f'Unknown region {region!r} in Logfire token, falling back to the US region. '
+                f'Known regions: {", ".join(sorted(REGIONS))}.',
+                category=LogfireConfigWarning,
+            )
             region = 'us'
 
     return REGIONS[region]['base_url']

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -275,11 +275,11 @@ class AdvancedOptions:
     Defaults to the `LOGFIRE_RESOURCE_DETECTORS` environment variable (a comma-separated list of names).
     """
 
-    def generate_base_url(self, token: str) -> str:
+    def generate_base_url(self, token: str, warn_unknown_region: bool = False) -> str:
         if self.base_url is not None:
             return self.base_url
 
-        return get_base_url_from_token(token)
+        return get_base_url_from_token(token, warn_unknown_region=warn_unknown_region)
 
 
 @dataclass
@@ -1364,7 +1364,7 @@ class LogfireConfig(_LogfireConfigData):
 
                     # Create exporters for each token
                     for token in token_list:
-                        base_url = self.advanced.generate_base_url(token)
+                        base_url = self.advanced.generate_base_url(token, warn_unknown_region=True)
                         otlp_forwarding_destinations.append((base_url, token))
                         headers = {'User-Agent': f'logfire/{VERSION}', 'Authorization': token}
                         session = OTLPExporterHttpSession()
@@ -2240,8 +2240,16 @@ def _get_creds_file(creds_dir: Path) -> Path:
     return creds_dir / CREDENTIALS_FILENAME
 
 
-def get_base_url_from_token(token: str) -> str:
-    """Get the base API URL from the token's region."""
+def get_base_url_from_token(token: str, warn_unknown_region: bool = False) -> str:
+    """Get the base API URL from the token's region.
+
+    Args:
+        token: The Logfire token to read the region from.
+        warn_unknown_region: Whether to emit a `LogfireConfigWarning` when the token's region is
+            unrecognised and the US region is used as a fallback. This is off by default so that
+            runtime helpers (e.g. the query/API clients and the CLI) never raise under
+            warnings-as-errors; it's enabled during configuration, where the warning is actionable.
+    """
     # default to US for tokens that were created before regions were added:
     region = 'us'
     if match := LOGFIRE_TOKEN_REGION_PATTERN.match(token):
@@ -2253,11 +2261,12 @@ def get_base_url_from_token(token: str) -> str:
             return 'https://logfire-eu.pydantic.info'
 
         if region not in REGIONS:
-            warn_at_user_stacklevel(
-                f'Unknown region {region!r} in Logfire token, falling back to the US region. '
-                f'Known regions: {", ".join(sorted(REGIONS))}.',
-                category=LogfireConfigWarning,
-            )
+            if warn_unknown_region:
+                warn_at_user_stacklevel(
+                    f'Unknown region {region!r} in Logfire token, falling back to the US region. '
+                    f'Known regions: {", ".join(sorted(REGIONS))}.',
+                    category=LogfireConfigWarning,
+                )
             region = 'us'
 
     return REGIONS[region]['base_url']

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -275,7 +275,13 @@ class AdvancedOptions:
     Defaults to the `LOGFIRE_RESOURCE_DETECTORS` environment variable (a comma-separated list of names).
     """
 
-    def generate_base_url(self, token: str, warn_unknown_region: bool = False) -> str:
+    def generate_base_url(self, token: str, warn_unknown_region: bool = True) -> str:
+        """Resolve the base API URL for `token`, honouring an explicitly configured `base_url`.
+
+        Every caller of this method is part of configuration, so unknown regions warn by default
+        here. Runtime helpers (the query/API clients and the CLI) call `get_base_url_from_token`
+        directly instead, which stays silent so they can't raise under warnings-as-errors.
+        """
         if self.base_url is not None:
             return self.base_url
 
@@ -1364,7 +1370,7 @@ class LogfireConfig(_LogfireConfigData):
 
                     # Create exporters for each token
                     for token in token_list:
-                        base_url = self.advanced.generate_base_url(token, warn_unknown_region=True)
+                        base_url = self.advanced.generate_base_url(token)
                         otlp_forwarding_destinations.append((base_url, token))
                         headers = {'User-Agent': f'logfire/{VERSION}', 'Authorization': token}
                         session = OTLPExporterHttpSession()

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2132,7 +2132,11 @@ def test_configure_unknown_token_region(capsys: pytest.CaptureFixture[str]) -> N
             'https://logfire-us.pydantic.dev/v1/info',
             json={'project_name': 'myproject', 'project_url': 'https://logfire-us.pydantic.dev'},
         )
-        configure(send_to_logfire='if-token-present', token='pylf_v1_unknownregion_foobarbaz')
+        with pytest.warns(LogfireConfigWarning) as warns:
+            configure(send_to_logfire='if-token-present', token='pylf_v1_unknownregion_foobarbaz')
+        assert str(warns[0].message) == snapshot(
+            "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
+        )
         wait_for_check_token_thread()
         assert len(request_mocker.request_history) == 1
         assert capsys.readouterr().err == 'Logfire project URL: https://logfire-us.pydantic.dev\n'
@@ -3129,6 +3133,15 @@ def test_staging_token_regions():
         )
         == 'https://logfire-eu.pydantic.info'
     )
+
+
+def test_known_token_regions_do_not_warn():
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert get_base_url_from_token('pylf_v1_us_123456') == 'https://logfire-us.pydantic.dev'
+        assert get_base_url_from_token('pylf_v1_eu_123456') == 'https://logfire-eu.pydantic.dev'
+        # Tokens predating regions have no region segment and must keep working silently.
+        assert get_base_url_from_token('legacy_token_no_region') == 'https://logfire-us.pydantic.dev'
 
 
 def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2134,10 +2134,13 @@ def test_configure_unknown_token_region(capsys: pytest.CaptureFixture[str]) -> N
         )
         with pytest.warns(LogfireConfigWarning) as warns:
             configure(send_to_logfire='if-token-present', token='pylf_v1_unknownregion_foobarbaz')
+            # Inside the `pytest.warns` block so that any warning from the background
+            # token-checking thread would be caught too: the token must warn exactly once.
+            wait_for_check_token_thread()
+        assert len(warns) == 1
         assert str(warns[0].message) == snapshot(
             "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
         )
-        wait_for_check_token_thread()
         assert len(request_mocker.request_history) == 1
         assert capsys.readouterr().err == 'Logfire project URL: https://logfire-us.pydantic.dev\n'
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -3138,10 +3138,34 @@ def test_staging_token_regions():
 def test_known_token_regions_do_not_warn():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        assert get_base_url_from_token('pylf_v1_us_123456') == 'https://logfire-us.pydantic.dev'
-        assert get_base_url_from_token('pylf_v1_eu_123456') == 'https://logfire-eu.pydantic.dev'
+        assert (
+            get_base_url_from_token('pylf_v1_us_123456', warn_unknown_region=True) == 'https://logfire-us.pydantic.dev'
+        )
+        assert (
+            get_base_url_from_token('pylf_v1_eu_123456', warn_unknown_region=True) == 'https://logfire-eu.pydantic.dev'
+        )
         # Tokens predating regions have no region segment and must keep working silently.
-        assert get_base_url_from_token('legacy_token_no_region') == 'https://logfire-us.pydantic.dev'
+        assert (
+            get_base_url_from_token('legacy_token_no_region', warn_unknown_region=True)
+            == 'https://logfire-us.pydantic.dev'
+        )
+
+
+def test_unknown_token_region_does_not_warn_by_default():
+    # Runtime helpers (query/API clients, CLI) must never raise under warnings-as-errors.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert get_base_url_from_token('pylf_v1_unknownregion_123456') == 'https://logfire-us.pydantic.dev'
+
+
+def test_unknown_token_region_warns_when_opted_in():
+    with pytest.warns(LogfireConfigWarning) as warns:
+        assert get_base_url_from_token('pylf_v1_unknownregion_123456', warn_unknown_region=True) == snapshot(
+            'https://logfire-us.pydantic.dev'
+        )
+    assert str(warns[0].message) == snapshot(
+        "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
+    )
 
 
 def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -3158,6 +3158,27 @@ def test_unknown_token_region_does_not_warn_by_default():
         assert get_base_url_from_token('pylf_v1_unknownregion_123456') == 'https://logfire-us.pydantic.dev'
 
 
+def test_generate_base_url_warns_about_unknown_region_by_default():
+    # All `generate_base_url` callers are configuration paths, so they all warn consistently:
+    # the exporter setup, the variables provider, lazy variable init and credential validation.
+    with pytest.warns(LogfireConfigWarning) as warns:
+        assert (
+            logfire.AdvancedOptions().generate_base_url('pylf_v1_unknownregion_123456')
+            == 'https://logfire-us.pydantic.dev'
+        )
+    assert str(warns[0].message) == snapshot(
+        "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
+    )
+
+
+def test_generate_base_url_with_explicit_base_url_does_not_warn():
+    # An explicit base_url overrides region routing entirely, so there's nothing to warn about.
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        advanced = logfire.AdvancedOptions(base_url='https://my-proxy.example.com')
+        assert advanced.generate_base_url('pylf_v1_unknownregion_123456') == 'https://my-proxy.example.com'
+
+
 def test_unknown_token_region_warns_when_opted_in():
     with pytest.warns(LogfireConfigWarning) as warns:
         assert get_base_url_from_token('pylf_v1_unknownregion_123456', warn_unknown_region=True) == snapshot(

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -929,7 +929,7 @@ class TestLocalVariableProvider:
 
 
 REMOTE_BASE_URL = 'http://localhost:8000/'
-REMOTE_TOKEN = 'pylf_v1_us_test_token'
+REMOTE_TOKEN = 'pylf_v1_local_test_token'
 REGION_API_KEY = 'pylf_v2_stagingeu_9f9ba85a-b759-4181-9527-d812e03f9f7f_0kYhc414Ys2FNDRdt5vFB05xFx5NjVcbcBMy4Kp6PH0W'
 
 

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -929,7 +929,7 @@ class TestLocalVariableProvider:
 
 
 REMOTE_BASE_URL = 'http://localhost:8000/'
-REMOTE_TOKEN = 'pylf_v1_local_test_token'
+REMOTE_TOKEN = 'pylf_v1_us_test_token'
 REGION_API_KEY = 'pylf_v2_stagingeu_9f9ba85a-b759-4181-9527-d812e03f9f7f_0kYhc414Ys2FNDRdt5vFB05xFx5NjVcbcBMy4Kp6PH0W'
 
 


### PR DESCRIPTION
Fixes #2220

## Problem

`get_base_url_from_token` silently falls back to the `us` region when a
token's region segment isn't recognised, so a misrouted deployment
presents as missing data instead of a visible signal.

## Fix

Kept the fallback (an observability SDK shouldn't crash the host app
over a config quirk), and added a warning right before it fires:

```python
if region not in REGIONS:
    warn_at_user_stacklevel(
        f'Unknown region {region!r} in Logfire token, falling back to the US region. '
        f'Known regions: {", ".join(sorted(REGIONS))}.',
        category=LogfireConfigWarning,
    )
    region = 'us'
```

Uses the existing `warn_at_user_stacklevel` helper (already used
elsewhere in `config.py`) so the warning points at the caller's code,
not internal SDK code. The known-regions list is read from `REGIONS` at
call time, so it stays correct as regions are added.

### Explicitly not changed

`UserTokenData.__str__` in `auth.py` has similar fallback logic, but it
is display-only (used for repr/logging, not routing), so I left it
unchanged to avoid emitting a warning from `__str__`.

## Tests

* Updated `test_configure_unknown_token_region` to assert the new
  warning (it previously asserted the silent behavior this PR changes).
* Added `test_known_token_regions_do_not_warn` to ensure valid regions,
  legacy (pre-region) tokens, and staging tokens remain warning-free.
* Renamed `tests/test_variables.py`'s `REMOTE_TOKEN` fixture from
  `pylf_v1_local_test_token` to `pylf_v1_us_test_token` — `local` isn't
  a real region and was triggering the new warning under this repo's
  `filterwarnings = ["error"]` pytest configuration. Both tokens resolve
  to the same URL.

Full suite passes locally: **2293 passed, 9 skipped, 2 xfailed**.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

