### PR TITLE
Add separate trace roots for manual spans

### DIFF
--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -209,7 +209,7 @@ except ValueError:
 Normally, a span created while another span is active becomes its child. This is not useful when the current
 operation schedules independent work, such as a background job, that should have its own trace.
 
-Pass the private `_new_trace=True` keyword to start a separate trace root. Logfire adds a span link, which records
+Pass `_new_trace=True` to start a separate trace root. Logfire adds a span link, which records
 the relationship, to the previously active span without making the new span its child. Other OpenTelemetry context
 values remain available, including baggage (small key/value data that rides along with a request across services).
 
@@ -222,6 +222,12 @@ with logfire.span('current operation'):
     with logfire.span('independent operation', _new_trace=True):
         logfire.info('This log is a child of the independent operation')
 ```
+
+To apply the same behavior to every call of a function, decorate it with
+`@logfire.instrument(new_trace=True)`.
+
+The new root appears as a separate trace in the Live view. The Logfire user interface does not currently draw the
+link back to the original trace; query the `otel_links` column with [SQL](../../reference/sql.md) to inspect it.
 
 ## Convenient function spans with `@logfire.instrument`
 

--- a/docs/guides/onboarding-checklist/add-manual-tracing.md
+++ b/docs/guides/onboarding-checklist/add-manual-tracing.md
@@ -204,6 +204,25 @@ except ValueError:
 
 `logfire.exception(...)` is equivalent to `logfire.error(..., _exc_info=True)`. You can also use `_exc_info` with the other logging methods if you want to record a traceback in a log with a non-error level. You can set `_exc_info` to a specific exception object if it's not the one being handled. Don't forget the leading underscore!
 
+## Start a separate trace
+
+Normally, a span created while another span is active becomes its child. This is not useful when the current
+operation schedules independent work, such as a background job, that should have its own trace.
+
+Pass the private `_new_trace=True` keyword to start a separate trace root. Logfire adds a span link, which records
+the relationship, to the previously active span without making the new span its child. Other OpenTelemetry context
+values remain available, including baggage (small key/value data that rides along with a request across services).
+
+```python
+import logfire
+
+logfire.configure()
+
+with logfire.span('current operation'):
+    with logfire.span('independent operation', _new_trace=True):
+        logfire.info('This log is a child of the independent operation')
+```
+
 ## Convenient function spans with `@logfire.instrument`
 
 Often you want to wrap a whole function in a span. Instead of doing this:

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -229,7 +229,7 @@ class Logfire:
             _exc_info: Set to an exception or a tuple as returned by [`sys.exc_info()`][sys.exc_info]
                 to record a traceback with the log message.
         """
-    def span(self, msg_template: str, /, *, _tags: Sequence[str] | None = None, _span_name: str | None = None, _level: LevelName | None = None, _links: Sequence[tuple[SpanContext, otel_types.Attributes]] = (), _span_kind: SpanKind = ..., **attributes: Any) -> LogfireSpan:
+    def span(self, msg_template: str, /, *, _tags: Sequence[str] | None = None, _span_name: str | None = None, _level: LevelName | None = None, _links: Sequence[tuple[SpanContext, otel_types.Attributes]] = (), _span_kind: SpanKind = ..., _new_trace: bool = False, **attributes: Any) -> LogfireSpan:
         """Context manager for creating a span.
 
         ```py
@@ -251,6 +251,8 @@ class Logfire:
                 If not provided, defaults to `INTERNAL`.
                 Users don't typically need to set this.
                 Not related to the `kind` column of the `records` table in Logfire.
+            _new_trace: Set to `True` to start a new trace root. When a valid span is current,
+                the new root includes a span link to it instead of using it as a parent.
             attributes: The arguments to include in the span and format the message template with.
                 Attributes starting with an underscore are not allowed.
         """
@@ -1488,7 +1490,7 @@ class FastLogfireSpan:
     def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any) -> None: ...
 
 class LogfireSpan(ReadableSpan):
-    def __init__(self, span_name: str, otlp_attributes: dict[str, otel_types.AttributeValue], tracer: _ProxyTracer, json_schema_properties: JsonSchemaProperties, links: Sequence[tuple[SpanContext, otel_types.Attributes]], span_kind: SpanKind = ...) -> None: ...
+    def __init__(self, span_name: str, otlp_attributes: dict[str, otel_types.AttributeValue], tracer: _ProxyTracer, json_schema_properties: JsonSchemaProperties, links: Sequence[tuple[SpanContext, otel_types.Attributes]], span_kind: SpanKind = ..., new_trace: bool = False) -> None: ...
     def __getattr__(self, name: str) -> Any: ...
     def __enter__(self) -> LogfireSpan: ...
     @handle_internal_errors

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -218,6 +218,7 @@ class Logfire:
         _level: LevelName | int | None = None,
         _links: Sequence[tuple[SpanContext, otel_types.Attributes]] = (),
         _span_kind: SpanKind = SpanKind.INTERNAL,
+        _new_trace: bool = False,
     ) -> LogfireSpan:
         try:
             if _level is not None:
@@ -274,6 +275,7 @@ class Logfire:
                 json_schema_properties,
                 links=_links,
                 span_kind=_span_kind,
+                new_trace=_new_trace,
             )
         except Exception:
             log_internal_error()
@@ -573,6 +575,7 @@ class Logfire:
         _level: LevelName | None = None,
         _links: Sequence[tuple[SpanContext, otel_types.Attributes]] = (),
         _span_kind: SpanKind = SpanKind.INTERNAL,
+        _new_trace: bool = False,
         **attributes: Any,
     ) -> LogfireSpan:
         """Context manager for creating a span.
