### PR TITLE
Check extra_patterns at configuration time

### DIFF
--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -14,6 +14,8 @@ from opentelemetry.attributes import BoundedAttributes
 from opentelemetry.sdk.trace import Event
 from opentelemetry.trace import Link
 
+from logfire.exceptions import LogfireConfigError
+
 from .constants import (
     ATTRIBUTES_CONFIG,
     ATTRIBUTES_JSON_SCHEMA_KEY,
@@ -205,12 +207,83 @@ class NoopScrubber(BaseScrubber):
 NOOP_SCRUBBER = NoopScrubber()
 
 
+def _has_numeric_backreference(pattern: str) -> bool:
+    r"""Whether `pattern` contains a backreference to a group by number, e.g. the `\1` in `(a)\1`.
+
+    Escapes and character classes are tracked because `\1` inside `[...]` is an octal escape,
+    and `\\1` is a literal backslash followed by a digit. Neither is a backreference.
+    """
+    in_class = False
+    i = 0
+    while i < len(pattern):
+        char = pattern[i]
+        if char == '\\' and i + 1 < len(pattern):
+            if not in_class and pattern[i + 1] in '123456789':
+                return True
+            i += 2
+            continue
+        if char == '[':
+            in_class = True
+        elif char == ']':
+            in_class = False
+        i += 1
+    return False
+
+
+def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
+    """Check user-supplied scrubbing patterns, raising `LogfireConfigError` on ones that can't work.
+
+    The patterns are joined into a single regex, so a mistake in one of them changes the behaviour of
+    the whole scrubber. Checking each pattern on its own here means the error can name the pattern
+    that caused it, and means these mistakes fail at configuration time instead of silently either
+    redacting everything or redacting nothing.
+    """
+    if patterns is None:
+        return []
+
+    if isinstance(patterns, str):
+        # `str` satisfies `Sequence[str]`, so this type checks cleanly, and then iterating the string
+        # turns 'password' into the alternation `p|a|s|s|w|o|r|d`, which matches nearly all text.
+        raise LogfireConfigError(
+            f'`extra_patterns` must be a sequence of regular expressions, not a single string. '
+            f'Use `extra_patterns=[{patterns!r}]` to pass one pattern.'
+        )
+
+    checked: list[str] = []
+    for pattern in patterns:
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE | re.DOTALL)
+        except re.error as e:
+            # Compiling here rather than after joining means the position in the message refers to
+            # this pattern, not to an offset within the combined pattern.
+            raise LogfireConfigError(f'Invalid regular expression in `extra_patterns`: {pattern!r}: {e}') from e
+
+        if compiled.search('') is not None:
+            raise LogfireConfigError(
+                f'The `extra_patterns` entry {pattern!r} matches the empty string, so it would match every '
+                f'value and redact all telemetry. Did you mean `+` where you wrote `*`?'
+            )
+
+        if _has_numeric_backreference(pattern):
+            # All the patterns share one group numbering space once they're joined, so a numeric
+            # backreference points at a group from another pattern and the pattern never matches.
+            raise LogfireConfigError(
+                f'The `extra_patterns` entry {pattern!r} contains a backreference to a group by number. '
+                f'Patterns are combined into a single regex, so numbered groups from different patterns '
+                f'would collide. Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
+            )
+
+        checked.append(pattern)
+
+    return checked
+
+
 class Scrubber(BaseScrubber):
     """Redacts potentially sensitive data."""
 
     def __init__(self, patterns: Sequence[str] | None, callback: ScrubCallback | None = None):
         # See ScrubbingOptions for more info on these parameters.
-        patterns = [_DEFAULT_PATTERN, *(patterns or [])]
+        patterns = [_DEFAULT_PATTERN, *_check_extra_patterns(patterns)]
         self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
         self._callback = callback
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -227,9 +227,17 @@ def _has_numeric_backreference(pattern: str) -> bool:
                     return True
             i += 2
             continue
-        if char == '[':
+        if char == '[' and not in_class:
             in_class = True
-        elif char == ']':
+            i += 1
+            # A `]` at the very start of a class is a member of it rather than the end of it,
+            # as in `[]a]`, and it may follow a negating `^`.
+            if i < len(pattern) and pattern[i] == '^':
+                i += 1
+            if i < len(pattern) and pattern[i] == ']':
+                i += 1
+            continue
+        if char == ']' and in_class:
             in_class = False
         i += 1
     return False

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import json
 import re
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -353,8 +354,13 @@ class Scrubber(BaseScrubber):
         # See ScrubbingOptions for more info on these parameters.
         patterns = [_DEFAULT_PATTERN, *_check_extra_patterns(patterns)]
         try:
