### PR TITLE
Document native Elasticsearch tracing

### DIFF
--- a/docs/integrations/databases/elasticsearch.md
+++ b/docs/integrations/databases/elasticsearch.md
@@ -26,17 +26,17 @@ pip install 'logfire' 'elasticsearch>=8.15'
 
 ## Trace Elasticsearch requests
 
-Call `logfire.configure()` before creating the Elasticsearch client. This activates Logfire's OTel
-tracer provider, which the client's native tracing uses automatically.
+Call `logfire.configure()` before making an Elasticsearch request. The client looks up the active
+OTel tracer provider when it starts a request, so you can create the client before or after this call.
 
 ```python skip-run="true" skip-reason="external-connection"
 from elasticsearch import Elasticsearch
 
 import logfire
 
-logfire.configure()
-
 client = Elasticsearch('http://localhost:9200')
+
+logfire.configure()
 client.search(index='products', query={'match': {'name': 'coffee'}})
 ```
 
@@ -51,10 +51,18 @@ export OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=raw
 ```
 
 !!! warning
-    Setting this option to `raw` can send query values to Logfire, where they are stored with the
-    span. Review the values your application puts in Elasticsearch queries before enabling it.
-    Logfire's [data scrubbing](../../how-to-guides/scrubbing.md) provides an additional safeguard,
-    but you should not rely on scrubbing to remove every sensitive value.
+    Setting this option to `raw` sends query values to Logfire, where they are stored with the span.
+    Logfire does not scrub the `db.query.text` attribute. Enable query capture only when the queries
+    do not contain sensitive values.
+
+## Stop tracing Elasticsearch requests
+
+The Elasticsearch client creates spans by default whenever an OTel tracer provider is active. To
+turn off its native tracing, set this environment variable before creating the client:
+
+```bash
+export OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED=false
+```
 
 ## Verify the spans
 
@@ -65,8 +73,9 @@ body.
 
 ## Troubleshoot missing spans
 
-- **No Elasticsearch spans appear:** check that you use `elasticsearch` 8.15 or later, and call
-  `logfire.configure()` before creating the client.
+- **No Elasticsearch spans appear:** check that you use `elasticsearch` 8.15 or later, call
+  `logfire.configure()` before the first request, and have not set
+  `OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED=false`.
 - **The query body is missing:** restart the application after setting
   `OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=raw`. Query capture is disabled by
   default.

--- a/docs/integrations/databases/elasticsearch.md
+++ b/docs/integrations/databases/elasticsearch.md
@@ -28,6 +28,8 @@ pip install 'logfire' 'elasticsearch>=8.15'
 
 Call `logfire.configure()` before making an Elasticsearch request. The client looks up the active
 OTel tracer provider when it starts a request, so you can create the client before or after this call.
+Requests made before configuration are not sent to Logfire, but requests made after configuration
+are traced normally.
 
 ```python skip-run="true" skip-reason="external-connection"
 from elasticsearch import Elasticsearch
