### PR TITLE
Document annotation categories, expected output, and export

### DIFF
--- a/docs/evaluate/annotate-agent-runs.md
+++ b/docs/evaluate/annotate-agent-runs.md
@@ -45,6 +45,21 @@ Use **Comment** to state the evidence you found in the run. Add **Tags** to grou
 
 ![The run annotation panel lets you choose a verdict, write a comment, and add tags.](../images/agent-run-annotation-form.png)
 
+### Add a category and an expected output
+
+Two more fields appear once a verdict says something went wrong. Both are optional.
+
+- **Category** appears for a **Neutral** or **Fail** verdict. Pick the failure mode from the list: `hallucination`, `wrong tool`, `off topic`, `refused`, `format error`, or `slow`. Using a consistent category is what lets you group failures later instead of reading every comment.
+- **Expected output** appears for a **Fail** verdict, and stays visible once it has content. Write the answer the agent should have given. This is the field that turns a failing run into a reusable test case, so write it out in full rather than describing it.
+
+## Export annotations for reuse
+
+On an agent's **Runs** tab, select **Export annotations** to download the saved annotations as a JSON Lines file (`annotations.jsonl`, one JSON object per line). Each line carries the run's trace and span IDs, agent name, verdict, category, expected output, comment, tags, the reviewer's email, and the timestamps.
+
+The export covers the runs currently in the table and respects its verdict, category, and tag filters. Filter to the failures you care about first, then export. An empty file usually means the filters exclude every saved annotation.
+
+Use the file to seed a [dataset](manage-datasets.md), so the runs your team marked **Fail** become the cases your next experiment has to pass.
+
 ## Verify the annotation
 
 After you save, the Runs tab's annotated count increases and the run shows its annotation. Return to **Annotations** to see the saved review in **Recent annotations**, where you can filter by verdict.
@@ -62,5 +77,6 @@ Open the interaction from **Agents** > **Runs**. Run annotations are attached to
 ## Next steps
 
 - [Human review](human-review.md): understand how direct review and annotation queues support evaluation work.
+- [Manage datasets](manage-datasets.md): turn exported annotations into repeatable test cases.
 - [Run an evaluation](evals-in-code.md): compare a fixed dataset against your scoring criteria.
 - [Live Evaluations](live-evals.md): score production traffic automatically, then use annotations for the cases that need human review.


### PR DESCRIPTION
`docs/evaluate/annotate-agent-runs.md` covered the verdict, comment, and tags, but three parts of the shipped annotation workflow were missing. Salvaged from #2085, which was closed as superseded.

- **Category**, the failure-mode dropdown shown for **Neutral** and **Fail** verdicts, with the six values it offers.
- **Expected output**, the corrected-answer field shown for **Fail** verdicts. This is the field that makes a failing run reusable as a test case.
- **Export annotations**, which downloads the runs table's annotations as JSON Lines, including which fields each line carries and how the table's filters narrow the export.

Export is the step that closes the loop from human review back to a dataset, so it also gets a pointer to [Manage datasets](https://github.com/pydantic/logfire/blob/main/docs/evaluate/manage-datasets.md).

## Verification

Each claim was checked against the current platform implementation rather than the UI alone: the field visibility rules and category list in `annotate-sidebar-form.tsx`, the export button and request in `agent-runs-table.tsx`, and the exported columns in `_annotation_export.py`.

`uv run pytest tests/test_docs.py -k formatting` passes.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

