### PR TITLE
docs: add OpenTelemetry migration guides + correct HTTP-only gRPC guidance

### DIFF
--- a/docs/how-to-guides/alternative-clients.md
+++ b/docs/how-to-guides/alternative-clients.md
@@ -15,13 +15,13 @@ these [environment variables](https://opentelemetry.io/docs/languages/sdk-config
     - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://logfire-us.pydantic.dev/v1/traces` for just traces
     - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://logfire-us.pydantic.dev/v1/metrics` for just metrics
     - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://logfire-us.pydantic.dev/v1/logs` for just logs
-- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` so the SDK exports over HTTP (see the warning below).
+- `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` so the SDK exports over HTTP (see the note below).
 - `OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` - see [Create Write Tokens](./create-write-tokens.md)
   to obtain a write token and replace `your-write-token` with it.
 - `OTEL_SERVICE_NAME=your-service-name` to set the name your service is grouped under in Logfire. Without it, your data appears under `(unknown)` in the [Services](../guides/web-ui/services.md) view.
 
-!!! warning "Set the protocol to `http/protobuf`"
-    Logfire receives OpenTelemetry data over HTTP, but many SDKs (for example Java, .NET, and anything using a gRPC exporter) default to gRPC. When an SDK exports over gRPC, it sends nothing to Logfire, often with only a connection error, or no error at all. Setting `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or the equivalent in code) is the most common fix when data never arrives.
+!!! note "HTTP or gRPC"
+    Logfire's managed platform accepts OpenTelemetry data over both HTTP and gRPC. This page uses HTTP (`http/protobuf`) because every SDK supports it out of the box; if your SDK defaults to gRPC (for example Java and .NET), you can leave it on gRPC or set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` to match these examples.
 
 !!! note
     This page shows `https://logfire-us.pydantic.dev` as the base URL which is for the US [region](../reference/data-regions.md).
@@ -180,7 +180,7 @@ Run your program, then open the [Live view](../guides/web-ui/live.md) for your p
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| Nothing arrives, with a connection error or no error at all | The SDK is exporting over its default gRPC protocol | Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or the equivalent in code). Logfire receives data over HTTP only. |
+| Nothing arrives, with a connection error or no error at all | The endpoint points at the wrong region, or (older self-hosted) a build without gRPC ingest | Confirm the endpoint matches your [data region](../reference/data-regions.md); on an older self-hosted Logfire, set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`. |
 | Requests rejected with `401` or `403` | Missing or invalid write token | Set `OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'` with a valid [write token](./create-write-tokens.md). |
 | Data appears under `(unknown)` in the [Services](../guides/web-ui/services.md) view | No service name set | Set `OTEL_SERVICE_NAME=your-service-name`. |
 | Connection or TLS errors | The endpoint points at the wrong region | Use `https://logfire-us.pydantic.dev` (US) or `https://logfire-eu.pydantic.dev` (EU). |

--- a/docs/languages/dotnet.md
+++ b/docs/languages/dotnet.md
@@ -41,8 +41,8 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 
 The endpoint above is for the US [data region](../reference/data-regions.md). If your project is in the EU region, use `https://logfire-eu.pydantic.dev` instead.
 
-!!! warning "Set the protocol to `http/protobuf`"
-    The .NET OTLP exporter defaults to gRPC, but Logfire receives data over OTLP on HTTP. You must set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or set it in code, shown below), otherwise nothing is sent and you get a connection error.
+!!! note "HTTP or gRPC"
+    The .NET OTLP exporter defaults to gRPC. Logfire's managed platform accepts both gRPC and HTTP, so the default works; this page uses HTTP (`http/protobuf`) to match the other language guides. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` (or set it in code, shown below) to follow these examples.
 
 **3. Add the code**
 
