### PR TITLE
Describe the feedback permission without naming an unreleased feature

### DIFF
--- a/docs/how-to-guides/slack-app.md
+++ b/docs/how-to-guides/slack-app.md
@@ -15,7 +15,7 @@ The Logfire Slack app brings your observability notifications into Slack. Instal
 - **Posts notifications** to the channels you choose: a firing alert or a new issue, rendered as a Slack message with a link back to Logfire.
 - **Lists the channels it has been invited to**, so you pick a destination instead of pasting a URL.
 - **Publishes a Home tab** describing the connection.
-- **Collects your rating of a finding** from Logfire's site reliability engineering (SRE) agent, which is enabled for selected organizations rather than generally available. A finding message carries **👍 Useful** and **👎 Not useful** buttons; 👎 opens a dialog where you can add an optional note. Adding a 👍 / 👎 reaction to the message works too. Rating or reacting to an alert or issue notification does nothing.
+- **Collects feedback on the notifications that ask for it.** Those messages carry **👍 Useful** and **👎 Not useful** buttons, and 👎 opens a dialog for an optional note. Adding a 👍 / 👎 reaction to one of them does the same thing. Alert and issue notifications do not ask for feedback, so reacting to one does nothing.
 
 The app never posts anywhere it has not been invited, and it does not join channels by itself.
 
@@ -25,14 +25,14 @@ The app never posts anywhere it has not been invited, and it does not join chann
 | --- | --- |
 | `chat:write` | Post notifications into the channels you pick |
 | `channels:read`, `groups:read` | List public and private channels the app is a member of, for the channel picker |
-| `reactions:read` | Receive the 👍 / 👎 you add to an SRE agent finding, as your rating of it |
+| `reactions:read` | Receive the 👍 / 👎 you add to a notification that asks for feedback, as your rating of it |
 | `team:read` | Show the workspace name and icon on the connection in Logfire |
 
 The app does not read your message history or your direct messages.
 
 ### Data and privacy
 
-Logfire stores the workspace grant (the bot token, encrypted at rest), the workspace's name and ID, the granted permissions, and the ID of each channel you select. Message content flows one way: Logfire posts notification text built from your telemetry, and the only inbound content it records is the finding feedback described above, meaning your rating and any note you write in the **Not useful** dialog.
+Logfire stores the workspace grant (the bot token, encrypted at rest), the workspace's name and ID, the granted permissions, and the ID of each channel you select. Message content flows one way: Logfire posts notification text built from your telemetry, and the only inbound content it records is the feedback described above, meaning your rating and any note you write in the **Not useful** dialog.
 
 See the [Pydantic privacy policy](https://pydantic.dev/legal/privacy-policy) for how we collect, manage, and store this data.
 


### PR DESCRIPTION
Follows up [#2277](https://github.com/pydantic/logfire/pull/2277). That page names Logfire's SRE agent as the thing a 👍 / 👎 rating feeds, and describes it as "enabled for selected organizations". The agent is neither generally available nor in early access, so the sentence announces an unreleased feature on a public page.

The permission still needs a reason, and the feedback itself is that reason: some notifications ask whether they were useful, and the rating is what `reactions:read` receives. That is true, sufficient for a reader deciding whether to grant the scope, and does not name the feature behind it.

Three lines change, all of them wording:

- The capability bullet describes the buttons and the note dialog without naming what posts them.
- The `reactions:read` row says "a notification that asks for feedback" instead of "an SRE agent finding".
- The privacy sentence says "the feedback described above" instead of "the finding feedback".

No behavior, scope, or structure changes.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