@@ -64,17 +66,10 @@ turn off its native tracing, set this environment variable before creating the c
 export OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED=false
 ```
 
-## Verify the spans
-
-Run the application and open Logfire's [Live view](../../guides/web-ui/live.md). Search for
-`elasticsearch` and make a request. You should see an Elasticsearch span with the request method,
-target, duration, and status. If query capture is enabled, the span also contains the search query
-body.
-
 ## Troubleshoot missing spans
 
 - **No Elasticsearch spans appear:** check that you use `elasticsearch` 8.15 or later, call
-  `logfire.configure()` before the first request, and have not set
+  `logfire.configure()` before the request you want to trace, and have not set
   `OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED=false`.
 - **The query body is missing:** restart the application after setting
   `OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=raw`. Query capture is disabled by

--- a/docs/integrations/databases/elasticsearch.md
+++ b/docs/integrations/databases/elasticsearch.md
@@ -1,0 +1,78 @@
+---
+title: "Instrument Elasticsearch: trace searches and other requests"
+description: "Trace requests made by the Elasticsearch Python client 8.15 and later with its native OpenTelemetry support."
+integration: otel
+---
+# Elasticsearch
+
+See every request your application makes to Elasticsearch, including its operation, duration,
+outcome, and target, as a **span** (one unit of work: a single operation, with a name, a start, and a
+duration) in Logfire.
+
+The Elasticsearch Python client has native **OpenTelemetry (OTel)** support from version 8.15. OTel
+is the open industry standard for collecting traces, metrics, and logs. The client creates its own
+spans through the active global tracer provider, so you do not need a Logfire wrapper or the older
+`opentelemetry-instrumentation-elasticsearch` package.
+
+{{ before_you_start() }}
+
+## Install the client
+
+Install Logfire and Elasticsearch 8.15 or later:
+
+```bash
+pip install 'logfire' 'elasticsearch>=8.15'
+```
+
+## Trace Elasticsearch requests
+
+Call `logfire.configure()` before creating the Elasticsearch client. This activates Logfire's OTel
+tracer provider, which the client's native tracing uses automatically.
+
+```python skip-run="true" skip-reason="external-connection"
+from elasticsearch import Elasticsearch
+
+import logfire
+
+logfire.configure()
+
+client = Elasticsearch('http://localhost:9200')
+client.search(index='products', query={'match': {'name': 'coffee'}})
+```
+
+## Control whether search queries are recorded
+
+By default, the client does not attach the search query body to spans because it can contain
+sensitive or personally identifiable information (PII). To record query bodies, set this environment
+variable before starting your application:
+
+```bash
+export OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=raw
+```
+
+!!! warning
+    Setting this option to `raw` can send query values to Logfire, where they are stored with the
+    span. Review the values your application puts in Elasticsearch queries before enabling it.
+    Logfire's [data scrubbing](../../how-to-guides/scrubbing.md) provides an additional safeguard,
+    but you should not rely on scrubbing to remove every sensitive value.
+
+## Verify the spans
+
+Run the application and open Logfire's [Live view](../../guides/web-ui/live.md). Search for
+`elasticsearch` and make a request. You should see an Elasticsearch span with the request method,
+target, duration, and status. If query capture is enabled, the span also contains the search query
+body.
+
+## Troubleshoot missing spans
+
+- **No Elasticsearch spans appear:** check that you use `elasticsearch` 8.15 or later, and call
+  `logfire.configure()` before creating the client.
+- **The query body is missing:** restart the application after setting
+  `OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=raw`. Query capture is disabled by
+  default.
+- **Duplicate spans appear:** remove `opentelemetry-instrumentation-elasticsearch` and its setup. The
+  client already creates spans natively.
+
+## Reference
+
+- [Elasticsearch Python client OpenTelemetry documentation](https://www.elastic.co/docs/reference/elasticsearch/clients/python/opentelemetry)

--- a/docs/integrations/databases/elasticsearch.md
+++ b/docs/integrations/databases/elasticsearch.md
@@ -9,9 +9,9 @@ See every request your application makes to Elasticsearch, including its operati
 outcome, and target, as a **span** (one unit of work: a single operation, with a name, a start, and a
 duration) in Logfire.
 
-The Elasticsearch Python client has native **OpenTelemetry (OTel)** support from version 8.15. OTel
-is the open industry standard for collecting traces, metrics, and logs. The client creates its own
-spans through the active global tracer provider, so you do not need a Logfire wrapper or the older
+Logfire is built on **OpenTelemetry (OTel)**, the open industry standard for collecting traces,
+metrics, and logs. From version 8.15, the Elasticsearch Python client uses OTel directly to create
+spans through the active global tracer provider. You do not need a Logfire wrapper or the older
 `opentelemetry-instrumentation-elasticsearch` package.
 
 {{ before_you_start() }}

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -34,7 +34,7 @@ If a package you are using is not listed in this documentation, please let us kn
 - _AI Agent Frameworks_ (Python, TypeScript, Go, Rust, .NET): CrewAI, AutoGen, Google ADK, smolagents, Strands, Agno, Haystack, Semantic Kernel, Vercel AI SDK, Mastra, Rig, and more. See [Agent Frameworks](agent-frameworks/index.md).
 - _No-code AI and workflow platforms_: Dify, Flowise, Goose, Langflow, LobeChat, n8n, and Open WebUI ([setup guides](no-code/index.md))
 - _Web Frameworks_: FastAPI, Django, Flask, Starlette, AIOHTTP, ASGI, WSGI
-- _Database Clients_: Psycopg, SQLAlchemy, Asyncpg, PyMongo, MySQL, SQLite3, Redis, BigQuery
+- _Database Clients_: Psycopg, SQLAlchemy, Asyncpg, PyMongo, MySQL, SQLite3, Redis, BigQuery, Elasticsearch
 - _HTTP Clients_: HTTPX, HTTPX2, Requests, AIOHTTP
 - _Task Queues and Schedulers_: Airflow, FastStream, Celery
 - _Logging Libraries_: Standard Library Logging, Loguru, Structlog
@@ -67,6 +67,7 @@ The below table lists these integrations and any corresponding `logfire.instrume
 | [BigQuery](databases/bigquery.md)         | Database                | N/A (built in, no config needed)                                                                                                                                       |
 | [Celery](event-streams/celery.md)         | Task Queue              | [`logfire.instrument_celery()`][logfire.Logfire.instrument_celery]                                                                                                     |
 | [Django](web-frameworks/django.md)        | Web Framework           | [`logfire.instrument_django()`][logfire.Logfire.instrument_django]                                                                                                     |