@@ -102,7 +102,7 @@ If you would rather not set environment variables, pass the options to `AddOtlpE
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Connection refused, or nothing arrives | The exporter is still using its default gRPC protocol against Logfire's HTTP endpoint | Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, or `Protocol = OtlpExportProtocol.HttpProtobuf` in code |
+| Connection refused, or nothing arrives | The endpoint points at the wrong region | Confirm the endpoint matches your [data region](../reference/data-regions.md) (`logfire-us`/`logfire-eu`) |
 | Nothing exported even though config looks right | The tracer provider only records sources you register | Make sure `.AddSource("...")` matches the name you passed to `new ActivitySource("...")` |
 | A 404 when configuring the endpoint in code | With `http/protobuf`, the code `Endpoint` property is used as-is and does not append the signal path | Include `/v1/traces` in the URL, or use the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable (which appends it for you) |
 | Can't tell what the SDK is doing | No local visibility into what is being recorded | Add the `OpenTelemetry.Exporter.Console` package, then `.AddConsoleExporter()` to the builder, to print each span to your terminal as it is created |

--- a/docs/languages/java.md
+++ b/docs/languages/java.md
@@ -69,7 +69,7 @@ Each row is one span, with its service, name, and duration. The screenshot shows
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| Nothing arrives | An older 1.x agent defaulted to gRPC | Upgrade to a 2.x agent, or keep `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` set |
+| Nothing arrives | The endpoint points at the wrong region | Confirm the endpoint matches your [data region](../reference/data-regions.md) |
 | No spans appear at all | The app did no instrumented work | Trigger an HTTP request or database call, or add [manual instrumentation](https://opentelemetry.io/docs/languages/java/api/) for your own code |
 | Can't tell what the agent is doing | No visibility into what it instruments | Run with `-Dotel.javaagent.debug=true` to log what the agent instruments and why nothing exports |
 | Connection or region errors | Wrong base URL | Give the bare base URL (`https://logfire-us.pydantic.dev`); the agent appends `/v1/traces`. Check the URL matches your [data region](../reference/data-regions.md) |

