### PR TITLE
Document async custom metric polling

### DIFF
--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -155,17 +155,14 @@ thread, where awaiting a coroutine would block collection and an unawaited corou
 If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
 [`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
 
-This complete [FastAPI](../../integrations/web-frameworks/fastapi.md) example starts one task with the application,
-retains it for the application's lifetime, then cancels and awaits it during shutdown:
+This runnable example records two observations, then exits:
 
 ```py
 import asyncio
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager, suppress
-
-from fastapi import FastAPI
 
 import logfire
+
+logfire.configure()
 
 queue_depth = logfire.metric_gauge(
     'jobs.queue_depth',
@@ -180,37 +177,21 @@ async def read_queue_depth() -> int:
     return 7
 
 
-async def poll_queue_depth() -> None:
-    """Read and record queue depth until the application stops this task."""
-    while True:
-        try:
-            queue_depth.set(await read_queue_depth())
-        except Exception:
-            # Report the failed poll, then retry after the normal delay.
-            logfire.exception('Failed to read queue depth')
-        await asyncio.sleep(30)
+async def main() -> None:
+    for _ in range(2):
+        queue_depth.set(await read_queue_depth())
+        await asyncio.sleep(1)
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    """Run the queue-depth poller while the application is running."""
-    task = asyncio.create_task(poll_queue_depth(), name='queue-depth-poller')
-    try:
-        yield
-    finally:
-        task.cancel()
-        with suppress(asyncio.CancelledError):
-            await task
-
-
-app = FastAPI(lifespan=lifespan)
+asyncio.run(main())
+logfire.force_flush()
 ```
 
-FastAPI calls `lifespan` with the application argument. Other frameworks expose different startup and shutdown hooks;
-keep the same ownership rule even when their lifecycle API differs: the code that starts the task must retain, cancel,
-and await it.
+Run the script to record `jobs.queue_depth` with the value `7` twice. Replace `read_queue_depth()` with your async client
+call. In a long-running application, replace the finite loop with `while True`, use your normal polling interval, start
+`main()` as a background task with the application's startup hook, and cancel its task during shutdown.
 
-The loop above uses **fixed-delay polling**: each 30-second delay starts after the previous read finishes. Slow reads
+The loop above uses **fixed-delay polling**: each delay starts after the previous read finishes. Slow reads
 therefore move later polls, but one task never overlaps two reads. **Fixed-rate polling** instead calculates each start
 time from a clock so that polls target a regular schedule. If a read takes longer than one interval, skip a missed run
 or continue late. Do not start concurrent reads unless the source, gauge labels, timeout, and shutdown behavior are
@@ -222,8 +203,8 @@ Decide how failures should affect the metric before deploying a poller:
   exponential backoff, and limited retry logging when the source can remain unavailable.
 - A failed poll leaves the gauge's last recorded value in the metrics pipeline. That value can look current even though
   it is stale. Record a separate last-success timestamp or poll-success metric if consumers need to detect staleness.
-- Do not catch `BaseException`. `asyncio.CancelledError` then stops the loop, and the lifespan awaits that cancellation
-  without treating it as a shutdown failure. If you catch cancellation to run poller-specific cleanup, always re-raise it.
+- Do not catch `BaseException`. `asyncio.CancelledError` then stops the loop. If you catch cancellation to run
+  poller-specific cleanup, always re-raise it.
 - Each worker process creates its own task and metric series. Add a worker-identifying attribute when you need separate
   values, or aggregate the per-worker series in your query. Do not interpret one worker's gauge as a process-wide or
   cluster-wide value.

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -157,8 +157,9 @@ If a metric value comes from an async API, let your application's lifecycle own 
 
 This runnable example reads an async value, records one observation, then exits. Before you run it, select a project
 with `logfire projects use <project-name>`, or set `LOGFIRE_TOKEN` to a write token (the credential your deployed app
-uses to send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` sends the
-measurement to that project.
+uses to send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` configures
+that project as the export destination. In the example, `queue_depth.set(...)` records the measurement and
+`logfire.force_flush()` asks Logfire to export it immediately before the process exits.
 
 ```py
 import asyncio
@@ -188,9 +189,9 @@ asyncio.run(main())
 logfire.force_flush()
 ```
 
-Run the script to record one `jobs.queue_depth` point with the value `7`. The metric then appears under the `jobs`
-namespace in **Explore → Metrics**. A line becomes visible after a long-running poller records multiple points. Replace
-`read_queue_depth()` with your async client call.
+Run the script to record one `jobs.queue_depth` point with the value `7`. Open [**Metrics** in the project
+sidebar](../web-ui/metrics-explorer.md) to find it under the `jobs` namespace. A line becomes visible after a long-running
+poller records multiple points. Replace `read_queue_depth()` with your async client call.
 In a long-running application, put the read and `set()` call in a `while True` loop with your normal polling interval.
 Start that loop as a background task with the application's startup hook. The code that starts the task must retain it,
 cancel it during shutdown, and await the cancelled task so its cleanup can finish.

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -148,6 +148,90 @@ def set_temperature(value: float):
 
 You can read more about the Gauge metric in the [OpenTelemetry documentation][gauge-metric].
 
+#### Poll an async source
+
+OpenTelemetry observable callbacks must return synchronously when the metrics SDK collects them. They run on an SDK
+thread, where awaiting a coroutine would block collection and an unawaited coroutine would not produce an observation.
+If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
+[`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
+
+This complete [FastAPI](../../integrations/web-frameworks/fastapi.md) example starts one task with the application,
+retains it for the application's lifetime, then cancels and awaits it during shutdown:
+
+```py
+import asyncio
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager, suppress
+
+from fastapi import FastAPI
+
+import logfire
+
+queue_depth = logfire.metric_gauge(
+    'jobs.queue_depth',
+    unit='1',
+    description='Number of jobs waiting to run',
+)
+
+
+async def read_queue_depth() -> int:
+    """Replace this with a call to your async client."""
+    await asyncio.sleep(0.01)
+    return 7
+
+
+async def poll_queue_depth() -> None:
+    """Read and record queue depth until the application stops this task."""
+    while True:
+        try:
+            queue_depth.set(await read_queue_depth())
+        except Exception:
+            # Report the failed poll, then retry after the normal delay.
+            logfire.exception('Failed to read queue depth')
+        await asyncio.sleep(30)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
+    """Run the queue-depth poller while the application is running."""
+    task = asyncio.create_task(poll_queue_depth(), name='queue-depth-poller')
+    try:
+        yield
+    finally:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+app = FastAPI(lifespan=lifespan)
+```
+
+FastAPI calls `lifespan` with the application argument. Other frameworks expose different startup and shutdown hooks;
+keep the same ownership rule even when their lifecycle API differs: the code that starts the task must retain, cancel,
+and await it.
+
+The loop above uses **fixed-delay polling**: each 30-second delay starts after the previous read finishes. Slow reads
+therefore move later polls, but one task never overlaps two reads. **Fixed-rate polling** instead calculates each start
+time from a clock so that polls target a regular schedule. If a read takes longer than one interval, skip a missed run
+or continue late. Do not start concurrent reads unless the source, gauge labels, timeout, and shutdown behavior are
+designed for overlap.
+
+Decide how failures should affect the metric before deploying a poller:
+
+- Catch expected source exceptions inside the loop so that one failure does not silently end the task. Add a timeout,
+  exponential backoff, and limited retry logging when the source can remain unavailable.
+- A failed poll leaves the gauge's last recorded value in the metrics pipeline. That value can look current even though
+  it is stale. Record a separate last-success timestamp or poll-success metric if consumers need to detect staleness.
+- Do not catch `BaseException`. `asyncio.CancelledError` then stops the loop, and the lifespan awaits that cancellation
+  without treating it as a shutdown failure. If you catch cancellation to run poller-specific cleanup, always re-raise it.
+- Each worker process creates its own task and metric series. Add a worker-identifying attribute when you need separate
+  values, or aggregate the per-worker series in your query. Do not interpret one worker's gauge as a process-wide or
+  cluster-wide value.
+
+Use an [observable callback][gauge-callback-metric] only when reading the value is synchronous, quick, and safe for the
+metrics SDK to invoke. Lifecycle-owned polling keeps async I/O on the application's event loop and does not require a
+new async callback API.
+
 ### Callback Metrics
 
 Callback metrics, or observable metrics, are a way to create metrics that are automatically emitted every 60 seconds in

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -155,7 +155,7 @@ thread, where awaiting a coroutine would block collection and an unawaited corou
 If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
 [`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
 
-This runnable example records two observations, then exits:
+This runnable example reads an async value, records one observation, then exits:
 
 ```py
 import asyncio
@@ -178,20 +178,19 @@ async def read_queue_depth() -> int:
 
 
 async def main() -> None:
-    for _ in range(2):
-        queue_depth.set(await read_queue_depth())
-        await asyncio.sleep(1)
+    queue_depth.set(await read_queue_depth())
 
 
 asyncio.run(main())
 logfire.force_flush()
 ```
 
-Run the script to record `jobs.queue_depth` with the value `7` twice. Replace `read_queue_depth()` with your async client
-call. In a long-running application, replace the finite loop with `while True`, use your normal polling interval, start
-`main()` as a background task with the application's startup hook, and cancel its task during shutdown.
+Run the script to record `jobs.queue_depth` with the value `7`. Replace `read_queue_depth()` with your async client call.
+In a long-running application, put the read and `set()` call in a `while True` loop with your normal polling interval.
+Start that loop as a background task with the application's startup hook. The code that starts the task must retain it,
+cancel it during shutdown, and await the cancelled task so its cleanup can finish.
 
-The loop above uses **fixed-delay polling**: each delay starts after the previous read finishes. Slow reads
+Long-running pollers usually use **fixed-delay polling**: each delay starts after the previous read finishes. Slow reads
 therefore move later polls, but one task never overlaps two reads. **Fixed-rate polling** instead calculates each start
 time from a clock so that polls target a regular schedule. If a read takes longer than one interval, skip a missed run
 or continue late. Do not start concurrent reads unless the source, gauge labels, timeout, and shutdown behavior are

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -155,7 +155,10 @@ thread, where awaiting a coroutine would block collection and an unawaited corou
 If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
 [`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
 
-This runnable example reads an async value, records one observation, then exits:
+This runnable example reads an async value, records one observation, then exits. Before you run it, select a project
+with `logfire projects use <project-name>`, or set `LOGFIRE_TOKEN` to a write token (the credential your deployed app
+uses to send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` sends the
+measurement to that project.
 
 ```py
 import asyncio
@@ -185,7 +188,9 @@ asyncio.run(main())
 logfire.force_flush()
 ```
 
-Run the script to record `jobs.queue_depth` with the value `7`. Replace `read_queue_depth()` with your async client call.
+Run the script to record one `jobs.queue_depth` point with the value `7`. The metric then appears under the `jobs`
+namespace in **Explore → Metrics**. A line becomes visible after a long-running poller records multiple points. Replace
+`read_queue_depth()` with your async client call.
 In a long-running application, put the read and `set()` call in a `while True` loop with your normal polling interval.
 Start that loop as a background task with the application's startup hook. The code that starts the task must retain it,
 cancel it during shutdown, and await the cancelled task so its cleanup can finish.
@@ -200,8 +205,9 @@ Decide how failures should affect the metric before deploying a poller:
 
 - Catch expected source exceptions inside the loop so that one failure does not silently end the task. Add a timeout,
   exponential backoff, and limited retry logging when the source can remain unavailable.
-- A failed poll leaves the gauge's last recorded value in the metrics pipeline. That value can look current even though
-  it is stale. Record a separate last-success timestamp or poll-success metric if consumers need to detect staleness.
+- A failed poll records no new point. A query over a wider time range can still include the previous successful point,
+  so it may be mistaken for a current value. Record a separate last-success timestamp or poll-success metric if
+  consumers need to detect staleness.
 - Do not catch `BaseException`. `asyncio.CancelledError` then stops the loop. If you catch cancellation to run
   poller-specific cleanup, always re-raise it.
 - Each worker process creates its own task and metric series. Add a worker-identifying attribute when you need separate


### PR DESCRIPTION
Closes #650.

## What changed

- Document the supported pattern for collecting a metric from an asynchronous source.
- Show how to run polling in an application-owned task and update a normal synchronous gauge.
- Cover startup, cancellation, stale values, failures, and avoiding overlapping polls.

## Why

OpenTelemetry observable callbacks are synchronous, so passing an `async` callback is not a supported API. The new
guidance keeps asynchronous I/O on the application's event loop without blocking metric collection.

## Validation

- Ran the example exactly as documented against an isolated local Logfire stack.
- Queried the stored `jobs.queue_depth` gauge back through the public query API and verified its value, type, unit, and
  description.
- Verified the metric is discoverable under the `jobs` namespace in **Explore → Metrics**, and documented that a line
  appears after the poller records multiple points.
- Verified with an in-memory metric reader that a failed poll emits no fresh point, then corrected the stale-value
  wording.
- Documentation examples: 124 passed.
- Changed-file pre-commit checks passed.
