### PR TITLE
Let `logfire auth` complete without a TTY

### DIFF
--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -18,12 +18,13 @@ def _read_line(prompt: str = '') -> str | None:
     piping the answers in is how scripts have always driven this command. Gating on
     isatty() would turn that into a hard failure.
 
-    `sys.stdin` can also be None (pythonw, some embedded runtimes) and reading it can
-    raise on a closed stream, so both are treated as "no answer available".
+    `sys.stdin` can also be None (pythonw, some embedded runtimes), where `input()` raises
+    `RuntimeError('lost sys.stdin')`, and reading a closed stream raises `ValueError`.
+    All of them mean the same thing here: no answer is available.
     """
     try:
         return input(prompt)
-    except (EOFError, AttributeError, ValueError):
+    except (EOFError, RuntimeError, AttributeError, ValueError):
         return None
 
 

--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -67,11 +67,19 @@ def parse_auth(args: argparse.Namespace) -> None:
                 # Nothing to read and nothing to guess from: which region holds your data
                 # is not ours to pick. It is answerable ahead of time, and saying so beats
                 # looping forever or raising EOFError from a prompt nobody can reply to.
-                raise LogfireConfigError(
-                    'Logfire is available in multiple data regions and no region was selected. '
-                    f'Pass one with `logfire --region {"|".join(REGIONS)} auth`, or run this in '
-                    'an interactive terminal to choose.'
+                #
+                # Written and exited rather than raised: an exception escapes `main()`,
+                # which catches only KeyboardInterrupt, so the caller gets a traceback --
+                # which is the thing this change set out to remove. Each region is spelled
+                # out as its own runnable line, because `--region us|eu` is a shell
+                # pipeline if you paste it.
+                sys.stderr.write(
+                    'Logfire is available in multiple data regions and no region was selected.\n'
+                    'Re-run in an interactive terminal to choose, or pass one:\n'
                 )
+                for region_id in REGIONS:
+                    sys.stderr.write(f'  logfire --region {region_id} auth\n')
+                sys.exit(1)
             try:
                 selected_region = int(answer)
             except ValueError:

--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -10,16 +10,21 @@ from ..auth import DEFAULT_FILE, UserTokenCollection, poll_for_token, request_de
 from ..config import REGIONS
 
 
-def _stdin_is_interactive() -> bool:
-    """Is there a person at a terminal who can answer a prompt?
+def _read_line(prompt: str = '') -> str | None:
+    """Read one line of input, or `None` if there is nothing there to read.
 
-    `sys.stdin` can be None (pythonw, some embedded runtimes) and `isatty()` can raise on
-    a closed stream, so neither is assumed.
+    Deliberately not `sys.stdin.isatty()`. That answers "is a terminal attached", which is
+    a different question: a pipe is not a tty and is perfectly answerable, and
+    piping the answers in is how scripts have always driven this command. Gating on
+    isatty() would turn that into a hard failure.
+
+    `sys.stdin` can also be None (pythonw, some embedded runtimes) and reading it can
+    raise on a closed stream, so both are treated as "no answer available".
     """
     try:
-        return bool(sys.stdin) and sys.stdin.isatty()
-    except (AttributeError, ValueError):  # pragma: no cover - defensive
-        return False
+        return input(prompt)
+    except (EOFError, AttributeError, ValueError):
+        return None
 
 
 def parse_auth(args: argparse.Namespace) -> None:
@@ -51,25 +56,24 @@ def parse_auth(args: argparse.Namespace) -> None:
         )
     )
     if not logfire_url:
-        if not _stdin_is_interactive():
-            # Which region your data lives in is not ours to guess, so this stays a
-            # required choice -- but it is answerable ahead of time, and saying so beats
-            # an EOFError from a prompt nobody can reply to.
-            raise LogfireConfigError(
-                'Logfire is available in multiple data regions and no region was selected. '
-                f'Pass one with `logfire --region {"|".join(REGIONS)} auth`, or run this in '
-                'an interactive terminal to choose.'
-            )
         selected_region = -1
         while not (1 <= selected_region <= len(REGIONS)):
             sys.stderr.write('Logfire is available in multiple data regions. Please select one:\n')
             for i, (region_id, region_data) in enumerate(REGIONS.items(), start=1):
                 sys.stderr.write(f'{i}. {region_id.upper()} (GCP region: {region_data["gcp_region"]})\n')
 