--- a/docs/migrating/aws.md
+++ b/docs/migrating/aws.md
@@ -1,0 +1,61 @@
+---
+title: "Migrate from AWS (CloudWatch / X-Ray) to Logfire"
+description: "Swap the AWS Distro for OpenTelemetry (ADOT) Collector's awsemf/awsxray exporters for an otlphttp exporter pointed at Logfire."
+---
+
+# Migrate from AWS (CloudWatch / X-Ray)
+
+If you send telemetry to Amazon CloudWatch and AWS X-Ray, you're most likely running the **AWS Distro for OpenTelemetry** (ADOT) Collector, exporting through the `awsxray` (traces), `awsemf` (metrics), and `awscloudwatchlogs` (logs) exporters. ADOT is a standard OpenTelemetry Collector, so migrating to Logfire means swapping those AWS exporters for an `otlphttp` exporter — see [Migrate to Logfire](overview.md) for the general shape.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If you run the ADOT Collector
+
+Replace the AWS exporters with one that targets Logfire, and reference it from each pipeline. Your receivers and processors don't change.
+
+The AWS exporters carry no credentials — they authenticate through the instance/task IAM role (the AWS SDK credential chain). Logfire uses a write token instead, in the `Authorization` header below.
+
+```yaml
+exporters:
+  # remove (or keep alongside during cutover):
+  # awsxray: {}
+  # awsemf: {}
+  # awscloudwatchlogs:
+  #   log_group_name: "your-log-group"
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+Because a pipeline can fan out, you can keep the AWS exporters and add `otlphttp/logfire` alongside them to run in parallel, then remove the AWS ones once you've rebuilt what you need in Logfire.
+
+## If your apps export OTLP
+
+If your services export OpenTelemetry Protocol (OTLP) straight to the ADOT Collector's OTLP receiver, point the SDK at Logfire instead:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Host & Kubernetes monitoring](../how-to-guides/otel-collector/otel-collector-overview.md) — collect infrastructure metrics with the Collector, the CloudWatch-style signals you may be replacing
+- AWS's own docs, to confirm your current ADOT exporters: [AWS Distro for OpenTelemetry — Collector](https://aws-otel.github.io/docs/getting-started/collector)

--- a/docs/migrating/datadog.md
+++ b/docs/migrating/datadog.md
@@ -1,0 +1,66 @@
+---
+title: "Migrate from Datadog to Logfire"
+description: "Move your OpenTelemetry traces, metrics, and logs from Datadog to Logfire by repointing the exporter — whether you send OTLP to the Datadog Agent or run the Datadog Distribution of the OpenTelemetry Collector."
+---
+
+# Migrate from Datadog
+
+Datadog ingests OpenTelemetry (OTel) two ways: OTel SDKs that export to the **Datadog Agent's** OpenTelemetry Protocol (OTLP) intake, or the **Datadog Distribution of the OpenTelemetry Collector** (DDOT) with the `datadog` exporter. In both cases your instrumentation is standard OpenTelemetry, so moving to Logfire is an exporter change — see [Migrate to Logfire](overview.md) for the general shape.
+
+!!! note "If you use `dd-trace` libraries"
+    Datadog's tracing libraries (`dd-trace-py`, `dd-trace-js`, …) are proprietary, not OpenTelemetry. If your apps are instrumented with those rather than OTel, adopt OpenTelemetry instrumentation first; from then on this guide applies. Anything already emitting OTLP just needs repointing.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP to the Datadog Agent
+
+You were pointing the OpenTelemetry SDK at the Agent's OTLP receiver (usually `http://localhost:4317`/`:4318`), or straight at Datadog's Direct OTLP Ingest endpoint. Either way, point it at Logfire instead — no agent in the middle:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## If you run a Collector with the `datadog` exporter (DDOT or upstream)
+
+Replace the `datadog` exporter with an `otlphttp` exporter that targets Logfire, and reference it from each pipeline. Receivers and processors stay as they are.
+
+```yaml
+exporters:
+  # remove (or keep alongside during cutover):
+  # datadog:
+  #   api:
+  #     site: datadoghq.com  # yours may differ: datadoghq.eu, us5.datadoghq.com, etc.
+  #     key: ${env:DD_API_KEY}
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+To run both during a cutover, list both exporters (`[datadog, otlphttp/logfire]`) and compare the same traffic in each backend before dropping Datadog.
+
+!!! note "HTTP or gRPC"
+    Logfire's managed platform accepts OTLP over both HTTP and gRPC. These examples use HTTP, the most broadly supported option.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds. If not, re-check the write token and region.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- [Logfire vs Datadog](https://pydantic.dev/logfire/vs-datadog) — how the platforms compare
+- Datadog's own docs, to confirm your current setup: [OpenTelemetry Collector & the Datadog exporter](https://docs.datadoghq.com/opentelemetry/setup/collector_exporter/)

--- a/docs/migrating/dynatrace.md
+++ b/docs/migrating/dynatrace.md
@@ -1,0 +1,58 @@
+---
+title: "Migrate from Dynatrace to Logfire"
+description: "Dynatrace exposes a native OTLP endpoint and ships its own Collector distribution — repoint either at Logfire with an exporter change."
+---
+
+# Migrate from Dynatrace
+
+Dynatrace has a native OTLP HTTP endpoint (`https://<your-env>.live.dynatrace.com/api/v2/otlp`), authenticated with an `Authorization: Api-Token <token>` header, and ships the **Dynatrace Distribution of the OpenTelemetry Collector** (the Dynatrace OTel Collector). Both are standard OpenTelemetry, so migrating to Logfire is an exporter change — see [Migrate to Logfire](overview.md) for the general shape.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP
+
+Point the SDK at Logfire and replace the Dynatrace API token with Logfire's write token:
+
+```sh
+# before (Dynatrace):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<env>.live.dynatrace.com/api/v2/otlp
+#   OTEL_EXPORTER_OTLP_HEADERS='Authorization=Api-Token dt0c01.XXXX'
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## If you run the Dynatrace Collector
+
+Replace the Dynatrace OTLP exporter with one that targets Logfire:
+
+```yaml
+exporters:
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      # was: Authorization: "Api-Token dt0c01.XXXX"
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+Keep both exporters in the pipeline to run in parallel during a cutover.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- Dynatrace's own docs, to confirm your current endpoint and token: [Export with OTLP](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/getting-started/otlp-export)

