### PR TITLE
Document how cases get into a hosted dataset

### DIFF
--- a/docs/evaluate/datasets-and-experiments.md
+++ b/docs/evaluate/datasets-and-experiments.md
@@ -26,6 +26,8 @@ The **New dataset** flow asks how you want to manage cases:
 
 Use stable dataset names so successive runs appear together. Names can contain `/`, which lets the Datasets page group related datasets by path prefix.
 
+The name is also the identity. Logfire keys the Datasets list on it, so a hosted dataset and a code-defined one sharing a name form a single entry carrying both the hosted cases and the experiment history. The choice above is therefore a starting point rather than a commitment: a dataset that begins in code can gain a hosted copy later under the same name.
+
 ## Use the workspace
 
 - [Manage datasets](manage-datasets.md) to find, create, import, and edit test cases.

--- a/docs/evaluate/datasets-sdk.md
+++ b/docs/evaluate/datasets-sdk.md
@@ -125,7 +125,7 @@ with LogfireAPIClient(api_key='your-api-key') as client:
 
 !!! note "Server-side limits on writes"
 
-    Cases are validated against the hosted dataset's JSON schemas on every write, and a request whose cases do not match is rejected in full rather than partially applied. A hosted dataset also holds at most 10,000 cases, so a bulk import beyond that fails instead of truncating. See [Manage datasets](manage-datasets.md#schemas-are-enforced-on-every-write).
+    Cases are validated against the hosted dataset's JSON schemas on every write, and a request whose cases do not match is rejected in full rather than partially applied. A hosted dataset also holds at most 10,000 cases, counted as the cases a push would create: updating existing named cases does not consume capacity, while every unnamed case does. A push that would exceed the limit fails instead of truncating. See [Manage datasets](manage-datasets.md#schemas-are-enforced-on-every-write).
 
 !!! note "Round-tripping evaluators"
 

--- a/docs/evaluate/datasets-sdk.md
+++ b/docs/evaluate/datasets-sdk.md
@@ -9,7 +9,7 @@ description: "Manage evaluation datasets programmatically with the Logfire Pytho
 
     The dataset management SDK is under `logfire.experimental.api_client`. The API may change in future releases.
 
-The SDK provides a typed Python client for managing datasets programmatically. This is the recommended approach when you want to define datasets in code, publish them to hosted storage, and later fetch them back for evaluation. You can also manage datasets through the [Web UI](datasets-and-experiments.md).
+The SDK provides a typed Python client for managing datasets programmatically. This is the recommended approach when you want to define datasets in code, publish them to hosted storage, and later fetch them back for evaluation. You can also [manage datasets in the web UI](manage-datasets.md).
 
 ## Installation
 
@@ -123,6 +123,10 @@ with LogfireAPIClient(api_key='your-api-key') as client:
 - it uploads all cases through the existing import/upsert API
 - it uses `on_case_conflict='update'` by default, so named cases are updated on repeat pushes
 
+!!! note "Server-side limits on writes"
+
+    Cases are validated against the hosted dataset's JSON schemas on every write, and a request whose cases do not match is rejected in full rather than partially applied. A hosted dataset also holds at most 10,000 cases, so a bulk import beyond that fails instead of truncating. See [Manage datasets](manage-datasets.md#schemas-are-enforced-on-every-write).
+
 !!! note "Round-tripping evaluators"
 
     `push_dataset(...)` uploads case-level evaluators with their cases, plus dataset-level `evaluators` and `report_evaluators` from the `Dataset` itself. Each push overwrites the hosted values, so removing an evaluator locally and re-pushing also clears it on the server.
@@ -229,4 +233,4 @@ client.delete_dataset('qa-golden-set')
 
 - **[Running Evaluations](evals-in-code.md)** --- Fetch your dataset and run evaluations with pydantic-evals.
 - **[SDK Reference](../reference/api/datasets.md)** --- Complete method signatures and exception reference.
-- **[Web UI Guide](datasets-and-experiments.md)** --- Manage datasets through the Logfire web interface.
+- **[Manage datasets](manage-datasets.md)** --- Create and curate datasets through the Logfire web interface.

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -86,7 +86,13 @@ A hosted dataset holds at most **10,000 cases**. Adding a case beyond that limit
 
 ### Schemas are enforced on every write
 