-            try:
-                selected_region = int(
-                    input(f'Selected region [{"/".join(str(i) for i in range(1, len(REGIONS) + 1))}]: ')
+            answer = _read_line(f'Selected region [{"/".join(str(i) for i in range(1, len(REGIONS) + 1))}]: ')
+            if answer is None:
+                # Nothing to read and nothing to guess from: which region holds your data
+                # is not ours to pick. It is answerable ahead of time, and saying so beats
+                # looping forever or raising EOFError from a prompt nobody can reply to.
+                raise LogfireConfigError(
+                    'Logfire is available in multiple data regions and no region was selected. '
+                    f'Pass one with `logfire --region {"|".join(REGIONS)} auth`, or run this in '
+                    'an interactive terminal to choose.'
                 )
+            try:
+                selected_region = int(answer)
             except ValueError:
                 selected_region = -1
         logfire_url = list(REGIONS.values())[selected_region - 1]['base_url']
@@ -77,20 +81,18 @@ def parse_auth(args: argparse.Namespace) -> None:
     device_code, frontend_auth_url = request_device_code(args._session, logfire_url)
     frontend_host = urlparse(frontend_auth_url).netloc
 
-    # Only pause when someone is there to press the key. The prompt exists to give a
-    # person a beat before a browser window appears; with no terminal there is no beat to
-    # give and no browser to open, and blocking on it turns the whole command into an
-    # EOFError traceback for every non-interactive caller -- CI, containers, and coding
-    # agents, which cannot supply a keystroke.
+    # This prompt exists to give a person a beat before a browser window appears. When
+    # there is no one to press the key -- CI, a container, a coding agent -- there is no
+    # beat to give and no browser to open, and BLOCKING on it turned the whole command
+    # into an EOFError traceback for every such caller.
     #
     # Nothing else about the flow needs a terminal: the URL is printed below and the
     # device-code poll simply waits, so a caller can surface the link and the login
     # completes when the user opens it.
-    if _stdin_is_interactive():
-        # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
-        sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
-        input()
-
+    #
+    # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
+    sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
+    if _read_line() is not None:
         try:
             webbrowser.open(frontend_auth_url, new=2)
         except webbrowser.Error:

--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -10,6 +10,18 @@ from ..auth import DEFAULT_FILE, UserTokenCollection, poll_for_token, request_de
 from ..config import REGIONS
 
 
+def _stdin_is_interactive() -> bool:
+    """Is there a person at a terminal who can answer a prompt?
+
+    `sys.stdin` can be None (pythonw, some embedded runtimes) and `isatty()` can raise on
+    a closed stream, so neither is assumed.
+    """
+    try:
+        return bool(sys.stdin) and sys.stdin.isatty()
+    except (AttributeError, ValueError):  # pragma: no cover - defensive
+        return False
+
+
 def parse_auth(args: argparse.Namespace) -> None:
     """Authenticate with Logfire.
 
@@ -39,6 +51,15 @@ def parse_auth(args: argparse.Namespace) -> None:
         )
     )
     if not logfire_url:
+        if not _stdin_is_interactive():
+            # Which region your data lives in is not ours to guess, so this stays a
+            # required choice -- but it is answerable ahead of time, and saying so beats
+            # an EOFError from a prompt nobody can reply to.
+            raise LogfireConfigError(
+                'Logfire is available in multiple data regions and no region was selected. '
+                f'Pass one with `logfire --region {"|".join(REGIONS)} auth`, or run this in '
+                'an interactive terminal to choose.'
+            )
         selected_region = -1
         while not (1 <= selected_region <= len(REGIONS)):
             sys.stderr.write('Logfire is available in multiple data regions. Please select one:\n')
@@ -56,14 +77,24 @@ def parse_auth(args: argparse.Namespace) -> None:
     device_code, frontend_auth_url = request_device_code(args._session, logfire_url)
     frontend_host = urlparse(frontend_auth_url).netloc
 
-    # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
-    sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
-    input()
+    # Only pause when someone is there to press the key. The prompt exists to give a
+    # person a beat before a browser window appears; with no terminal there is no beat to
+    # give and no browser to open, and blocking on it turns the whole command into an
+    # EOFError traceback for every non-interactive caller -- CI, containers, and coding
+    # agents, which cannot supply a keystroke.
+    #
+    # Nothing else about the flow needs a terminal: the URL is printed below and the
+    # device-code poll simply waits, so a caller can surface the link and the login
+    # completes when the user opens it.
+    if _stdin_is_interactive():
+        # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
+        sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
+        input()
 
-    try:
-        webbrowser.open(frontend_auth_url, new=2)
-    except webbrowser.Error:
-        pass
+        try:
+            webbrowser.open(frontend_auth_url, new=2)
+        except webbrowser.Error:
+            pass
     sys.stderr.writelines(
         (
             f"Please open {frontend_auth_url} in your browser to authenticate if it hasn't already.\n",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -687,6 +687,28 @@ def test_auth_reads_piped_answers_even_though_a_pipe_is_not_a_tty(tmp_path: Path
     assert 'fake_token' in auth_file.read_text()
 
 
+def test_read_line_returns_none_when_stdin_is_unavailable() -> None:
+    """Every way stdin can be missing means the same thing: no answer is available.
+
+    `input()` raises RuntimeError when `sys.stdin` is None (pythonw, some embedded
+    runtimes) and ValueError on a closed stream. The docstring claimed these were handled
+    before they actually were.
+    """
+    from logfire._internal.cli.auth import _read_line
+
+    for exc in (EOFError, RuntimeError, ValueError, AttributeError):
+        with patch('logfire._internal.cli.auth.input', side_effect=exc):
+            assert _read_line('prompt') is None, exc
+
+    # And the real thing, not a mock of it.
+    original = sys.stdin
+    try:
+        sys.stdin = None  # type: ignore[assignment]
+        assert _read_line('prompt') is None
+    finally:
+        sys.stdin = original
+
+
 def test_auth_temp_failure(tmp_path: Path) -> None:
     auth_file = tmp_path / 'default.toml'
     with ExitStack() as stack:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -541,9 +541,6 @@ def test_auth(tmp_path: Path, webbrowser_error: bool, capsys: pytest.CaptureFixt
         # Necessary to assert that credentials are written to the `auth_file` (which happens from the `cli` module)
         stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
         stack.enter_context(patch('logfire._internal.cli.auth.input'))
-        # This test is the interactive path. pytest captures stdin, so it is not a
-        # tty and the prompts would otherwise be skipped.
-        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=True))
         webbrowser_open = stack.enter_context(
             patch('webbrowser.open', side_effect=webbrowser.Error if webbrowser_error is True else None)
         )
@@ -603,10 +600,8 @@ def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path) -> No
     with ExitStack() as stack:
         stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
         stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=False))
-        # If anything tries to read a keystroke, fail loudly rather than hanging or
-        # raising EOFError somewhere further down.
-        mock_input = stack.enter_context(patch('logfire._internal.cli.auth.input'))
+        # No stdin: reading raises EOFError, exactly as it does under `< /dev/null`.
+        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=EOFError))
         webbrowser_open = stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
 
         m = requests_mock.Mocker()
@@ -622,8 +617,8 @@ def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path) -> No
 
         main(['--region', 'us', 'auth'])
 
-    mock_input.assert_not_called()
-    # No terminal means no browser to open for anyone to see; the URL is printed instead.
+    # It may try to read -- that is fine and is how it detects there is nothing there.
+    # What must not happen is a crash, or a browser opened for an audience of nobody.
     webbrowser_open.assert_not_called()
     assert 'fake_token' in auth_file.read_text()
 
@@ -638,10 +633,43 @@ def test_auth_non_interactive_without_a_region_says_what_to_do(tmp_path: Path) -
     with ExitStack() as stack:
         stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
         stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=False))
+        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=EOFError))
 
         with pytest.raises(LogfireConfigError, match='no region was selected'):
             main(['auth'])
+
+
+def test_auth_reads_piped_answers_even_though_a_pipe_is_not_a_tty(tmp_path: Path) -> None:
+    """`printf '1\\n\\n' | logfire auth` must keep working.
+
+    Piping answers is how scripts have always driven this command. An earlier version of
+    this fix gated the prompts on `sys.stdin.isatty()`, which is a different question --
+    a pipe is not a tty -- and so refused input that was sitting right there, turning a
+    working setup script into a hard error. Found by running the real CLI in a container
+    with its stdin on a pipe.
+    """
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        # '1' selects the first region; '' is the Enter keypress before the browser opens.
+        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=['1', '']))
+        stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
+        )
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
+            text='{"token": "fake_token", "expiration": "fake_exp"}',
+        )
+
+        main(['auth'])
+
+    assert 'fake_token' in auth_file.read_text()
 
 
 def test_auth_temp_failure(tmp_path: Path) -> None:
@@ -738,7 +766,6 @@ def test_auth_no_region_specified(tmp_path: Path) -> None:
         # 'not_an_int' is used as the first input to test that invalid inputs are supported,
         # '2' will result in the EU region being used:
         stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=['not_an_int', '2', '']))
-        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=True))
         stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
 
         m = requests_mock.Mocker()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -541,6 +541,9 @@ def test_auth(tmp_path: Path, webbrowser_error: bool, capsys: pytest.CaptureFixt
         # Necessary to assert that credentials are written to the `auth_file` (which happens from the `cli` module)
         stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
         stack.enter_context(patch('logfire._internal.cli.auth.input'))
+        # This test is the interactive path. pytest captures stdin, so it is not a
+        # tty and the prompts would otherwise be skipped.
+        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=True))
         webbrowser_open = stack.enter_context(
             patch('webbrowser.open', side_effect=webbrowser.Error if webbrowser_error is True else None)
         )
@@ -585,6 +588,60 @@ expiration = "fake_exp"
         )
 
         webbrowser_open.assert_called_once_with('http://example.com/auth', new=2)
+
+
+def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path) -> None:
+    """`logfire --region us auth` works with no terminal attached.
+
+    The device flow needs no keypress: the URL is printed and the poll simply waits, so a
+    caller can surface the link and the login completes when the user opens it. The
+    "Press Enter to open ... in your browser" prompt was the only thing in the way, and it
+    turned every non-interactive invocation -- CI, containers, coding agents -- into an
+    EOFError traceback.
+    """
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=False))
+        # If anything tries to read a keystroke, fail loudly rather than hanging or
+        # raising EOFError somewhere further down.
+        mock_input = stack.enter_context(patch('logfire._internal.cli.auth.input'))
+        webbrowser_open = stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
+        )
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
+            text='{"token": "fake_token", "expiration": "fake_exp"}',
+        )
+
+        main(['--region', 'us', 'auth'])
+
+    mock_input.assert_not_called()
+    # No terminal means no browser to open for anyone to see; the URL is printed instead.
+    webbrowser_open.assert_not_called()
+    assert 'fake_token' in auth_file.read_text()
+
+
+def test_auth_non_interactive_without_a_region_says_what_to_do(tmp_path: Path) -> None:
+    """Which region holds your data is not ours to guess, so it stays a required choice.
+
+    It is answerable ahead of time with `--region`, and saying so beats raising EOFError
+    from a prompt the caller cannot reply to.
+    """
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=False))
+
+        with pytest.raises(LogfireConfigError, match='no region was selected'):
+            main(['auth'])
 
 
 def test_auth_temp_failure(tmp_path: Path) -> None:
@@ -681,6 +738,7 @@ def test_auth_no_region_specified(tmp_path: Path) -> None:
         # 'not_an_int' is used as the first input to test that invalid inputs are supported,
         # '2' will result in the EU region being used:
         stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=['not_an_int', '2', '']))
+        stack.enter_context(patch('logfire._internal.cli.auth._stdin_is_interactive', return_value=True))
         stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
 
         m = requests_mock.Mocker()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -587,7 +587,7 @@ expiration = "fake_exp"
         webbrowser_open.assert_called_once_with('http://example.com/auth', new=2)
 
 
-def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path) -> None:
+def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """`logfire --region us auth` works with no terminal attached.
 
     The device flow needs no keypress: the URL is printed and the poll simply waits, so a
@@ -621,9 +621,14 @@ def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path) -> No
     # What must not happen is a crash, or a browser opened for an audience of nobody.
     webbrowser_open.assert_not_called()
     assert 'fake_token' in auth_file.read_text()
