### PR TITLE
Correct the docs that said Logfire ingests OTLP over HTTP only

### DIFF
--- a/docs/integrations/agent-frameworks/agent-framework-dotnet.md
+++ b/docs/integrations/agent-frameworks/agent-framework-dotnet.md
@@ -95,8 +95,9 @@ Protocol metrics exporter. Microsoft Agent Framework runs also appear in the spe
 [support matrix](support-matrix.md) shows which columns each view populates.
 
 !!! warning "Common pitfalls"
-    - **Default OTLP protocol is gRPC.** Set `OtlpExportProtocol.HttpProtobuf` and supply the full `/v1/traces`
-      path with per-signal `AddOtlpExporter` (it isn't appended automatically).
+    - **Default OTLP protocol is gRPC.** Logfire accepts both, but the endpoint has to match: gRPC takes the
+      bare base URL. This setup uses `OtlpExportProtocol.HttpProtobuf`, which needs the full `/v1/traces` path
+      with per-signal `AddOtlpExporter` (it isn't appended automatically).
     - **`sourceName` must match `AddSource`.** If you omit `sourceName`, register the defaults instead:
       `AddSource("Experimental.Microsoft.Agents.AI")` (agent) and
       `AddSource("Experimental.Microsoft.Extensions.AI")` (chat client).

--- a/docs/integrations/agent-frameworks/genkit-go.md
+++ b/docs/integrations/agent-frameworks/genkit-go.md
@@ -114,8 +114,8 @@ view populates. Use `https://logfire-eu.pydantic.dev/v1/traces` for the EU regio
 
 !!! warning "Common pitfalls"
     - **Set the global provider before `genkit.Init`**, or early spans are dropped.
-    - **Use the HTTP exporter** (`otlptracehttp`) with the `/v1/traces` path — the gRPC exporter won't match
-      Logfire's HTTP ingest.
+    - **Match the exporter to the endpoint.** This setup uses `otlptracehttp` with the `/v1/traces` path.
+      Logfire also accepts gRPC (`otlptracegrpc`), which takes the bare base URL and no path.
     - **Flush on exit.** The `defer tp.Shutdown(ctx)` flushes the batch exporter; without it a short program may
       exit before spans are sent.
 

--- a/docs/integrations/agent-frameworks/langchain-js.md
+++ b/docs/integrations/agent-frameworks/langchain-js.md
@@ -101,7 +101,8 @@ You'll see the graph run, its model calls, and the `lookup_incident` tool call a
     - **`LANGSMITH_OTEL_ONLY=true`** stops LangSmith from also shipping traces to its own backend, so you don't
       need a `LANGSMITH_API_KEY`.
     - **Flush on exit.** Short-lived scripts and serverless must `await ...shutdown()` (or `forceFlush()`) or
-      spans are lost. Use the HTTP/protobuf exporter (`@opentelemetry/exporter-trace-otlp-proto`), not gRPC.
+      spans are lost. This setup uses the HTTP/protobuf exporter (`@opentelemetry/exporter-trace-otlp-proto`)
+      with the `/v1/traces` URL; Logfire also accepts gRPC, which needs the bare base URL instead.
 
 ## Managed prompts
 

--- a/docs/integrations/agent-frameworks/semantic-kernel-dotnet.md
+++ b/docs/integrations/agent-frameworks/semantic-kernel-dotnet.md
@@ -117,9 +117,10 @@ Agents-view features, so use Live or Explore to inspect the complete trace. Sema
 the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns each view populates.
 
 !!! warning "Common pitfalls"
-    - **Default OTLP protocol is gRPC.** **Logfire** ingests OTLP/HTTP, so you must set
-      `OtlpExportProtocol.HttpProtobuf`, and with per-signal `AddOtlpExporter` supply the **full** path
-      (`/v1/traces`, `/v1/metrics`) yourself — it isn't appended automatically.
+    - **Default OTLP protocol is gRPC.** **Logfire** accepts both, but the endpoint has to match: gRPC takes
+      the bare base URL, while this setup uses `OtlpExportProtocol.HttpProtobuf`. With per-signal
+      `AddOtlpExporter` on HTTP, supply the **full** path (`/v1/traces`, `/v1/metrics`) yourself: it isn't
+      appended automatically.
     - **No diagnostics, no spans.** Without `EnableOTelDiagnostics` (metadata) or
       `EnableOTelDiagnosticsSensitive` (also prompts/completions), SK's AI connectors emit nothing. Set the
       switch (or env var `SEMANTICKERNEL_EXPERIMENTAL_GENAI_ENABLE_OTEL_DIAGNOSTICS[_SENSITIVE]=true`) before

--- a/docs/integrations/agent-frameworks/support-matrix.md
+++ b/docs/integrations/agent-frameworks/support-matrix.md
@@ -76,7 +76,7 @@ agent-run span the Agents view recognizes (they emit an LLM or chain span, or a 
 | [LangChain (JS)](langchain-js.md) | ● | ○ | Traced via LangSmith's own convention. |
 | [Instructor](../llms/instructor.md) | ● | ○ | LLM-only; not an agent framework. |
 | [Eino (Go)](eino.md) | ● | ○ | No agent-run convention we detect today. |
-| [Letta](../llms/letta.md) | ● | ○ | Server traces flow via an OpenTelemetry Collector; no agent-run span is detected. |
+| [Letta](../llms/letta.md) | ● | ○ | Server traces export directly over OTLP/gRPC, with a collector optional; no agent-run span is detected. |
 | [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ○ | No OpenTelemetry exporter yet; instrument the underlying model client for LLM spans only. |
 | [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ○ | Emits native gen_ai `invoke_agent`/`chat`/`execute_tool` spans (LLMs view, tokens, and cost populate), but sets no `gen_ai.agent.name`, so the Agents view does not detect the run. |
 

--- a/docs/integrations/llms/letta.md
+++ b/docs/integrations/llms/letta.md
@@ -1,67 +1,39 @@
 ---
 title: "Pydantic Logfire Integrations: Letta"
-description: "Send Letta (formerly MemGPT) server telemetry to Pydantic Logfire via an OpenTelemetry Collector."
+description: "Send Letta (formerly MemGPT) server telemetry straight to Pydantic Logfire over OTLP/gRPC, with no collector in between."
 integration: otel
 ---
 # Letta
 
 [Letta](https://docs.letta.com/) (formerly **MemGPT**) is a framework and server for building stateful agents
-with long-term memory. The Letta **server** has native OTLP export built in, but it speaks **OTLP/gRPC only**
-and exposes a single endpoint env var with no way to set auth headers. **Logfire**'s direct ingest is
-OTLP/HTTP, so the robust path is to run a small [OpenTelemetry Collector](../../how-to-guides/otel-collector/otel-collector-overview.md)
-that receives Letta's gRPC traces and forwards them to **Logfire** over HTTP with your write token.
+with long-term memory. The Letta **server** has native OTLP export built in and speaks **OTLP/gRPC**, which
+**Logfire** accepts, so the server can send traces straight to your project with no collector in between.
+
+Letta exposes only an endpoint setting of its own, but the OpenTelemetry exporter underneath it still reads the
+standard `OTEL_EXPORTER_OTLP_HEADERS` environment variable, which is how your write token gets attached.
 
 ```mermaid
 flowchart LR
-    L[Letta server] -- OTLP/gRPC :4317 --> C[OTel Collector]
-    C -- OTLP/HTTP + Authorization --> LF[Logfire]
+    L[Letta server] -->|"OTLP/gRPC + Authorization: write token"| LF[Logfire]
 ```
 
 ## Installation
 
 ```bash
-# Letta server + Python client
 pip install letta letta-client
-# The collector runs as a container:
-# docker pull otel/opentelemetry-collector-contrib
-```
-
-## Collector configuration
-
-Create `otel-collector-config.yaml`:
-
-```yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317 # Letta exports here
-
-exporters:
-  otlphttp/logfire:
-    endpoint: 'https://logfire-us.pydantic.dev' # use logfire-eu.pydantic.dev for the EU region
-    headers:
-      Authorization: '${LOGFIRE_WRITE_TOKEN}'
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [otlphttp/logfire]
 ```
 
 ## Running it
 
-```bash
-# 1. Start the collector (forwards to Logfire)
-export LOGFIRE_WRITE_TOKEN="your-logfire-write-token"
-docker run -p 127.0.0.1:4317:4317 \
-  -v "$PWD/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml" \
-  -e LOGFIRE_WRITE_TOKEN \
-  otel/opentelemetry-collector-contrib
+Create a [write token](../../how-to-guides/create-write-tokens.md) from **Project → Settings → Write tokens**,
+then start the Letta server with both variables set:
 
-# 2. Start the Letta server pointed at the collector
-export LETTA_OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+```bash
+# Where to send traces: your region's base URL, no path (gRPC addresses a method, not a path)
+export LETTA_OTEL_EXPORTER_OTLP_ENDPOINT="https://logfire-us.pydantic.dev"
+# How Logfire knows which project they belong to, read by the OTel exporter underneath Letta
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=your-logfire-write-token"
+
 letta server
 ```
 
@@ -89,15 +61,78 @@ for message in response.messages:
     print(message)
 ```
 
-Each request to the Letta server now produces traces (including the underlying LLM provider requests) that flow
-through the collector into **Logfire**.
+## Verify
+
+Open the [Live view](../../guides/web-ui/live.md) for your project. Spans start arriving as the server boots,
+under the service name `letta-server`, so the [Services](../../guides/web-ui/services.md) view is another
+quick way to confirm data is landing. Letta sends metrics to the same endpoint as well, so those appear
+alongside the traces.
+
+Letta instruments its own server work, so exercising the server through the client shown above produces spans
+for the work each request does, including the underlying LLM provider calls.
+
+If nothing arrives, the server logs the export failure. `Missing or invalid authorization header` means
+`OTEL_EXPORTER_OTLP_HEADERS` did not reach the server process, and `Unknown token` means it did but the token
+is wrong for this region.
 
 !!! warning "Important details"
-    - **Telemetry is server-side.** Tracing is emitted by the `letta server` process, not by `letta-client`.
-      Set `LETTA_OTEL_EXPORTER_OTLP_ENDPOINT` where the server runs.
-    - **gRPC only.** `LETTA_OTEL_EXPORTER_OTLP_ENDPOINT` must point at a gRPC OTLP receiver (port `4317`), not
-      an HTTP `/v1/traces` URL. You can't point it directly at **Logfire** — hence the collector.
-    - **Region.** Match `logfire-us.pydantic.dev` or `logfire-eu.pydantic.dev` to your project's region.
+    - **Telemetry is server-side.** Tracing is emitted by the `letta server` process, not by `letta-client`,
+      so both environment variables go where the server runs. In Docker or Kubernetes that means the Letta
+      container, not your shell.
+    - **gRPC, so no path.** `LETTA_OTEL_EXPORTER_OTLP_ENDPOINT` takes the bare base URL. A `/v1/traces` URL
+      is an HTTP path and does not work over gRPC.
+    - **The token rides on a standard variable.** Letta has no setting of its own for headers. It passes only
+      the endpoint to the OpenTelemetry exporter, and the exporter reads `OTEL_EXPORTER_OTLP_HEADERS` itself.
+      A tool that clears unrecognized environment variables will strip it.
+    - **Setting the endpoint is what turns tracing on**, so there is no separate enable flag. There is a kill
+      switch though: if `LETTA_DISABLE_TRACING` is set, the server skips tracing setup entirely and exports
+      nothing, whatever else you configure.
+    - **Region.** Match `logfire-us.pydantic.dev` or `logfire-eu.pydantic.dev` to your project's region, and
+      use a write token from that same region.
+
+## When you still want a collector
+
+Sending direct needs nothing extra to run. Put an
+[OpenTelemetry Collector](../../how-to-guides/otel-collector/otel-collector-overview.md) in between when you
+want what a collector adds: batching or retry across several Letta servers, redacting attributes before they
+leave your network, or fanning the same traces out to more than one backend. The configuration below is a
+plain pass-through that forwards everything to Logfire, so it is the starting point you add those processors
+and exporters to, not an example of them.
+
+Point Letta at the collector (`LETTA_OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"`, and no
+`OTEL_EXPORTER_OTLP_HEADERS`, since the collector attaches the token instead), then save this as
+`otel-collector-config.yaml` in the directory you run the container from:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317 # Letta exports here
+
+exporters:
+  otlphttp/logfire:
+    endpoint: 'https://logfire-us.pydantic.dev' # use logfire-eu.pydantic.dev for the EU region
+    headers:
+      Authorization: '${LOGFIRE_WRITE_TOKEN}'
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/logfire]
+    metrics: # Letta exports metrics too; without this pipeline the collector drops them
+      receivers: [otlp]
+      exporters: [otlphttp/logfire]
+```
+
+```bash
+export LOGFIRE_WRITE_TOKEN="your-logfire-write-token"
+docker run -p 127.0.0.1:4317:4317 \
+  -v "$PWD/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml" \
+  -e LOGFIRE_WRITE_TOKEN \
+  otel/opentelemetry-collector-contrib
+```
 
 ## Managed prompts
 

--- a/docs/reference/limits.md
+++ b/docs/reference/limits.md
@@ -14,7 +14,7 @@ Logfire applies a few limits to the data you send. Going past one either **drops
 | Size of one span, log, or metric point | 10 MB | Oversized values are shortened; the record is stored |
 | Long text fields | 512 bytes for span names, service names, and the message shown in the UI; 32,000 bytes for exception messages and stack traces | The value is shortened; the record is stored |
 
-The limits are the same in the [US and EU regions](data-regions.md) and are not configurable per project. Separately, [Summary metrics](#summary-metrics-are-not-supported) are not stored at all.
+The limits above are the same in the [US and EU regions](data-regions.md), the same whether you send over HTTP or gRPC, and are not configurable per project. Only the error code differs by protocol: an oversized request is refused with `413 Payload Too Large` on HTTP and `OUT_OF_RANGE` on gRPC. Separately, [Summary metrics](#summary-metrics-are-not-supported) are not stored at all.
 
 ## Timestamps
 
@@ -40,7 +40,7 @@ A `Summary` is dropped on arrival. When a request carries `Summary` metrics alon
 
 | Symptom | Cause | Fix |
 | --- | --- | --- |
-| The exporter reports the payload is too large and a batch never arrives | The request was over 100 MB | Lower the batch size for that signal (`OTEL_BSP_MAX_EXPORT_BATCH_SIZE` for spans, `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` for logs), and shrink individual records: a smaller batch does not help when one record is itself oversized |
+| The exporter reports `413` or `OUT_OF_RANGE` and a batch never arrives | The request was over 100 MB | Lower the batch size for that signal (`OTEL_BSP_MAX_EXPORT_BATCH_SIZE` for spans, `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` for logs), and shrink individual records: a smaller batch does not help when one record is itself oversized |
 | Data from one host never appears, and the project has `logfire ingest error` records | That host's clock has drifted outside the window | Run a time sync daemon on the host |
 | A backfill or replay produces no data | The records are older than 24 hours | Backfilling historical data is not supported |
 | A value displays with `...` in the middle | The record was over 10 MB | Check the **Truncation** section on the record to see everything that was cut |


### PR DESCRIPTION
OTLP/gRPC ingest is live in both regions on the same hostname and port 443. Several pages still tell readers gRPC will not reach Logfire.

**Stacked on #2262**, which creates `docs/reference/limits.md`. Merge that first, or retarget this to `main` afterwards.

## Scope shrank: #2272 already covered part of this

Bill's #2272 landed the `alternative-clients`, `.NET` and `Java` corrections on main while this was open, with a lighter touch than this branch had. Rather than re-litigate freshly merged wording, this PR **drops** its versions of those three files. Main's `HTTP or gRPC` note is now the single home for the protocol choice, and this PR does not add a competing section.

That took the diff from 9 files to 7, and removed the `Choose a protocol` section this PR previously introduced.

## What #2272 did not cover

**Four agent-framework pages still say gRPC will not work:**

| Page | Was |
|---|---|
| genkit-go | "the gRPC exporter won't match Logfire's HTTP ingest" |
| langchain-js | "Use the HTTP/protobuf exporter, not gRPC" |
| semantic-kernel-dotnet | "Logfire ingests OTLP/HTTP, so you must set HttpProtobuf" |
| agent-framework-dotnet | implied HTTP is required |

Each now says both protocols are accepted and that the endpoint has to match: gRPC takes the bare base URL, HTTP appends `/v1/traces`. That mismatch is the real failure mode behind the symptom those bullets described. No example was switched to gRPC, so every tested snippet stays tested.

**Letta no longer needs a collector.** The page required one because Letta "has no way to set auth headers". That premise was wrong: Letta passes only the endpoint to the standard OpenTelemetry gRPC exporter, and that exporter reads `OTEL_EXPORTER_OTLP_HEADERS` from the environment itself. Direct is now the documented path, two environment variables and no container, with the collector kept as a section for fan-out, redaction, or batching across servers.

**The support matrix** still described Letta as flowing through a collector.

**The limits page** names the gRPC error code beside the HTTP one, in two lines. The 8-concurrent-streams and one-minute request ceilings were dropped by the same standard #2262 applies: neither drops data, no real client approaches either, and both are internals worth keeping free to change.

## Verification

- **gRPC ingest is live**: an unauthenticated probe of the OTLP export path on both regions returns `grpc-status: 16` / `Missing or invalid authorization header`, so it reaches the auth layer rather than being refused earlier.
- **The Letta claim was tested twice.** Against production with Letta's exact exporter shape (`OTLPSpanExporter(endpoint=...)`, no headers argument) and a fake token: with `OTEL_EXPORTER_OTLP_HEADERS` set Logfire answers `Unknown token`; without it, `Missing or invalid authorization header`. The header reaches us. Then `letta server` was run locally against a throwaway OTLP/gRPC receiver: it transmits the `Authorization` header and emits spans under `service.name=letta-server`, scope `letta.otel.tracing`, and exports metrics to the same endpoint, which is why the collector example has a `metrics` pipeline.
- **What gates tracing** is confirmed from Letta's source: `if otlp_endpoint and not settings.disable_tracing`, with the `letta_` env prefix, hence the `LETTA_DISABLE_TRACING` note.

Not verified: that a fully booted Letta server emits a span per HTTP request. It needs a migrated Postgres and the published wheel ships no alembic config, so the spans captured came from startup work. The page is worded to match what was observed.

## Note on the rebase

Rebuilt on the current base rather than rebased. The old branch predated the TypeScript URL cleanup in #2287, and replaying its commits would have reverted `instrument/typescript/` back to `typescript-sdk/` across several files.

Substantially AI-drafted (Claude Opus 5), written against `dev-docs/documentation-style-guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
