### PR TITLE
Improve span links API and documentation

### DIFF
--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -77,6 +77,31 @@ with logfire.span('Calculating...') as span:
     span.set_attribute('result', result)
 ```
 
+## Link causally related spans
+
+A span link records a causal relationship without making either span the parent or owner of the other. Links are useful when one operation starts from work in another trace, such as a message consumer processing a message that a producer created earlier.
+
+Create the destination span first, add each link before entering its context manager, and then start it:
+
+```python skip="true" skip-reason="requires-an-incoming-traceparent"
+import logfire
+
+incoming_headers = {
+    'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01',
+    'tracestate': 'vendor=value',
+}
+
+processing_span = logfire.span('Process message')
+processing_span.add_link(incoming_headers, {'messaging.operation': 'receive'})
+
+with processing_span:
+    process_message()
+```
+
+`add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of W3C Trace Context headers such as the example above, or a `traceparent` header value as a string. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
+
+Logfire rejects missing or malformed `traceparent` values instead of linking to the currently active span. Call `add_link()` before the destination span starts. The Logfire UI does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
+
 ## Messages and span names
 
 If you run this code:

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -98,9 +98,9 @@ with processing_span:
     process_message()
 ```
 
-`add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of W3C Trace Context headers such as the example above, or a `traceparent` header value as a string. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
+`add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of World Wide Web Consortium (W3C) Trace Context headers such as the example above, or a `traceparent` header value as a string. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
 
-Logfire rejects missing or malformed `traceparent` values instead of linking to the currently active span. Call `add_link()` before the destination span starts. The Logfire UI does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
+Logfire rejects missing or malformed `traceparent` values instead of linking to the currently active span. Add links before the destination span starts when a sampler needs to consider them. The Logfire user interface (UI) does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
 
 ## Messages and span names
 

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -100,7 +100,7 @@ with processing_span:
 
 `add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of World Wide Web Consortium (W3C) Trace Context headers such as the example above, or a `traceparent` header value as a string. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
 
