### PR TITLE
ci: run full dependency matrix on labeled PRs

### DIFF
--- a/.agents/skills/update-deps/SKILL.md
+++ b/.agents/skills/update-deps/SKILL.md
@@ -1,31 +1,32 @@
 ---
 name: update-deps
-description: "Create a PR in which all dependencies are updated to their latest versions and CI is passing. Only user initiated."
+description: "Update all project dependencies to their latest versions, fix compatibility failures, and open a passing PR. Use only when the user explicitly asks to run a dependency update."
 ---
 
-Steps:
+# Update dependencies
 
-Stop and complain if there are uncommitted changes in the working directory.
-git checkout main && git pull origin main
-git checkout -b update-deps-<date>
-uv sync --upgrade
-git commit uv.lock -m "chore: Update dependencies"
+## Prepare the branch
 
-Run these, make any fixes needed, and commit the results (including automated changes) for each step where there are changes:
+1. Stop and report any uncommitted changes. Do not modify or stash them.
+2. Run `git checkout main && git pull origin main`.
+3. Create `update-deps-<date>`.
+4. Run `uv sync --upgrade`.
+5. Commit only `uv.lock` with `gcap uv.lock -m "chore: Update dependencies"`.
 
-Always commit by listing specific files (never `git commit -am` / `git add -A`) — the user may have their own uncommitted edits in the working tree at any point, and blanket staging can sweep them into your commits.
+Always list specific files in every staging and commit command. Never use blanket staging or `git commit -am`.
 
-make format && make lint && make typecheck && make docs
-(usually these all pass without changes)
+## Validate locally
 
-uv run pytest --inline-snapshot=fix
+Run `make format && make lint && make typecheck && make docs`. Commit any automated changes as focused commits.
 
-Running tests the first time will likely update some snapshots. Just commit those changes even if some tests are still failing.
+Run `uv run pytest --inline-snapshot=fix`. The first run may update snapshots. Inspect and commit valid snapshot changes even if other tests failed, then rerun only the failed tests. If snapshots change repeatedly, replace nondeterministic fields with appropriate `dirty_equals` matchers.
 
-After seeing what tests fail the first time, any future running of tests in this workflow should only be for some small subset. The full test suite will run in CI.
+Do not rerun the full suite locally after the first run; CI will do that.
 
-Run failed tests again. If the same snapshots get updated again, use `dirty_equals` matchers to handle non-deterministic fields.
+## Open and finish the PR
 
-`git push origin HEAD` and create a PR with whatever you have so far. No description needed.
+Push the branch and open a non-draft PR with no description and the `test:all-deps` label. Open it even if failures remain so CI can expose version-specific compatibility failures.
 
-For remaining test failures, investigate and explain the problem.
+Keep the label on the PR. It runs every supported Pydantic and OpenTelemetry version when added and after each later push. Do not treat regular CI passing as sufficient.
+
+Watch both regular CI and the full dependency compatibility workflow. Investigate failures across the whole affected dependency-version range, make small focused commits, and continue until all checks pass and no review threads need a response.

--- a/.agents/skills/update-deps/SKILL.md
+++ b/.agents/skills/update-deps/SKILL.md
@@ -1,32 +1,33 @@
 ---
 name: update-deps
-description: "Update all project dependencies to their latest versions, fix compatibility failures, and open a passing PR. Use only when the user explicitly asks to run a dependency update."
+description: "Create a PR in which all dependencies are updated to their latest versions and CI is passing. Only user initiated."
 ---
 
-# Update dependencies
+Steps:
 
-## Prepare the branch
+Stop and complain if there are uncommitted changes in the working directory.
+git checkout main && git pull origin main
+git checkout -b update-deps-<date>
+uv sync --upgrade
+git commit uv.lock -m "chore: Update dependencies"
 
-1. Stop and report any uncommitted changes. Do not modify or stash them.
-2. Run `git checkout main && git pull origin main`.
-3. Create `update-deps-<date>`.
-4. Run `uv sync --upgrade`.
-5. Commit only `uv.lock` with `gcap uv.lock -m "chore: Update dependencies"`.
+Run these, make any fixes needed, and commit the results (including automated changes) for each step where there are changes:
 
-Always list specific files in every staging and commit command. Never use blanket staging or `git commit -am`.
+Always commit by listing specific files (never `git commit -am` / `git add -A`) — the user may have their own uncommitted edits in the working tree at any point, and blanket staging can sweep them into your commits.
 
-## Validate locally
+make format && make lint && make typecheck && make docs
+(usually these all pass without changes)
 
-Run `make format && make lint && make typecheck && make docs`. Commit any automated changes as focused commits.
+uv run pytest --inline-snapshot=fix
 
-Run `uv run pytest --inline-snapshot=fix`. The first run may update snapshots. Inspect and commit valid snapshot changes even if other tests failed, then rerun only the failed tests. If snapshots change repeatedly, replace nondeterministic fields with appropriate `dirty_equals` matchers.
+Running tests the first time will likely update some snapshots. Just commit those changes even if some tests are still failing.
 
-Do not rerun the full suite locally after the first run; CI will do that.
+After seeing what tests fail the first time, any future running of tests in this workflow should only be for some small subset. The full test suite will run in CI.
 
-## Open and finish the PR
+Run failed tests again. If the same snapshots get updated again, use `dirty_equals` matchers to handle non-deterministic fields.
 
-Push the branch and open a non-draft PR with no description and the `test:all-deps` label. Open it even if failures remain so CI can expose version-specific compatibility failures.
+`git push origin HEAD` and create a PR with the `test:all-deps` label. No description needed.
 