-If a dataset defines schemas, they are enforced on every write, not just used as a hint for teammates. Logfire validates each case against them whenever you add, update, or import one, through the UI and the SDK alike, and rejects the whole request when a field does not match. The error names the failing field and the reason.
+If a dataset defines schemas, they are enforced on every write, not just used as a hint for teammates. Logfire validates each case against them whenever you add, update, or import one, through the UI and the SDK alike, and rejects the whole request when a field does not match. A bulk import is rejected in full rather than partially applied.
+
+The error names the failing field and the reason, for example:
+
+```text
+Schema validation failed: inputs.question: 123 is not of type 'string'
+```
 
 Two details matter when you plan a schema:
 

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -86,7 +86,7 @@ Cases reach a hosted dataset three ways. They combine freely in one dataset:
 
 Adding from Live view is the path that turns production behavior into test cases, and it is usually where a shared dataset starts. The SDK is the only path that scales to many cases at once; the Cases tab reaches it through the code snippets described above, so bulk work runs from your machine rather than in the browser.
 
-A hosted dataset holds at most **10,000 cases**. Adding a case beyond that limit is rejected, including in bulk, so a large import needs splitting across datasets.
+A hosted dataset holds at most **10,000 cases**, counted as the cases a write would create. Updating a case that already matches by name does not consume capacity, so a dataset sitting at the limit can still be re-pushed; a case with no name always counts as new. An import that would take the dataset past 10,000 is rejected as a whole rather than partly applied, so a large one needs splitting across datasets.
 
 ### Schemas are enforced on every write
 
@@ -136,7 +136,7 @@ This is expected when the cases remain only in code. Use **Sync cases to Logfire
 
 Widen the time range and clear the type filter. Also check **Hidden** if you previously hid the dataset for yourself.
 
-If the project has a very large number of dataset names, the list is capped and keeps the most recently active names, so an older one can fall outside it. Search by name rather than scrolling: the search runs before the cap is applied, so it reaches datasets the list itself does not show.
+The code-defined half of the list is capped: if the project has a very large number of dataset names, it keeps the most recently active ones and an older name can fall outside the cap. Hosted datasets are not capped. Search by name rather than scrolling, because the search runs before the cap is applied and so reaches names the list itself does not show.
 
 A code-defined dataset also disappears once all of its experiments are archived, because nothing is left to derive it from. Hosted datasets are unaffected. Restore the dataset by unarchiving an experiment, or create a hosted dataset with that name to keep it in the list permanently.
 

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -68,7 +68,9 @@ After creation, use the **Cases** tab to maintain the dataset:
 
 **Add cases from code** and **Sync cases from code** both open a code snippet for you to run. Neither transfers anything on its own. Both arrive prefilled with the dataset's name and the type names taken from its schemas, so the difference is only which SDK call they hand you. `add_cases(...)` adds the cases you pass, updating any that match an existing case name. `push_dataset(...)` pushes a whole local `Dataset`: it creates or updates the hosted dataset's schemas and evaluators, then upserts the cases you passed.
 
