### PR TITLE
Clarify Open WebUI telemetry scope

### DIFF
--- a/docs/integrations/no-code/open-webui.md
+++ b/docs/integrations/no-code/open-webui.md
@@ -10,6 +10,8 @@ See Open WebUI HTTP requests, database and cache calls, metrics, and logs in Log
 
 Open WebUI sends this data using the OpenTelemetry Protocol (OTLP), the standard wire format Logfire uses to receive telemetry. Its documented authentication settings support Basic authentication rather than Logfire's write-token header, so this setup uses an OpenTelemetry Collector to add that header.
 
+This setup provides application and infrastructure telemetry. Open WebUI's built-in OpenTelemetry integration does not produce AI-specific spans for prompts, model responses, token usage, or cost.
+
 The [OpenTelemetry Collector](../../how-to-guides/otel-collector/otel-collector-overview.md) is a separate program that sits between Open WebUI and Logfire, gathering telemetry and forwarding it. This route requires access to Open WebUI's runtime configuration. The official Docker images include the OpenTelemetry dependencies. A source or `pip` installation may need the optional OpenTelemetry packages described in the vendor documentation.
 
 !!! warning "Review request, database, and log data"


### PR DESCRIPTION
## Summary

- clarify that the built-in OpenTelemetry integration provides application and infrastructure telemetry
- state that it does not emit AI-specific spans for prompts, model responses, token usage, or cost

## Validation

- `uv run pre-commit run --files docs/integrations/no-code/open-webui.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

