### PR TITLE
Add filesystem usage system metrics

### DIFF
--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -96,8 +96,9 @@ To collect lots of detailed data about all available metrics, use `logfire.instr
 ### Monitor filesystem capacity
 
 Track when an application filesystem is running out of usable space. Filesystem capacity metrics are opt-in:
-neither the `basic` nor `full` configuration includes them. If you omit `paths` or use `None`, Logfire monitors
-the filesystem containing the process's current working directory.
+neither the `basic` nor `full` configuration includes them. Logfire monitors the filesystem containing the
+process's current working directory if you set the whole metric value to `None`, omit `paths` from its options,
+or set `paths` to `None`.
 
 ```py
 import logfire

--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -114,7 +114,8 @@ logfire.instrument_system_metrics(
         'system.filesystem.usage': filesystem_options,
         'system.filesystem.limit': filesystem_options,
         'system.filesystem.utilization': filesystem_options,
-    }
+    },
+    base=None,
 )
 ```
 

--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -93,6 +93,76 @@ logfire.instrument_system_metrics({
 
 To collect lots of detailed data about all available metrics, use `logfire.instrument_system_metrics(base='full')`.
 
+### Monitor filesystem capacity
+
+Track when an application filesystem is running out of usable space. Filesystem capacity metrics are opt-in:
+neither the `basic` nor `full` configuration includes them. If you omit `paths` or use `None`, Logfire monitors
+the filesystem containing the process's current working directory.
+
+```py
+import logfire
+
+logfire.configure()
+
+filesystem_options = {
+    'paths': ['/var/lib/my-app', '/srv/data'],
+    'states': ['used', 'free', 'reserved'],
+}
+logfire.instrument_system_metrics(
+    {
+        'system.filesystem.usage': filesystem_options,
+        'system.filesystem.limit': filesystem_options,
+        'system.filesystem.utilization': filesystem_options,
+    }
+)
+```
+
+Logfire creates only the metric names that you include. If you include more than one name with an options
+dictionary, use the same options for each. The metrics follow OpenTelemetry (OTel), the open industry standard
+for collecting traces, metrics, and logs:
+
+- `system.filesystem.usage` is an observable up-down counter, a value that Logfire reads during collection and
+  that can increase or decrease. It reports `used`, `free`, and filesystem-reserved bytes. With all three states,
+  the values add up to the total capacity.
+- `system.filesystem.limit` is an observable up-down counter that reports total capacity in bytes.
+- `system.filesystem.utilization` is a gauge from 0 to 1 with `system.filesystem.state="used"`. It reports
+  `used / (used + free)`, the fraction available to an ordinary user that is already used. Reserved Unix blocks
+  therefore do not prevent a full application filesystem from reading 100% used.
+
+Each metric includes the device, mount point, filesystem type, and read/write mode when the operating system
+provides them.
+
+!!! warning "Filesystem metrics can send up to 160 series per process"
+    You can configure at most 32 paths. If all 32 resolve to different filesystems, enabling all three metrics
+    with the default states produces five series per path: three usage states, one limit, and one utilization.
+    Each series adds stored data and can increase your cost. Choose a small, fixed list of application paths.
+
+Logfire removes duplicate paths when it can identify the same device and mount point. Mount enumeration can be
+unavailable, so this deduplication is best effort. Consider these environment-specific details:
+
+- **Linux:** Select a path on each separate mount that matters, such as `/var/lib/my-app` and `/srv/data`.
+- **macOS:** Current macOS systems split the read-only System volume from the writable Data volume. Logfire maps
+  writable paths such as `/Users/...` and the sealed root path `/` to the Data volume.
+- **Windows:** Select paths on the drives or Universal Naming Convention (UNC) shares that the application uses.
+  If Windows does not enumerate a share, Logfire uses its UNC share name as a fallback identity. Different names
+  for the same storage may then produce separate series.
+- **Containers:** A path may describe a container overlay or mounted volume rather than the host disk.
+- **Quotas:** Operating-system or storage quotas may impose a lower usable limit than the filesystem reports.
+- **Multiple processes:** Each instrumented process emits the same filesystem series. Group by host and
+  filesystem attributes rather than adding duplicate values across processes.
+
+For host-wide infrastructure monitoring, use an
+[OpenTelemetry Collector](../how-to-guides/otel-collector/host-monitoring.md), a separate program that sits
+between your apps and Logfire, gathering telemetry and forwarding it. This avoids sending the same filesystem
+series from every application process.
+
+#### Verify filesystem metrics
+
+Leave the program running for at least one collection interval. In **Metrics explorer**, select
+`system.filesystem.usage`, then group by `system.filesystem.mountpoint` and `system.filesystem.state`. You should
+see the expected mount points with `used`, `free`, and `reserved` series. If a selected path disappears or becomes
+inaccessible, Logfire warns once for that path and continues collecting the other paths and system metrics.
+
 !!! warning "`base='full'` sends much more data, and can cost more"
     The amount of data collected by `base='full'` can be expensive, especially if you have many servers,
     and this is easy to forget about. If you enable this, be sure to monitor your usage and costs.

--- a/logfire-api/logfire_api/_internal/integrations/system_metrics.pyi
+++ b/logfire-api/logfire_api/_internal/integrations/system_metrics.pyi
@@ -1,11 +1,50 @@
+import os
 from _typeshed import Incomplete
 from collections.abc import Iterable
 from logfire import Logfire as Logfire
-from typing import Literal
+from threading import local
+from typing import Literal, Protocol, TypedDict
 from typing_extensions import LiteralString
 
-MetricName: type[Literal['system.cpu.simple_utilization', 'system.cpu.time', 'system.cpu.utilization', 'system.memory.usage', 'system.memory.utilization', 'system.swap.usage', 'system.swap.utilization', 'system.disk.io', 'system.disk.operations', 'system.disk.time', 'system.network.dropped.packets', 'system.network.packets', 'system.network.errors', 'system.network.io', 'system.network.connections', 'system.thread_count', 'process.open_file_descriptor.count', 'process.context_switches', 'process.cpu.time', 'process.cpu.utilization', 'process.cpu.core_utilization', 'process.disk.io', 'process.memory.usage', 'process.memory.virtual', 'process.thread.count', 'process.runtime.gc_count', 'cpython.gc.collected_objects', 'cpython.gc.collections', 'cpython.gc.uncollectable_objects']]
-Config = dict[MetricName, Iterable[str] | None]
+MetricName: type[Literal['system.cpu.simple_utilization', 'system.cpu.time', 'system.cpu.utilization', 'system.memory.usage', 'system.memory.utilization', 'system.swap.usage', 'system.swap.utilization', 'system.disk.io', 'system.disk.operations', 'system.disk.time', 'system.filesystem.usage', 'system.filesystem.limit', 'system.filesystem.utilization', 'system.network.dropped.packets', 'system.network.packets', 'system.network.errors', 'system.network.io', 'system.network.connections', 'system.thread_count', 'process.open_file_descriptor.count', 'process.context_switches', 'process.cpu.time', 'process.cpu.utilization', 'process.cpu.core_utilization', 'process.disk.io', 'process.memory.usage', 'process.memory.virtual', 'process.thread.count', 'process.runtime.gc_count', 'cpython.gc.collected_objects', 'cpython.gc.collections', 'cpython.gc.uncollectable_objects']]
+
+class FilesystemConfig(TypedDict, total=False):
+    """Configuration for the filesystem metric family."""
+    paths: Iterable[str | os.PathLike[str]] | None
+    states: Iterable[Literal['used', 'free', 'reserved']]
+MetricConfig = Iterable[str] | FilesystemConfig | None
+Config = dict[MetricName, MetricConfig]
+logger: Incomplete
+
+class DiskUsage(Protocol):
+    @property
+    def total(self) -> int: ...
+    @property
+    def used(self) -> int: ...
+    @property
+    def free(self) -> int: ...
+
+class DiskPartition(Protocol):
+    @property
+    def device(self) -> str: ...
+    @property
+    def mountpoint(self) -> str: ...
+    @property
+    def fstype(self) -> str: ...
+    @property
+    def opts(self) -> str: ...
+
+FilesystemMetricName: Incomplete
+FilesystemState: Incomplete
+
+class _FilesystemCallbackState(local):
+    cached_observations: tuple[tuple[DiskUsage, dict[str, str]], ...]
+    pending_metrics: set[FilesystemMetricName]
+    def __init__(self) -> None: ...
+
+FILESYSTEM_METRICS: tuple[FilesystemMetricName, ...]
+FILESYSTEM_STATES: tuple[FilesystemState, ...]
+MAX_FILESYSTEM_PATHS: int
 CPU_FIELDS: list[LiteralString]
 MEMORY_FIELDS: list[LiteralString]
 FULL_CONFIG: Config
@@ -14,6 +53,8 @@ Base: Incomplete
 
 def get_base_config(base: Base) -> Config: ...
 def instrument_system_metrics(logfire_instance: Logfire, config: Config | None = None, base: Base = 'basic'): ...
+def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enabled: set[FilesystemMetricName]) -> None:
+    """Create selected OpenTelemetry filesystem metrics for a bounded list of paths."""
 def measure_simple_cpu_utilization(logfire_instance: Logfire): ...
 def measure_process_runtime_cpu_utilization(logfire_instance: Logfire): ...
 def measure_process_cpu_utilization(logfire_instance: Logfire): ...

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -6,7 +6,7 @@ import os
 import sys
 from collections.abc import Callable, Iterable, Sequence
 from platform import python_implementation
-from threading import Lock
+from threading import Lock, local
 from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 
 from opentelemetry.metrics import CallbackOptions, Observation
@@ -142,6 +142,16 @@ class DiskPartition(Protocol):
 FilesystemMetricName = Literal['system.filesystem.usage', 'system.filesystem.limit', 'system.filesystem.utilization']
 FilesystemState = Literal['used', 'free', 'reserved']
 
+
+class _FilesystemCallbackState(local):
+    cached_observations: tuple[tuple[DiskUsage, dict[str, str]], ...]
+    pending_metrics: set[FilesystemMetricName]
+
+    def __init__(self) -> None:
+        self.cached_observations = ()
+        self.pending_metrics = set()
+
+
 FILESYSTEM_METRICS: tuple[FilesystemMetricName, ...] = (
     'system.filesystem.usage',
     'system.filesystem.limit',
@@ -274,6 +284,7 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
     warned_paths: set[str] = set()
     partition_warning_emitted = False
     warning_lock = Lock()
+    callback_state = _FilesystemCallbackState()
 
     def collect_filesystems() -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
         nonlocal partition_warning_emitted
@@ -336,8 +347,17 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
             observations.append((usage, attributes))
         return tuple(observations)
 
+    def observations(metric: FilesystemMetricName) -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
+        # OpenTelemetry invokes all callbacks for one reader on the same thread. Keep that reader's metrics on one
+        # coherent disk sample without sharing mutable collection state across concurrent reader threads.
+        if metric not in callback_state.pending_metrics:
+            callback_state.cached_observations = collect_filesystems()
+            callback_state.pending_metrics = set(enabled)
+        callback_state.pending_metrics.discard(metric)
+        return callback_state.cached_observations
+
     def usage_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in collect_filesystems():
+        for usage, attributes in observations('system.filesystem.usage'):
             values = {
                 'used': usage.used,
                 'free': usage.free,
@@ -347,11 +367,11 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
                 yield Observation(values[state], {**attributes, 'system.filesystem.state': state})
 
     def limit_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in collect_filesystems():
+        for usage, attributes in observations('system.filesystem.limit'):
             yield Observation(usage.total, attributes)
 
     def utilization_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in collect_filesystems():
+        for usage, attributes in observations('system.filesystem.utilization'):
             available = usage.used + usage.free
             yield Observation(
                 usage.used / available if available else 0,

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -465,7 +465,7 @@ def _partition_for_path(path: str, partitions: Iterable[DiskPartition]) -> DiskP
         else:
             try:
                 contains = path_module.commonpath((normalized_path, mountpoint)) == mountpoint
-            except ValueError:  # Different Windows drives.
+            except ValueError:
                 contains = False
         if contains:
             candidates.append((len(mountpoint), partition))

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -6,6 +6,7 @@ import os
 import sys
 from collections.abc import Callable, Iterable, Sequence
 from platform import python_implementation
+from threading import Lock
 from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 
 from opentelemetry.metrics import CallbackOptions, Observation
@@ -103,7 +104,7 @@ MetricName: type[
 class FilesystemConfig(TypedDict, total=False):
     """Configuration for the filesystem metric family."""
 
-    paths: Iterable[str | os.PathLike[str]]
+    paths: Iterable[str | os.PathLike[str]] | None
     states: Iterable[Literal['used', 'free', 'reserved']]
 
 
@@ -247,16 +248,19 @@ def instrument_system_metrics(logfire_instance: Logfire, config: Config | None =
 
 def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enabled: set[FilesystemMetricName]) -> None:
     """Create selected OpenTelemetry filesystem metrics for a bounded list of paths."""
+    configured_paths: Iterable[str | os.PathLike[str]] | None
     if config is None:
-        configured_paths: Iterable[str | os.PathLike[str]] = [os.getcwd()]
+        configured_paths = None
         configured_states: Iterable[FilesystemState] = FILESYSTEM_STATES
     elif isinstance(config, dict):
         filesystem_config = cast(FilesystemConfig, config)
-        configured_paths = filesystem_config.get('paths', [os.getcwd()])
+        configured_paths = filesystem_config.get('paths')
         configured_states = filesystem_config.get('states', FILESYSTEM_STATES)
     else:
         raise ValueError('Filesystem metric configuration must be a dictionary or None.')
 
+    if configured_paths is None:
+        configured_paths = [os.getcwd()]
     raw_paths = list(configured_paths)
     if len(raw_paths) > MAX_FILESYSTEM_PATHS:
         raise ValueError(f'At most {MAX_FILESYSTEM_PATHS} filesystem paths can be configured.')
@@ -269,8 +273,7 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
 
     warned_paths: set[str] = set()
     partition_warning_emitted = False
-    cached_observations: tuple[tuple[DiskUsage, dict[str, str]], ...] = ()
-    pending_metrics: set[FilesystemMetricName] = set()
+    warning_lock = Lock()
 
     def collect_filesystems() -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
         nonlocal partition_warning_emitted
@@ -278,9 +281,11 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
         try:
             # Use named attributes below. Some supported psutil 5.9 platforms append maxfile and maxpath.
             partitions = cast(Sequence[DiskPartition], psutil.disk_partitions(all=True))
-        except (OSError, NotImplementedError, psutil.Error) as exc:
-            if not partition_warning_emitted:
+        except (OSError, NotImplementedError, ValueError, psutil.Error) as exc:
+            with warning_lock:
+                should_warn = not partition_warning_emitted
                 partition_warning_emitted = True
+            if should_warn:
                 logger.warning('Unable to inspect filesystem mount points: %s', exc)
             partitions = ()
 
@@ -291,7 +296,7 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
             if key not in usage_cache:
                 try:
                     usage_cache[key] = cast(DiskUsage, psutil.disk_usage(path))
-                except (OSError, NotImplementedError, psutil.Error) as exc:
+                except (OSError, NotImplementedError, ValueError, psutil.Error) as exc:
                     usage_cache[key] = exc
             return usage_cache[key]
 
@@ -313,8 +318,10 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
 
             if isinstance(usage, BaseException):
                 warning_key = _path_key(selected_path)
-                if warning_key not in warned_paths:
+                with warning_lock:
+                    should_warn = warning_key not in warned_paths
                     warned_paths.add(warning_key)
+                if should_warn:
                     logger.warning('Unable to collect filesystem metrics for %r: %s', selected_path, usage)
                 continue
 
@@ -329,18 +336,8 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
             observations.append((usage, attributes))
         return tuple(observations)
 
-    def observations(metric: FilesystemMetricName) -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
-        nonlocal cached_observations, pending_metrics
-        # Every enabled observable instrument is called once per SDK collection. Keep one coherent disk sample
-        # until the exact enabled subset has consumed it, then refresh at the start of the next collection.
-        if metric not in pending_metrics:
-            cached_observations = collect_filesystems()
-            pending_metrics = set(enabled)
-        pending_metrics.discard(metric)
-        return cached_observations
-
     def usage_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in observations('system.filesystem.usage'):
+        for usage, attributes in collect_filesystems():
             values = {
                 'used': usage.used,
                 'free': usage.free,
@@ -350,11 +347,11 @@ def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enab
                 yield Observation(values[state], {**attributes, 'system.filesystem.state': state})
 
     def limit_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in observations('system.filesystem.limit'):
+        for usage, attributes in collect_filesystems():
             yield Observation(usage.total, attributes)
 
     def utilization_callback(_options: CallbackOptions) -> Iterable[Observation]:
-        for usage, attributes in observations('system.filesystem.utilization'):
+        for usage, attributes in collect_filesystems():
             available = usage.used + usage.free
             yield Observation(
                 usage.used / available if available else 0,

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -477,8 +477,8 @@ def _partition_for_path(path: str, partitions: Iterable[DiskPartition]) -> DiskP
     for partition in partitions:
         raw_mountpoint = partition.mountpoint
         path_module = ntpath if _is_windows_path(path) or _is_windows_path(raw_mountpoint) else os.path
-        normalized_path = path_module.normcase(path_module.abspath(path))
-        mountpoint = path_module.normcase(path_module.abspath(raw_mountpoint))
+        normalized_path = path_module.normcase(path_module.realpath(path_module.abspath(path)))
+        mountpoint = path_module.normcase(path_module.realpath(path_module.abspath(raw_mountpoint)))
         if path_module is ntpath:
             boundary = mountpoint.rstrip('\\/') + '\\'
             contains = normalized_path == mountpoint or normalized_path.startswith(boundary)
@@ -493,7 +493,11 @@ def _partition_for_path(path: str, partitions: Iterable[DiskPartition]) -> DiskP
 
 
 def _is_windows_path(path: str) -> bool:
-    return path.startswith(('\\\\', '//')) or bool(ntpath.splitdrive(path)[0])
+    if path.startswith('\\\\'):
+        return True
+    if path.startswith('//'):
+        return os.name == 'nt'
+    return bool(ntpath.splitdrive(path)[0])
 
 
 def _absolute_path(path: str) -> str:

--- a/logfire/_internal/integrations/system_metrics.py
+++ b/logfire/_internal/integrations/system_metrics.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
+import ntpath
+import os
 import sys
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Sequence
 from platform import python_implementation
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, Literal, Protocol, TypedDict, cast
 
 from opentelemetry.metrics import CallbackOptions, Observation
 
@@ -38,6 +41,9 @@ MetricName: type[
         'system.disk.io',
         'system.disk.operations',
         'system.disk.time',
+        'system.filesystem.usage',
+        'system.filesystem.limit',
+        'system.filesystem.utilization',
         'system.network.dropped.packets',
         'system.network.packets',
         'system.network.errors',
@@ -69,6 +75,9 @@ MetricName: type[
     'system.disk.io',
     'system.disk.operations',
     'system.disk.time',
+    'system.filesystem.usage',
+    'system.filesystem.limit',
+    'system.filesystem.utilization',
     'system.network.dropped.packets',
     'system.network.packets',
     'system.network.errors',
@@ -90,7 +99,55 @@ MetricName: type[
     'cpython.gc.uncollectable_objects',
 ]
 
-Config = dict[MetricName, Iterable[str] | None]
+
+class FilesystemConfig(TypedDict, total=False):
+    """Configuration for the filesystem metric family."""
+
+    paths: Iterable[str | os.PathLike[str]]
+    states: Iterable[Literal['used', 'free', 'reserved']]
+
+
+MetricConfig = Iterable[str] | FilesystemConfig | None
+Config = dict[MetricName, MetricConfig]
+
+logger = logging.getLogger(__name__)
+
+
+class DiskUsage(Protocol):
+    @property
+    def total(self) -> int: ...
+
+    @property
+    def used(self) -> int: ...
+
+    @property
+    def free(self) -> int: ...
+
+
+class DiskPartition(Protocol):
+    @property
+    def device(self) -> str: ...
+
+    @property
+    def mountpoint(self) -> str: ...
+
+    @property
+    def fstype(self) -> str: ...
+
+    @property
+    def opts(self) -> str: ...
+
+
+FilesystemMetricName = Literal['system.filesystem.usage', 'system.filesystem.limit', 'system.filesystem.utilization']
+FilesystemState = Literal['used', 'free', 'reserved']
+
+FILESYSTEM_METRICS: tuple[FilesystemMetricName, ...] = (
+    'system.filesystem.usage',
+    'system.filesystem.limit',
+    'system.filesystem.utilization',
+)
+FILESYSTEM_STATES: tuple[FilesystemState, ...] = ('used', 'free', 'reserved')
+MAX_FILESYSTEM_PATHS = 32
 
 # All the cpu_times fields provided by psutil (used by system_metrics) across all platforms,
 # except for 'guest' and 'guest_nice' which are included in 'user' and 'nice' in Linux (see psutil._cpu_tot_time).
@@ -156,6 +213,17 @@ def get_base_config(base: Base) -> Config:
 def instrument_system_metrics(logfire_instance: Logfire, config: Config | None = None, base: Base = 'basic'):
     config = {**get_base_config(base), **(config or {})}
 
+    filesystem_config = {name: config.pop(name) for name in FILESYSTEM_METRICS if name in config}
+    if filesystem_config:
+        values = list(filesystem_config.values())
+        if any(value != values[0] for value in values[1:]):
+            raise ValueError('Filesystem metric keys must use the same configuration.')
+        measure_filesystems(
+            logfire_instance,
+            values[0],
+            enabled=cast(set[FilesystemMetricName], set(filesystem_config)),
+        )
+
     if 'system.cpu.simple_utilization' in config:
         measure_simple_cpu_utilization(logfire_instance)
 
@@ -175,6 +243,250 @@ def instrument_system_metrics(logfire_instance: Logfire, config: Config | None =
 
     instrumentor = SystemMetricsInstrumentor(config=config)  # pyright: ignore[reportArgumentType]
     instrumentor.instrument(meter_provider=logfire_instance.config.get_meter_provider())
+
+
+def measure_filesystems(logfire_instance: Logfire, config: MetricConfig, *, enabled: set[FilesystemMetricName]) -> None:
+    """Create selected OpenTelemetry filesystem metrics for a bounded list of paths."""
+    if config is None:
+        configured_paths: Iterable[str | os.PathLike[str]] = [os.getcwd()]
+        configured_states: Iterable[FilesystemState] = FILESYSTEM_STATES
+    elif isinstance(config, dict):
+        filesystem_config = cast(FilesystemConfig, config)
+        configured_paths = filesystem_config.get('paths', [os.getcwd()])
+        configured_states = filesystem_config.get('states', FILESYSTEM_STATES)
+    else:
+        raise ValueError('Filesystem metric configuration must be a dictionary or None.')
+
+    raw_paths = list(configured_paths)
+    if len(raw_paths) > MAX_FILESYSTEM_PATHS:
+        raise ValueError(f'At most {MAX_FILESYSTEM_PATHS} filesystem paths can be configured.')
+    paths = [_absolute_path(os.fsdecode(path)) for path in raw_paths]
+
+    states = tuple(dict.fromkeys(configured_states))
+    invalid_states = set(states) - set(FILESYSTEM_STATES)
+    if invalid_states:
+        raise ValueError(f'Invalid filesystem states: {sorted(invalid_states)}')
+
+    warned_paths: set[str] = set()
+    partition_warning_emitted = False
+    cached_observations: tuple[tuple[DiskUsage, dict[str, str]], ...] = ()
+    pending_metrics: set[FilesystemMetricName] = set()
+
+    def collect_filesystems() -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
+        nonlocal partition_warning_emitted
+
+        try:
+            # Use named attributes below. Some supported psutil 5.9 platforms append maxfile and maxpath.
+            partitions = cast(Sequence[DiskPartition], psutil.disk_partitions(all=True))
+        except (OSError, NotImplementedError, psutil.Error) as exc:
+            if not partition_warning_emitted:
+                partition_warning_emitted = True
+                logger.warning('Unable to inspect filesystem mount points: %s', exc)
+            partitions = ()
+
+        usage_cache: dict[str, DiskUsage | BaseException] = {}
+
+        def usage_for(path: str) -> DiskUsage | BaseException:
+            key = _path_key(path)
+            if key not in usage_cache:
+                try:
+                    usage_cache[key] = cast(DiskUsage, psutil.disk_usage(path))
+                except (OSError, NotImplementedError, psutil.Error) as exc:
+                    usage_cache[key] = exc
+            return usage_cache[key]
+
+        observations: list[tuple[DiskUsage, dict[str, str]]] = []
+        seen: set[tuple[str, str]] = set()
+        for selected_path in paths:
+            partition: DiskPartition | None = None
+            usage: DiskUsage | BaseException
+
+            data_partition = _macos_data_partition(selected_path, partitions)
+            if data_partition is not None:
+                usage = usage_for(data_partition.mountpoint)
+                if not isinstance(usage, BaseException):
+                    partition = data_partition
+                else:
+                    usage = usage_for(selected_path)
+            else:
+                usage = usage_for(selected_path)
+
+            if isinstance(usage, BaseException):
+                warning_key = _path_key(selected_path)
+                if warning_key not in warned_paths:
+                    warned_paths.add(warning_key)
+                    logger.warning('Unable to collect filesystem metrics for %r: %s', selected_path, usage)
+                continue
+
+            if partition is None:
+                partition = _identify_partition(selected_path, usage, partitions, usage_for)
+
+            attributes = _filesystem_attributes(selected_path, partition)
+            identity = _filesystem_identity(attributes)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            observations.append((usage, attributes))
+        return tuple(observations)
+
+    def observations(metric: FilesystemMetricName) -> tuple[tuple[DiskUsage, dict[str, str]], ...]:
+        nonlocal cached_observations, pending_metrics
+        # Every enabled observable instrument is called once per SDK collection. Keep one coherent disk sample
+        # until the exact enabled subset has consumed it, then refresh at the start of the next collection.
+        if metric not in pending_metrics:
+            cached_observations = collect_filesystems()
+            pending_metrics = set(enabled)
+        pending_metrics.discard(metric)
+        return cached_observations
+
+    def usage_callback(_options: CallbackOptions) -> Iterable[Observation]:
+        for usage, attributes in observations('system.filesystem.usage'):
+            values = {
+                'used': usage.used,
+                'free': usage.free,
+                'reserved': max(usage.total - usage.used - usage.free, 0),
+            }
+            for state in states:
+                yield Observation(values[state], {**attributes, 'system.filesystem.state': state})
+
+    def limit_callback(_options: CallbackOptions) -> Iterable[Observation]:
+        for usage, attributes in observations('system.filesystem.limit'):
+            yield Observation(usage.total, attributes)
+
+    def utilization_callback(_options: CallbackOptions) -> Iterable[Observation]:
+        for usage, attributes in observations('system.filesystem.utilization'):
+            available = usage.used + usage.free
+            yield Observation(
+                usage.used / available if available else 0,
+                {**attributes, 'system.filesystem.state': 'used'},
+            )
+
+    if 'system.filesystem.usage' in enabled:
+        logfire_instance.metric_up_down_counter_callback(
+            'system.filesystem.usage',
+            [usage_callback],
+            unit='By',
+            description="Reports a filesystem's space usage across different states.",
+        )
+    if 'system.filesystem.limit' in enabled:
+        logfire_instance.metric_up_down_counter_callback(
+            'system.filesystem.limit',
+            [limit_callback],
+            unit='By',
+            description='The total storage capacity of the filesystem.',
+        )
+    if 'system.filesystem.utilization' in enabled:
+        logfire_instance.metric_gauge_callback(
+            'system.filesystem.utilization',
+            [utilization_callback],
+            unit='1',
+            description='Fraction of filesystem bytes used.',
+        )
+
+
+def _identify_partition(
+    path: str,
+    usage: DiskUsage,
+    partitions: Sequence[DiskPartition],
+    usage_for: Callable[[str], DiskUsage | BaseException],
+) -> DiskPartition | None:
+    """Identify the measured partition, preferring lexical containment except for macOS Data firmlinks."""
+    lexical = _partition_for_path(path, partitions)
+    if sys.platform != 'darwin' or lexical is None or _path_key(lexical.mountpoint) != '/':
+        return lexical
+
+    candidates: list[tuple[int, DiskPartition]] = []
+    for partition in partitions:
+        partition_usage = usage_for(partition.mountpoint)
+        if not isinstance(partition_usage, BaseException) and partition_usage.total == usage.total:
+            distance = abs(partition_usage.used - usage.used) + abs(partition_usage.free - usage.free)
+            candidates.append((distance, partition))
+
+    if not candidates:
+        return lexical
+    best_distance = min(distance for distance, _partition in candidates)
+    matches = [partition for distance, partition in candidates if distance == best_distance]
+    if lexical in matches:
+        return lexical
+    if len(matches) == 1 and _path_key(matches[0].mountpoint) == '/System/Volumes/Data':
+        return matches[0]
+    return lexical
+
+
+def _macos_data_partition(path: str, partitions: Sequence[DiskPartition]) -> DiskPartition | None:
+    """Resolve the sealed macOS root to the writable Data volume."""
+    if sys.platform != 'darwin' or _path_key(path) != '/':
+        return None
+    return next(
+        (partition for partition in partitions if _path_key(partition.mountpoint) == '/System/Volumes/Data'), None
+    )
+
+
+def _filesystem_attributes(path: str, partition: DiskPartition | None) -> dict[str, str]:
+    if partition is None:
+        device, mountpoint = _fallback_filesystem_identity(path)
+        return {'system.device': device, 'system.filesystem.mountpoint': mountpoint}
+
+    attributes = {
+        'system.device': partition.device,
+        'system.filesystem.mountpoint': partition.mountpoint,
+        'system.filesystem.mode': 'ro' if 'ro' in {option.lower() for option in partition.opts.split(',')} else 'rw',
+    }
+    if partition.fstype:
+        attributes['system.filesystem.type'] = partition.fstype.lower()
+    return attributes
+
+
+def _fallback_filesystem_identity(path: str) -> tuple[str, str]:
+    """Return a stable best-effort identity when psutil does not enumerate the partition."""
+    if _is_windows_path(path):
+        drive, _tail = ntpath.splitdrive(path)
+        if drive:
+            mountpoint = drive if drive.startswith(('\\\\', '//')) else drive + '\\'
+            return drive, mountpoint
+    return path, path
+
+
+def _filesystem_identity(attributes: dict[str, str]) -> tuple[str, str]:
+    return (
+        _path_key(attributes['system.device']) if attributes.get('system.device') else '',
+        _path_key(attributes['system.filesystem.mountpoint']),
+    )
+
+
+def _partition_for_path(path: str, partitions: Iterable[DiskPartition]) -> DiskPartition | None:
+    """Return the most specific psutil partition containing path, including UNC mount points."""
+    candidates: list[tuple[int, DiskPartition]] = []
+    for partition in partitions:
+        raw_mountpoint = partition.mountpoint
+        path_module = ntpath if _is_windows_path(path) or _is_windows_path(raw_mountpoint) else os.path
+        normalized_path = path_module.normcase(path_module.abspath(path))
+        mountpoint = path_module.normcase(path_module.abspath(raw_mountpoint))
+        if path_module is ntpath:
+            boundary = mountpoint.rstrip('\\/') + '\\'
+            contains = normalized_path == mountpoint or normalized_path.startswith(boundary)
+        else:
+            try:
+                contains = path_module.commonpath((normalized_path, mountpoint)) == mountpoint
+            except ValueError:  # Different Windows drives.
+                contains = False
+        if contains:
+            candidates.append((len(mountpoint), partition))
+    return max(candidates, default=(0, None), key=lambda item: item[0])[1]
+
+
+def _is_windows_path(path: str) -> bool:
+    return path.startswith(('\\\\', '//')) or bool(ntpath.splitdrive(path)[0])
+
+
+def _absolute_path(path: str) -> str:
+    path_module = ntpath if _is_windows_path(path) else os.path
+    return path_module.abspath(path)
+
+
+def _path_key(path: str) -> str:
+    path_module = ntpath if _is_windows_path(path) else os.path
+    return path_module.normcase(path_module.abspath(path))
 
 
 def measure_simple_cpu_utilization(logfire_instance: Logfire):

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -254,7 +254,7 @@ def test_filesystem_metrics(metrics_reader: InMemoryMetricReader, monkeypatch: p
     )
     metrics = {metric['name']: metric for metric in get_collected_metrics(metrics_reader)}
 
-    assert usage_calls == ['/work/app']
+    assert usage_calls == ['/work/app'] * 3
     assert set(metrics) == {
         'system.filesystem.usage',
         'system.filesystem.limit',
@@ -287,8 +287,12 @@ def test_filesystem_metrics(metrics_reader: InMemoryMetricReader, monkeypatch: p
     SystemMetricsInstrumentor().uninstrument()
 
 
+@pytest.mark.parametrize('error', [OSError('gone'), ValueError('invalid path')])
 def test_filesystem_failures_warn_once_and_keep_other_metrics(
-    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    error: Exception,
+    metrics_reader: InMemoryMetricReader,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     partition_calls = 0
 
@@ -298,7 +302,7 @@ def test_filesystem_failures_warn_once_and_keep_other_metrics(
         raise system_metrics.psutil.AccessDenied(pid=1, name='partitions')
 
     def disk_usage(path: str) -> None:
-        raise OSError('gone')
+        raise error
 
     monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
     monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
@@ -309,7 +313,7 @@ def test_filesystem_failures_warn_once_and_keep_other_metrics(
         get_collected_metrics(metrics_reader)
     assert [record.message for record in caplog.records if record.name == system_metrics.__name__] == [
         "Unable to inspect filesystem mount points: (pid=1, name='partitions')",
-        "Unable to collect filesystem metrics for '/gone': gone",
+        f"Unable to collect filesystem metrics for '/gone': {error}",
     ]
     assert partition_calls == 2
     assert 'system.cpu.simple_utilization' in get_collected_metric_names(metrics_reader)
@@ -376,6 +380,29 @@ def test_filesystem_config_validation() -> None:
 
     with pytest.raises(ValueError, match='must be a dictionary or None'):
         logfire.instrument_system_metrics({'system.filesystem.limit': ['/']}, base=None)
+
+
+def test_filesystem_none_paths_uses_current_working_directory(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    usage_calls: list[str] = []
+
+    monkeypatch.setattr(system_metrics.os, 'getcwd', lambda: '/work')
+
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return []
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+
+    def disk_usage(path: str) -> Usage:
+        usage_calls.append(path)
+        return Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+    logfire.instrument_system_metrics({'system.filesystem.limit': {'paths': None}}, base=None)
+
+    assert get_collected_metrics(metrics_reader)[0]['data']['data_points'][0]['value'] == 100
+    assert usage_calls == ['/work']
 
 
 def test_macos_firmlink_and_root_use_data_volume(

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -254,7 +254,7 @@ def test_filesystem_metrics(metrics_reader: InMemoryMetricReader, monkeypatch: p
     )
     metrics = {metric['name']: metric for metric in get_collected_metrics(metrics_reader)}
 
-    assert usage_calls == ['/work/app'] * 3
+    assert usage_calls == ['/work/app']
     assert set(metrics) == {
         'system.filesystem.usage',
         'system.filesystem.limit',

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import NamedTuple
 
 import psutil
@@ -607,6 +608,33 @@ def test_partition_for_path_tolerates_commonpath_value_error(monkeypatch: pytest
         '/work/app', [Partition('/dev/data', '/work', 'ext4', 'rw')]
     )
     assert partition is None
+
+
+def test_partition_for_path_resolves_symlinks(tmp_path: Path) -> None:
+    volume = tmp_path / 'volume'
+    app = volume / 'app'
+    app.mkdir(parents=True)
+    symlink = tmp_path / 'symlink'
+    symlink.symlink_to(volume, target_is_directory=True)
+
+    partition = system_metrics._partition_for_path(  # pyright: ignore[reportPrivateUsage]
+        str(symlink / 'app'),
+        [
+            Partition('/dev/root', '/', 'ext4', 'rw'),
+            Partition('/dev/volume', str(volume), 'ext4', 'rw'),
+        ],
+    )
+
+    assert partition is not None
+    assert partition.device == '/dev/volume'
+
+
+@pytest.mark.parametrize(('os_name', 'expected'), [('posix', False), ('nt', True)])
+def test_forward_slash_unc_detection_depends_on_platform(
+    os_name: str, expected: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(system_metrics.os, 'name', os_name)
+    assert system_metrics._is_windows_path('//srv/data') is expected  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.parametrize(

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import logging
+from typing import NamedTuple
+
 import psutil
 import pytest
 from inline_snapshot import snapshot
@@ -7,8 +10,32 @@ from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrument
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 
 import logfire
+from logfire._internal.integrations import system_metrics
 from logfire._internal.integrations.system_metrics import get_base_config
 from tests.test_metrics import get_collected_metrics
+
+
+class Partition(NamedTuple):
+    device: str
+    mountpoint: str
+    fstype: str
+    opts: str
+
+
+class PartitionWithLimits(NamedTuple):
+    device: str
+    mountpoint: str
+    fstype: str
+    opts: str
+    maxfile: int
+    maxpath: int
+
+
+class Usage(NamedTuple):
+    total: int
+    used: int
+    free: int
+    percent: float
 
 
 def get_collected_metric_names(metrics_reader: InMemoryMetricReader) -> list[str]:
@@ -196,3 +223,300 @@ def test_empty_base():
 def test_invalid_base():
     with pytest.raises(ValueError):
         get_base_config('invalid')  # type: ignore
+
+
+def test_filesystem_metrics(metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch) -> None:
+    partition = PartitionWithLimits('/dev/data', '/work', 'EXT4', 'rw,relatime', 255, 1024)
+    usage = Usage(100, 40, 50, 80)
+    usage_calls: list[str] = []
+
+    def disk_partitions(*, all: bool) -> list[PartitionWithLimits]:
+        return [partition]
+
+    def disk_usage(path: str) -> Usage:
+        usage_calls.append(path)
+        return usage
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    filesystem_config: system_metrics.FilesystemConfig = {
+        'paths': ['/work/app'],
+        'states': ['used', 'reserved'],
+    }
+    logfire.instrument_system_metrics(
+        {
+            'system.filesystem.usage': filesystem_config,
+            'system.filesystem.limit': filesystem_config,
+            'system.filesystem.utilization': filesystem_config,
+        },
+        base=None,
+    )
+    metrics = {metric['name']: metric for metric in get_collected_metrics(metrics_reader)}
+
+    assert usage_calls == ['/work/app']
+    assert set(metrics) == {
+        'system.filesystem.usage',
+        'system.filesystem.limit',
+        'system.filesystem.utilization',
+    }
+    assert metrics['system.filesystem.usage']['unit'] == 'By'
+    assert metrics['system.filesystem.usage']['data']['is_monotonic'] is False
+    points = metrics['system.filesystem.usage']['data']['data_points']
+    assert [(point['attributes']['system.filesystem.state'], point['value']) for point in points] == [
+        ('used', 40),
+        ('reserved', 10),
+    ]
+    assert points[0]['attributes'] == {
+        'system.device': '/dev/data',
+        'system.filesystem.mode': 'rw',
+        'system.filesystem.mountpoint': '/work',
+        'system.filesystem.state': 'used',
+        'system.filesystem.type': 'ext4',
+    }
+    assert metrics['system.filesystem.limit']['unit'] == 'By'
+    assert metrics['system.filesystem.limit']['data']['is_monotonic'] is False
+    limit_point = metrics['system.filesystem.limit']['data']['data_points'][0]
+    assert limit_point['value'] == 100
+    assert limit_point['attributes']['system.filesystem.mode'] == 'rw'
+    assert metrics['system.filesystem.utilization']['unit'] == '1'
+    utilization_point = metrics['system.filesystem.utilization']['data']['data_points'][0]
+    assert utilization_point['value'] == pytest.approx(40 / 90)
+    assert utilization_point['attributes']['system.filesystem.state'] == 'used'
+    assert utilization_point['attributes']['system.filesystem.mode'] == 'rw'
+    SystemMetricsInstrumentor().uninstrument()
+
+
+def test_filesystem_failures_warn_once_and_keep_other_metrics(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    partition_calls = 0
+
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        nonlocal partition_calls
+        partition_calls += 1
+        raise system_metrics.psutil.AccessDenied(pid=1, name='partitions')
+
+    def disk_usage(path: str) -> None:
+        raise OSError('gone')
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+    logfire.instrument_system_metrics({'system.filesystem.utilization': {'paths': ['/gone']}}, base='basic')
+
+    with caplog.at_level(logging.WARNING):
+        get_collected_metrics(metrics_reader)
+        get_collected_metrics(metrics_reader)
+    assert [record.message for record in caplog.records if record.name == system_metrics.__name__] == [
+        "Unable to inspect filesystem mount points: (pid=1, name='partitions')",
+        "Unable to collect filesystem metrics for '/gone': gone",
+    ]
+    assert partition_calls == 2
+    assert 'system.cpu.simple_utilization' in get_collected_metric_names(metrics_reader)
+
+
+def test_filesystem_exact_metric_subset(metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch) -> None:
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return [Partition('/dev/data', '/work', 'ext4', 'ro,relatime')]
+
+    def disk_usage(path: str) -> Usage:
+        return Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics({'system.filesystem.limit': {'paths': ['/work/app']}}, base=None)
+    metrics = get_collected_metrics(metrics_reader)
+
+    assert [metric['name'] for metric in metrics] == ['system.filesystem.limit']
+    assert metrics[0]['data']['data_points'][0]['attributes']['system.filesystem.mode'] == 'ro'
+
+
+def test_filesystem_enumeration_failure_uses_fallback_identity(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        raise NotImplementedError('unsupported')
+
+    def disk_usage(path: str) -> Usage:
+        return Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics({'system.filesystem.limit': {'paths': ['/work/app']}}, base=None)
+    point = get_collected_metrics(metrics_reader)[0]['data']['data_points'][0]
+
+    assert point['attributes'] == {
+        'system.device': '/work/app',
+        'system.filesystem.mountpoint': '/work/app',
+    }
+
+
+def test_filesystem_config_validation() -> None:
+    with pytest.raises(ValueError, match='At most 32 filesystem paths'):
+        logfire.instrument_system_metrics(
+            {'system.filesystem.usage': {'paths': [f'/mnt/{index}' for index in range(33)]}}, base=None
+        )
+
+    with pytest.raises(ValueError, match='Invalid filesystem states'):
+        logfire.instrument_system_metrics(
+            {'system.filesystem.usage': {'states': ['used', 'cached']}},
+            base=None,
+        )
+
+    with pytest.raises(ValueError, match='Filesystem metric keys must use the same configuration'):
+        logfire.instrument_system_metrics(
+            {
+                'system.filesystem.usage': {'paths': ['/']},
+                'system.filesystem.limit': {'paths': ['/tmp']},
+            },
+            base=None,
+        )
+
+    with pytest.raises(ValueError, match='must be a dictionary or None'):
+        logfire.instrument_system_metrics({'system.filesystem.limit': ['/']}, base=None)
+
+
+def test_macos_firmlink_and_root_use_data_volume(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = Partition('/dev/system', '/', 'apfs', 'ro')
+    data = Partition('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')
+    root_usage = Usage(100, 10, 40, 20)
+    data_usage = Usage(100, 50, 40, 55)
+    calls: list[str] = []
+
+    def disk_usage(path: str) -> Usage:
+        calls.append(path)
+        return {
+            '/': root_usage,
+            '/System/Volumes/Data': data_usage,
+            '/Users/me/app': data_usage,
+        }[path]
+
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return [root, data]
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics(
+        {'system.filesystem.limit': {'paths': ['/', '/Users/me/app']}},
+        base=None,
+    )
+    points = get_collected_metrics(metrics_reader)[0]['data']['data_points']
+
+    assert len(points) == 1
+    assert points[0]['value'] == data_usage.total
+    assert points[0]['attributes'] == {
+        'system.device': '/dev/data',
+        'system.filesystem.mode': 'rw',
+        'system.filesystem.mountpoint': '/System/Volumes/Data',
+        'system.filesystem.type': 'apfs',
+    }
+    assert calls.count('/System/Volumes/Data') == 1
+    assert calls.count('/Users/me/app') == 1
+    assert calls.count('/') == 1
+
+
+def test_equal_usage_bind_mount_prefers_lexical_partition(monkeypatch: pytest.MonkeyPatch) -> None:
+    root = Partition('/dev/root', '/', 'ext4', 'rw')
+    selected = Partition('/dev/data', '/srv/data', 'ext4', 'rw')
+    bind = Partition('/dev/data', '/mnt/bind', 'ext4', 'rw')
+    usage = Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'linux')
+    partition = system_metrics._identify_partition(  # pyright: ignore[reportPrivateUsage]
+        '/srv/data/app', usage, [root, selected, bind], lambda path: usage
+    )
+
+    assert partition is selected
+
+
+def test_macos_ambiguous_usage_match_does_not_choose_unrelated_partition(monkeypatch: pytest.MonkeyPatch) -> None:
+    root = Partition('/dev/system', '/', 'apfs', 'ro')
+    data = Partition('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')
+    clone = Partition('/dev/clone', '/Volumes/clone', 'apfs', 'rw')
+    selected_usage = Usage(100, 50, 40, 55)
+    root_usage = Usage(100, 10, 40, 20)
+    usages = {'/': root_usage, '/System/Volumes/Data': selected_usage, '/Volumes/clone': selected_usage}
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
+    partition = system_metrics._identify_partition(  # pyright: ignore[reportPrivateUsage]
+        '/Users/me/app', selected_usage, [root, data, clone], lambda path: usages[path]
+    )
+
+    assert partition is root
+
+
+def test_macos_firmlink_matching_tolerates_a_changed_sample(monkeypatch: pytest.MonkeyPatch) -> None:
+    root = Partition('/dev/system', '/', 'apfs', 'ro')
+    data = Partition('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')
+    selected_usage = Usage(100, 50, 40, 55)
+    usages = {
+        '/': Usage(100, 10, 40, 20),
+        '/System/Volumes/Data': Usage(100, 51, 39, 56),
+    }
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
+    partition = system_metrics._identify_partition(  # pyright: ignore[reportPrivateUsage]
+        '/Users/me/app', selected_usage, [root, data], lambda path: usages[path]
+    )
+
+    assert partition is data
+
+
+def test_windows_unc_fallback_is_case_insensitive(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return []
+
+    def disk_usage(path: str) -> Usage:
+        return Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics(
+        {'system.filesystem.limit': {'paths': [r'\\server\share\app', r'\\SERVER\SHARE\other']}},
+        base=None,
+    )
+    points = get_collected_metrics(metrics_reader)[0]['data']['data_points']
+
+    assert len(points) == 1
+    assert points[0]['attributes'] == {
+        'system.device': r'\\server\share',
+        'system.filesystem.mountpoint': r'\\server\share',
+    }
+
+
+@pytest.mark.parametrize(
+    ('path', 'partitions', 'expected_device'),
+    [
+        (
+            '/var/lib/app/data',
+            [('/dev/root', '/', 'ext4', 'rw'), ('/dev/data', '/var/lib/app', 'xfs', 'rw')],
+            '/dev/data',
+        ),
+        (
+            '/System/Volumes/Data/Users/me/app',
+            [('/dev/system', '/', 'apfs', 'ro'), ('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')],
+            '/dev/data',
+        ),
+        (
+            r'\\server\share\apps\service',
+            [(r'\\SERVER\SHARE', r'\\SERVER\SHARE', 'NTFS', 'rw')],
+            r'\\SERVER\SHARE',
+        ),
+        (r'D:\apps\service', [('C:', 'C:\\', 'NTFS', 'rw'), ('D:', 'D:\\', 'NTFS', 'rw')], 'D:'),
+    ],
+)
+def test_partition_for_path(path: str, partitions: list[tuple[str, str, str, str]], expected_device: str) -> None:
+    partition = system_metrics._partition_for_path(  # pyright: ignore[reportPrivateUsage]
+        path, (Partition(*values) for values in partitions)
+    )
+    assert partition is not None
+    assert partition.device == expected_device

--- a/tests/otel_integrations/test_system_metrics.py
+++ b/tests/otel_integrations/test_system_metrics.py
@@ -405,6 +405,29 @@ def test_filesystem_none_paths_uses_current_working_directory(
     assert usage_calls == ['/work']
 
 
+def test_filesystem_none_config_uses_current_working_directory(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return []
+
+    def disk_usage(path: str) -> Usage:
+        return Usage(100, 40, 50, 80)
+
+    monkeypatch.setattr(system_metrics.os, 'getcwd', lambda: '/work')
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics({'system.filesystem.limit': None}, base=None)
+
+    point = get_collected_metrics(metrics_reader)[0]['data']['data_points'][0]
+    assert point['value'] == 100
+    assert point['attributes'] == {
+        'system.device': '/work',
+        'system.filesystem.mountpoint': '/work',
+    }
+
+
 def test_macos_firmlink_and_root_use_data_volume(
     metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -448,6 +471,37 @@ def test_macos_firmlink_and_root_use_data_volume(
     assert calls.count('/') == 1
 
 
+def test_macos_data_volume_failure_falls_back_to_root(
+    metrics_reader: InMemoryMetricReader, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = Partition('/dev/system', '/', '', 'ro')
+    data = Partition('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')
+    root_usage = Usage(100, 10, 40, 20)
+
+    def disk_usage(path: str) -> Usage:
+        if path == data.mountpoint:
+            raise OSError('data unavailable')
+        assert path == root.mountpoint
+        return root_usage
+
+    def disk_partitions(*, all: bool) -> list[Partition]:
+        return [root, data]
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
+    monkeypatch.setattr(system_metrics.psutil, 'disk_partitions', disk_partitions)
+    monkeypatch.setattr(system_metrics.psutil, 'disk_usage', disk_usage)
+
+    logfire.instrument_system_metrics({'system.filesystem.limit': {'paths': ['/']}}, base=None)
+    point = get_collected_metrics(metrics_reader)[0]['data']['data_points'][0]
+
+    assert point['value'] == root_usage.total
+    assert point['attributes'] == {
+        'system.device': '/dev/system',
+        'system.filesystem.mode': 'ro',
+        'system.filesystem.mountpoint': '/',
+    }
+
+
 def test_equal_usage_bind_mount_prefers_lexical_partition(monkeypatch: pytest.MonkeyPatch) -> None:
     root = Partition('/dev/root', '/', 'ext4', 'rw')
     selected = Partition('/dev/data', '/srv/data', 'ext4', 'rw')
@@ -473,6 +527,19 @@ def test_macos_ambiguous_usage_match_does_not_choose_unrelated_partition(monkeyp
     monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
     partition = system_metrics._identify_partition(  # pyright: ignore[reportPrivateUsage]
         '/Users/me/app', selected_usage, [root, data, clone], lambda path: usages[path]
+    )
+
+    assert partition is root
+
+
+def test_macos_failed_usage_matches_use_lexical_partition(monkeypatch: pytest.MonkeyPatch) -> None:
+    root = Partition('/dev/system', '/', 'apfs', 'ro')
+    data = Partition('/dev/data', '/System/Volumes/Data', 'apfs', 'rw')
+    selected_usage = Usage(100, 50, 40, 55)
+
+    monkeypatch.setattr(system_metrics.sys, 'platform', 'darwin')
+    partition = system_metrics._identify_partition(  # pyright: ignore[reportPrivateUsage]
+        '/Users/me/app', selected_usage, [root, data], lambda path: OSError(f'{path} unavailable')
     )
 
     assert partition is root
@@ -518,6 +585,28 @@ def test_windows_unc_fallback_is_case_insensitive(
         'system.device': r'\\server\share',
         'system.filesystem.mountpoint': r'\\server\share',
     }
+
+
+def test_windows_fallback_handles_an_unparseable_drive(monkeypatch: pytest.MonkeyPatch) -> None:
+    def splitdrive(path: str) -> tuple[str, str]:
+        return '', path
+
+    monkeypatch.setattr(system_metrics.ntpath, 'splitdrive', splitdrive)
+
+    path = r'\\invalid'
+    assert system_metrics._fallback_filesystem_identity(path) == (path, path)  # pyright: ignore[reportPrivateUsage]
+
+
+def test_partition_for_path_tolerates_commonpath_value_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def commonpath(paths: tuple[str, str]) -> str:
+        raise ValueError('different drives')
+
+    monkeypatch.setattr(system_metrics.os.path, 'commonpath', commonpath)
+
+    partition = system_metrics._partition_for_path(  # pyright: ignore[reportPrivateUsage]
+        '/work/app', [Partition('/dev/data', '/work', 'ext4', 'rw')]
+    )
+    assert partition is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #859.

## What changed

- Add opt-in `system.filesystem.usage`, `system.filesystem.limit`, and `system.filesystem.utilization` metrics.
- Report used, free, and reserved bytes with OpenTelemetry filesystem attributes.
- Support an explicit bounded list of paths, deduplicate mounts, and degrade safely when `psutil` cannot inspect a path or partition.
- Handle the writable macOS Data volume, Windows/UNC paths, mount modes, and filesystem types.
- Document configuration, units, cardinality, and platform behavior.

## Why

The existing disk metrics describe I/O activity but not whether a filesystem is approaching capacity. These metrics allow users to alert on usable free space and utilization directly through `instrument_system_metrics()`.

## Validation

- 10 focused filesystem tests.
- Full system-metrics suite: 20 passed; two unrelated macOS `psutil.swap_memory()` environment failures were reproduced separately.
- Documentation tests.
- Ruff, Ruff format, Pyright, pre-commit hooks, and `git diff --check`.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