--- a/docs/migrating/elastic.md
+++ b/docs/migrating/elastic.md
@@ -1,0 +1,62 @@
+---
+title: "Migrate from Elastic to Logfire"
+description: "Repoint the Elastic Distributions of OpenTelemetry (EDOT) — or any OTLP exporter aimed at your Elastic OTLP endpoint — at Logfire."
+---
+
+# Migrate from Elastic
+
+Elastic's observability is fed by OTLP, either through the **Elastic Distributions of OpenTelemetry** (EDOT — Elastic's Collector and SDK distributions) or by pointing OTel SDKs at the **Elastic Cloud Managed OTLP Endpoint** (mOTLP). Authentication uses an `Authorization: ApiKey <key>` header. Because it's standard OpenTelemetry, migrating to Logfire is an exporter change — see [Migrate to Logfire](overview.md) for the general shape.
+
+!!! note "On an older Elastic Cloud APM deployment?"
+    If your config points at `https://<deployment>.apm.<region>.cloud.es.io:443` with an `Authorization=Bearer <secret-token>` header (rather than the Managed OTLP Endpoint and `ApiKey`), the migration is identical — swap that endpoint and header for the two Logfire lines below.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP
+
+Point the SDK at Logfire and replace Elastic's API key header with Logfire's write token:
+
+```sh
+# before (Elastic — copy your Managed OTLP Endpoint from Elastic Cloud; the
+# API key from Kibana does not include the "ApiKey " scheme, so add it yourself):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://<your-managed-otlp-endpoint>
+#   OTEL_EXPORTER_OTLP_HEADERS='Authorization=ApiKey your-elastic-api-key'
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## If you run the EDOT Collector
+
+Change the exporter's endpoint and header to Logfire's:
+
+```yaml
+exporters:
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      # was: Authorization: "ApiKey your-elastic-api-key"
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+Keep both exporters in the pipeline to run in parallel during a cutover.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- Elastic's own docs, to confirm your current endpoint and header: [Elastic Cloud Managed OTLP Endpoint](https://www.elastic.co/docs/reference/opentelemetry/motlp)