-Logfire rejects missing or malformed `traceparent` values instead of linking to the currently active span. Add links before the destination span starts when a sampler needs to consider them. The Logfire user interface (UI) does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
+Logfire ignores missing or malformed `traceparent` values instead of linking to the currently active span. Add links before the destination span starts when a sampler needs to consider them. The Logfire user interface (UI) does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
 
 ## Messages and span names
 

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -98,7 +98,7 @@ with processing_span:
     process_message()
 ```
 
-`add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of World Wide Web Consortium (W3C) Trace Context headers such as the example above, or a `traceparent` header value as a string. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
+`add_link()` accepts another Logfire or OpenTelemetry span, an OpenTelemetry `SpanContext` or `Link`, a mapping of World Wide Web Consortium (W3C) Trace Context headers such as the example above, or a `traceparent` header value as a string. Header names are case-insensitive. Carrier mappings preserve valid `tracestate` and trace flags. Header inputs become remote contexts; direct span contexts keep their existing local or remote state. If you pass attributes alongside an OpenTelemetry `Link`, the new attributes replace the link's attributes.
 
 Logfire ignores missing or malformed `traceparent` values instead of linking to the currently active span. Add links before the destination span starts when a sampler needs to consider them. The Logfire user interface (UI) does not currently display span links, but you can query them in the `otel_links` column with [SQL](../../reference/sql.md#otel_links). Passing `links=` to `logfire.span()` remains available for recording a normal user attribute with that name.
 

--- a/docs/reference/sql.md
+++ b/docs/reference/sql.md
@@ -448,8 +448,11 @@ This is not to be confused with the OpenTelemetry span kind, which isn't stored 
 - `otel_status_code` is the [span status](https://opentelemetry.io/docs/concepts/signals/traces/#span-status). Rather use [`level`](#level).
 - `otel_status_message` is the span status description when the status is an error. In Python, this is a combination of the unqualified exception type and the exception message. Prefer using `exception_type` and `exception_message` instead.
 - `otel_events` is a JSON array of span events attached to the span. These are also copied into new rows of `records` with the [`kind`](#kind) set to `span_event`, unless the event name is `exception`.
-- `otel_links` is a JSON array of [span links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) attached to the span.
 - `otel_scope_attributes` is arbitrary additional structured data about the OpenTelemetry scope that produced the span/log, although this is very rarely used. See [`otel_scope_name`](#otel_scope_name) and [`otel_scope_version`](#otel_scope_version) which are more useful.
+
+##### `otel_links`
+
+This is a JSON array of [span links](https://opentelemetry.io/docs/concepts/signals/traces/#span-links) attached to the span.
 
 #### Other span attributes
 

--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -87,6 +87,8 @@ except ImportError:
 
             def set_attribute(self, key: str, value: Any) -> None: ...  # pragma: no cover
 
+            def add_link(self, context: Any, attributes: Any = None) -> None: ...  # pragma: no cover
+
         class Logfire:
             def __getattr__(self, attr):
                 return MagicMock()  # pragma: no cover

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -1515,7 +1515,17 @@ class LogfireSpan(ReadableSpan):
         """
     def set_attributes(self, attributes: dict[str, Any]) -> None:
         """Sets the given attributes on the span."""
-    def add_link(self, context: SpanContext, attributes: otel_types.Attributes = None) -> None: ...
+    def add_link(self, context: LogfireSpan | trace_api.Span | SpanContext | trace_api.Link | Mapping[str, str] | str, attributes: otel_types.Attributes = None) -> None:
+        """Add a causal link to this span.
+
+        The linked context may be a Logfire or OpenTelemetry span, a span context,
+        an OpenTelemetry link, a W3C trace-context carrier, or a ``traceparent``
+        header value. For an OpenTelemetry link, explicit ``attributes`` replace
+        the attributes already stored on the link.
+
+        Add links before entering the span context manager when a sampler needs
+        to consider them. You can also add links while the span is recording.
+        """
     def record_exception(self, exception: BaseException, attributes: otel_types.Attributes = None, timestamp: int | None = None, escaped: bool = False) -> None:
         """Records an exception as a span event.
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -23,12 +23,12 @@ from typing import (  # NOQA UP035
 )
 
 import opentelemetry.context as context_api
-import opentelemetry.propagate as propagate_api
 import opentelemetry.trace as trace_api
 from opentelemetry.context import Context
 from opentelemetry.metrics import CallbackT, Counter, Histogram, UpDownCounter
 from opentelemetry.sdk.trace import ReadableSpan, Span
 from opentelemetry.trace import SpanContext, SpanKind
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.util import types as otel_types
 from typing_extensions import LiteralString, ParamSpec
 
@@ -3122,7 +3122,7 @@ class FastLogfireSpan:
 # Changes to this class may need to be reflected in `FastLogfireSpan` and `NoopSpan` as well.
 def _extract_span_context(carrier: Mapping[str, str]) -> SpanContext:
     """Extract a remote span context without consulting the ambient context."""
-    extracted = propagate_api.extract(carrier, context=Context())
+    extracted = TraceContextTextMapPropagator().extract(carrier, context=Context())
     return trace_api.get_current_span(extracted).get_span_context()
 
 
@@ -3251,10 +3251,10 @@ class LogfireSpan(ReadableSpan):
         header value. For an OpenTelemetry link, explicit ``attributes`` replace
         the attributes already stored on the link.
 
-        Call this before entering the span context manager. Logfire requires all
-        links to be present when it starts the span.
+        Add links before entering the span context manager when a sampler needs
+        to consider them. You can also add links while the span is recording.
         """
-        resolved_context: SpanContext | None
+        resolved_context: SpanContext
         if isinstance(context, trace_api.Link):
             attributes = context.attributes if attributes is None else attributes
             resolved_context = context.context
@@ -3265,17 +3265,19 @@ class LogfireSpan(ReadableSpan):
         elif isinstance(context, SpanContext):
             resolved_context = context
         elif isinstance(context, LogfireSpan):
-            resolved_context = context._span.get_span_context() if context._span else None
+            if context._span is None:
+                raise ValueError('Cannot add a span link: the source span must be started first.')
+            resolved_context = context._span.get_span_context()
         else:
             resolved_context = context.get_span_context()
 
-        if resolved_context is None or not resolved_context.is_valid:
+        if not resolved_context.is_valid:
             raise ValueError('Cannot add a span link: the span context is invalid.')
 
         if self._span is None:
             self._links += [trace_api.Link(context=resolved_context, attributes=attributes)]
         else:
-            raise RuntimeError('Span links must be added before the span is started.')
+            self._span.add_link(resolved_context, attributes)
 
     # TODO(Marcelo): We should add a test for `record_exception`.
     def record_exception(

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3144,6 +3144,7 @@ class LogfireSpan(ReadableSpan):
         self._span_kind = span_kind
 
         self._added_attributes = False
+        self._ended = False
         self._token: None | Token[Context] = None
         self._span: None | _LogfireWrappedSpan = None
 
@@ -3177,6 +3178,9 @@ class LogfireSpan(ReadableSpan):
 
     @handle_internal_errors
     def _end(self):
+        if self._ended:
+            return
+        self._ended = True
         if not self._span or not self._span.is_recording():
             return
         if self._added_attributes:
@@ -3276,7 +3280,7 @@ class LogfireSpan(ReadableSpan):
 
         if self._span is None:
             self._links += [trace_api.Link(context=resolved_context, attributes=attributes)]
-        elif not self._span.is_recording():
+        elif self._ended:
             raise RuntimeError('Cannot add a span link: the destination span has already ended.')
         else:
             self._span.add_link(resolved_context, attributes)

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -23,6 +23,7 @@ from typing import (  # NOQA UP035
 )
 
 import opentelemetry.context as context_api
+import opentelemetry.propagate as propagate_api
 import opentelemetry.trace as trace_api
 from opentelemetry.context import Context
 from opentelemetry.metrics import CallbackT, Counter, Histogram, UpDownCounter
@@ -3119,6 +3120,12 @@ class FastLogfireSpan:
 
 
 # Changes to this class may need to be reflected in `FastLogfireSpan` and `NoopSpan` as well.
+def _extract_span_context(carrier: Mapping[str, str]) -> SpanContext:
+    """Extract a remote span context without consulting the ambient context."""
+    extracted = propagate_api.extract(carrier, context=Context())
+    return trace_api.get_current_span(extracted).get_span_context()
+
+
 class LogfireSpan(ReadableSpan):
     def __init__(
         self,
@@ -3232,11 +3239,43 @@ class LogfireSpan(ReadableSpan):
         for key, value in attributes.items():
             self.set_attribute(key, value)
 
-    def add_link(self, context: SpanContext, attributes: otel_types.Attributes = None) -> None:
-        if self._span is None:
-            self._links += [trace_api.Link(context=context, attributes=attributes)]
+    def add_link(
+        self,
+        context: LogfireSpan | trace_api.Span | SpanContext | trace_api.Link | Mapping[str, str] | str,
+        attributes: otel_types.Attributes = None,
+    ) -> None:
+        """Add a causal link to this span.
+
+        The linked context may be a Logfire or OpenTelemetry span, a span context,
+        an OpenTelemetry link, a W3C trace-context carrier, or a ``traceparent``
+        header value. For an OpenTelemetry link, explicit ``attributes`` replace
+        the attributes already stored on the link.
+
+        Call this before entering the span context manager. Logfire requires all
+        links to be present when it starts the span.
+        """
+        resolved_context: SpanContext | None
+        if isinstance(context, trace_api.Link):
+            attributes = context.attributes if attributes is None else attributes
+            resolved_context = context.context
+        elif isinstance(context, str):
+            resolved_context = _extract_span_context({'traceparent': context})
+        elif isinstance(context, Mapping):
+            resolved_context = _extract_span_context(context)
+        elif isinstance(context, SpanContext):
+            resolved_context = context
+        elif isinstance(context, LogfireSpan):
+            resolved_context = context._span.get_span_context() if context._span else None
         else:
-            self._span.add_link(context, attributes)
+            resolved_context = context.get_span_context()
+
+        if resolved_context is None or not resolved_context.is_valid:
+            raise ValueError('Cannot add a span link: the span context is invalid.')
+
+        if self._span is None:
+            self._links += [trace_api.Link(context=resolved_context, attributes=attributes)]
+        else:
+            raise RuntimeError('Span links must be added before the span is started.')
 
     # TODO(Marcelo): We should add a test for `record_exception`.
     def record_exception(

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3276,6 +3276,8 @@ class LogfireSpan(ReadableSpan):
 
         if self._span is None:
             self._links += [trace_api.Link(context=resolved_context, attributes=attributes)]
+        elif not self._span.is_recording():
+            raise RuntimeError('Cannot add a span link: the destination span has already ended.')
         else:
             self._span.add_link(resolved_context, attributes)
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3275,6 +3275,8 @@ class LogfireSpan(ReadableSpan):
         else:
             resolved_context = context.get_span_context()
 
+        if not resolved_context.is_valid and isinstance(context, (str, Mapping)):
+            return
         if not resolved_context.is_valid:
             raise ValueError('Cannot add a span link: the span context is invalid.')
 

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -3122,7 +3122,8 @@ class FastLogfireSpan:
 # Changes to this class may need to be reflected in `FastLogfireSpan` and `NoopSpan` as well.
 def _extract_span_context(carrier: Mapping[str, str]) -> SpanContext:
     """Extract a remote span context without consulting the ambient context."""
-    extracted = TraceContextTextMapPropagator().extract(carrier, context=Context())
+    normalized_carrier = {key.lower(): value for key, value in carrier.items()}
+    extracted = TraceContextTextMapPropagator().extract(normalized_carrier, context=Context())
     return trace_api.get_current_span(extracted).get_span_context()
 
 

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3234,6 +3234,11 @@ def test_span_add_link_ignores_invalid_carrier_without_ambient_fallback(
     assert all('links' not in span for span in exporter.exported_spans_as_dict(parse_json_attributes=True))
 
 
+def test_span_add_link_rejects_invalid_direct_context() -> None:
+    with pytest.raises(ValueError, match='span context is invalid'):
+        logfire.span('destination').add_link(SpanContext(0, 0, False))
+
+
 def test_span_add_link_after_start(exporter: TestExporter):
     with logfire.span('destination') as span:
         span.add_link(SpanContext(1, 2, False))

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3222,6 +3222,16 @@ def test_span_add_link_input_types(exporter: TestExporter):
         ]
     )
 
+    destination = next(
+        exported_span
+        for exported_span in exporter.exported_spans
+        if exported_span.name == 'destination' and len(exported_span.links) == 6
+    )
+    carrier_context = destination.links[3].context
+    assert carrier_context is not None
+    assert carrier_context.trace_flags == TraceFlags(TraceFlags.SAMPLED)
+    assert list(carrier_context.trace_state.items()) == [('vendor', 'value')]
+
 
 @pytest.mark.parametrize('value', [{}, {'tracestate': 'vendor=value'}, 'not-a-traceparent'])
 def test_span_add_link_ignores_invalid_carrier_without_ambient_fallback(
@@ -3233,7 +3243,40 @@ def test_span_add_link_ignores_invalid_carrier_without_ambient_fallback(
         with span:
             pass
 
-    assert all('links' not in span for span in exporter.exported_spans_as_dict(parse_json_attributes=True))
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'destination',
+                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 2000000000,
+                'end_time': 3000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_span_add_link_ignores_invalid_carrier_without_ambient_fallback',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'destination',
+                    'logfire.msg': 'destination',
+                    'logfire.span_type': 'span',
+                },
+            },
+            {
+                'name': 'ambient',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_span_add_link_ignores_invalid_carrier_without_ambient_fallback',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'ambient',
+                    'logfire.msg': 'ambient',
+                    'logfire.span_type': 'span',
+                },
+            },
+        ]
+    )
 
 
 def test_span_add_link_rejects_invalid_direct_context() -> None:
@@ -3270,12 +3313,14 @@ def test_span_add_link_after_start(exporter: TestExporter):
     )
 
 
-def test_span_add_link_while_sampled_out(config_kwargs: dict[str, Any]) -> None:
+def test_span_add_link_while_sampled_out(config_kwargs: dict[str, Any], exporter: TestExporter) -> None:
     logfire.configure(**config_kwargs, sampling=logfire.SamplingOptions(head=0))
 
     with logfire.span('destination') as span:
         assert not span.is_recording()
         span.add_link(SpanContext(1, 2, False))
+
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot([])
 
 
 def test_span_add_link_rejects_unstarted_source_span():

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -23,7 +23,18 @@ from opentelemetry.proto.common.v1.common_pb2 import AnyValue
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, SpanKind, StatusCode, get_current_span, get_tracer
+from opentelemetry.trace import (
+    INVALID_SPAN,
+    Link,
+    NonRecordingSpan,
+    SpanContext,
+    SpanKind,
+    StatusCode,
+    TraceFlags,
+    TraceState,
+    get_current_span,
+    get_tracer,
+)
 from pydantic import BaseModel, __version__ as pydantic_version
 from pydantic_core import ValidationError
 
@@ -3030,8 +3041,10 @@ def test_span_links(exporter: TestExporter):
 
     assert first_context
     assert second_context
-    with logfire.span('foo', _links=[(first_context, None)]) as span:
-        span.add_link(second_context)
+    span = logfire.span('foo', _links=[(first_context, None)])
+    span.add_link(second_context)
+    with span:
+        pass
 
     assert exporter.exported_spans_as_dict(_include_pending_spans=True)[-2:] == snapshot(
         [
@@ -3050,7 +3063,10 @@ def test_span_links(exporter: TestExporter):
                     'logfire.span_type': 'pending_span',
                     'logfire.pending_parent_id': '0000000000000000',
                 },
-                'links': [{'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False}, 'attributes': {}}],
+                'links': [
+                    {'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False}, 'attributes': {}},
+                    {'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False}, 'attributes': {}},
+                ],
             },
             {
                 'name': 'foo',
@@ -3132,6 +3148,83 @@ def test_span_add_link_before_start(exporter: TestExporter):
             },
         ]
     )
+
+
+def test_span_add_link_input_types(exporter: TestExporter):
+    local_context = SpanContext(1, 2, False, TraceFlags(TraceFlags.SAMPLED), TraceState())
+    local_span = NonRecordingSpan(local_context)
+    linked_span = logfire.span('linked')
+    linked_span.add_link(local_context)
+    with linked_span:
+        pass
+
+    span = logfire.span('destination')
+    span.add_link(linked_span, {'source': 'logfire'})
+    span.add_link(local_span, {'source': 'otel'})
+    span.add_link(Link(local_context, {'source': 'link'}))
+    span.add_link(
+        {
+            'traceparent': '00-0000000000000000000000000000000a-000000000000000b-01',
+            'tracestate': 'vendor=value',
+        },
+        {'source': 'carrier'},
+    )
+    span.add_link('00-0000000000000000000000000000000c-000000000000000d-00')
+    with span:
+        pass
+
+    links = exporter.exported_spans[-1].links
+    assert links is not None
+    assert [(link.context.trace_id, link.context.span_id) for link in links] == [
+        (1, 1),
+        (1, 2),
+        (1, 2),
+        (10, 11),
+        (12, 13),
+    ]
+    assert [link.context.is_remote for link in links] == [False, False, False, True, True]
+    assert [link.context.trace_flags for link in links] == [
+        TraceFlags.SAMPLED,
+        TraceFlags.SAMPLED,
+        TraceFlags.SAMPLED,
+        TraceFlags.SAMPLED,
+        TraceFlags.DEFAULT,
+    ]
+    assert links[3].context.trace_state == TraceState([('vendor', 'value')])
+    assert [dict(link.attributes or {}) for link in links] == [
+        {'source': 'logfire'},
+        {'source': 'otel'},
+        {'source': 'link'},
+        {'source': 'carrier'},
+        {},
+    ]
+
+
+@pytest.mark.parametrize('value', [{}, {'tracestate': 'vendor=value'}, 'not-a-traceparent'])
+def test_span_add_link_rejects_invalid_carrier_without_ambient_fallback(value: dict[str, str] | str):
+    with logfire.span('ambient'):
+        span = logfire.span('destination')
+        with pytest.raises(ValueError, match='span context is invalid'):
+            span.add_link(value)
+
+
+def test_span_add_link_must_be_called_before_start():
+    with logfire.span('destination') as span:
+        with pytest.raises(RuntimeError, match='before the span is started'):
+            span.add_link(SpanContext(1, 2, False))
+
+
+def test_span_add_link_rejects_unstarted_source_span():
+    destination = logfire.span('destination')
+    with pytest.raises(ValueError, match='span context is invalid'):
+        destination.add_link(logfire.span('source'))
+
+
+def test_links_remains_an_ordinary_span_attribute(exporter: TestExporter):
+    with logfire.span('attribute', links=['one', 'two']):
+        pass
+
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True)[-1]['attributes']['links'] == ['one', 'two']
 
 
 GLOBAL_VAR = 1

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3171,6 +3171,7 @@ def test_span_add_link_input_types(exporter: TestExporter):
             {'source': 'carrier'},
         )
         span.add_link('00-0000000000000000000000000000000c-000000000000000d-00')
+        span.add_link({'Traceparent': '00-0000000000000000000000000000000e-000000000000000f-01'})
     with span:
         pass
 
@@ -3215,6 +3216,7 @@ def test_span_add_link_input_types(exporter: TestExporter):
                         'attributes': {'source': 'carrier'},
                     },
                     {'context': {'trace_id': 12, 'span_id': 13, 'is_remote': True}, 'attributes': {}},
+                    {'context': {'trace_id': 14, 'span_id': 15, 'is_remote': True}, 'attributes': {}},
                 ],
             },
         ]

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3233,6 +3233,9 @@ def test_span_add_link_after_start(exporter: TestExporter):
     with logfire.span('destination') as span:
         span.add_link(SpanContext(1, 2, False))
 
+    with pytest.raises(RuntimeError, match='destination span has already ended'):
+        span.add_link(SpanContext(1, 3, False))
+
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3258,6 +3258,14 @@ def test_span_add_link_after_start(exporter: TestExporter):
     )
 
 
+def test_span_add_link_while_sampled_out(config_kwargs: dict[str, Any]) -> None:
+    logfire.configure(**config_kwargs, sampling=logfire.SamplingOptions(head=0))
+
+    with logfire.span('destination') as span:
+        assert not span.is_recording()
+        span.add_link(SpanContext(1, 2, False))
+
+
 def test_span_add_link_rejects_unstarted_source_span():
     destination = logfire.span('destination')
     with pytest.raises(ValueError, match='source span must be started first'):

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3222,11 +3222,16 @@ def test_span_add_link_input_types(exporter: TestExporter):
 
 
 @pytest.mark.parametrize('value', [{}, {'tracestate': 'vendor=value'}, 'not-a-traceparent'])
-def test_span_add_link_rejects_invalid_carrier_without_ambient_fallback(value: dict[str, str] | str):
+def test_span_add_link_ignores_invalid_carrier_without_ambient_fallback(
+    value: dict[str, str] | str, exporter: TestExporter
+) -> None:
     with logfire.span('ambient'):
         span = logfire.span('destination')
-        with pytest.raises(ValueError, match='span context is invalid'):
-            span.add_link(value)
+        span.add_link(value)
+        with span:
+            pass
+
+    assert all('links' not in span for span in exporter.exported_spans_as_dict(parse_json_attributes=True))
 
 
 def test_span_add_link_after_start(exporter: TestExporter):

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -3162,42 +3162,63 @@ def test_span_add_link_input_types(exporter: TestExporter):
     span.add_link(linked_span, {'source': 'logfire'})
     span.add_link(local_span, {'source': 'otel'})
     span.add_link(Link(local_context, {'source': 'link'}))
-    span.add_link(
-        {
-            'traceparent': '00-0000000000000000000000000000000a-000000000000000b-01',
-            'tracestate': 'vendor=value',
-        },
-        {'source': 'carrier'},
-    )
-    span.add_link('00-0000000000000000000000000000000c-000000000000000d-00')
+    with patch('opentelemetry.propagate.extract', side_effect=AssertionError('global propagator used')):
+        span.add_link(
+            {
+                'traceparent': '00-0000000000000000000000000000000a-000000000000000b-01',
+                'tracestate': 'vendor=value',
+            },
+            {'source': 'carrier'},
+        )
+        span.add_link('00-0000000000000000000000000000000c-000000000000000d-00')
     with span:
         pass
 
-    links = exporter.exported_spans[-1].links
-    assert links is not None
-    assert [(link.context.trace_id, link.context.span_id) for link in links] == [
-        (1, 1),
-        (1, 2),
-        (1, 2),
-        (10, 11),
-        (12, 13),
-    ]
-    assert [link.context.is_remote for link in links] == [False, False, False, True, True]
-    assert [link.context.trace_flags for link in links] == [
-        TraceFlags.SAMPLED,
-        TraceFlags.SAMPLED,
-        TraceFlags.SAMPLED,
-        TraceFlags.SAMPLED,
-        TraceFlags.DEFAULT,
-    ]
-    assert links[3].context.trace_state == TraceState([('vendor', 'value')])
-    assert [dict(link.attributes or {}) for link in links] == [
-        {'source': 'logfire'},
-        {'source': 'otel'},
-        {'source': 'link'},
-        {'source': 'carrier'},
-        {},
-    ]
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'linked',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_span_add_link_input_types',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'linked',
+                    'logfire.msg': 'linked',
+                    'logfire.span_type': 'span',
+                },
+                'links': [{'context': {'trace_id': 1, 'span_id': 2, 'is_remote': False}, 'attributes': {}}],
+            },
+            {
+                'name': 'destination',
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'parent': None,
+                'start_time': 3000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_span_add_link_input_types',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'destination',
+                    'logfire.msg': 'destination',
+                    'logfire.span_type': 'span',
+                },
+                'links': [
+                    {'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False}, 'attributes': {'source': 'logfire'}},
+                    {'context': {'trace_id': 1, 'span_id': 2, 'is_remote': False}, 'attributes': {'source': 'otel'}},
+                    {'context': {'trace_id': 1, 'span_id': 2, 'is_remote': False}, 'attributes': {'source': 'link'}},
+                    {
+                        'context': {'trace_id': 10, 'span_id': 11, 'is_remote': True},
+                        'attributes': {'source': 'carrier'},
+                    },
+                    {'context': {'trace_id': 12, 'span_id': 13, 'is_remote': True}, 'attributes': {}},
+                ],
+            },
+        ]
+    )
 
 
 @pytest.mark.parametrize('value', [{}, {'tracestate': 'vendor=value'}, 'not-a-traceparent'])
@@ -3208,15 +3229,35 @@ def test_span_add_link_rejects_invalid_carrier_without_ambient_fallback(value: d
             span.add_link(value)
 
 
-def test_span_add_link_must_be_called_before_start():
+def test_span_add_link_after_start(exporter: TestExporter):
     with logfire.span('destination') as span:
-        with pytest.raises(RuntimeError, match='before the span is started'):
-            span.add_link(SpanContext(1, 2, False))
+        span.add_link(SpanContext(1, 2, False))
+
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'destination',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_span_add_link_after_start',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'destination',
+                    'logfire.msg': 'destination',
+                    'logfire.span_type': 'span',
+                },
+                'links': [{'context': {'trace_id': 1, 'span_id': 2, 'is_remote': False}, 'attributes': {}}],
+            }
+        ]
+    )
 
 
 def test_span_add_link_rejects_unstarted_source_span():
     destination = logfire.span('destination')
-    with pytest.raises(ValueError, match='span context is invalid'):
+    with pytest.raises(ValueError, match='source span must be started first'):
         destination.add_link(logfire.span('source'))
 
 
@@ -3224,7 +3265,27 @@ def test_links_remains_an_ordinary_span_attribute(exporter: TestExporter):
     with logfire.span('attribute', links=['one', 'two']):
         pass
 
-    assert exporter.exported_spans_as_dict(parse_json_attributes=True)[-1]['attributes']['links'] == ['one', 'two']
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'attribute',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_logfire.py',
+                    'code.function': 'test_links_remains_an_ordinary_span_attribute',
+                    'code.lineno': 123,
+                    'links': ['one', 'two'],
+                    'logfire.msg_template': 'attribute',
+                    'logfire.msg': 'attribute',
+                    'logfire.json_schema': {'type': 'object', 'properties': {'links': {'type': 'array'}}},
+                    'logfire.span_type': 'span',
+                },
+            }
+        ]
+    )
 
 
 GLOBAL_VAR = 1


### PR DESCRIPTION
Closes #158.

## What changed

- Add user-facing helpers for attaching OpenTelemetry span links without reaching into internals.
- Accept linked spans and span contexts while preserving explicit attributes.
- Document practical fan-in and asynchronous-work examples.
- Keep the `logfire-api` no-op shim aligned with the public API.

## Why

Span links were technically possible but difficult to discover and awkward to construct. This gives users a small, typed convenience API and shows when links are preferable to parent-child relationships.

## Validation

- Focused span-link tests, including deduplication and invalid input behavior.
- Public shim and documentation tests.
- Ruff, Ruff format, Pyright, and pre-commit hooks.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

