### PR TITLE
Add explicit titles to comparison documentation

### DIFF
--- a/docs/comparisons/arize-phoenix.md
+++ b/docs/comparisons/arize-phoenix.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Arize Phoenix"
+---
+
 # Logfire vs Arize Phoenix
 
 Arize Phoenix is an ML observability platform focused on model monitoring, drift detection, and LLM tracing. Logfire is an AI-native observability platform built on OpenTelemetry. While both help you observe AI applications, they come from different backgrounds and serve different needs.

--- a/docs/comparisons/datadog.md
+++ b/docs/comparisons/datadog.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Datadog"
+---
+
 # Logfire vs Datadog
 
 Datadog is a comprehensive enterprise monitoring platform. Logfire is an AI-native observability platform built on OpenTelemetry. While both offer APM capabilities, their architectures and pricing models are fundamentally different.

--- a/docs/comparisons/grafana.md
+++ b/docs/comparisons/grafana.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Grafana"
+---
+
 # Logfire vs Grafana
 
 Grafana is a powerful open-source visualization platform that works with various data sources including Tempo (traces), Loki (logs), and Prometheus (metrics). Logfire is a managed observability platform with integrated visualization. Both can display your observability data, but they take very different approaches.

--- a/docs/comparisons/index.md
+++ b/docs/comparisons/index.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Alternatives"
+---
+
 # Logfire vs Alternatives
 
 ## AI Observability That Actually Works

--- a/docs/comparisons/langfuse.md
+++ b/docs/comparisons/langfuse.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Langfuse"
+---
+
 # Logfire vs Langfuse
 
 Both Logfire and Langfuse help you observe AI/LLM applications, but they take fundamentally different approaches. Langfuse focuses specifically on LLM tracing, while Logfire is an AI-native full-stack observability platform.

--- a/docs/comparisons/langsmith.md
+++ b/docs/comparisons/langsmith.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs LangSmith"
+---
+
 # Logfire vs LangSmith
 
 LangSmith is the observability and evaluation platform from the LangChain team. Logfire, combined with Pydantic AI, offers a production-grade alternative built on software engineering fundamentals.

--- a/docs/comparisons/sentry.md
+++ b/docs/comparisons/sentry.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs Sentry"
+---
+
 # Logfire vs Sentry
 
 Sentry is a mature error monitoring platform. Logfire is an AI-native observability platform built on OpenTelemetry with full-stack monitoring capabilities. While Sentry excels at catching and tracking errors, Logfire provides complete visibility into your application's behavior, AI to API.

--- a/docs/comparisons/signoz.md
+++ b/docs/comparisons/signoz.md
@@ -1,3 +1,7 @@
+---
+title: "Logfire vs SigNoz"
+---
+
 # Logfire vs SigNoz
 
 SigNoz is an open-source observability platform available as both a self-hosted solution and a managed cloud service. Logfire is an AI-native observability platform, also built on OpenTelemetry, with full-stack monitoring capabilities and (Enterprise) self-hosting options. Both platforms support logs, traces, and metrics, but they serve different needs.


### PR DESCRIPTION
## Problem

Logfire comparison documents rely on a compact sidebar label. Explicit metadata makes their intended page titles durable and clear at the source.

## Change

Add `title` frontmatter to the eight comparison documents that lacked it, matching each page's H1. `braintrust.md` already has equivalent metadata on the current base branch.

## Validation

- Reviewed the rendered output with the paired unified-docs sync change: titles and H1s render as `Logfire vs ...` while navigation remains compact.
- `git diff --check`

## Related

Paired with [pydantic/unified-docs#186](https://github.com/pydantic/unified-docs/pull/186), which separates sidebar labels from document titles.
