### PR TITLE
docs: note OpenInference agents show no aggregate cost

### DIFF
--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -24,6 +24,9 @@ Logfire detects an agent from either of two span conventions, so most agent fram
 - **OpenTelemetry GenAI** (`gen_ai.operation.name = 'invoke_agent'`): [Pydantic AI](https://ai.pydantic.dev) emits these natively, as does any SDK that follows the [GenAI agent conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md).
 - **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, AutoGen, and the OpenAI Agents SDK.
 
+!!! note "Cost for OpenInference-detected agents"
+    OpenInference spans don't report a per-call cost, so these agents show no cost in the Agents list and the **Metrics** tab. An individual run's **Summary** still shows an estimated cost, derived from its model and token counts.
+
 See the integration guide for your framework to set up the instrumentation that produces these spans.
 
 ## Agent detail


### PR DESCRIPTION
Follow-up to #2270 (CodeRabbit asked us to state OpenInference cost fidelity).

OpenInference spans carry no per-call cost, so the **Agents list** and **Metrics** tab cost totals read zero for OpenInference-detected agents. An individual run's **Summary** still shows an estimated cost, derived from its model and token counts (Logfire computes it client-side via `@pydantic/genai-prices`).

This is the accurate, narrow limitation. An earlier draft caveat claimed cost, the Tools tab, and the Messages tab were all unpopulated for OpenInference; verifying against the code showed those are populated in the run detail, so that draft was dropped.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