+| [Elasticsearch](databases/elasticsearch.md) | Database              | N/A (native OpenTelemetry support in the client)                                                                                                                       |
 | [FastAPI](web-frameworks/fastapi.md)      | Web Framework           | [`logfire.instrument_fastapi()`][logfire.Logfire.instrument_fastapi]                                                                                                   |
 | [FastStream](event-streams/faststream.md) | Task Queue              | N/A (built in, config needed)                                                                                                                                          |
 | [Flask](web-frameworks/flask.md)          | Web Framework           | [`logfire.instrument_flask()`][logfire.Logfire.instrument_flask]                                                                                                       |

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -333,6 +333,9 @@ navigation:
           - page: "BigQuery"
             path: "integrations/databases/bigquery.md"
             slug: "integrations/databases/bigquery"
+          - page: "Elasticsearch"
+            path: "integrations/databases/elasticsearch.md"
+            slug: "integrations/databases/elasticsearch"
       - section: "HTTP Clients"
         contents:
           - page: "HTTPX"

--- a/logfire/_internal/cli/run.py
+++ b/logfire/_internal/cli/run.py
@@ -51,7 +51,6 @@ OTEL_INSTRUMENTATION_MAP = {
     'opentelemetry-instrumentation-celery': 'celery',
     'opentelemetry-instrumentation-confluent-kafka': 'confluent_kafka',
     'opentelemetry-instrumentation-django': 'django',
-    'opentelemetry-instrumentation-elasticsearch': 'elasticsearch',
     'opentelemetry-instrumentation-falcon': 'falcon',
     'opentelemetry-instrumentation-fastapi': 'fastapi',
     'opentelemetry-instrumentation-flask': 'flask',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ dev = [
     "aiohttp >= 3.10.9",
     "redis >= 5.1.1",
     "pymongo >= 4.10.1",
+    "elasticsearch >= 8.15",
     "fastapi != 0.124.3, != 0.124.4",
     "Flask >= 3.0.3",
     "django >= 4.2.16",

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -2,6 +2,7 @@ from typing import Any, NamedTuple
 
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
 from elasticsearch import Elasticsearch
+from inline_snapshot import snapshot
 
 from logfire._internal.exporters.test import TestExporter
 
@@ -54,10 +55,26 @@ def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
 
     assert response['hits']['total']['value'] == 0
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
-    assert len(spans) == 1
-    assert spans[0]['name'] == 'search'
-    attributes = spans[0]['attributes']
-    assert attributes['logfire.msg'] == 'search'
-    assert attributes['http.request.method'] == 'POST'
-    assert attributes['url.full'] == 'http://localhost:9200/products/_search'
-    assert attributes.get('db.system.name', attributes.get('db.system')) == 'elasticsearch'
+    assert spans == snapshot(
+        [
+            {
+                'name': 'search',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'search',
+                    'db.operation.parameter.index': 'products',
+                    'db.system.name': 'elasticsearch',
+                    'db.operation.name': 'search',
+                    'url.full': 'http://localhost:9200/products/_search',
+                    'http.request.method': 'POST',
+                    'server.address': 'localhost',
+                    'server.port': 9200,
+                    'db.response.status_code': '200',
+                },
+            }
+        ]
+    )

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -1,0 +1,54 @@
+from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
+from elastic_transport._node._base import NodeApiResponse
+from elastic_transport.client_utils import DEFAULT, DefaultType
+from elasticsearch import Elasticsearch
+
+from logfire._internal.exporters.test import TestExporter
+
+
+class OfflineNode(BaseNode):
+    """Return an Elasticsearch response without making a network request."""
+
+    def perform_request(
+        self,
+        method: str,
+        target: str,
+        body: bytes | None = None,
+        headers: HttpHeaders | None = None,
+        request_timeout: float | DefaultType | None = DEFAULT,
+    ) -> NodeApiResponse:
+        del method, target, body, headers, request_timeout
+        meta = ApiResponseMeta(
+            status=200,
+            http_version='1.1',
+            headers=HttpHeaders(
+                {
+                    'content-type': 'application/json',
+                    'x-elastic-product': 'Elasticsearch',
+                }
+            ),
+            duration=0.001,
+            node=self.config,
+        )
+        response = (
+            b'{"took":1,"timed_out":false,'
+            b'"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},'
+            b'"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
+        )
+        return NodeApiResponse(meta, response)
+
+
+def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
+    client = Elasticsearch('http://localhost:9200', node_class=OfflineNode)
+
+    response = client.search(index='products', query={'match': {'name': 'coffee'}})
+
+    assert response['hits']['total']['value'] == 0
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    assert len(spans) == 1
+    assert spans[0]['name'] == 'search'
+    attributes = spans[0]['attributes']
+    assert attributes['logfire.msg'] == 'search'
+    assert attributes['http.request.method'] == 'POST'
+    assert attributes['url.full'] == 'http://localhost:9200/products/_search'
+    assert attributes.get('db.system.name', attributes.get('db.system')) == 'elasticsearch'

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -59,7 +59,7 @@ class OfflineNode(BaseNode):
 def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
     client = Elasticsearch('http://localhost:9200', node_class=OfflineNode)
 
-    response = client.search(index='products', query={'match': {'name': 'coffee'}})
+    response = client.search(index='products', query={'match': {'secret': 'coffee'}})
 
     assert response == RESPONSE_DICT
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
@@ -77,7 +77,7 @@ def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
                     'db.operation.parameter.index': 'products',
                     'db.system.name': 'elasticsearch',
                     'db.operation.name': 'search',
-                    'db.query.text': {'query': {'match': {'name': 'coffee'}}},
+                    'db.query.text': {'query': {'match': {'secret': 'coffee'}}},
                     'url.full': 'http://localhost:9200/products/_search',
                     'http.request.method': 'POST',
                     'server.address': 'localhost',

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -1,9 +1,16 @@
+from typing import Any, NamedTuple
+
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
-from elastic_transport._node._base import NodeApiResponse
-from elastic_transport.client_utils import DEFAULT, DefaultType
 from elasticsearch import Elasticsearch
 
 from logfire._internal.exporters.test import TestExporter
+
+
+class OfflineNodeResponse(NamedTuple):
+    """Public tuple protocol returned by ``BaseNode.perform_request()``."""
+
+    meta: ApiResponseMeta
+    body: bytes
 
 
 class OfflineNode(BaseNode):
@@ -15,8 +22,8 @@ class OfflineNode(BaseNode):
         target: str,
         body: bytes | None = None,
         headers: HttpHeaders | None = None,
-        request_timeout: float | DefaultType | None = DEFAULT,
-    ) -> NodeApiResponse:
+        request_timeout: Any = None,
+    ) -> Any:
         del method, target, body, headers, request_timeout
         meta = ApiResponseMeta(
             status=200,
@@ -35,7 +42,9 @@ class OfflineNode(BaseNode):
             b'"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},'
             b'"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
         )