-Keep the label on the PR. It runs every supported Pydantic and OpenTelemetry version when added and after each later push. Do not treat regular CI passing as sufficient.
+For remaining test failures, investigate and explain the problem.
 
-Watch both regular CI and the full dependency compatibility workflow. Investigate failures across the whole affected dependency-version range, make small focused commits, and continue until all checks pass and no review threads need a response.
+Keep the label on the PR and wait for both regular CI and the full dependency compatibility workflow to pass. The full workflow reruns after each push while the label is present.

--- a/.github/workflows/deps_test.yml
+++ b/.github/workflows/deps_test.yml
@@ -9,7 +9,15 @@ on:
 
   # Run the full compatibility matrix on labeled PRs, including after later pushes.
   pull_request:
-    types: [labeled, synchronize, reopened]
+    types:
+      - opened # Run when the PR is created with the label already attached.
+      - labeled # Run when the label is added to an existing PR.
+      - synchronize # Rerun after a push while the label is present.
+      - reopened # Rerun when a labeled PR is reopened.
+
+concurrency:
+  group: deps-test-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions: { }
 

--- a/.github/workflows/deps_test.yml
+++ b/.github/workflows/deps_test.yml
@@ -7,6 +7,10 @@ on:
   # Can be triggered manually from the actions tab, if needed
   workflow_dispatch:
 
+  # Run the full compatibility matrix on labeled PRs, including after later pushes.
+  pull_request:
+    types: [labeled, synchronize, reopened]
+
 permissions: { }
 
 env:
@@ -15,6 +19,7 @@ env:
 
 jobs:
   test:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'test:all-deps') }}
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
     runs-on: ubuntu-latest
     strategy:
@@ -110,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     # only run if the test job failed
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name != 'pull_request' }}
 
     steps:
       - name: Send slack message

--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -17,9 +17,6 @@ import logfire
 from logfire._internal.utils import get_version
 from logfire.testing import TestExporter
 
-if get_version(pydantic.__version__) < get_version('2.10.0'):
-    pytest.skip('LiteLLM requires Pydantic >= 2.10', allow_module_level=True)
-
 
 @contextmanager
 def _event_loop_policy(policy: asyncio.AbstractEventLoopPolicy) -> Generator[None, None, None]:
@@ -112,6 +109,9 @@ You can install this with:
 
 
 @pytest.mark.vcr()
+@pytest.mark.skipif(
+    get_version(pydantic.__version__) < get_version('2.10.0'), reason='LiteLLM requires Pydantic >= 2.10'
+)
 def test_dspy_instrumentation(exporter: TestExporter, isolated_litellm_event_loop: None) -> None:
     # Skip test if dspy can't be imported due to compatibility issues
     dspy = pytest.importorskip('dspy', reason='DSPy import failed due to environment incompatibility')

--- a/tests/otel_integrations/test_dspy.py
+++ b/tests/otel_integrations/test_dspy.py
@@ -17,8 +17,8 @@ import logfire
 from logfire._internal.utils import get_version
 from logfire.testing import TestExporter
 
-if get_version(pydantic.__version__) < get_version('2.5.0'):
-    pytest.skip('DSPy/LiteLLM requires Pydantic >= 2.5 for Discriminator import', allow_module_level=True)
+if get_version(pydantic.__version__) < get_version('2.10.0'):
+    pytest.skip('LiteLLM requires Pydantic >= 2.10', allow_module_level=True)
 
 
 @contextmanager

--- a/tests/otel_integrations/test_litellm.py
+++ b/tests/otel_integrations/test_litellm.py
@@ -27,7 +27,9 @@ You can install this with:
 
 
 @pytest.mark.vcr()
-@pytest.mark.skipif(get_version(pydantic.__version__) < get_version('2.5.0'), reason='Requires newer pydantic version')
+@pytest.mark.skipif(
+    get_version(pydantic.__version__) < get_version('2.10.0'), reason='LiteLLM requires Pydantic >= 2.10'
+)
 def test_litellm_instrumentation(exporter: TestExporter) -> None:
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=DeprecationWarning)

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -17,6 +17,7 @@ from logfire._internal.auto_trace.import_hook import LogfireFinder
 from logfire._internal.utils import get_version
 
 pydantic_pre_2_5 = get_version(pydantic_version) < get_version('2.5.0')
+pydantic_pre_2_10 = get_version(pydantic_version) < get_version('2.10.0')
 
 
 @pytest.fixture(autouse=True)
@@ -299,7 +300,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire__all__.remove('instrument_google_genai')
 
     assert hasattr(logfire_api, 'instrument_litellm')
-    if not pydantic_pre_2_5:
+    if not pydantic_pre_2_10:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)
             try:
@@ -311,7 +312,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire__all__.remove('instrument_litellm')
 
     assert hasattr(logfire_api, 'instrument_dspy')
-    if not pydantic_pre_2_5:
+    if not pydantic_pre_2_10:
         # DSPy emits deprecation warnings while being instrumented; pytest treats warnings as errors.
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=DeprecationWarning)


### PR DESCRIPTION
- Add a persistent `test:all-deps` PR label that runs the full Pydantic and OpenTelemetry compatibility matrix when applied and after every subsequent push.
- Cancel superseded PR matrix runs while leaving scheduled/manual runs independent.
- Update the dependency-update skill to apply the label and require both regular CI and the full compatibility workflow to pass.
- Guard LiteLLM and DSPy integration checks below Pydantic 2.10, matching LiteLLM's declared compatibility requirement uncovered by the new matrix run.