-            self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
-        except re.error as e:
+            with warnings.catch_warnings():
+                # Before 3.11, a global flag away from the start of the expression was a
+                # DeprecationWarning rather than an error, and it silently applies to every
+                # pattern, the defaults included. Treat it the same way on every version.
+                warnings.simplefilter('error', DeprecationWarning)
+                self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
+        except (re.error, DeprecationWarning) as e:
             # Entries that are each valid can still be invalid together, e.g. two of them using the
             # same group name, or one setting a global flag such as `(?i)` away from the start.
             raise LogfireConfigError(

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -304,6 +304,11 @@ def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
         )
 
     checked: list[str] = []
+    # Groups are numbered across the joined pattern in order, so only the groups that come before
+    # an entry shift its own numbering. The default pattern uses non-capturing groups throughout,
+    # but count it rather than assuming that stays true.
+    preceding_groups = re.compile(_DEFAULT_PATTERN).groups
+
     for index, pattern in enumerate(patterns):
         entry = f'The `extra_patterns` entry at index {index}'
 
@@ -319,19 +324,23 @@ def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
 
         if _matches_without_consuming(compiled):
             raise LogfireConfigError(
-                f'{entry} can match without consuming any characters, so it would match every value '
-                f'and redact all telemetry. Did you mean `+` where you wrote `*`?'
+                f'{entry} can match without consuming any characters, so it reports a match on values '
+                f'containing nothing sensitive, which are then redacted with an empty reason. '
+                f'A `*` where you meant `+`, or a look-around with nothing beside it, will do this.'
             )
 
-        if _has_numeric_backreference(pattern):
-            # All the patterns share one group numbering space once they're joined, so a numeric
-            # backreference points at a group from another pattern and the pattern never matches.
+        if preceding_groups and _has_numeric_backreference(pattern):
+            # Only groups from earlier entries shift this one's numbering. With none of them, a
+            # backreference still refers to this pattern's own group and works as written.
             raise LogfireConfigError(
-                f'{entry} contains a backreference to a group by number. Patterns are combined into a '
-                f'single regex, so numbered groups from different patterns would collide. '
-                f'Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
+                f'{entry} refers to a group by number, but {preceding_groups} capturing '
+                f'{"group appears" if preceding_groups == 1 else "groups appear"} before it once the '
+                f'patterns are combined into a single regex, so the numbering shifts and it would '
+                f'point at the wrong group. Use a named group instead, e.g. `(?P<name>...)` and '
+                f'`(?P=name)`, or make the earlier groups non-capturing with `(?:...)`.'
             )
 
+        preceding_groups += compiled.groups
         checked.append(pattern)
 
     return checked
@@ -343,7 +352,17 @@ class Scrubber(BaseScrubber):
     def __init__(self, patterns: Sequence[str] | None, callback: ScrubCallback | None = None):
         # See ScrubbingOptions for more info on these parameters.
         patterns = [_DEFAULT_PATTERN, *_check_extra_patterns(patterns)]
-        self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
+        try:
+            self._pattern = re.compile('|'.join(patterns), re.IGNORECASE | re.DOTALL)
+        except re.error as e:
+            # Entries that are each valid can still be invalid together, e.g. two of them using the
+            # same group name, or one setting a global flag such as `(?i)` away from the start.
+            raise LogfireConfigError(
+                f'The `extra_patterns` entries are combined into a single regular expression, and '
+                f'together they do not form a valid one: {e}. Two entries using the same group name, '
+                f'or an inline flag such as `(?i)`, will do this. Note that patterns are always '
+                f'matched case-insensitively.'
+            ) from e
         self._callback = callback
 
     def scrub_log(self, log: LogRecord) -> LogRecord:

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -6,6 +6,7 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from importlib import import_module
 from typing import Any, TypedDict, cast
 
 import typing_extensions
@@ -234,21 +235,49 @@ def _has_numeric_backreference(pattern: str) -> bool:
 
 
 # Ordinary characters covering the classes a pattern is most likely to be written against.
