### PR TITLE
Document that extra_patterns are matched on the calling thread

### DIFF
--- a/docs/how-to-guides/scrubbing.md
+++ b/docs/how-to-guides/scrubbing.md
@@ -35,6 +35,22 @@ logfire.info(
 )
 ```
 
+!!! warning "Custom patterns are matched on your own thread"
+
+    Scrubbing runs while the span is created, on the thread that called into Logfire, not on the
+    exporting thread. The time a pattern takes to match is therefore time your own code spends
+    waiting.
+
+    This matters because the values being matched are often influenced by whoever is talking to your
+    application — a request field, a header, a form value. A pattern that backtracks, such as one
+    with a quantifier inside a quantifier, takes time that grows exponentially with the length of the
+    value. With `extra_patterns=[r'(a+)+$']` and a value of 24 `a` characters followed by `!`, a
+    single `logfire.info` call blocks for around a second; a few more characters and it does not
+    finish.
+
+    The default patterns are not affected — they match in linear time. If you add your own, prefer
+    a specific pattern over a general one, avoid nesting quantifiers, and anchor where you can.
+
 Here are the default scrubbing patterns:
 
 ```python

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -114,6 +114,11 @@ class ScrubbingOptions:
     A sequence of regular expressions to detect sensitive data that should be redacted.
     For example, the default includes `'password'`, `'secret'`, and `'api[._ -]?key'`.
     The specified patterns are combined with the default patterns.
+
+    These patterns are matched while the span is created, on the calling thread, against values that
+    are often influenced by the caller of your application. A pattern that backtracks, such as one
+    with a quantifier inside a quantifier, therefore blocks your own code for a time that grows
+    exponentially with the length of the value being matched.
     """
 
 


### PR DESCRIPTION
Scrubbing happens while the span is created, on the thread that called into Logfire, rather than on the exporting thread. Time spent matching a custom pattern is therefore time the caller spends waiting, and the values being matched are frequently derived from a request. Nothing currently says so, and the consequence is not obvious from the API.

Fixes #2235.

Measured on this branch with `extra_patterns=[r'(a+)+$']` against `'a' * n + '!'`:

| value length | time for one call |
|---|---|
| 16 | 3 ms |
| 20 | 50 ms |
| 22 | 201 ms |
| 24 | 806 ms |

Growth is exponential, so a slightly longer value does not finish. `(a+)+$` is contrived, but a quantifier inside a quantifier is easy to write by accident, and a value long enough to trigger it can arrive from outside.

The 18 default patterns match in linear time and are unaffected, so this is specific to `extra_patterns`. The note goes on the field itself and in the scrubbing guide, since the guide is where someone is when they decide to add a pattern.

This is documentation only. Rejecting these patterns at configuration time was the other option raised on the issue, but detecting backtracking behaviour statically isn't reachable with `re`, and a shape-based check would reject working patterns while missing others, so a note on the field seemed the honest scope. Happy to be told otherwise.

Related: #2258 adds configuration-time checks for the `extra_patterns` mistakes that *are* statically detectable (#2234, #2237), and touches the same docstring — whichever merges second will need a trivial rebase.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