+    # With no browser to open, the printed URL is the ONLY way the caller can surface the
+    # login to a person -- so it is the feature here, not incidental output.
+    assert 'http://example.com/auth' in capsys.readouterr().err
 
 
-def test_auth_non_interactive_without_a_region_says_what_to_do(tmp_path: Path) -> None:
+def test_auth_non_interactive_without_a_region_says_what_to_do(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Which region holds your data is not ours to guess, so it stays a required choice.
 
     It is answerable ahead of time with `--region`, and saying so beats raising EOFError
@@ -635,8 +640,18 @@ def test_auth_non_interactive_without_a_region_says_what_to_do(tmp_path: Path) -
         stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
         stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=EOFError))
 
-        with pytest.raises(LogfireConfigError, match='no region was selected'):
+        # A clean exit, not an exception: anything escaping `main()` reaches the user as
+        # a traceback.
+        with pytest.raises(SystemExit) as exc_info:
             main(['auth'])
+        assert exc_info.value.code == 1
+
+    err = capsys.readouterr().err
+    assert 'no region was selected' in err
+    # Each suggestion must be runnable as printed. `--region us|eu` is a shell pipeline.
+    assert '  logfire --region us auth' in err
+    assert '  logfire --region eu auth' in err
+    assert 'us|eu' not in err
 
 
 def test_auth_reads_piped_answers_even_though_a_pipe_is_not_a_tty(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -694,16 +694,18 @@ def test_read_line_returns_none_when_stdin_is_unavailable() -> None:
     runtimes) and ValueError on a closed stream. The docstring claimed these were handled
     before they actually were.
     """
-    from logfire._internal.cli.auth import _read_line
+    from logfire._internal.cli.auth import _read_line  # pyright: ignore[reportPrivateUsage]
 
     for exc in (EOFError, RuntimeError, ValueError, AttributeError):
         with patch('logfire._internal.cli.auth.input', side_effect=exc):
             assert _read_line('prompt') is None, exc
 
-    # And the real thing, not a mock of it.
+    # And the real thing, not a mock of it: `sys.stdin = None` is exactly what pythonw and
+    # some embedded runtimes leave behind, and it is what makes `input()` raise
+    # RuntimeError rather than any of the others.
     original = sys.stdin
     try:
-        sys.stdin = None  # type: ignore[assignment]
+        sys.stdin = None
         assert _read_line('prompt') is None
     finally:
         sys.stdin = original


### PR DESCRIPTION
Fixes #2274.

`logfire auth` blocks on `input()` twice, so any caller without a terminal — CI, a container, a coding agent — gets an `EOFError` traceback on the first command in our own setup instructions.

```console
$ logfire --region us auth < /dev/null
  ...
  File ".../logfire/_internal/cli/auth.py", line 61, in parse_auth
    input()
EOFError: EOF when reading a line
```

## The change

**Read stdin and handle `EOFError`, rather than checking `isatty()`.** That distinction turned out to matter — see below. It covers all three cases with no special-casing: a terminal, a pipe with answers in it, and nothing at all.

**`Press Enter to open <host> in your browser...` no longer blocks when there is nothing to read.** Nothing is done with the result — it exists to give a person a beat before a browser window appears, and with no one there, there is no beat to give and no browser to open (so none is opened). Everything else in the flow already works headless: the URL is printed and the device-code poll simply waits, so a caller can surface the link and the login completes when the user opens it.

**The region stays a real choice.** Which region holds your data is not ours to guess, so with no answer available the caller is told what to pass and the command exits 1 — no traceback, and each suggestion is a line you can paste:

```console
$ logfire auth < /dev/null
Logfire is available in multiple data regions and no region was selected.
Re-run in an interactive terminal to choose, or pass one:
  logfire --region us auth
  logfire --region eu auth
```

Interactive behaviour is unchanged.

## A correction, and why the first version was wrong

The first version of this PR gated the prompts on `sys.stdin.isatty()`. That is a different question — *"is a terminal attached"* rather than *"can I read an answer"* — and it broke a case that worked before:

```console
$ printf '1\n\n' | logfire auth      # worked on main; hard-failed on the first version
LogfireConfigError: ... no region was selected ...
```

A pipe is not a tty, but the answers are sitting right there. Piping them in is how scripts have always driven this command, so gating on `isatty()` would have turned working setup scripts into a hard error — trading one broken caller for another.

I found this by running the real CLI in a container with its stdin on a pipe, which is how our own tooling drives it. Reading and handling `EOFError` is both simpler and correct for all three shapes.

## Verified

In a container against a real backend:

| stdin | before | after |
| --- | --- | --- |
| `< /dev/null`, `--region us` | `EOFError` traceback | authenticated, credentials written |
| `< /dev/null`, no region | `EOFError` traceback | clean guidance on stderr, exit 1 |
| `printf '1\n\n' \|` (a pipe) | works | works |

## Tests

Two new tests for the headless cases, and one that pins the pipe case above so the `isatty()` mistake cannot come back — I confirmed it goes red when the gate is reinstated. The tests also assert the login URL is printed (with no browser to open, it is the only way to surface the login to a person) and that the region suggestions never regress into the un-pasteable `us|eu` form.

`tests/test_cli.py tests/test_auth.py`: **222 passed**.

Two pre-existing tests exercise the interactive path by patching `input` directly, and are unchanged.
