### PR TITLE
fix: validate extra scrubbing patterns

### DIFF
--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -14,6 +14,8 @@ from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.trace import Event
 from opentelemetry.trace import Link
 
+from logfire.exceptions import LogfireConfigError
+
 from .constants import (
     ATTRIBUTES_CONFIG,
     ATTRIBUTES_JSON_SCHEMA_KEY,
@@ -114,7 +116,32 @@ class ScrubbingOptions:
     A sequence of regular expressions to detect sensitive data that should be redacted.
     For example, the default includes `'password'`, `'secret'`, and `'api[._ -]?key'`.
     The specified patterns are combined with the default patterns.
+    Patterns that match the empty string are rejected because they would redact every value.
     """
+
+    def __post_init__(self):
+        if isinstance(self.extra_patterns, str):
+            raise LogfireConfigError(
+                '`extra_patterns` must be a sequence of regular expressions, not a single string. '
+                "Use `extra_patterns=['password']` instead of `extra_patterns='password'`."
+            )
+
+        for pattern in self.extra_patterns or ():
+            try:
+                compiled_pattern = re.compile(pattern, re.IGNORECASE | re.DOTALL)
+            except re.error as error:
+                raise LogfireConfigError(
+                    f'Invalid regular expression in `extra_patterns`: {pattern!r}: {error}'
+                ) from error
+
+            # Boundaries and lookarounds can produce empty matches only when surrounding text is present.
+            empty_match_probe = f'a0 _-\n{pattern}'
+            if compiled_pattern.match('') is not None or any(
+                match.start() == match.end() for match in compiled_pattern.finditer(empty_match_probe)
+            ):
+                raise LogfireConfigError(
+                    f'`extra_patterns` must not contain regular expressions that match the empty string: {pattern!r}'
+                )
 
 
 class BaseScrubber(ABC):

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -15,6 +15,7 @@ from opentelemetry.trace.propagation import get_current_span
 
 import logfire
 from logfire._internal.scrubbing import DEFAULT_PATTERNS, NoopScrubber, Scrubber
+from logfire.exceptions import LogfireConfigError
 from logfire.testing import TestExporter, TestLogExporter
 
 DEFAULT_PATTERN_EXAMPLES = {
@@ -443,6 +444,33 @@ def test_scrubbing_config(exporter: TestExporter, logs_exporter: TestLogExporter
             }
         ]
     )
+
+
+def test_scrubbing_config_rejects_bare_string_pattern():
+    with pytest.raises(LogfireConfigError) as exc_info:
+        logfire.ScrubbingOptions(extra_patterns='password')
+
+    assert str(exc_info.value) == (
+        '`extra_patterns` must be a sequence of regular expressions, not a single string. '
+        "Use `extra_patterns=['password']` instead of `extra_patterns='password'`."
+    )
+
+
+@pytest.mark.parametrize('pattern', ['', '[0-9]*', r'\b', r'\A\Z'])
+def test_scrubbing_config_rejects_empty_matching_pattern(pattern: str):
+    with pytest.raises(LogfireConfigError) as exc_info:
+        logfire.ScrubbingOptions(extra_patterns=[pattern])
+
+    assert str(exc_info.value) == (
+        f'`extra_patterns` must not contain regular expressions that match the empty string: {pattern!r}'
+    )
+
+
+def test_scrubbing_config_reports_invalid_pattern():
+    with pytest.raises(LogfireConfigError) as exc_info:
+        logfire.ScrubbingOptions(extra_patterns=['foo('])
+
+    assert str(exc_info.value).startswith("Invalid regular expression in `extra_patterns`: 'foo(': ")
 
 
 def test_dont_scrub_resource(exporter: TestExporter, config_kwargs: dict[str, Any]):


### PR DESCRIPTION
## Summary

- reject a bare string passed to `ScrubbingOptions.extra_patterns` with an actionable list-form error
- validate each custom regex independently and identify malformed entries
- reject custom patterns that can produce zero-length matches before they redact unrelated telemetry
- add regression coverage for bare strings, malformed regexes, quantifiers, boundaries, and empty-only patterns

A bare string currently satisfies `Sequence[str]` and is iterated character by character. Zero-length matches are also treated as a reason to replace the complete value. Both cases can silently redact harmless telemetry.

Fixes #2234

## Testing

- `uv run --no-sync pytest tests/test_secret_scrubbing.py -q` (25 passed)
- `uv run --no-sync ruff check`
- `uv run --no-sync ruff format --check --diff`
- `uv run --no-sync pyright logfire/_internal/scrubbing.py tests/test_secret_scrubbing.py` (0 errors)
- applicable pre-commit hooks passed; the repository-wide Pyright hook was skipped on Windows after its 28 POSIX API errors were reproduced on untouched `main`
- full pytest attempt: 2247 passed, 14 skipped, 2 xfailed; 51 failures and 8 errors remained in unrelated Windows/integration paths, including unavailable Docker services, external CLI fixtures, and platform-specific snapshots

## AI assistance

Implemented with OpenAI Codex assistance. I reviewed the issue, implementation, diff, and verification results.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