-# A pattern that matches an empty span anywhere in here matches an empty span in most values.
+# Only used if the minimum width can't be read from the parsed pattern, see below.
 _ZERO_WIDTH_PROBE = 'aA0_ -.'
+
+
+def _min_match_width(pattern: str) -> int | None:
+    """The fewest characters `pattern` has to consume to match, or `None` if that can't be read.
+
+    The regex parser knows this, but it lives in a private module which was named `sre_parse`
+    before 3.11, so treat it as something that may not be there.
+    """
+    for module_name in ('re._parser', 'sre_parse'):
+        try:
+            parser = cast('Any', import_module(module_name))
+        except ImportError:  # pragma: no cover
+            continue
+
+        try:
+            return cast('tuple[int, int]', parser.parse(pattern).getwidth())[0]
+        except Exception:  # pragma: no cover
+            return None
+
+    return None  # pragma: no cover
 
 
 def _matches_without_consuming(compiled: re.Pattern[str]) -> bool:
     r"""Whether `compiled` can match without consuming any characters.
 
     Such a pattern reports a match on values containing nothing sensitive, so every value is
-    redacted, with an empty string as the reason. `search('')` catches the patterns that match
-    the empty string outright, such as `[0-9]*`. Patterns like `\b` and `(?=.)` need a non-empty
-    subject before they match an empty span, which is what the probe is for.
+    redacted, with an empty string as the reason.
+
+    The minimum width the pattern can match answers this exactly: it is 0 for `[0-9]*`, `\b` and
+    `(?=x)`, and at least 1 for a pattern that has to consume something. If it can't be read,
+    fall back to trying the pattern out: `search('')` covers the patterns matching the empty
+    string outright, and the probe covers the ones needing a subject before they match an
+    empty span, though it can't cover a subject the probe doesn't contain.
     """
-    if compiled.search('') is not None:
+    min_width = _min_match_width(compiled.pattern)
+    if min_width is not None:  # pragma: no branch
+        return min_width == 0
+
+    if compiled.search('') is not None:  # pragma: no cover
         return True
-    return any(match.group(0) == '' for match in compiled.finditer(_ZERO_WIDTH_PROBE))
+    return any(match.group(0) == '' for match in compiled.finditer(_ZERO_WIDTH_PROBE))  # pragma: no cover
 
 
 def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
@@ -279,7 +308,7 @@ def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
         entry = f'The `extra_patterns` entry at index {index}'
 
         if not isinstance(pattern, str):  # pyright: ignore[reportUnnecessaryIsInstance]
-            raise LogfireConfigError(f'{entry} is a {type(pattern).__name__}, but it must be a string.')
+            raise LogfireConfigError(f'{entry} is of type {type(pattern).__name__}, but it must be a string.')
 
         try:
             compiled = re.compile(pattern, re.IGNORECASE | re.DOTALL)

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -212,6 +212,7 @@ def _has_numeric_backreference(pattern: str) -> bool:
 
     Escapes and character classes are tracked because `\1` inside `[...]` is an octal escape,
     and `\\1` is a literal backslash followed by a digit. Neither is a backreference.
+    Three octal digits are an octal escape too, so `\123` is the character `S`, not a backreference.
     """
     in_class = False
     i = 0
@@ -219,7 +220,9 @@ def _has_numeric_backreference(pattern: str) -> bool:
         char = pattern[i]
         if char == '\\' and i + 1 < len(pattern):
             if not in_class and pattern[i + 1] in '123456789':
-                return True
+                escape = pattern[i + 1 : i + 4]
+                if not (len(escape) == 3 and all(digit in '01234567' for digit in escape)):
+                    return True
             i += 2
             continue
         if char == '[':
@@ -230,13 +233,34 @@ def _has_numeric_backreference(pattern: str) -> bool:
     return False
 
 
+# Ordinary characters covering the classes a pattern is most likely to be written against.
+# A pattern that matches an empty span anywhere in here matches an empty span in most values.
+_ZERO_WIDTH_PROBE = 'aA0_ -.'
+
+
+def _matches_without_consuming(compiled: re.Pattern[str]) -> bool:
+    r"""Whether `compiled` can match without consuming any characters.
+
+    Such a pattern reports a match on values containing nothing sensitive, so every value is
+    redacted, with an empty string as the reason. `search('')` catches the patterns that match
+    the empty string outright, such as `[0-9]*`. Patterns like `\b` and `(?=.)` need a non-empty
+    subject before they match an empty span, which is what the probe is for.
+    """
+    if compiled.search('') is not None:
+        return True
+    return any(match.group(0) == '' for match in compiled.finditer(_ZERO_WIDTH_PROBE))
+
+
 def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
     """Check user-supplied scrubbing patterns, raising `LogfireConfigError` on ones that can't work.
 
     The patterns are joined into a single regex, so a mistake in one of them changes the behaviour of
