### PR TITLE
Document the Slack app's real permissions and finding buttons

### DIFF
--- a/docs/how-to-guides/slack-app.md
+++ b/docs/how-to-guides/slack-app.md
@@ -15,7 +15,7 @@ The Logfire Slack app brings your observability notifications into Slack. Instal
 - **Posts notifications** to the channels you choose: a firing alert or a new issue, rendered as a Slack message with a link back to Logfire.
 - **Lists the channels it has been invited to**, so you pick a destination instead of pasting a URL.
 - **Publishes a Home tab** describing the connection.
-- **Reads 👍 / 👎 reactions on the messages it posted.** This is how you rate a finding from Logfire's site reliability engineering (SRE) agent, which is enabled for selected organizations rather than generally available. Reacting to an alert or issue notification does nothing.
+- **Collects your rating of a finding** from Logfire's site reliability engineering (SRE) agent, which is enabled for selected organizations rather than generally available. A finding message carries **👍 Useful** and **👎 Not useful** buttons; 👎 opens a dialog where you can add an optional note. Adding a 👍 / 👎 reaction to the message works too. Rating or reacting to an alert or issue notification does nothing.
 
 The app never posts anywhere it has not been invited, and it does not join channels by itself.
 
@@ -26,14 +26,13 @@ The app never posts anywhere it has not been invited, and it does not join chann
 | `chat:write` | Post notifications into the channels you pick |
 | `channels:read`, `groups:read` | List public and private channels the app is a member of, for the channel picker |
 | `reactions:read` | Receive the 👍 / 👎 you add to an SRE agent finding, as your rating of it |
-| `reactions:write` | Acknowledge that rating with a reaction of its own |
 | `team:read` | Show the workspace name and icon on the connection in Logfire |
 
 The app does not read your message history or your direct messages.
 
 ### Data and privacy
 
-Logfire stores the workspace grant (the bot token, encrypted at rest), the workspace's name and ID, the granted permissions, and the ID of each channel you select. Message content flows one way: Logfire posts notification text built from your telemetry, and the only inbound content it records is the reaction feedback described above.
+Logfire stores the workspace grant (the bot token, encrypted at rest), the workspace's name and ID, the granted permissions, and the ID of each channel you select. Message content flows one way: Logfire posts notification text built from your telemetry, and the only inbound content it records is the finding feedback described above, meaning your rating and any note you write in the **Not useful** dialog.
 
 See the [Pydantic privacy policy](https://pydantic.dev/legal/privacy-policy) for how we collect, manage, and store this data.
 


### PR DESCRIPTION
Follows up [#2266](https://github.com/pydantic/logfire/pull/2266), which shipped the Slack App page while two platform changes were still in flight. Both have merged, so the page is now wrong in three places.

## What changes

- **Drops the `reactions:write` row** from the permissions table. The app no longer requests that scope, and the acknowledgement reaction it promised was never implemented: the `add_reaction` helper had no caller. The table now lists exactly the five scopes the install asks for.
- **Rewrites the finding-rating bullet.** Rating a finding is now a pair of **👍 Useful** / **👎 Not useful** buttons on the message, with 👎 opening a dialog for an optional note. Reactions still work, so both are described.
- **Names the note in the privacy section**, since it is user-typed content Logfire stores alongside the rating.

Nothing else on the page changes, and no other docs page lists the scopes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

