### PR TITLE
Document the PR iteration loop for AI coding assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,9 @@ CI is required to pass on main, so pre-existing CI failures are unlikely. If the
 
 ## Coverage
 
-Coverage must be 100%. The bar is the `uv run coverage report --fail-under 100` step of the `coverage` job in [`.github/workflows/main.yml`](.github/workflows/main.yml), not `pyproject.toml` — `[tool.coverage.report]` sets no `fail_under`, so a plain local `coverage report` exits 0 on a regression. Run `make testcov`, then `uv run coverage report --fail-under 100`, before pushing. CI combines coverage across the whole test matrix, so a line reached only by another matrix job shows as missed locally; investigate a local miss before deleting or excluding the code.
+Coverage must be 100%. The bar is the `uv run coverage report --fail-under 100` step of the `coverage` job in [`.github/workflows/main.yml`](.github/workflows/main.yml), not `pyproject.toml` — `[tool.coverage.report]` sets no `fail_under`, so reading `pyproject.toml` suggests there is no bar and a plain `coverage report` exits 0 on a regression.
+
+Let CI measure it rather than running the suite under coverage locally: CI combines coverage across the whole test matrix, so a line reached only by another matrix job looks missed on one machine, and a local number is both slow to get and misleading. When the `coverage` job fails it names the file and the missing lines and branches; cover those and push again. Reach for a local run only to check a specific file you are iterating on, with `uv run coverage run -m pytest <the relevant tests>` followed by `uv run coverage report --include='*/<file>.py'`.
 
 ## The check job
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,7 @@ Let CI measure it rather than running the suite under coverage locally: CI combi
 
 ## The check job
 
-The `check` job only aggregates the other jobs with the `alls-green` action and produces no result of its own. When `check` fails, open the job it names and read that job's log.
+The `check` job runs no checks of its own: it uses the `alls-green` action to combine the other jobs' results into a single pass or fail. Its log therefore only names which job failed, so open that job and read its log to find the cause.
 
 ## Pydantic version coverage
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,11 +102,31 @@ The `logfire-api` package is a no-op shim that libraries can depend on to avoid 
 
 CI is required to pass on main, so pre-existing CI failures are unlikely. If the same test fails across multiple Python version jobs, it's almost certainly caused by your changes — investigate rather than assuming it's a flaky pre-existing issue.
 
+## Coverage
+
+Coverage must be 100%. The bar is the `uv run coverage report --fail-under 100` step of the `coverage` job in [`.github/workflows/main.yml`](.github/workflows/main.yml), not `pyproject.toml` — `[tool.coverage.report]` sets no `fail_under`, so a plain local `coverage report` exits 0 on a regression. Run `make testcov`, then `uv run coverage report --fail-under 100`, before pushing. CI combines coverage across the whole test matrix, so a line reached only by another matrix job shows as missed locally; investigate a local miss before deleting or excluding the code.
+
+## The check job
+
+The `check` job only aggregates the other jobs with the `alls-green` action and produces no result of its own. When `check` fails, open the job it names and read that job's log.
+
 ## Pydantic version coverage
 
 PR CI only tests pydantic latest plus one extra job at pydantic 2.4. The full set of supported minor versions (2.4, 2.5, 2.6, ... up through main) is exercised by the weekly job in `.github/workflows/weekly_deps_test.yml`, which is the contract: every minor version listed there is meant to keep working.
 
 When something fails on pydantic 2.4, do not assume it is a 2.4-only quirk. The same problem is likely to affect some of 2.5–2.11 as well. Investigate which versions are actually affected (e.g. read the upstream changelog, install one of the in-between versions locally and reproduce) and fix or work around for the whole affected range. A green PR CI is not enough — if you only verify against 2.4 and latest, the weekly job will fail later even though the PR merged cleanly.
+
+# Iterating on a pull request
+
+A pull request is ready when CI is green and no review thread is unresolved. Run this loop until both hold.
+
+1. Watch the checks until they settle, then fix every failure.
+2. Read each new review comment. Several AI reviewers comment on pull requests here; verify each finding against this repository's code, configuration and history before acting on it. Do not assume a reviewer is right, and do not assume it is wrong.
+3. Fix what the valid findings call for. Reply to every thread with what you changed, or with the evidence that the finding does not apply here.
+4. Resolve each thread once you have replied. Leave a thread unresolved only to hold an open question that needs a maintainer's decision — one the repository's own docs, configuration and history cannot settle.
+5. Return to step 1 after every push, because reviewers comment again on the new commit.
+
+A reviewer can be right about Python in general and wrong about this repository. For example, a reviewer may report a Ruff `S106` violation (hardcoded password passed as an argument). `[tool.ruff.lint]` in `pyproject.toml` selects `E4`, `E7`, `E9` and `F`, plus an `extend-select` list that does not contain `S`, and `uv run ruff check --select S106` reports many pre-existing hits. The rule is not enabled, so there is nothing to fix. Check the configuration that governs a finding before you accept it.
 
 # Misc
 


### PR DESCRIPTION
> This pull request was posted by Claude Code using claude-opus-5 on behalf of David.

Adds a section to `CLAUDE.md` (which `AGENTS.md` symlinks to) describing the loop an AI coding assistant should run after opening a pull request: watch CI, verify each reviewer finding against this repository before acting on it, reply to and resolve threads, and repeat after every push.

Also documents two CI facts under the existing `# CI` section, both of which are easy to get wrong from the repository alone:

- the 100% coverage bar lives in the `coverage` job of `.github/workflows/main.yml`, not in `pyproject.toml`, so a local `coverage report` passes on a regression;
- the `check` job only aggregates the other jobs via `alls-green`, so its failure log is never the real one.

**Why**: assistants working on pull requests here repeatedly lose time to the same three things — concluding there is no coverage bar because `pyproject.toml` has no `fail_under`, debugging the `check` aggregator instead of the job it names, and accepting reviewer findings that this repository's own configuration rules out (for instance a Ruff `S106` report, when `[tool.ruff.lint]` does not select `S`). Writing the loop and the three facts down puts them in context before the mistake instead of after it.

**New public surface**: none — documentation only.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