-    the whole scrubber. Checking each pattern on its own here means the error can name the pattern
-    that caused it, and means these mistakes fail at configuration time instead of silently either
+    the whole scrubber. Checking each pattern on its own here means the error can say which entry
+    caused it, and means these mistakes fail at configuration time instead of silently either
     redacting everything or redacting nothing.
+
+    The messages identify an entry by its index rather than quoting it, because a pattern may be a
+    literal sensitive value, and an error raised at startup tends to end up in a log.
     """
     if patterns is None:
         return []
@@ -245,32 +269,38 @@ def _check_extra_patterns(patterns: Sequence[str] | None) -> list[str]:
         # `str` satisfies `Sequence[str]`, so this type checks cleanly, and then iterating the string
         # turns 'password' into the alternation `p|a|s|s|w|o|r|d`, which matches nearly all text.
         raise LogfireConfigError(
-            f'`extra_patterns` must be a sequence of regular expressions, not a single string. '
-            f'Use `extra_patterns=[{patterns!r}]` to pass one pattern.'
+            '`extra_patterns` must be a sequence of regular expressions, not a single string. '
+            'A string is itself a sequence, so it would be read one character at a time. '
+            'Wrap it in a list to pass a single pattern.'
         )
 
     checked: list[str] = []
-    for pattern in patterns:
+    for index, pattern in enumerate(patterns):
+        entry = f'The `extra_patterns` entry at index {index}'
+
+        if not isinstance(pattern, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise LogfireConfigError(f'{entry} is a {type(pattern).__name__}, but it must be a string.')
+
         try:
             compiled = re.compile(pattern, re.IGNORECASE | re.DOTALL)
         except re.error as e:
             # Compiling here rather than after joining means the position in the message refers to
             # this pattern, not to an offset within the combined pattern.
-            raise LogfireConfigError(f'Invalid regular expression in `extra_patterns`: {pattern!r}: {e}') from e
+            raise LogfireConfigError(f'{entry} is not a valid regular expression: {e}') from e
 
-        if compiled.search('') is not None:
+        if _matches_without_consuming(compiled):
             raise LogfireConfigError(
-                f'The `extra_patterns` entry {pattern!r} matches the empty string, so it would match every '
-                f'value and redact all telemetry. Did you mean `+` where you wrote `*`?'
+                f'{entry} can match without consuming any characters, so it would match every value '
+                f'and redact all telemetry. Did you mean `+` where you wrote `*`?'
             )
 
         if _has_numeric_backreference(pattern):
             # All the patterns share one group numbering space once they're joined, so a numeric
             # backreference points at a group from another pattern and the pattern never matches.
             raise LogfireConfigError(
-                f'The `extra_patterns` entry {pattern!r} contains a backreference to a group by number. '
-                f'Patterns are combined into a single regex, so numbered groups from different patterns '
-                f'would collide. Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
+                f'{entry} contains a backreference to a group by number. Patterns are combined into a '
+                f'single regex, so numbered groups from different patterns would collide. '
+                f'Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
             )
 
         checked.append(pattern)

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -766,7 +766,9 @@ def test_extra_patterns_rejects_bare_string():
 def test_extra_patterns_rejects_non_string_entry():
     with pytest.raises(LogfireConfigError) as exc_info:
         Scrubber(['fine', 123])  # pyright: ignore[reportArgumentType]
-    assert str(exc_info.value) == snapshot('The `extra_patterns` entry at index 1 is a int, but it must be a string.')
+    assert str(exc_info.value) == snapshot(
+        'The `extra_patterns` entry at index 1 is of type int, but it must be a string.'
+    )
 
 
 @pytest.mark.parametrize(
@@ -778,6 +780,9 @@ def test_extra_patterns_rejects_non_string_entry():
         '(?:)',
         r'\b',  # only matches an empty span once there's a subject
         '(?=.)',
+        '(?=z)',  # a subject the probe doesn't contain
+        '(?<=a)',
+        '(?:password)?',
     ],
 )
 def test_extra_patterns_rejects_pattern_matching_nothing(pattern: str):

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -758,13 +758,30 @@ def test_extra_patterns_rejects_bare_string():
         Scrubber('password')
     assert str(exc_info.value) == snapshot(
         '`extra_patterns` must be a sequence of regular expressions, not a single string. '
-        "Use `extra_patterns=['password']` to pass one pattern."
+        'A string is itself a sequence, so it would be read one character at a time. '
+        'Wrap it in a list to pass a single pattern.'
     )
 
 
-@pytest.mark.parametrize('pattern', ['', '[0-9]*', 'x*', '(?:)'])
-def test_extra_patterns_rejects_empty_matching_pattern(pattern: str):
-    with pytest.raises(LogfireConfigError, match='matches the empty string'):
+def test_extra_patterns_rejects_non_string_entry():
+    with pytest.raises(LogfireConfigError) as exc_info:
+        Scrubber(['fine', 123])  # pyright: ignore[reportArgumentType]
+    assert str(exc_info.value) == snapshot('The `extra_patterns` entry at index 1 is a int, but it must be a string.')
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    [
+        '',
+        '[0-9]*',
+        'x*',
+        '(?:)',
+        r'\b',  # only matches an empty span once there's a subject
+        '(?=.)',
+    ],
+)
+def test_extra_patterns_rejects_pattern_matching_nothing(pattern: str):
+    with pytest.raises(LogfireConfigError, match='can match without consuming any characters'):
         Scrubber([pattern])
 
 
@@ -774,7 +791,7 @@ def test_extra_patterns_rejects_numeric_backreference():
     with pytest.raises(LogfireConfigError) as exc_info:
         Scrubber(['(a)', r'(b)\1'])
     assert str(exc_info.value) == snapshot(
-        "The `extra_patterns` entry '(b)\\\\1' contains a backreference to a group by number. "
+        'The `extra_patterns` entry at index 1 contains a backreference to a group by number. '
         'Patterns are combined into a single regex, so numbered groups from different patterns '
         'would collide. Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
     )
@@ -785,13 +802,22 @@ def test_extra_patterns_named_backreference_is_allowed():
     assert scrubber.scrub_value(('attributes', 'x'), 'value with bb inside')[0] == snapshot("[Scrubbed due to 'bb']")
 
 
+def test_extra_patterns_octal_escape_is_allowed():
+    # `\123` is the character `S`, not a backreference to group 123.
+    scrubber = Scrubber([r'sea\123hell'])
+    assert scrubber.scrub_value(('attributes', 'x'), 'the seaShell value')[0] == snapshot(
+        "[Scrubbed due to 'seaShell']"
+    )
+
+
 def test_extra_patterns_invalid_regex_reports_own_position():
     # Compiling each pattern separately means the reported position is an offset into the user's
     # pattern rather than into the combined pattern.
     with pytest.raises(LogfireConfigError) as exc_info:
         Scrubber(['foo('])
     assert str(exc_info.value) == snapshot(
-        "Invalid regular expression in `extra_patterns`: 'foo(': missing ), unterminated subpattern at position 3"
+        'The `extra_patterns` entry at index 0 is not a valid regular expression: '
+        'missing ), unterminated subpattern at position 3'
     )
 
 
@@ -800,6 +826,7 @@ def test_extra_patterns_invalid_regex_reports_own_position():
     [
         (r'(a)\1', True),
         (r'(a)\9', True),
+        (r'\123', False),  # three octal digits are an octal escape
         (r'\\1', False),  # escaped backslash then a literal digit
         (r'[\1]', False),  # octal escape inside a character class
         (r'(?P<a>x)(?P=a)', False),

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -790,16 +790,34 @@ def test_extra_patterns_rejects_pattern_matching_nothing(pattern: str):
         Scrubber([pattern])
 
 
-def test_extra_patterns_rejects_numeric_backreference():
-    # Patterns share one group numbering space once joined, so `\1` here would point at a group
-    # from another pattern and the pattern would silently never match.
+def test_extra_patterns_rejects_numeric_backreference_after_a_capturing_group():
+    # `(a)` is group 1 once joined, so the `\1` here points at it rather than at `(b)`,
+    # and the pattern silently never matches.
     with pytest.raises(LogfireConfigError) as exc_info:
         Scrubber(['(a)', r'(b)\1'])
     assert str(exc_info.value) == snapshot(
-        'The `extra_patterns` entry at index 1 contains a backreference to a group by number. '
-        'Patterns are combined into a single regex, so numbered groups from different patterns '
-        'would collide. Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
+        'The `extra_patterns` entry at index 1 refers to a group by number, but 1 capturing group '
+        'appears before it once the patterns are combined into a single regex, so the numbering '
+        'shifts and it would point at the wrong group. Use a named group instead, e.g. '
+        '`(?P<name>...)` and `(?P=name)`, or make the earlier groups non-capturing with `(?:...)`.'
     )
+
+
+def test_extra_patterns_allows_backreference_with_no_preceding_group():
+    # The default patterns capture nothing, so a lone `\1` keeps its own numbering and works.
+    scrubber = Scrubber([r'(.)\1'])
+    assert scrubber.scrub_value(('attributes', 'x'), 'a value with bb inside')[0] == snapshot("[Scrubbed due to 'bb']")
+    # Non-capturing groups in an earlier entry don't shift the numbering either.
+    assert Scrubber(['(?:foo)', r'(.)\1'])
+
+
+def test_extra_patterns_rejects_entries_only_invalid_once_combined():
+    with pytest.raises(LogfireConfigError, match='together they do not form a valid one') as exc_info:
+        Scrubber(['(?P<c>a)', '(?P<c>b)'])
+    assert 'same group name' in str(exc_info.value)
+
+    with pytest.raises(LogfireConfigError, match='together they do not form a valid one'):
+        Scrubber(['(?i)foo'])
 
 
 def test_extra_patterns_named_backreference_is_allowed():

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -852,6 +852,9 @@ def test_extra_patterns_invalid_regex_reports_own_position():
         (r'\123', False),  # three octal digits are an octal escape
         (r'\\1', False),  # escaped backslash then a literal digit
         (r'[\1]', False),  # octal escape inside a character class
+        (r'[]a\1]', False),  # a `]` opening a class is a member of it, not the end
+        (r'[^]a\1]', False),
+        (r'[a][b]\1', True),  # two complete classes, then a real backreference
         (r'(?P<a>x)(?P=a)', False),
         (r'\0', False),
         ('plain', False),

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -14,7 +14,13 @@ from opentelemetry.sdk.environment_variables import OTEL_RESOURCE_ATTRIBUTES
 from opentelemetry.trace.propagation import get_current_span
 
 import logfire
-from logfire._internal.scrubbing import DEFAULT_PATTERNS, NoopScrubber, Scrubber
+from logfire._internal.scrubbing import (
+    DEFAULT_PATTERNS,
+    NoopScrubber,
+    Scrubber,
+    _has_numeric_backreference,  # pyright: ignore[reportPrivateUsage]
+)
+from logfire.exceptions import LogfireConfigError
 from logfire.testing import TestExporter, TestLogExporter
 
 DEFAULT_PATTERN_EXAMPLES = {
@@ -743,3 +749,63 @@ def test_logfire_token_prefix_scrubbing(exporter: TestExporter):
             }
         ]
     )
+
+
+def test_extra_patterns_rejects_bare_string():
+    # `str` satisfies `Sequence[str]`, so this type checks, and iterating it would build the
+    # alternation `p|a|s|s|w|o|r|d`, redacting nearly every value.
+    with pytest.raises(LogfireConfigError) as exc_info:
+        Scrubber('password')
+    assert str(exc_info.value) == snapshot(
+        '`extra_patterns` must be a sequence of regular expressions, not a single string. '
+        "Use `extra_patterns=['password']` to pass one pattern."
+    )
+
+
+@pytest.mark.parametrize('pattern', ['', '[0-9]*', 'x*', '(?:)'])
+def test_extra_patterns_rejects_empty_matching_pattern(pattern: str):
+    with pytest.raises(LogfireConfigError, match='matches the empty string'):
+        Scrubber([pattern])
+
+
+def test_extra_patterns_rejects_numeric_backreference():
+    # Patterns share one group numbering space once joined, so `\1` here would point at a group
+    # from another pattern and the pattern would silently never match.
+    with pytest.raises(LogfireConfigError) as exc_info:
+        Scrubber(['(a)', r'(b)\1'])
+    assert str(exc_info.value) == snapshot(
+        "The `extra_patterns` entry '(b)\\\\1' contains a backreference to a group by number. "
+        'Patterns are combined into a single regex, so numbered groups from different patterns '
+        'would collide. Use a named group instead, e.g. `(?P<name>...)` and `(?P=name)`.'
+    )
+
+
+def test_extra_patterns_named_backreference_is_allowed():
+    scrubber = Scrubber([r'(?P<char>[a-z])(?P=char)'])
+    assert scrubber.scrub_value(('attributes', 'x'), 'value with bb inside')[0] == snapshot("[Scrubbed due to 'bb']")
+
+
+def test_extra_patterns_invalid_regex_reports_own_position():
+    # Compiling each pattern separately means the reported position is an offset into the user's
+    # pattern rather than into the combined pattern.
+    with pytest.raises(LogfireConfigError) as exc_info:
+        Scrubber(['foo('])
+    assert str(exc_info.value) == snapshot(
+        "Invalid regular expression in `extra_patterns`: 'foo(': missing ), unterminated subpattern at position 3"
+    )
+
+
+@pytest.mark.parametrize(
+    'pattern,expected',
+    [
+        (r'(a)\1', True),
+        (r'(a)\9', True),
+        (r'\\1', False),  # escaped backslash then a literal digit
+        (r'[\1]', False),  # octal escape inside a character class
+        (r'(?P<a>x)(?P=a)', False),
+        (r'\0', False),
+        ('plain', False),
+    ],
+)
+def test_has_numeric_backreference(pattern: str, expected: bool):
+    assert _has_numeric_backreference(pattern) is expected


### PR DESCRIPTION
`ScrubbingOptions.extra_patterns` entries are joined with the default patterns into one regex. A mistake in a single entry therefore changes the behaviour of the whole scrubber, and does so silently — either redacting every value or redacting none. This checks each pattern on its own before joining, so those cases raise `LogfireConfigError` at configuration time.

Fixes #2234. Fixes #2237.

### Cases now rejected

| Input | Current behaviour on `main` | Now |
|---|---|---|
| `extra_patterns='password'` | iterated per character into `p\|a\|s\|s\|w\|o\|r\|d`, redacting nearly every value | error naming the `['password']` form |
| `extra_patterns=['[0-9]*']` | matches every value, reason string empty | error |
| `extra_patterns=['(a)', r'(b)\1']` | `\1` refers to `(a)`, so the pattern never matches and the data is exported | error pointing at named groups |
| `extra_patterns=['foo(']` | `missing ), unterminated subpattern at position 281` | same message at position 3 |

The first three are silent, which is what makes them worth an error rather than a warning: the first two destroy all telemetry for the process, and the third exports data the user asked to have redacted.

Named groups (`(?P<name>...)` / `(?P=name)`) are unaffected by the joining because names aren't renumbered, so they're what the backreference message recommends, and there's a test covering that they still work.

### Notes for review

- Validation lives in `Scrubber.__init__` rather than a `ScrubbingOptions.__post_init__` so that it also covers direct construction; `config.py` is the only other caller.
- `_has_numeric_backreference` tracks escapes and character classes, since `\1` inside `[...]` is an octal escape and `\\1` is a literal backslash followed by a digit. Both are covered by tests.
- The empty-string check uses `compiled.search('')`, which catches `''`, `[0-9]*` and similar. It does not catch a pattern like `\b` that only ever matches zero-width in context — that still yields `[Scrubbed due to '']`. Happy to extend this if you'd prefer it handled here; I left it out because the alternatives I could see either probe with an arbitrary sample string or move the check to match time, and moving it to match time would turn over-redaction into under-redaction, which seems like the wrong direction for a scrubber.
- #2235 (nested-quantifier patterns running on the application thread) is the third of the trio and isn't addressed here — it's a documentation change rather than validation, so it seemed better kept separate. Happy to follow up with it.

### Verification

- `make test` on this branch: 2306 passed, 6 failed. The same failures occur on `main` (2291 passed, 7 failed) and are unrelated — missing local service dependencies for celery/mysql/redis, plus some order-dependent tests in the existing suite. The difference of 15 passing tests is exactly the tests added here.
- `make lint` and `make typecheck` are clean.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