-        return NodeApiResponse(meta, response)
+        # `BaseNode.perform_request()` documents this public tuple protocol even
+        # though elastic-transport's concrete return type is private.
+        return OfflineNodeResponse(meta, response)
 
 
 def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -2,6 +2,7 @@ import json
 import os
 from typing import Any, NamedTuple
 
+import pytest
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
 from elasticsearch import Elasticsearch
 from inline_snapshot import snapshot
@@ -87,3 +88,15 @@ def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
             }
         ]
     )
+
+
+def test_native_elasticsearch_instrumentation_can_be_disabled(
+    exporter: TestExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv('OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_ENABLED', 'false')
+    client = Elasticsearch('http://localhost:9200', node_class=OfflineNode)
+
+    response = client.search(index='products', query={'match': {'name': 'coffee'}})
+
+    assert response == RESPONSE_DICT
+    assert exporter.exported_spans == []

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -1,10 +1,11 @@
+import json
 from typing import Any, NamedTuple
 
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
 from elasticsearch import Elasticsearch
 from inline_snapshot import snapshot
 
-from logfire._internal.exporters.test import TestExporter
+from logfire.testing import TestExporter
 
 
 class OfflineNodeResponse(NamedTuple):
@@ -12,6 +13,14 @@ class OfflineNodeResponse(NamedTuple):
 
     meta: ApiResponseMeta
     body: bytes
+
+
+RESPONSE_DICT: dict[str, Any] = {
+    'took': 1,
+    'timed_out': False,
+    '_shards': {'total': 1, 'successful': 1, 'skipped': 0, 'failed': 0},
+    'hits': {'total': {'value': 0, 'relation': 'eq'}, 'max_score': None, 'hits': []},
+}
 
 
 class OfflineNode(BaseNode):
@@ -38,11 +47,7 @@ class OfflineNode(BaseNode):
             duration=0.001,
             node=self.config,
         )
