### PR TITLE
Match each extra scrubbing pattern independently

### DIFF
--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -35,6 +35,18 @@ logfire.info(
 )
 ```
 
+Each pattern is matched on its own, so a pattern behaves exactly as it would if you passed it to
+`re.compile` yourself. In particular, a capture group — a bracketed part of a pattern, such as the
+`(\d{2})` below — belongs to the pattern it is written in, so you can refer back to it with `\1`
+without the other patterns interfering:
+
+```python
+import logfire
+
+# Redacts a repeated pair of digits, e.g. '1212', but not '1234'.
+logfire.configure(scrubbing=logfire.ScrubbingOptions(extra_patterns=[r'(\d{2})\1']))
+```
+
 Here are the default scrubbing patterns:
 
 ```python

--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -42,7 +42,7 @@ so you can point back at it with `\1` without the other patterns interfering:
 ```python
 import logfire
 
-# Redacts a repeated pair of digits, e.g. '1212', but not '1234'.
+# Redacts a value containing a repeated pair of digits, e.g. 'card 1212', but not 'card 1234'.
 logfire.configure(scrubbing=logfire.ScrubbingOptions(extra_patterns=[r'(\d{2})\1']))
 ```
 

--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -35,10 +35,9 @@ logfire.info(
 )
 ```
 
-Each pattern is matched on its own, so a pattern behaves exactly as it would if you passed it to
-`re.compile` yourself. In particular, a capture group — a bracketed part of a pattern, such as the
-`(\d{2})` below — belongs to the pattern it is written in, so you can refer back to it with `\1`
-without the other patterns interfering:
+Patterns are applied case-insensitively, and `.` also matches newlines. A capture group — a
+bracketed part of a pattern, such as the `(\d{2})` below — belongs to the pattern it is written in,
+so you can point back at it with `\1` without the other patterns interfering:
 
 ```python
 import logfire

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -261,7 +261,11 @@ def _compile_patterns(extra_patterns: Sequence[str] | None) -> list[re.Pattern[s
 
     def flush_joinable():
         if joinable:
-            compiled_patterns.append(re.compile('|'.join(joinable), _SCRUBBING_FLAGS))
+            with warnings.catch_warnings():
+                # Each pattern has already been compiled on its own, which is where any warning
+                # belongs: it names a position in the user's pattern, not in the combined one.
+                warnings.simplefilter('ignore')
+                compiled_patterns.append(re.compile('|'.join(joinable), _SCRUBBING_FLAGS))
             joinable.clear()
 
     for pattern in extra_patterns or []:

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import copy
 import json
 import re
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, TypedDict, cast
 
 import typing_extensions
@@ -68,6 +70,8 @@ DEFAULT_PATTERNS = [
 # position in large strings. Custom patterns are not constrained by this prefix.
 _DEFAULT_PATTERN_START_CHARS = 'pmsacljx_'
 _DEFAULT_PATTERN = rf'(?=[{_DEFAULT_PATTERN_START_CHARS}])(?:{"|".join(DEFAULT_PATTERNS)})'
+
+_SCRUBBING_FLAGS = re.IGNORECASE | re.DOTALL
 
 JsonPath: typing_extensions.TypeAlias = 'tuple[str | int, ...]'
 
@@ -205,13 +209,82 @@ class NoopScrubber(BaseScrubber):
 NOOP_SCRUBBER = NoopScrubber()
 
 
+def _compile_pattern(pattern: str) -> re.Pattern[str]:
+    """Compile one pattern on its own, naming it if it's invalid.
+
+    Compiling separately means the position in the error message points into the pattern
+    the user actually wrote, instead of into the combined pattern they never see.
+    """
+    try:
+        return re.compile(pattern, _SCRUBBING_FLAGS)
+    except re.error as e:
+        raise re.error(f'{e.msg} (in scrubbing pattern {pattern!r})', pattern, e.pos) from e
+
+
+def _can_be_joined(pattern: str) -> bool:
+    """Whether `pattern` still means the same thing after another pattern in an alternation.
+
+    Global inline flags such as `(?s)` are only allowed at the very start of a pattern, so a pattern
+    using them can't be combined with any other. Python 3.10 only warns about this, later versions
+    raise, so turn the warning into an error to get the same answer everywhere.
+    """
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error')
+            re.compile(f'x|{pattern}', _SCRUBBING_FLAGS)
+    except (re.error, DeprecationWarning):
+        return False
+    return True
+
+
+def _compile_patterns(extra_patterns: Sequence[str] | None) -> list[re.Pattern[str]]:
+    """Compile the default and extra patterns into as few regexes as possible.
+
+    Patterns are combined into one alternation wherever that's safe, because one regex search
+    is considerably cheaper than one per pattern on the short strings that most span attributes
+    are made of.
+
+    A pattern containing a capture group can't be combined: all patterns in an alternation share
+    one group numbering space, so its groups would be renumbered, and a numeric backreference or
+    conditional in it would then refer to a group belonging to another pattern. That pattern would
+    silently never match, and data the user expected to be redacted would be exported. Giving such
+    a pattern its own regex keeps its group numbering to itself, so it behaves as written.
+    """
+    joinable = [_DEFAULT_PATTERN]
+    separate: list[re.Pattern[str]] = []
+    for pattern in extra_patterns or []:
+        compiled = _compile_pattern(pattern)
+        if compiled.groups or not _can_be_joined(pattern):
+            separate.append(compiled)
+        else:
+            joinable.append(pattern)
+    # The separate patterns go last, so when two patterns match at the same position the combined
+    # one wins, as it would have when everything was in a single alternation.
+    return [re.compile('|'.join(joinable), _SCRUBBING_FLAGS), *separate]
+
+
+def _leftmost_match(patterns: Sequence[re.Pattern[str]], value: str) -> re.Match[str] | None:
+    """Find the leftmost match of any pattern, as a single combined pattern would.
+
+    Where several patterns match at the same position the earliest one wins, which is also how
+    `re` picks between the branches of an alternation.
+    """
+    best: re.Match[str] | None = None
+    for pattern in patterns:
+        match = pattern.search(value)
+        if match and (best is None or match.start() < best.start()):
+            best = match
+            if best.start() == 0:  # No later pattern can match further left.
+                break
+    return best
+
+
 class Scrubber(BaseScrubber):
     """Redacts potentially sensitive data."""
 
     def __init__(self, patterns: Sequence[str] | None, callback: ScrubCallback | None = None):
         # See ScrubbingOptions for more info on these parameters.
-        patterns = [_DEFAULT_PATTERN, *(patterns or [])]
-        self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
+        self._patterns = _compile_patterns(patterns)
         self._callback = callback
 
     def scrub_log(self, log: LogRecord) -> LogRecord:
@@ -251,7 +324,11 @@ class SpanScrubber:
     """
 
     def __init__(self, parent: Scrubber):
-        self._pattern = parent._pattern  # pyright: ignore[reportPrivateUsage]
+        patterns = parent._patterns  # pyright: ignore[reportPrivateUsage]
+        # Runs for every attribute key and value, so call the single regex directly when there's only one.
+        self._search: Callable[[str], re.Match[str] | None] = (
+            patterns[0].search if len(patterns) == 1 else partial(_leftmost_match, patterns)
+        )
         self._callback = parent._callback  # pyright: ignore[reportPrivateUsage]
         self.scrubbed: list[ScrubbedNote] = []
         self.did_scrub = False
@@ -315,7 +392,7 @@ class SpanScrubber:
         Similar to the truncation code, it should use the field names in the frontend, e.g. `otel_events`.
         """
         if isinstance(value, str):
-            if match := self._pattern.search(value):
+            if match := self._search(value):
                 if match.span() == (0, len(value)):
                     # If the *whole* string matches, e.g. the value is literally 'password' and nothing more,
                     # it's considered safe.
@@ -333,7 +410,7 @@ class SpanScrubber:
             for k, v in cast('Mapping[str, Any]', value).items():
                 if k in BaseScrubber.SAFE_KEYS:
                     result[k] = v
-                elif match := self._pattern.search(k):
+                elif match := self._search(k):
                     redacted = self._redact(ScrubMatch(path + (k,), v, match))
                     if isinstance(redacted, str) and isinstance(v, Sequence) and not isinstance(v, str):
                         redacted = [redacted]

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -226,11 +226,14 @@ def _can_be_joined(pattern: str) -> bool:
 
     Global inline flags such as `(?s)` are only allowed at the very start of a pattern, so a pattern
     using them can't be combined with any other. Python 3.10 only warns about this, later versions
-    raise, so turn the warning into an error to get the same answer everywhere.
+    raise, so turn that warning into an error to get the same answer everywhere. Any other warning
+    is silenced: the pattern has already been compiled on its own, which is where the user should
+    hear about it once.
     """
     try:
         with warnings.catch_warnings():
-            warnings.simplefilter('error')
+            warnings.simplefilter('ignore')
+            warnings.simplefilter('error', DeprecationWarning)
             re.compile(f'x|{pattern}', _SCRUBBING_FLAGS)
     except (re.error, DeprecationWarning):
         return False
@@ -249,18 +252,27 @@ def _compile_patterns(extra_patterns: Sequence[str] | None) -> list[re.Pattern[s
     conditional in it would then refer to a group belonging to another pattern. That pattern would
     silently never match, and data the user expected to be redacted would be exported. Giving such
     a pattern its own regex keeps its group numbering to itself, so it behaves as written.
+
+    Only neighbouring patterns are combined, so the result stays in the configured order. Where two
+    patterns match at the same position the earlier one has always won, and it still does.
     """
+    compiled_patterns: list[re.Pattern[str]] = []
     joinable = [_DEFAULT_PATTERN]
-    separate: list[re.Pattern[str]] = []
+
+    def flush_joinable():
+        if joinable:
+            compiled_patterns.append(re.compile('|'.join(joinable), _SCRUBBING_FLAGS))
+            joinable.clear()
+
     for pattern in extra_patterns or []:
         compiled = _compile_pattern(pattern)
         if compiled.groups or not _can_be_joined(pattern):
-            separate.append(compiled)
+            flush_joinable()
+            compiled_patterns.append(compiled)
         else:
             joinable.append(pattern)
-    # The separate patterns go last, so when two patterns match at the same position the combined
-    # one wins, as it would have when everything was in a single alternation.
-    return [re.compile('|'.join(joinable), _SCRUBBING_FLAGS), *separate]
+    flush_joinable()
+    return compiled_patterns
 
 
 def _leftmost_match(patterns: Sequence[re.Pattern[str]], value: str) -> re.Match[str] | None:

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -210,12 +210,17 @@ def test_invalid_extra_pattern_is_named_in_the_error(extra_pattern: str):
     assert exc_info.value.pos <= len(extra_pattern)
 
 
-def test_extra_pattern_warning_is_not_turned_into_an_error():
-    """A pattern that only warns still works, e.g. `[[a]`, which warns about a possible nested set."""
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')  # anything raised here would reach the user's `configure()` call
-        with pytest.warns(FutureWarning, match='Possible nested set'):
-            scrubber = Scrubber(['[[a]'])
+def test_extra_pattern_warning_is_raised_once_and_is_not_an_error():
+    """A pattern that only warns still works, e.g. `[[a]`, which warns about a possible nested set.
+
+    The user should hear about it once, from compiling their own pattern. A second warning from the
+    combined pattern would report a position they can't act on.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        scrubber = Scrubber(['[[a]'])
+
+    assert [str(warning.message) for warning in caught] == ['Possible nested set at position 1']
 
     result, _ = scrubber.scrub_value(('attributes', 'value'), 'q [a')
     assert result == "[Scrubbed due to '[']"

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import re
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -147,6 +148,38 @@ def test_extra_patterns_are_matched_independently(extra_patterns: list[str], val
     assert scrubbed_notes == [{'path': ('attributes', 'value'), 'matched_substring': expected_match}]
 
 
+@pytest.mark.parametrize(
+    ('extra_patterns', 'expected_result'),
+    [
+        pytest.param([r'(TOKEN=)', r'TOKEN=.*'], "[Scrubbed due to 'TOKEN=']", id='grouped-pattern-first'),
+        pytest.param([r'TOKEN=.*', r'(TOKEN=)'], 'TOKEN=secret', id='grouped-pattern-second'),
+    ],
+)
+def test_extra_patterns_keep_their_configured_order(extra_patterns: list[str], expected_result: str):
+    """Where two patterns match at the same position, the earlier one wins, as in one alternation.
+
+    Compiling a pattern separately must not move it, in either direction. `TOKEN=.*` matches the
+    whole value, which `scrub` treats as safe and keeps, so promoting it above `(TOKEN=)` would
+    export the value instead of redacting it.
+    """
+    result, _ = Scrubber(extra_patterns).scrub_value(('attributes', 'value'), 'TOKEN=secret')
+
+    assert result == expected_result
+
+
+def test_earlier_pattern_wins_the_callback():
+    """The callback gets the match of the pattern that would have won a single alternation."""
+    groups: list[dict[str, str | Any]] = []
+
+    def callback(match: logfire.ScrubMatch):
+        groups.append(match.pattern_match.groupdict())
+        return match.value
+
+    Scrubber([r'(?P<x>zzz)', 'zzz'], callback).scrub_value(('attributes', 'value'), 'q zzz')
+
+    assert groups == [{'x': 'zzz'}]
+
+
 def test_extra_pattern_match_only_contains_its_own_groups():
     """The match passed to the callback belongs to the pattern that matched, not to a combined one."""
     scrub_matches: list[logfire.ScrubMatch] = []
@@ -163,17 +196,29 @@ def test_extra_pattern_match_only_contains_its_own_groups():
     assert pattern_match.groupdict() == {'mine': 'zzz'}
 
 
-@pytest.mark.parametrize(
-    ('extra_pattern', 'message'),
-    [
-        ('bad[(', "unterminated character set (in scrubbing pattern 'bad[(') at position 3"),
-        (r'\1', "invalid group reference 1 (in scrubbing pattern '\\\\1') at position 1"),
-    ],
-)
-def test_invalid_extra_pattern_is_named_in_the_error(extra_pattern: str, message: str):
-    """The position in the error must point into the pattern the user wrote."""
-    with pytest.raises(re.error, match=re.escape(message)):
+@pytest.mark.parametrize('extra_pattern', ['bad[(', r'\1'])
+def test_invalid_extra_pattern_is_named_in_the_error(extra_pattern: str):
+    """The error must name the offending pattern, and give a position inside it.
+
+    Only the part of the message this module adds is asserted. The rest is CPython's wording,
+    which is free to differ between the Python versions this package supports.
+    """
+    with pytest.raises(re.error, match=re.escape(f'(in scrubbing pattern {extra_pattern!r})')) as exc_info:
         Scrubber(['custom', extra_pattern])
+
+    assert exc_info.value.pos is not None
+    assert exc_info.value.pos <= len(extra_pattern)
+
+
+def test_extra_pattern_warning_is_not_turned_into_an_error():
+    """A pattern that only warns still works, e.g. `[[a]`, which warns about a possible nested set."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')  # anything raised here would reach the user's `configure()` call
+        with pytest.warns(FutureWarning, match='Possible nested set'):
+            scrubber = Scrubber(['[[a]'])
+
+    result, _ = scrubber.scrub_value(('attributes', 'value'), 'q [a')
+    assert result == "[Scrubbed due to '[']"
 
 
 @pytest.mark.parametrize(
@@ -183,6 +228,8 @@ def test_invalid_extra_pattern_is_named_in_the_error(extra_pattern: str, message
         (['custom', r'\d+'], 1),
         ([r'(b)\1'], 2),
         (['custom', r'(b)\1', r'(?P<x>c)'], 3),
+        # A joinable pattern after a separated one starts a new regex, to keep the configured order.
+        ([r'(b)\1', 'custom'], 3),
     ],
 )
 def test_only_patterns_with_groups_need_their_own_regex(
@@ -199,7 +246,7 @@ def test_scrub_with_backreference_pattern(exporter: TestExporter, config_kwargs:
     # contain neither `a` nor `bb`, so only the values decide what is redacted.
     logfire.info('hi', hit='q bb', miss='q zz')
 
-    assert exporter.exported_spans_as_dict() == snapshot(
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
                 'name': 'hi',
@@ -217,8 +264,8 @@ def test_scrub_with_backreference_pattern(exporter: TestExporter, config_kwargs:
                     'code.lineno': 123,
                     'hit': "[Scrubbed due to 'bb']",
                     'miss': 'q zz',
-                    'logfire.json_schema': '{"type":"object","properties":{"hit":{},"miss":{}}}',
-                    'logfire.scrubbed': '[{"path": ["attributes", "hit"], "matched_substring": "bb"}]',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'hit': {}, 'miss': {}}},
+                    'logfire.scrubbed': [{'path': ['attributes', 'hit'], 'matched_substring': 'bb'}],
                 },
             }
         ]

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -126,6 +126,105 @@ def test_default_pattern_start_chars_cover_each_pattern():
         assert (actual.span(), actual.group(0)) == (expected.span(), expected.group(0))
 
 
+@pytest.mark.parametrize(
+    ('extra_patterns', 'value', 'expected_match'),
+    [
+        pytest.param(['(a)', r'(b)\1'], 'q bb', 'bb', id='backreference'),
+        pytest.param(['(a)', r'(b)\1'], 'bb q', 'bb', id='backreference-at-start-of-value'),
+        pytest.param([r'(a)', r'(x)?(?(1)y|z)'], 'q xy', 'xy', id='conditional-reference'),
+        pytest.param([r'(?P<x>aaa)', r'(?P<x>bbb)'], 'q bbb', 'bbb', id='duplicate-group-names'),
+        pytest.param([r'(?s)fo.o'], 'q fo\no', 'fo\no', id='global-inline-flag'),
+    ],
+)
+def test_extra_patterns_are_matched_independently(extra_patterns: list[str], value: str, expected_match: str):
+    """Each extra pattern must behave as it does on its own, whatever the other patterns are."""
+    for pattern in extra_patterns:
+        re.compile(pattern, re.IGNORECASE | re.DOTALL)  # each pattern is valid by itself
+
+    result, scrubbed_notes = Scrubber(extra_patterns).scrub_value(('attributes', 'value'), value)
+
+    assert result == f'[Scrubbed due to {expected_match!r}]'
+    assert scrubbed_notes == [{'path': ('attributes', 'value'), 'matched_substring': expected_match}]
+
+
+def test_extra_pattern_match_only_contains_its_own_groups():
+    """The match passed to the callback belongs to the pattern that matched, not to a combined one."""
+    scrub_matches: list[logfire.ScrubMatch] = []
+
+    def callback(match: logfire.ScrubMatch):
+        scrub_matches.append(match)
+        return match.value
+
+    Scrubber([r'(?P<mine>zzz)'], callback).scrub_value(('attributes', 'value'), 'q zzz')
+
+    assert len(scrub_matches) == 1
+    pattern_match = scrub_matches[0].pattern_match
+    assert pattern_match.groups() == ('zzz',)
+    assert pattern_match.groupdict() == {'mine': 'zzz'}
+
+
+@pytest.mark.parametrize(
+    ('extra_pattern', 'message'),
+    [
+        ('bad[(', "unterminated character set (in scrubbing pattern 'bad[(') at position 3"),
+        (r'\1', "invalid group reference 1 (in scrubbing pattern '\\\\1') at position 1"),
+    ],
+)
+def test_invalid_extra_pattern_is_named_in_the_error(extra_pattern: str, message: str):
+    """The position in the error must point into the pattern the user wrote."""
+    with pytest.raises(re.error, match=re.escape(message)):
+        Scrubber(['custom', extra_pattern])
+
+
+@pytest.mark.parametrize(
+    ('extra_patterns', 'expected_number_of_regexes'),
+    [
+        (None, 1),
+        (['custom', r'\d+'], 1),
+        ([r'(b)\1'], 2),
+        (['custom', r'(b)\1', r'(?P<x>c)'], 3),
+    ],
+)
+def test_only_patterns_with_groups_need_their_own_regex(
+    extra_patterns: list[str] | None, expected_number_of_regexes: int
+):
+    """Scrubbing runs on the application's thread, so the usual case must stay a single search."""
+    assert len(Scrubber(extra_patterns)._patterns) == expected_number_of_regexes  # pyright: ignore[reportPrivateUsage]
+
+
+def test_scrub_with_backreference_pattern(exporter: TestExporter, config_kwargs: dict[str, Any]):
+    logfire.configure(scrubbing=logfire.ScrubbingOptions(extra_patterns=['(a)', r'(b)\1']), **config_kwargs)
+
+    # `hit` is matched by the backreference pattern, `miss` by nothing. The keys deliberately
+    # contain neither `a` nor `bb`, so only the values decide what is redacted.
+    logfire.info('hi', hit='q bb', miss='q zz')
+
+    assert exporter.exported_spans_as_dict() == snapshot(
+        [
+            {
+                'name': 'hi',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 1000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 9,
+                    'logfire.msg_template': 'hi',
+                    'logfire.msg': 'hi',
+                    'code.filepath': 'test_secret_scrubbing.py',
+                    'code.function': 'test_scrub_with_backreference_pattern',
+                    'code.lineno': 123,
+                    'hit': "[Scrubbed due to 'bb']",
+                    'miss': 'q zz',
+                    'logfire.json_schema': '{"type":"object","properties":{"hit":{},"miss":{}}}',
+                    'logfire.scrubbed': '[{"path": ["attributes", "hit"], "matched_substring": "bb"}]',
+                },
+            }
+        ]
+    )
+
+
 def test_scrub_attribute(exporter: TestExporter):
     logfire.info(
         'Password: {user_password}',


### PR DESCRIPTION
Fixes #2237

`Scrubber.__init__` joined every pattern into a single alternation, so all patterns shared one
capture-group numbering space. A numeric backreference in one `extra_patterns` entry referred to a
group in an earlier entry rather than to its own, so the pattern silently never matched and data the
user expected to be redacted was exported.

**What this changes**

Patterns are still combined into one regex wherever that is safe, and only neighbouring patterns are
combined, so the compiled list stays in the configured order. A pattern that contains a capture group
is compiled on its own, which keeps its group numbering to itself, so its groups, backreferences and
conditionals mean what they say.

The condition is a capture group, not a backreference, and it is read from the public
`re.Pattern.groups` attribute. A group is the necessary condition for the bug — there is no
backreference or conditional reference without one — so this needs no parsing of regex source and
rejects nothing that works today. A grouped pattern with no backreference is separated too, which
costs one extra search and changes no behaviour.

Four things are fixed by the same change:

| Configuration | Before | After |
|---|---|---|
| `extra_patterns=['(a)', r'(b)\1']`, value `'q bb'` | not redacted | `[Scrubbed due to 'bb']` |
| `extra_patterns=['(a)', r'(x)?(?(1)y\|z)']`, value `'q xy'` | not redacted | `[Scrubbed due to 'xy']` |
| `extra_patterns=[r'(?P<x>aaa)', r'(?P<x>bbb)']` | `re.error: redefinition of group name 'x' as group 2; was group 1 at position 272` | works |
| `extra_patterns=[r'(?s)fo.o']` | `re.error: global flags not at the start of the expression at position 259` | works |

The last two were loud rather than silent, but the positions in those messages index the combined
pattern, which the user never wrote. Compiling each pattern separately also fixes that: an invalid
pattern now reports `unterminated character set (in scrubbing pattern 'bad[(') at position 3`.

**Performance**

Scrubbing runs on the application's thread during span creation, so the joining is worth keeping.
None of the 18 default patterns contains a capture group, so the default configuration — and any
configuration whose extra patterns have no groups — still compiles to exactly one regex and does
exactly one search per value, as it does today. `SpanScrubber` binds that single pattern's `search`
directly, so there is no added call on the common path.

Scrubbing a span of five attributes, 20k iterations, Python 3.13, three alternating rounds of
`main` and this branch to cancel drift (ranges across rounds):

```
                 main            this branch
default          3.94-3.98 us    4.02-4.15 us
plain extra      4.54-4.56 us    4.59-4.75 us
grouped extra    4.60-4.68 us    4.93-4.98 us
```

A configuration with no capture groups is within a few percent of `main`, close to the noise floor
of this measurement. Only a user who writes a capture group pays the real cost of a second search,
and that is the case that was silently broken.

A test asserts the number of compiled regexes for five configurations, so a later refactor cannot
quietly turn the single search into one per pattern.

**A note on the reproduction in the issue**

The snippet in #2237 still returns `'bb'` after this change, for an unrelated reason: `scrub` treats
a value as safe when the *whole* string matches, so `'bb'` against `(b)\1` is a full match and is
kept, exactly as the value `'password'` is kept today
([`scrubbing.py`](https://github.com/pydantic/logfire/blob/main/logfire/_internal/scrubbing.py#L392-L395)).
Using `'q bb'` shows the real difference. The same confound applies to the conditional-reference
case: with the value `'z'` the joined pattern happens to agree with the standalone one, so `'q xy'`
is used in the test instead.

**Tests**

`tests/test_secret_scrubbing.py` gains 18 cases: five for patterns matched independently, two for
patterns keeping their configured order, two for the callback receiving the right match, two for
error messages naming the pattern, one for a pattern that only warns, five for the number of
compiled regexes, and one end-to-end `logfire.configure` test with a snapshot.

**Checks**

Run in Docker against a clean `origin/main` for comparison:

- `ruff check`, `ruff format --check`, `pyright` — clean.
- Python 3.13: 2310 passed, 5 failed. Python 3.10: 2306 passed, 6 failed. Every failure also fails
  on unmodified `main` in the same image (`main` is 6 failed on 3.13, 7 on 3.10) — they need a
  Docker socket or a subprocess that the container does not have.
- On the host, where those pass: 2325 passed, 9 skipped, 2 xfailed, 0 failed.
- `logfire/_internal/scrubbing.py` is at 100% statement and branch coverage.

**Open question for maintainers**

`docs/how-to-guides/scrubbing.md` describes `extra_patterns` as "a list of regex strings" and says
nothing about capture groups, so I could not find a statement of whether a group in an extra pattern
is meant to work at all. This PR makes it work, which is the reading that rejects nothing users
already have. The alternative in the issue — refusing numeric backreferences with a clear error — is
a smaller change but turns some working patterns into a startup error. Please let me know what is
best product behaviour and what are recommended user flows; I am happy to swap this for the
rejecting version if that is what you want.

Docs changed, so the `trigger:docs` label would be needed for a preview.

**Left out deliberately**

An empty extra pattern (`''`, or an equivalent such as `'a*'`) matches at every position, so every
string value in every span is replaced by `[Scrubbed due to '']`. That is a separate root cause with
its own behaviour question — whether to reject such a pattern at configure time — so I have not
mixed it into this PR. Would you like an issue for it?