@@ -596,6 +599,8 @@ class Logfire:
                 If not provided, defaults to `INTERNAL`.
                 Users don't typically need to set this.
                 Not related to the `kind` column of the `records` table in Logfire.
+            _new_trace: Set to `True` to start a new trace root. When a valid span is current,
+                the new root includes a span link to it instead of using it as a parent.
             attributes: The arguments to include in the span and format the message template with.
                 Attributes starting with an underscore are not allowed.
         """
@@ -609,6 +614,7 @@ class Logfire:
             _level=_level,
             _links=_links,
             _span_kind=_span_kind,
+            _new_trace=_new_trace,
         )
 
     @overload
@@ -3128,6 +3134,7 @@ class LogfireSpan(ReadableSpan):
         json_schema_properties: JsonSchemaProperties,
         links: Sequence[tuple[SpanContext, otel_types.Attributes]],
         span_kind: SpanKind = SpanKind.INTERNAL,
+        new_trace: bool = False,
     ) -> None:
         self._span_name = span_name
         self._otlp_attributes = otlp_attributes
@@ -3135,6 +3142,7 @@ class LogfireSpan(ReadableSpan):
         self._json_schema_properties = json_schema_properties
         self._links = list(trace_api.Link(context=context, attributes=attributes) for context, attributes in links)
         self._span_kind = span_kind
+        self._new_trace = new_trace
 
         self._added_attributes = False
         self._token: None | Token[Context] = None
@@ -3149,11 +3157,19 @@ class LogfireSpan(ReadableSpan):
     def _start(self):
         if self._span is not None:
             return
+        context: Context | None = None
+        links = self._links
+        if self._new_trace:
+            previous_span_context = trace_api.get_current_span().get_span_context()
+            context = trace_api.set_span_in_context(trace_api.INVALID_SPAN)
+            if previous_span_context.is_valid and all(link.context != previous_span_context for link in links):
+                links = [*links, trace_api.Link(previous_span_context)]
         self._span = self._tracer.start_span(
             name=self._span_name,
             attributes=self._otlp_attributes,
-            links=self._links,
+            links=links,
             kind=self._span_kind,
+            context=context,
         )
 
     @handle_internal_errors

--- a/tests/test_logfire.py
+++ b/tests/test_logfire.py
@@ -23,7 +23,17 @@ from opentelemetry.proto.common.v1.common_pb2 import AnyValue
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
-from opentelemetry.trace import INVALID_SPAN, SpanKind, StatusCode, get_current_span, get_tracer
+from opentelemetry.trace import (
+    INVALID_SPAN,
+    NonRecordingSpan,
+    SpanContext,
+    SpanKind,
+    StatusCode,
+    TraceFlags,
+    get_current_span,
+    get_tracer,
+    use_span,
+)
 from pydantic import BaseModel, __version__ as pydantic_version
 from pydantic_core import ValidationError
 
@@ -3079,6 +3089,129 @@ def test_span_links(exporter: TestExporter):
             },
         ]
     )
+
+
+def test_span_new_trace_preserves_context_and_restores_parent(exporter: TestExporter, config_kwargs: dict[str, Any]):
+    config_kwargs['add_baggage_to_attributes'] = True
+    logfire.configure(**config_kwargs)
+
+    with logfire.set_baggage(customer='acme'):
+        with logfire.span('parent'):
+            parent_context = get_current_span().get_span_context()
+            with logfire.span('new root', _new_trace=True):
+                assert logfire.get_baggage() == {'customer': 'acme'}
+                logfire.info('child log')
+                with logfire.span('child span'):
+                    pass
+            assert get_current_span().get_span_context() == parent_context
+
+            with pytest.raises(ValueError, match='boom'):
+                with logfire.span('exceptional root', _new_trace=True):
+                    raise ValueError('boom')
+            assert get_current_span().get_span_context() == parent_context
+
+    spans = {span['name']: span for span in exporter.exported_spans_as_dict()}
+    assert spans['new root']['parent'] is None
+    assert spans['new root']['context']['trace_id'] != spans['parent']['context']['trace_id']
+    assert spans['new root']['links'] == [{'context': spans['parent']['context'], 'attributes': {}}]
+    assert spans['new root']['attributes']['customer'] == 'acme'
+    assert spans['child log']['parent'] == spans['new root']['context']
+    assert spans['child span']['parent'] == spans['new root']['context']
+    assert spans['exceptional root']['parent'] is None
+    assert spans['exceptional root']['links'] == [{'context': spans['parent']['context'], 'attributes': {}}]
+
+
+def test_span_new_trace_link_order_and_deduplication(exporter: TestExporter):
+    with logfire.span('explicit first'):
+        first_context = get_current_span().get_span_context()
+    with logfire.span('current'):
+        current_context = get_current_span().get_span_context()
+        with logfire.span(
+            'new root',
+            _new_trace=True,
+            _links=[
+                (first_context, {'order': 1}),
+                (current_context, {'explicit': True}),
+                (first_context, {'order': 2}),
+            ],
+        ):
+            pass
+
+    span = next(span for span in exporter.exported_spans_as_dict() if span['name'] == 'new root')
+    assert span['parent'] is None
+    assert [link['context']['trace_id'] for link in span['links']] == [
+        first_context.trace_id,
+        current_context.trace_id,
+        first_context.trace_id,
+    ]
+    assert [link['attributes'] for link in span['links']] == [
+        {'order': 1},
+        {'explicit': True},
+        {'order': 2},
+    ]
+
+
+def test_span_new_trace_without_current_span(exporter: TestExporter):
+    with logfire.span('new root', _new_trace=True):
+        pass
+
+    span = exporter.exported_spans_as_dict()[0]
+    assert span['parent'] is None
+    assert 'links' not in span
+
+
+def test_span_new_trace_uses_context_at_start(exporter: TestExporter):
+    with logfire.span('construction parent'):
+        construction_parent = get_current_span().get_span_context()
+        new_root = logfire.span('new root', _new_trace=True)
+        assert get_current_span().get_span_context() == construction_parent
+
+    with logfire.span('start parent'):
+        with new_root:
+            pass
+
+    spans = {span['name']: span for span in exporter.exported_spans_as_dict()}
+    assert spans['new root']['parent'] is None
+    assert spans['new root']['links'] == [{'context': spans['start parent']['context'], 'attributes': {}}]
+
+
+def test_span_new_trace_from_unsampled_span(exporter: TestExporter):
+    unsampled_context = SpanContext(
+        trace_id=10,
+        span_id=20,
+        is_remote=False,
+        trace_flags=TraceFlags(0),
+    )
+
+    with use_span(NonRecordingSpan(unsampled_context)):
+        with logfire.span('new root', _new_trace=True):
+            pass
+
+    [span] = exporter.exported_spans_as_dict()
+    assert span['parent'] is None
+    assert span['context']['trace_id'] != unsampled_context.trace_id
+    assert span['links'] == [
+        {
+            'context': {
+                'trace_id': unsampled_context.trace_id,
+                'span_id': unsampled_context.span_id,
+                'is_remote': False,
+            },
+            'attributes': {},
+        }
+    ]
+
+
+def test_span_new_trace_filtered_by_level(exporter: TestExporter, config_kwargs: dict[str, Any]):
+    config_kwargs['min_level'] = 'info'
+    logfire.configure(**config_kwargs)
+
+    with logfire.span('parent'):
+        parent_context = get_current_span().get_span_context()
+        with logfire.span('filtered', _level='debug', _new_trace=True):
+            assert get_current_span().get_span_context() == parent_context
+
+    assert [span['name'] for span in exporter.exported_spans_as_dict()] == ['parent']
 
 
 def test_span_add_link_before_start(exporter: TestExporter):

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -128,7 +128,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     assert hasattr(logfire_api, 'LevelName')
     logfire__all__.remove('LevelName')
 
-    with logfire_api.span('test span') as span:
+    with logfire_api.span('test span', _new_trace=True) as span:
         assert isinstance(span, logfire_api.LogfireSpan)
         span.set_attribute('foo', 'bar')
 


### PR DESCRIPTION
Closes #1218.

## Summary

- add the private `_new_trace=True` keyword to `logfire.span()`
- start that span as a new trace root and link it to the previously active span
- preserve other OpenTelemetry context values, including baggage
- document the background-job use case and the resulting trace relationship

## Root cause and impact

Manual spans always inherited the active OpenTelemetry span as their parent. Work scheduled from a long-running request could therefore remain nested beneath that request, even when the scheduled work represented an independent operation.

The new option replaces only the parent span with an invalid parent context when the span actually starts. This preserves lazy and filtered-span behavior, keeps baggage available, and creates one link to the prior valid span unless the caller already supplied that link. Existing span behavior is unchanged unless callers opt in.

## Validation

- focused new-trace tests: 6 passed
- Logfire API shim tests: 3 passed, 1 skipped
- documentation tests: 124 passed
- full `tests/test_logfire.py` and shim run: 121 passed, 2 skipped; two sandbox semaphore failures passed when rerun with host permission
- Ruff and Ruff formatting
- Pyright
- `uv lock --check`
- repository pre-commit hooks


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