-Neither call deletes anything. A case you remove from your local dataset stays in the hosted one until you delete it there, so a hosted dataset can accumulate cases your code no longer defines. See the [Datasets SDK](datasets-sdk.md) for both.
+Neither call deletes a case. One you remove from your local dataset stays in the hosted one until you delete it there, so a hosted dataset can accumulate cases your code no longer defines.
+
+Evaluators are the exception. They are overwritten by whatever you push rather than merged, so an evaluator you remove locally is cleared on the server by the next push. See the [Datasets SDK](datasets-sdk.md) for both.
 
 If Logfire already discovered a code-defined dataset with the same name, creating its hosted counterpart can import the latest cases instead of starting empty. Review the imported cases before relying on them as a shared test set.
 

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -79,10 +79,10 @@ Cases reach a hosted dataset three ways. They combine freely in one dataset:
 | Path | Volume | Use it when |
 | --- | --- | --- |
 | [Live view](#add-a-case-from-a-production-trace) | One case per span | A real request is worth keeping as a regression case |
-| [The Cases tab](#create-a-hosted-dataset) | One case at a time | You are hand-writing a specific edge case |
+| **Add case** on the [Cases tab](#create-a-hosted-dataset) | One case at a time | You are hand-writing a specific edge case |
 | [The SDK](datasets-sdk.md) | Bulk | Cases are generated, migrated, or already in code |
 
-Adding from Live view is the path that turns production behavior into test cases, and it is usually where a shared dataset starts. The SDK is the only path that scales to many cases at once.
+Adding from Live view is the path that turns production behavior into test cases, and it is usually where a shared dataset starts. The SDK is the only path that scales to many cases at once; the Cases tab reaches it through the code snippets described above, so bulk work runs from your machine rather than in the browser.
 
 A hosted dataset holds at most **10,000 cases**. Adding a case beyond that limit is rejected, including in bulk, so a large import needs splitting across datasets.
 

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -7,7 +7,16 @@ description: "Create a hosted or code-defined evaluation dataset, curate its cas
 
 Build a dataset, a stable collection of test cases that you can run repeatedly as your agent, model, or prompt changes.
 
-Open a project, then select **AI Evaluations** > **Datasets & experiments**. The **Datasets** tab shows hosted and code-defined datasets in the selected time range.
+Open a project, then select **AI Evaluations** > **Datasets & experiments**. The **Datasets** tab lists both kinds of dataset together.
+
+## Understand what the list contains
+
+The list combines two sources, keyed on the dataset name:
+
+- **Hosted** datasets are records stored on Logfire. They are always listed, whatever time range you have selected.
+- **Code-defined** datasets are not stored as records at all. Logfire derives them from the experiments that ran against them, so a code-defined dataset appears once an experiment reports its name, and only while that experiment falls inside the selected time range.
+
+A name that exists in both sources is **one row, not two**. Creating a hosted dataset named `support/routing` when your code already runs experiments under that name merges them: the row shows the hosted cases and the experiment history together, marked **Hosted**. This is why stable names matter. A name that changes between runs produces a new row each time instead of accumulating history under one.
 
 ## Find the dataset you need
 
@@ -16,7 +25,7 @@ Use the controls above the list to narrow a large project:
 - Search for a dataset name.
 - Filter **Type** to **Hosted** or **Code-defined**.
 - Set **Group by** to **Type**, **Path prefix**, or **None**.
-- Change the time range if an older dataset is missing.
+- Change the time range if an older code-defined dataset is missing.
 
 Choose stable, descriptive names. Use names such as `support/routing` and `support/response-quality` when path-prefix grouping will help your team navigate related datasets.
 
@@ -50,14 +59,41 @@ You can skip schemas and the first case. Add them later when the shape becomes c
 After creation, use the **Cases** tab to maintain the dataset:
 
 - **Add case** creates a case in the web UI.
-- **Add cases from code** shows the code needed to publish cases.
-- **Sync cases from code** imports code-defined cases into the hosted dataset.
+- **Add cases from code** opens a prefilled `add_cases(...)` snippet for appending or updating individual cases.
+- **Sync cases from code** opens a prefilled `push_dataset(...)` snippet for publishing a whole local dataset.
 - **Export** downloads the cases for reuse outside Logfire.
 - **Edit** changes the dataset name, description, or schemas.
 
 ![Edit the cases in a hosted dataset](../images/guide/evals/hosted-dataset-cases.webp)
 
+**Add cases from code** and **Sync cases from code** both open a code snippet for you to run. Neither transfers anything on its own. Both snippets arrive prefilled with the dataset's name and the type names taken from its schemas, so the difference between them is only which SDK call they hand you: `add_cases(...)` appends to what is already there, and `push_dataset(...)` publishes a local `Dataset` as a whole. See the [Datasets SDK](datasets-sdk.md) for both.
+
 If Logfire already discovered a code-defined dataset with the same name, creating its hosted counterpart can import the latest cases instead of starting empty. Review the imported cases before relying on them as a shared test set.
+
+## How cases get into a hosted dataset
+
+Cases reach a hosted dataset three ways. They combine freely in one dataset:
+
+| Path | Volume | Use it when |
+| --- | --- | --- |
+| [Live view](#add-a-case-from-a-production-trace) | One case per span | A real request is worth keeping as a regression case |
+| [The Cases tab](#create-a-hosted-dataset) | One case at a time | You are hand-writing a specific edge case |
+| [The SDK](datasets-sdk.md) | Bulk | Cases are generated, migrated, or already in code |
+
+Adding from Live view is the path that turns production behavior into test cases, and it is usually where a shared dataset starts. The SDK is the only path that scales to many cases at once.
+
+A hosted dataset holds at most **10,000 cases**. Adding a case beyond that limit is rejected, including in bulk, so a large import needs splitting across datasets.
+
+### Schemas are enforced on every write
+
+If a dataset defines schemas, they are enforced on every write, not just used as a hint for teammates. Logfire validates each case against them whenever you add, update, or import one, through the UI and the SDK alike, and rejects the whole request when a field does not match. The error names the failing field and the reason.
+
+Two details matter when you plan a schema:
+
+- Only fields that are present are validated. A schema on `expected_output` or `metadata` does not force a case to carry one; it constrains the value when a case does.
+- Schemas are enforced from the moment you define them, but they are not applied retroactively. Cases that predate a schema stay as they are, and you find out they no longer match the next time something writes to them.
+
+Define schemas once the shape of a case has settled. Adding them early to a dataset you are still exploring turns every subsequent write into a validation error.
 
 ## Add a case from a production trace
 
@@ -76,7 +112,7 @@ Before running an experiment, confirm that:
 
 - the dataset has a stable name that future runs will reuse;
 - hosted cases have the expected input and optional expected output;
-- schemas describe the data you want teammates to enter;
+- schemas match the cases already in the dataset, so later writes are not rejected;
 - the dataset appears in the intended path-prefix group;
 - **Review experiments** opens the expected run history.
 
@@ -90,9 +126,21 @@ This is expected when the cases remain only in code. Use **Sync cases to Logfire
 
 Widen the time range and clear the type filter. Also check **Hidden** if you previously hid the dataset for yourself.
 
+If the project has a very large number of dataset names, the list is capped and keeps the most recently active names, so an older one can fall outside it. Search by name rather than scrolling: the search runs before the cap is applied, so it reaches datasets the list itself does not show.
+
+A code-defined dataset also disappears once all of its experiments are archived, because nothing is left to derive it from. Hosted datasets are unaffected. Restore the dataset by unarchiving an experiment, or create a hosted dataset with that name to keep it in the list permanently.
+
+### A dataset is named `Untitled`
+
+An experiment that reports no dataset name is grouped under a single placeholder rather than being dropped. Every unnamed run in the project collects into that one row, so it is a mixture rather than a dataset. Set a `name` on the `Dataset` in your eval code to separate the runs.
+
 ### The list contains many one-off datasets
 
 Use **Group by: Path prefix** for consistently named datasets. Hide temporary entries for yourself, then change the code to reuse stable names for future runs.
+
+### Adding a case fails validation
+
+The dataset has schemas and the case does not match one of them. The error names the field and the reason. Either correct the case, or relax the schema under **Edit** if the dataset's shape has genuinely changed. Existing cases are not rechecked when you change a schema, so a dataset can hold cases that would no longer be accepted.
 
 ## Next steps
 

--- a/docs/evaluate/manage-datasets.md
+++ b/docs/evaluate/manage-datasets.md
@@ -66,7 +66,9 @@ After creation, use the **Cases** tab to maintain the dataset:
 
 ![Edit the cases in a hosted dataset](../images/guide/evals/hosted-dataset-cases.webp)
 
-**Add cases from code** and **Sync cases from code** both open a code snippet for you to run. Neither transfers anything on its own. Both snippets arrive prefilled with the dataset's name and the type names taken from its schemas, so the difference between them is only which SDK call they hand you: `add_cases(...)` appends to what is already there, and `push_dataset(...)` publishes a local `Dataset` as a whole. See the [Datasets SDK](datasets-sdk.md) for both.
+**Add cases from code** and **Sync cases from code** both open a code snippet for you to run. Neither transfers anything on its own. Both arrive prefilled with the dataset's name and the type names taken from its schemas, so the difference is only which SDK call they hand you. `add_cases(...)` adds the cases you pass, updating any that match an existing case name. `push_dataset(...)` pushes a whole local `Dataset`: it creates or updates the hosted dataset's schemas and evaluators, then upserts the cases you passed.
+
+Neither call deletes anything. A case you remove from your local dataset stays in the hosted one until you delete it there, so a hosted dataset can accumulate cases your code no longer defines. See the [Datasets SDK](datasets-sdk.md) for both.
 
 If Logfire already discovered a code-defined dataset with the same name, creating its hosted counterpart can import the latest cases instead of starting empty. Review the imported cases before relying on them as a shared test set.
 
@@ -99,7 +101,7 @@ Two details matter when you plan a schema:
 - Only fields that are present are validated. A schema on `expected_output` or `metadata` does not force a case to carry one; it constrains the value when a case does.
 - Schemas are enforced from the moment you define them, but they are not applied retroactively. Cases that predate a schema stay as they are, and you find out they no longer match the next time something writes to them.
 
-Define schemas once the shape of a case has settled. Adding them early to a dataset you are still exploring turns every subsequent write into a validation error.
+Define schemas once the shape of a case has settled. While the shape is still moving, a schema rejects each write that has drifted from it, so it is usually easier to add cases first and describe them once the pattern is clear.
 
 ## Add a case from a production trace
 


### PR DESCRIPTION
Follow-up to the concept gaps identified while revisiting #1876. That PR targeted `docs/evaluate/datasets/index.md`, which no longer exists after the evals docs restructure; this reworks the surviving concepts into the current page layout and corrects claims that no longer match the product.

## What was wrong

**Schemas read as advisory.** The docs said schemas "describe the data you want teammates to enter". They are enforced: every case is validated against the dataset's JSON schemas on add, update, and import, through the UI and SDK alike, and a non-matching request is rejected in full. Nothing warned a user that defining a schema can start rejecting writes, nor that existing cases are not rechecked when a schema changes, so a dataset can hold cases that would no longer be accepted.

**"Add cases from code" vs "Sync cases from code" were undistinguished, and one was described incorrectly.** They sat as adjacent bullets, the second claiming to import code-defined cases into the hosted dataset. Neither transfers anything. Both open a prefilled code snippet for you to run: `add_cases(...)` and `push_dataset(...)` respectively.

**The Datasets list was described as time-range-bounded for both kinds.** Hosted datasets are listed regardless of the selected time range. Only code-defined datasets are derived from experiments, so only those are bounded by it. The troubleshooting advice to widen the time range was therefore misleading for hosted datasets.

**The identity model was unstated.** The list is keyed on the dataset name, so a hosted dataset and a code-defined one sharing a name are a single row carrying both the hosted cases and the experiment history. This is the unstated reason "use stable names" keeps appearing as advice throughout these pages.

## What this adds

- A **"How cases get into a hosted dataset"** section: the three population paths (Live view, the Cases tab, the SDK) with their volume and when to reach for each, plus the 10,000-case ceiling.
- A **"Schemas are enforced on every write"** subsection: what is validated, the verbatim error format, that only present fields are checked (so a schema on `expected_output` or `metadata` does not make one mandatory), and that schema changes are not retroactive.
- Troubleshooting for: a case failing validation; the `Untitled` placeholder that collects every experiment reporting no dataset name; code-defined datasets disappearing once all their experiments are archived; and the list row cap, which makes search rather than scrolling the way to reach an old dataset.
- The identity/merge rule on the concept page.
- Repointed the SDK page's two "Web UI Guide" links at `manage-datasets.md`. They pointed at `datasets-and-experiments.md`, the concept page rather than the UI walkthrough.

## How the claims were verified

Every behavioral claim was checked by **executing the code**, not by reading it:

- **Frontend**, via vitest against the real modules: `getHostedAddCasesSnippet` emits `client.add_cases(...)` and `getHostedPushDatasetSnippet` emits `client.push_dataset(...)`, both prefilled with the dataset name and with type names taken from the schemas; `buildUnifiedDatasetsFromNames` collapses a hosted and a code-defined dataset of the same name into one `isHosted: true` row; `datasetDisplayName` renders the unnamed sentinel as `Untitled`.
- **Backend**, by running `_build_validators` / `_validate_case_against_schemas` under Python 3.14: a wrong-typed or missing required field is rejected with `Schema validation failed: inputs.question: 123 is not of type 'string'`; an absent or explicitly-null `expected_output` is accepted even when an output schema exists; a present-but-wrong one is rejected; with no schemas defined nothing is enforced. `MAX_CASES_PER_DATASET` is 10,000.
- The whole `src/app/evals` suite (77 files, 573 tests) passes on current `main`.

**Reviewer note, possible test gap:** no test in the backend suite asserts a schema-validation rejection. The raise sites carry `# pragma: full coverage`, and the case-limit path has a test (`'Dataset cannot exceed 10,000 cases'`) while the validation path does not. The behavior is real, but it is currently unguarded.

## Notes

- Prose only, no new Python examples, so the `test_docs` example checks are unaffected.
- These labels are what the `evals_workspace` flag produces. It is in `SHIPPED_FEATURE_FLAGS` and catalogued as a shipped fallback, so it defaults on; with it off the badge reads `Local` and the button reads `Push dataset from code`.
- I could not run a local stack in this environment: the egress policy returns 403 for both `us-docker.pkg.dev` and Docker Hub's blob CDN, so no images can be pulled or built. The verification above is what replaced it.
- I could not run the pre-commit hooks either: this environment has uv 0.8.17 and the repo requires >= 0.12.1. The hooks that apply to a Markdown-only change (`end-of-file-fixer`, `trailing-whitespace`) I verified by hand; the rest are Python- and workflow-scoped and match no file in this diff.
- One claim I deliberately did not make: what happens to an in-flight experiment when a schema is tightened mid-run, because I did not verify it.

Add the `trigger:docs` label if you want a rendered preview on this PR.