-        response = (
-            b'{"took":1,"timed_out":false,'
-            b'"_shards":{"total":1,"successful":1,"skipped":0,"failed":0},'
-            b'"hits":{"total":{"value":0,"relation":"eq"},"max_score":null,"hits":[]}}'
-        )
+        response = json.dumps(RESPONSE_DICT).encode()
         # `BaseNode.perform_request()` documents this public tuple protocol even
         # though elastic-transport's concrete return type is private.
         return OfflineNodeResponse(meta, response)
@@ -53,7 +58,7 @@ def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
 
     response = client.search(index='products', query={'match': {'name': 'coffee'}})
 
-    assert response['hits']['total']['value'] == 0
+    assert response == RESPONSE_DICT
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     assert spans == snapshot(
         [

--- a/tests/otel_integrations/test_elasticsearch.py
+++ b/tests/otel_integrations/test_elasticsearch.py
@@ -1,4 +1,5 @@
 import json
+import os
 from typing import Any, NamedTuple
 
 from elastic_transport import ApiResponseMeta, BaseNode, HttpHeaders
@@ -6,6 +7,8 @@ from elasticsearch import Elasticsearch
 from inline_snapshot import snapshot
 
 from logfire.testing import TestExporter
+
+os.environ['OTEL_PYTHON_INSTRUMENTATION_ELASTICSEARCH_CAPTURE_SEARCH_QUERY'] = 'raw'
 
 
 class OfflineNodeResponse(NamedTuple):
@@ -74,6 +77,7 @@ def test_native_elasticsearch_instrumentation(exporter: TestExporter) -> None:
                     'db.operation.parameter.index': 'products',
                     'db.system.name': 'elasticsearch',
                     'db.operation.name': 'search',
+                    'db.query.text': {'query': {'match': {'name': 'coffee'}}},
                     'url.full': 'http://localhost:9200/products/_search',
                     'http.request.method': 'POST',
                     'server.address': 'localhost',

--- a/uv.lock
+++ b/uv.lock
@@ -1266,6 +1266,36 @@ wheels = [
 ]
 
 [[package]]
+name = "elastic-transport"
+version = "9.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "sniffio" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/be/a719a217ed7f179c9e41821dff9dfd28415b21bc94da9d35fff84f7951b2/elastic_transport-9.4.2.tar.gz", hash = "sha256:366f4614f4544c5fb5d780c82f57af8f30492b44a68ed20750390aa81e20c2ea", size = 79310, upload-time = "2026-06-16T15:27:17.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e4/9b7ef7a8e0bb416e0fe1879c92295041cf81e5a47e3c3110744e89b6eb35/elastic_transport-9.4.2-py3-none-any.whl", hash = "sha256:33dc89bb1855faa8b98ae8b036405a39c562778dbcdbe4a00a2eaf753148556c", size = 66314, upload-time = "2026-06-16T15:27:15.875Z" },
+]
+
+[[package]]
+name = "elasticsearch"
+version = "9.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "elastic-transport" },
+    { name = "python-dateutil" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/f6/23e897503cbd9c22bb21cdba480160987909d2137efeeb41582b776898d4/elasticsearch-9.5.0.tar.gz", hash = "sha256:c37576ba04d04200a05012db99bc99024000ae15b9ebdd683966aa8a0e6cd1c4", size = 923577, upload-time = "2026-08-04T17:55:58.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/8c/d84fe1f2a6f60ce1fbc682a2e98776575d7b73e60680ac5aa90f53052466/elasticsearch-9.5.0-py3-none-any.whl", hash = "sha256:010e04f44fd161428f0ab7f94b93a533d3dcc3285d02c9df509b4e0127916420", size = 1011512, upload-time = "2026-08-04T17:55:54.792Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2632,6 +2662,7 @@ dev = [
     { name = "django", version = "5.2.16", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.0.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "dspy" },
+    { name = "elasticsearch" },
     { name = "eval-type-backport" },
     { name = "fastapi" },
     { name = "faststream", extra = ["redis"] },
@@ -2781,6 +2812,7 @@ dev = [
     { name = "dirty-equals", specifier = ">=0.8.0" },
     { name = "django", specifier = ">=4.2.16" },
     { name = "dspy", specifier = ">=3.1.0" },
+    { name = "elasticsearch", specifier = ">=8.15" },
     { name = "eval-type-backport", specifier = ">=0.2.0" },
     { name = "fastapi", specifier = "!=0.124.3,!=0.124.4" },
     { name = "faststream", extras = ["redis"], specifier = ">=0.5.0" },


### PR DESCRIPTION
## What changed

- Add an Elasticsearch integration guide for the Python client's native OpenTelemetry tracing.
- Explain that `logfire.configure()` activates the global tracer provider used by Elasticsearch 8.15 and later, with no Logfire wrapper or contrib instrumentor.
- Document query-body capture at its privacy decision point and use the client's supported `raw` value.
- Remove Elasticsearch from the CLI's legacy contrib-instrumentor map.
- Add a real offline client test using a custom `BaseNode`, and add Elasticsearch only to development dependencies so CI can exercise that behavior.

## Why

Elasticsearch 8.15 and later emit native OpenTelemetry spans through the active global tracer provider. The existing CLI map could recommend the older `opentelemetry-instrumentation-elasticsearch` package, which can duplicate the client's native spans. The integration also had no first-party setup or troubleshooting guide.

## Impact

Users can configure Elasticsearch tracing with the supported native path and verify the resulting request span in Logfire. Existing runtime dependencies and the public Logfire API are unchanged. The new Elasticsearch dependency is test-only.

## Checks

- Offline Elasticsearch integration test: current 9.5 and documented minimum 8.15
- Focused integration and CLI checks: 26 passed
- Documentation tests: 123 passed
- Full CLI tests: 195 passed
- Ruff, Ruff format, direct Pyright, lock check, and changed-file pre-commit hooks
- `git diff --check`

The new documentation was AI-assisted and then edited and verified against the current Elasticsearch client documentation and real client behavior.

Closes #1538


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

