### PR TITLE
docs: recommend OpenInference for LangChain/LangGraph agents on the Agents page

### DIFF
--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -5,7 +5,7 @@ description: "See every AI agent in your project, drill into individual runs end
 
 # Agents
 
-The **Agents view** is the entry point for finding and inspecting the AI agents running in your application. Logfire discovers an agent automatically from your traces: any span that follows the [OpenTelemetry semantic conventions for generative AI (GenAI) agents](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md), specifically an `invoke_agent` operation (`gen_ai.operation.name = 'invoke_agent'`), becomes an agent run. [Pydantic AI](https://ai.pydantic.dev) emits these spans natively, and any other SDK that follows the conventions appears here too.
+The **Agents view** is the entry point for finding and inspecting the AI agents running in your application. Logfire discovers an agent automatically from your traces: any span that follows the [OpenTelemetry semantic conventions for generative AI (GenAI) agents](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md), specifically an `invoke_agent` operation (`gen_ai.operation.name = 'invoke_agent'`), becomes an agent run. [Pydantic AI](https://ai.pydantic.dev) emits these spans natively, and any other SDK that follows the conventions appears here too. Logfire also detects agents instrumented with [OpenInference](https://github.com/Arize-ai/openinference), which covers many popular frameworks; see [Supported frameworks](#supported-frameworks).
 
 You'll find Agents in the project sidebar. The time picker is shared with the rest of the observability surfaces.
 
@@ -16,6 +16,15 @@ Each agent detected in the selected time window appears as one row, with its run
 ![The Agents list, one card per detected agent](../../images/agents/agents-list.png)
 
 If you don't see an agent you expect, widen the time range: the list only reflects agent activity in the current window.
+
+## Supported frameworks
+
+Logfire detects an agent from either of two span conventions, so most agent frameworks appear on this page with no extra work:
+
+- **OpenTelemetry GenAI** (`gen_ai.operation.name = 'invoke_agent'`): [Pydantic AI](https://ai.pydantic.dev) emits these natively, as does any SDK that follows the [GenAI agent conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md).
+- **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, AutoGen, and the OpenAI Agents SDK.
+
+See the integration guide for your framework to set up the instrumentation that produces these spans.
 
 ## Agent detail
 

--- a/docs/integrations/llms/langchain.md
+++ b/docs/integrations/llms/langchain.md
@@ -21,6 +21,9 @@ environment variables, and Logfire receives the data.
 - Model calls, with the conversation and the number of tokens used
 - Nested steps of a chain or agent, shown as child spans in one trace
 
+!!! note "For the Agents page, instrument with OpenInference"
+    This LangSmith export shows your chains and agents in the [Live view](../../guides/web-ui/live.md), but it does not mark an agent root span, so your agents do not appear on the [Agents page](../../guides/web-ui/agents.md). To list them there, instrument with OpenInference instead: see [Show your agents on the Agents page](#show-your-agents-on-the-agents-page) below.
+
 !!! note "Prompts and responses are sent to Logfire"
     Your prompts, the model's responses, and any tool inputs are recorded as span attributes and
     stored in Logfire, so they can include personal or proprietary data. Use
@@ -91,6 +94,35 @@ Run your program, then open your project in the
 [Logfire web app](https://logfire.pydantic.dev/) and go to the **Live** view. Within a few seconds you
 should see a trace for the agent run, with a span for each step. Click into it to see the model calls
 and tool calls.
+
+## Show your agents on the Agents page
+
+The LangSmith export above lands your traces in the [Live view](../../guides/web-ui/live.md), but it does not mark an agent root span, so your agents do not appear on the [Agents page](../../guides/web-ui/agents.md). If you want them there, instrument with [OpenInference](https://github.com/Arize-ai/openinference) instead of the LangSmith export:
+
+```bash
+pip install openinference-instrumentation-langchain
+```
+
+```python skip-run="true" skip-reason="external-connection"
+from openinference.instrumentation.langchain import LangChainInstrumentor
+
+import logfire
+
+logfire.configure()
+LangChainInstrumentor().instrument()
+```
+
+### Deep agents
+
+A [deep agent](https://github.com/langchain-ai/deepagents) built with `create_deep_agent` runs as a LangGraph graph. OpenInference marks the graph's root span as the agent only when the agent has a name, so pass `name=`:
+
+```python skip="true" skip-reason="incomplete"
+from deepagents import create_deep_agent
+
+agent = create_deep_agent(tools=[...], system_prompt='...', name='research_agent')
+```
+
+The deep agent then appears on the Agents page as `research_agent`. Without a name, its root span is a generic graph span, so it does not appear as its own row. Sub-agents run as nested graphs, so only the top-level deep agent appears; the sub-agent's own model and tool calls are still visible inside that agent's runs.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What
Documents that agents appear on the **Agents** page via the OpenTelemetry GenAI `invoke_agent` span or an OpenInference `AGENT` span, and recommends **OpenInference** for LangChain/LangGraph agents.

## Changes
- **`guides/web-ui/agents.md`**: a framework-agnostic **"Supported frameworks"** section: the two detection conventions and the frameworks each covers, pointing readers to each framework's integration guide. No framework-specific setup lives on the Agents page.
- **`integrations/llms/langchain.md`**: a **"Show your agents on the Agents page"** section (with an early pointer note). It explains that the LangSmith OpenTelemetry export lands traces in the Live view but marks no agent root span, so to list agents on the Agents page you instrument with `openinference-instrumentation-langchain` instead. A **Deep agents** subsection documents that you must pass `name=` to `create_deep_agent` (its root is otherwise a generic graph span) and that sub-agents run as nested graphs, so only the top-level agent appears.

## Why OpenInference
The OTel GenAI `invoke_agent` LangChain instrumentation is still beta and currently errors on LangGraph 1.x, so OpenInference is the reliable path to get LangChain/LangGraph agents (including deep agents) on the Agents page today. Verified against real captures on the backend.

## Verification
`tests/test_docs.py::test_formatting` passes; internal links resolve; Python examples are tagged `skip-run` / `skip` so the docs runner does not execute them.