--- a/docs/migrating/grafana.md
+++ b/docs/migrating/grafana.md
@@ -1,0 +1,55 @@
+---
+title: "Migrate from Grafana Cloud to Logfire"
+description: "Repoint Grafana Alloy — or any OTLP exporter aimed at Grafana Cloud's Tempo/Loki/Mimir — at Logfire, and query everything with SQL instead of three languages."
+---
+
+# Migrate from Grafana Cloud
+
+Grafana Cloud's recommended pipeline is **Grafana Alloy**, Grafana's distribution of the OpenTelemetry Collector, exporting OTLP to the Grafana Cloud endpoint (Tempo for traces, Loki for logs, Mimir for metrics). Because that's standard OpenTelemetry, migrating to Logfire is an exporter change — see [Migrate to Logfire](overview.md) for the general shape.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP to Grafana Cloud
+
+Grafana Cloud authenticates OTLP with HTTP Basic auth (`instanceID:token`). Point the SDK at Logfire and replace that with Logfire's `Authorization` header:
+
+```sh
+# before (Grafana Cloud — copy your exact values from the Grafana Cloud
+# "OpenTelemetry" tile, which generates the endpoint and Basic-auth header):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp-gateway-<region>.grafana.net/otlp
+#   OTEL_EXPORTER_OTLP_HEADERS='Authorization=Basic <base64 instanceID:token>'
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## If you run Grafana Alloy
+
+Change the `otelcol.exporter.otlphttp` block's endpoint and auth to Logfire, and keep the rest of your pipeline. Alloy uses its own configuration syntax:
+
+```hcl
+otelcol.exporter.otlphttp "logfire" {
+  client {
+    endpoint = "https://logfire-us.pydantic.dev"  // or https://logfire-eu.pydantic.dev
+    headers  = {
+      "Authorization" = "Bearer " + sys.env("LOGFIRE_TOKEN"),
+    }
+  }
+}
+```
+
+Then point your processors' `output` at `otelcol.exporter.otlphttp.logfire.input`. During a cutover you can send to both Grafana Cloud and Logfire from the same pipeline.
+
+!!! note "Three query languages → one"
+    Grafana uses PromQL, LogQL, and TraceQL — one per signal. Logfire queries traces, metrics, and logs together with SQL (PostgreSQL-compatible), so dashboards and alerts you rebuild in Logfire share a single query language.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Logfire vs Grafana](https://pydantic.dev/logfire/vs-grafana) — how the platforms compare
+- Grafana's own docs, to confirm your current endpoint and header: [Send data to the Grafana Cloud OTLP endpoint](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) and the [`otelcol.exporter.otlphttp`](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlphttp/) Alloy component

--- a/docs/migrating/honeycomb.md
+++ b/docs/migrating/honeycomb.md
@@ -1,0 +1,61 @@
+---
+title: "Migrate from Honeycomb to Logfire"
+description: "Honeycomb is OpenTelemetry-native, so moving to Logfire is a one-line exporter change: swap the endpoint and the x-honeycomb-team header for Logfire's."
+---
+
+# Migrate from Honeycomb
+
+Honeycomb is OpenTelemetry-native — you already send OpenTelemetry Protocol (OTLP) data, authenticated with the `x-honeycomb-team` header, to `api.honeycomb.io` (or `api.eu1.honeycomb.io` for EU). Migrating to Logfire swaps the endpoint and that header for Logfire's `Authorization` header. Nothing else changes; see [Migrate to Logfire](overview.md) for the general shape.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP
+
+Point the SDK's OTLP variables at Logfire and replace the Honeycomb team header with `Authorization`:
+
+```sh
+# before (Honeycomb):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+#   OTEL_EXPORTER_OTLP_HEADERS='x-honeycomb-team=your-honeycomb-key'
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+## If you run the OpenTelemetry Collector
+
+Change the Honeycomb exporter's endpoint and header to Logfire's:
+
+```yaml
+exporters:
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      # was: "x-honeycomb-team": "your-honeycomb-key"
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+To cut over gradually, keep both exporters in the pipeline and compare the same traffic in each before removing Honeycomb.
+
+!!! note "Datasets → SQL"
+    Honeycomb groups data into datasets you query with its Query Builder. In Logfire everything lives in one project you query with SQL (PostgreSQL-compatible), so a saved Honeycomb query becomes a SQL statement. If your setup also sends an `x-honeycomb-dataset` header (required by Honeycomb Classic, and by metrics even in the Environments model), just drop it — Logfire routes everything into one project and doesn't use dataset headers.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- Honeycomb's own docs, to confirm your current endpoint and header: [Send Data with the OpenTelemetry Collector](https://docs.honeycomb.io/send-data/opentelemetry/collector)

--- a/docs/migrating/new-relic.md
+++ b/docs/migrating/new-relic.md
@@ -1,0 +1,66 @@
+---
+title: "Migrate from New Relic to Logfire"
+description: "New Relic accepts OTLP directly, so migrating to Logfire swaps the endpoint and the api-key header for Logfire's Authorization header."
+---
+
+# Migrate from New Relic
+
+New Relic accepts OpenTelemetry data over OTLP — the OpenTelemetry Protocol — at `otlp.nr-data.net`, authenticated with an `api-key` header carrying your license key. Migrating to Logfire swaps the endpoint and that header — see [Migrate to Logfire](overview.md) for the general shape.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If your apps export OTLP
+
+Point the SDK at Logfire and replace New Relic's `api-key` header with `Authorization`:
+
+```sh
+# before (New Relic):
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net   # EU: otlp.eu01.nr-data.net · FedRAMP: gov-otlp.nr-data.net
+#   OTEL_EXPORTER_OTLP_HEADERS='api-key=your-license-key'
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+New Relic recommends OTLP over HTTP (`http/protobuf`); keeping that protocol when you repoint is the simplest path. (Logfire's managed platform accepts both HTTP and gRPC.)
+
+!!! note "Metric temporality"
+    New Relic requires delta metric temporality, so you likely set `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta`. You can leave it — Logfire accepts delta (its own SDK uses delta for counters and histograms) — or drop the override to fall back to your SDK's default.
+
+## If you run the OpenTelemetry Collector
+
+Change the exporter's endpoint and header to Logfire's:
+
+```yaml
+exporters:
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      # was: api-key: your-license-key
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+Keep both exporters in the pipeline to run in parallel during a cutover.
+
+!!! note "HTTP or gRPC"
+    Logfire's managed platform accepts OTLP over both HTTP and gRPC. These examples use HTTP, the most broadly supported option.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- New Relic's own docs, to confirm your current endpoint and header: [OpenTelemetry: OTLP](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/)

--- a/docs/migrating/overview.md
+++ b/docs/migrating/overview.md
@@ -1,0 +1,106 @@
+---
+title: "Migrate to Logfire from another OpenTelemetry backend"
+description: "Already sending OpenTelemetry data to Datadog, Grafana, Honeycomb, or another vendor? Migrate to Logfire by repointing your exporter — no re-instrumentation, no application code changes."
+---
+
+# Migrate to Logfire
+
+Logfire is a fully compliant [OpenTelemetry](https://opentelemetry.io/) backend. If your services already emit OpenTelemetry data — from OTel SDKs, from a Collector distribution such as [Grafana Alloy](grafana.md), the [Splunk](splunk.md) or [Datadog](datadog.md) distro, [ADOT](aws.md), or [EDOT](elastic.md), or from a vendor agent's OTLP intake — you already did the hard part. Migrating to Logfire means **repointing the exporter**, not re-instrumenting your applications.
+
+Nothing about your instrumentation changes: the same spans, metrics, and logs your code already produces are sent to Logfire instead of (or as well as) your current vendor. There is no proprietary agent and no Logfire-specific SDK requirement — the standard OpenTelemetry exporter is all you need.
+
+## What you need
+
+- **A Logfire project and its write token.** The write token is the credential that selects the destination project and authorizes writes. Create one under **Project → Settings → Write tokens** (see [Create Write Tokens](../how-to-guides/create-write-tokens.md)). Treat it like a password: set it from an environment variable, never commit it.
+- **Your data region's endpoint:**
+    - US: `https://logfire-us.pydantic.dev`
+    - EU: `https://logfire-eu.pydantic.dev`
+
+  Every example below uses the US endpoint; swap in the EU one if your project lives there. See [Data regions](../reference/data-regions.md).
+
+## The two paths
+
+However your telemetry reaches your current vendor, one of these two changes points it at Logfire instead.
+
+### Path A — OTel SDKs (or any OTLP exporter)
+
+If your applications export OTLP directly (via the OpenTelemetry SDK's environment variables, or a vendor SDK built on OTel), set three variables:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+# optional but recommended, so your service isn't grouped under "(unknown)":
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+That's the whole change. See [Alternative clients](../how-to-guides/alternative-clients.md) for worked Python, Node.js, and Rust examples.
+
+!!! note "Agent-side processing"
+    If your telemetry currently flows through a vendor agent or Collector that samples, filters, enriches, or scrubs it, sending straight from an SDK skips that processing. Keep an OpenTelemetry Collector in the path (Path B), with the same processors, if you rely on it.
+
+### Path B — the OpenTelemetry Collector (any distribution)
+
+If you run a Collector — the upstream `otelcol`, or a vendor distribution like Alloy, ADOT, EDOT, or the Splunk/Datadog distros — add an `otlphttp` exporter that targets Logfire and reference it from each pipeline:
+
+```yaml
+exporters:
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+Your receivers and processors don't change. See the [OpenTelemetry Collector](../how-to-guides/otel-collector/otel-collector-overview.md) guide for the full picture.
+
+!!! note "HTTP or gRPC"
+    Logfire's managed platform accepts OTLP over both **HTTP** and **gRPC**. These examples use HTTP (`http/protobuf`) because every OpenTelemetry SDK and Collector supports it out of the box.
+
+## Cut over without a gap
+
+Because an OpenTelemetry pipeline can fan out to more than one destination, you don't have to switch in one step. Keep your existing exporter and add Logfire alongside it, then compare the same traffic in both backends before you remove the old one:
+
+```yaml
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/your-current-vendor, otlphttp/logfire]
+```
+
+Run in parallel for as long as you like, rebuild the dashboards and alerts you rely on in Logfire, then drop the old exporter.
+
+## What changes, and what doesn't
+
+| Stays the same | You rebuild in Logfire |
+| --- | --- |
+| Your instrumentation (SDKs, auto-instrumentation, semantic conventions) | Dashboards |
+| The spans, metrics, and logs you already emit | Alerts |
+| Your Collector receivers and processors | Saved queries / monitors |
+
+Instrumentation is portable because it's OpenTelemetry; dashboards and alerts are vendor-specific by nature, so those are recreated once against Logfire. Logfire queries everything with SQL (PostgreSQL-compatible), so a saved query is a SQL statement rather than a proprietary expression.
+
+## Per-vendor guides
+
+- [Datadog](datadog.md)
+- [Grafana Cloud / Grafana Alloy](grafana.md)
+- [Honeycomb](honeycomb.md)
+- [New Relic](new-relic.md)
+- [Dynatrace](dynatrace.md)
+- [Splunk Observability Cloud](splunk.md)
+- [Elastic](elastic.md)
+- [AWS (ADOT → CloudWatch / X-Ray)](aws.md)
+
+Using a backend that isn't listed? If it speaks OTLP, the two paths above still apply — point the exporter at Logfire.
+
+## Verify
+
+Run your workload, then open the [Live view](../guides/web-ui/live.md) for your project. New traces should appear within a few seconds. If nothing shows up, confirm the write token is set and the endpoint matches your data region.

--- a/docs/migrating/splunk.md
+++ b/docs/migrating/splunk.md
@@ -1,0 +1,70 @@
+---
+title: "Migrate from Splunk Observability Cloud to Logfire"
+description: "Swap the Splunk Distribution of the OpenTelemetry Collector's sapm/signalfx exporters for an otlphttp exporter pointed at Logfire."
+---
+
+# Migrate from Splunk Observability Cloud
+
+Splunk Observability Cloud is fed by the **Splunk Distribution of the OpenTelemetry Collector**, which exports through the `sapm` (traces) and `signalfx` (metrics) exporters — and often `splunk_hec` for logs — to a realm-based ingest endpoint, authenticated with an access token. Those are Splunk-specific exporters wrapped around standard OpenTelemetry data, so migrating to Logfire means swapping them for an `otlphttp` exporter — see [Migrate to Logfire](overview.md) for the general shape.
+
+!!! note "Newer Splunk collectors already use `otlphttp`"
+    Splunk now recommends `otlphttp` for traces; the `sapm` exporter is deprecated. If your collector already uses `otlphttp` with an `X-SF-Token` header, the change is even smaller — repoint the endpoint to Logfire and swap `X-SF-Token: <token>` for `Authorization: Bearer <token>`.
+
+You'll need a Logfire [write token](../how-to-guides/create-write-tokens.md) and your [region](../reference/data-regions.md) endpoint (`https://logfire-us.pydantic.dev` or `-eu`).
+
+## If you run the Splunk Collector
+
+Replace the Splunk exporters with one that targets Logfire, and reference it from each pipeline. Your receivers and processors don't change.
+
+```yaml
+exporters:
+  # remove (or keep alongside during cutover):
+  # sapm:                      # traces
+  #   access_token: "${env:SPLUNK_ACCESS_TOKEN}"
+  #   endpoint: "https://ingest.<realm>.signalfx.com/v2/trace"
+  # signalfx:                  # metrics
+  #   access_token: "${env:SPLUNK_ACCESS_TOKEN}"
+  #   realm: "<realm>"
+  # splunk_hec:                # logs (and splunk_hec/profiling, if present)
+  #   token: "${env:SPLUNK_HEC_TOKEN}"
+  #   endpoint: "https://<splunk-host>:8088/services/collector"
+  otlphttp/logfire:
+    endpoint: "https://logfire-us.pydantic.dev"  # or https://logfire-eu.pydantic.dev
+    headers:
+      Authorization: "Bearer ${env:LOGFIRE_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp/logfire]
+    metrics:
+      exporters: [otlphttp/logfire]
+    logs:
+      exporters: [otlphttp/logfire]
+```
+
+!!! note "Don't forget logs"
+    Splunk setups often send **logs** (and profiling) through a separate `splunk_hec` exporter rather than `sapm`/`signalfx`. Point the `logs` pipeline at `otlphttp/logfire` too — if a `splunk_hec` exporter stays wired into that pipeline, your logs keep flowing to Splunk.
+
+## If your apps export OTLP
+
+If your services export OpenTelemetry Protocol (OTLP) straight to the Splunk Collector's OTLP receiver, point the SDK at Logfire instead:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://logfire-us.pydantic.dev
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=your-write-token'
+export OTEL_SERVICE_NAME=your-service-name
+```
+
+To cut over gradually, keep the Splunk exporters and add `otlphttp/logfire` alongside them, then compare the same traffic in each backend before removing Splunk.
+
+## Verify
+
+Run your workload and open the [Live view](../guides/web-ui/live.md). Traces should appear within seconds.
+
+## See also
+
+- [Migrate to Logfire](overview.md) — the general two-path pattern and parallel-run guidance
+- [Alternative clients](../how-to-guides/alternative-clients.md) — worked SDK examples
+- Splunk's own docs, to confirm your current exporters and token: [Splunk Distribution of the OpenTelemetry Collector](https://github.com/signalfx/splunk-otel-collector)

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -1127,13 +1127,50 @@ navigation:
           - page: "Track & alert on LLM cost"
             path: "cookbook/track-llm-cost.md"
             slug: "cookbook/track-llm-cost"
-      # Head-to-head comparison pages (vs Datadog, Grafana, Langfuse, …) were
-      # consolidated onto the public marketing site (pydantic.dev/logfire/vs-*);
-      # the docs redirect the old URLs there. The Braintrust *migration* guide is
-      # a how-to, not a comparison, so it moves into its own Migrating section.
-      # Its slug (and alias) are kept unchanged so existing links keep working.
+      # The head-to-head comparison pages (vs Datadog, Grafana, …) moved to the
+      # public marketing site (pydantic.dev/logfire/vs-*); the docs redirect the
+      # old URLs there. This section is about *migrating* to Logfire — pointing an
+      # existing OpenTelemetry pipeline (SDKs or a Collector distribution) at us —
+      # plus the Braintrust eval-data migration guide (slug kept unchanged so its
+      # existing links and alias keep working).
       - section: "Migrating"
         contents:
+          - page: "Overview"
+            path: "migrating/overview.md"
+            slug: "migrate/overview"
+            title: "Migrate to Logfire from another OpenTelemetry backend"
+          - page: "From Datadog"
+            path: "migrating/datadog.md"
+            slug: "migrate/datadog"
+            title: "Migrate from Datadog to Logfire"
+          - page: "From Grafana Cloud"
+            path: "migrating/grafana.md"
+            slug: "migrate/grafana"
+            title: "Migrate from Grafana Cloud to Logfire"
+          - page: "From Honeycomb"
+            path: "migrating/honeycomb.md"
+            slug: "migrate/honeycomb"
+            title: "Migrate from Honeycomb to Logfire"
+          - page: "From New Relic"
+            path: "migrating/new-relic.md"
+            slug: "migrate/new-relic"
+            title: "Migrate from New Relic to Logfire"
+          - page: "From Dynatrace"
+            path: "migrating/dynatrace.md"
+            slug: "migrate/dynatrace"
+            title: "Migrate from Dynatrace to Logfire"
+          - page: "From Splunk"
+            path: "migrating/splunk.md"
+            slug: "migrate/splunk"
+            title: "Migrate from Splunk Observability Cloud to Logfire"
+          - page: "From Elastic"
+            path: "migrating/elastic.md"
+            slug: "migrate/elastic"
+            title: "Migrate from Elastic to Logfire"
+          - page: "From AWS (CloudWatch / X-Ray)"
+            path: "migrating/aws.md"
+            slug: "migrate/aws"
+            title: "Migrate from AWS to Logfire"
           - page: "Move from Braintrust"
             path: "comparisons/migrate-from-braintrust.md"
             source: "plain"


### PR DESCRIPTION
Adds a **Migrating** section to the Logfire docs — how to move to Logfire from another observability backend — and corrects the now-stale "HTTP-only" gRPC guidance across the OTel docs.

The premise is simple: Logfire is a standard OpenTelemetry backend, so if you already emit OTel (from SDKs or a Collector distribution), migrating is an exporter change, not re-instrumentation.

### Migration guides
- **Overview** — the two paths (OTel SDK environment variables; the Collector's `otlphttp` exporter), write-token and region setup, running both backends in parallel for a zero-gap cutover, and a note that sending straight from an SDK skips any agent-side sampling/processing.
- **Per-vendor guides**, each with before/after config for the vendor's SDK path *and* its Collector distribution:
  Datadog (Agent OTLP / DDOT) · Grafana Cloud (Alloy) · Honeycomb · New Relic · Dynatrace · Splunk · Elastic (EDOT) · AWS (ADOT → CloudWatch/X-Ray).

Every vendor endpoint, auth header, and exporter/distribution name was verified against that vendor's own documentation, and each page links its source.

### gRPC guidance correction
`fusionfire` now ingests OTLP over **gRPC** as well as HTTP (pydantic/platform #15498) — verified live against `logfire-us`. The second commit replaces the stale "Logfire is HTTP-only / gRPC sends nothing" warnings in `how-to-guides/alternative-clients.md`, the `.NET`, and the `Java` guides with an accurate "accepts HTTP **and** gRPC" note. The examples still use HTTP (`http/protobuf`) as the broadly-compatible default; the claim is scoped to the managed platform.

### Verification
End-to-end smoke test (a stock OTel Collector and Grafana Alloy, plus direct SDK export) confirmed the documented config ingests: HTTP and gRPC both land, `Bearer` auth works, and `logfire-us.pydantic.dev` is the correct endpoint.
