### PR TITLE
Restore the async metric polling loop

### DIFF
--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -155,16 +155,19 @@ thread, where awaiting a coroutine would block collection and an unawaited corou
 If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
 [`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
 
-This runnable example reads an async value, records one observation, then exits. Before you run it, select a project
-with `logfire projects use <project-name>`, or set `LOGFIRE_TOKEN` to a write token (the credential your deployed app
-uses to send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` configures
-that project as the export destination. In the example, `queue_depth.set(...)` records the measurement and
-`logfire.force_flush()` asks Logfire to export it immediately before the process exits.
+This runnable example starts a polling task and runs until you press Ctrl+C. Before you run it, select a project with
+`logfire projects use <project-name>`, or set `LOGFIRE_TOKEN` to a write token (the credential your deployed app uses to
+send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` configures that project
+as the export destination. In the example, `queue_depth.set(...)` updates the current measurement. The metrics SDK
+exports it on its regular collection schedule, and `logfire.force_flush()` requests a final export during shutdown.
 
-```py
+```py hl_lines="23-30 33-40" skip-run="true" skip-reason="long-running"
 import asyncio
+from contextlib import suppress
 
 import logfire
+
+POLL_INTERVAL_SECONDS = 30
 
 logfire.configure()
 
@@ -181,20 +184,41 @@ async def read_queue_depth() -> int:
     return 7
 
 
+async def poll_queue_depth() -> None:
+    """Update the gauge until the application stops this task."""
+    while True:
+        try:
+            queue_depth.set(await read_queue_depth())
+        except Exception:
+            logfire.exception('Failed to read queue depth')
+        await asyncio.sleep(POLL_INTERVAL_SECONDS)
+
+
 async def main() -> None:
-    queue_depth.set(await read_queue_depth())
+    poller = asyncio.create_task(poll_queue_depth(), name='queue-depth-poller')
+    try:
+        await asyncio.Event().wait()  # Keep this standalone example running.
+    finally:
+        poller.cancel()
+        with suppress(asyncio.CancelledError):
+            await poller
 
 
-asyncio.run(main())
-logfire.force_flush()
+try:
+    asyncio.run(main())
+except KeyboardInterrupt:
+    pass
+finally:
+    logfire.force_flush()
 ```
 
-Run the script to record one `jobs.queue_depth` point with the value `7`. Open [**Metrics** in the project
-sidebar](../web-ui/metrics-explorer.md) to find it under the `jobs` namespace. A line becomes visible after a long-running
-poller records multiple points. Replace `read_queue_depth()` with your async client call.
-In a long-running application, put the read and `set()` call in a `while True` loop with your normal polling interval.
-Start that loop as a background task with the application's startup hook. The code that starts the task must retain it,
-cancel it during shutdown, and await the cancelled task so its cleanup can finish.
+Run the script to update `jobs.queue_depth` immediately and then every 30 seconds. Open [**Metrics** in the project
+sidebar](../web-ui/metrics-explorer.md) to find it under the `jobs` namespace. A line becomes visible after Logfire
+collects multiple points. Press Ctrl+C to stop the script and export its final value.
+
+Replace `read_queue_depth()` with your async client call. In a real application, create the `poll_queue_depth()` task in
+the application's startup hook instead of `main()`. Keep the same ownership shown above: the code that starts the task
+must retain it, cancel it during shutdown, and await the cancelled task so its cleanup can finish.
 
 Long-running pollers usually use **fixed-delay polling**: each delay starts after the previous read finishes. Slow reads
 therefore move later polls, but one task never overlaps two reads. **Fixed-rate polling** instead calculates each start

--- a/docs/guides/onboarding-checklist/add-metrics.md
+++ b/docs/guides/onboarding-checklist/add-metrics.md
@@ -155,13 +155,11 @@ thread, where awaiting a coroutine would block collection and an unawaited corou
 If a metric value comes from an async API, let your application's lifecycle own a polling task and update a normal
 [`logfire.metric_gauge`][logfire.Logfire.metric_gauge].
 
-This runnable example starts a polling task and runs until you press Ctrl+C. Before you run it, select a project with
-`logfire projects use <project-name>`, or set `LOGFIRE_TOKEN` to a write token (the credential your deployed app uses to
-send data to a Logfire project) from **Project → Settings → Write tokens**. `logfire.configure()` configures that project
-as the export destination. In the example, `queue_depth.set(...)` updates the current measurement. The metrics SDK
-exports it on its regular collection schedule, and `logfire.force_flush()` requests a final export during shutdown.
+This runnable example starts a polling task and runs until you press Ctrl+C. `queue_depth.set(...)` updates the current
+measurement. The metrics SDK exports it on its regular collection schedule, and `logfire.force_flush()` requests a
+final export during shutdown.
 
-```py hl_lines="23-30 33-40" skip-run="true" skip-reason="long-running"
+```py hl_lines="23-32 35-42" skip-run="true" skip-reason="long-running"
 import asyncio
 from contextlib import suppress
 
@@ -188,9 +186,11 @@ async def poll_queue_depth() -> None:
     """Update the gauge until the application stops this task."""
     while True:
         try:
-            queue_depth.set(await read_queue_depth())
-        except Exception:
+            value = await read_queue_depth()
+        except Exception:  # Replace with the exception your client raises.
             logfire.exception('Failed to read queue depth')
+        else:
+            queue_depth.set(value)
         await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 
@@ -212,9 +212,9 @@ finally:
     logfire.force_flush()
 ```
 
-Run the script to update `jobs.queue_depth` immediately and then every 30 seconds. Open [**Metrics** in the project
-sidebar](../web-ui/metrics-explorer.md) to find it under the `jobs` namespace. A line becomes visible after Logfire
-collects multiple points. Press Ctrl+C to stop the script and export its final value.
+Run the script to update `jobs.queue_depth` immediately, then wait 30 seconds after each read before reading again. Open
+[**Metrics** in the project sidebar](../web-ui/metrics-explorer.md) to find it under the `jobs` namespace. A line becomes
+visible after Logfire collects multiple points. Press Ctrl+C to stop the script and export its final value.
 
 Replace `read_queue_depth()` with your async client call. In a real application, create the `poll_queue_depth()` task in
 the application's startup hook instead of `main()`. Keep the same ownership shown above: the code that starts the task


### PR DESCRIPTION
Follow-up to #2247.

## What changed

- Replace the one-shot async gauge example with a real fixed-delay polling loop.
- Keep the example framework-independent while showing task ownership directly: retain the task, cancel it, and await it during shutdown.
- Run until Ctrl+C, record the first value immediately, and request a final metric export during shutdown.
- Clarify that gauge updates and metric exports happen on separate schedules.

## Why

The revision made in response to the original review made the snippet terminate quickly, but it also removed the polling loop that readers need to adapt. This restores the central pattern in executable code without bringing FastAPI back into the example.

## User impact

Readers can now copy a minimal polling task and see the startup, failure, interval, cancellation, and shutdown behavior together instead of reconstructing the loop from prose.

## Validation

- `uv run pytest tests/test_docs.py -q`: 123 passed.
- `uv run prek --files docs/guides/onboarding-checklist/add-metrics.md`: passed.
- Ran the long-running snippet locally with sending disabled, interrupted it with SIGINT, and confirmed clean shutdown without a traceback.

The snippet is marked `skip-run="true"` in the docs suite because it intentionally waits for Ctrl+C; the suite still lints it.

## AI assistance

Codex drafted this follow-up from maintainer feedback. The diff is left as a draft for human review.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

