### PR TITLE
Add `logfire projects list --json`

### DIFF
--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import functools
+import json
 import logging
 import platform
 import sys
@@ -138,16 +139,26 @@ def parse_list_projects(args: argparse.Namespace) -> None:
     """List user projects."""
     client = LogfireClient.from_url(args.logfire_url)
 
-    projects = client.get_user_projects()
+    projects = sorted(client.get_user_projects(), key=itemgetter('organization_name', 'project_name'))
+
+    if args.json:
+        # stdout, so it can be piped. The human-readable table below deliberately stays on
+        # stderr -- anything already parsing it keeps working, and mixing the two streams
+        # would put the banner in the middle of the JSON.
+        sys.stdout.write(
+            json.dumps(
+                [{'organization_name': p['organization_name'], 'project_name': p['project_name']} for p in projects]
+            )
+            + '\n'
+        )
+        return
+
     if projects:
         sys.stderr.write("List of the projects you have write access to (requires the 'write_token' permission):\n\n")
         sys.stderr.write(
             _pretty_table(
                 ['Organization', 'Project'],
-                [
-                    [project['organization_name'], project['project_name']]
-                    for project in sorted(projects, key=itemgetter('organization_name', 'project_name'))
-                ],
+                [[project['organization_name'], project['project_name']] for project in projects],
             )
         )
     else:
@@ -363,6 +374,7 @@ def _main(args: list[str] | None = None) -> None:
     projects_subparsers = cmd_projects.add_subparsers()
 
     cmd_projects_list = projects_subparsers.add_parser('list', help='list projects')
+    cmd_projects_list.add_argument('--json', action='store_true', help='output JSON to stdout instead of a table')
     cmd_projects_list.set_defaults(func=parse_list_projects)
 
     cmd_projects_new = projects_subparsers.add_parser('new', help='create a new project')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -770,6 +770,70 @@ def test_projects_list_no_project(default_credentials: Path, capsys: pytest.Capt
         )
 
 
+def test_projects_list_json(default_credentials: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--json` goes to STDOUT so it can be piped, and is sorted like the table."""
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/writable-projects/',
+            json=[
+                {'organization_name': 'test-org', 'project_name': 'zulu'},
+                {'organization_name': 'test-org', 'project_name': 'alpha'},
+            ],
+        )
+
+        main(['projects', 'list', '--json'])
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == snapshot(
+            [
+                {'organization_name': 'test-org', 'project_name': 'alpha'},
+                {'organization_name': 'test-org', 'project_name': 'zulu'},
+            ]
+        )
+        # Nothing on stderr: a caller redirecting only stdout must get clean JSON, with no
+        # banner or table interleaved.
+        assert captured.err == ''
+
+
+def test_projects_list_json_no_projects(default_credentials: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty is `[]`, not the prose message.
+
+    A caller parsing this should not have to special-case "no projects" by matching
+    English, and `logfire projects list` exits 0 either way, so the text was the only
+    signal available.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.get('https://logfire-us.pydantic.dev/v1/writable-projects/', json=[])
+
+        main(['projects', 'list', '--json'])
+
+        captured = capsys.readouterr()
+        assert json.loads(captured.out) == []
+        assert captured.err == ''
+
+
 def test_projects_new_with_project_name_and_org(
     tmp_dir_cwd: Path, default_credentials: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
Adds `--json` to `logfire projects list`.

## Why

`logfire projects list` is the natural first step for anything that needs to *act* on the list rather than show it to a person — pick the only project, or branch on how many there are. Today that is harder than it looks:

- the table is written to **stderr**, so `logfire projects list | grep ...` returns nothing;
- there is no machine-readable output, so the alternative is parsing an ASCII table with a `|` separator and a `---` rule;
- the command **exits 0** whether or not you have any projects, so "none" can only be detected by matching the English sentence `No projects found for the current user...`.

The stderr part is not hypothetical — I lost an hour to it in a setup script that used `2>/dev/null` and silently discarded the very thing it was matching.

This matters most right after signup. Signing up creates your first project, so the common case is *"one project exists; link this folder to it"* — and a caller has to read the list to find its name.

## The change

```console
$ logfire projects list --json
[{"organization_name": "agent-eval", "project_name": "my-first-app"}]

$ logfire projects list --json          # with no projects
[]
```

- goes to **stdout**, so it pipes;
- empty is `[]`, not prose;
- sorted the same way the table is;
- the human-readable table is **unchanged** and stays on stderr, so anything already parsing it keeps working, and nothing is interleaved into the JSON.

Which makes the whole decision a one-liner:

```console
$ logfire projects list --json | jq 'length'
```

→ `0` create one · `1` use it · `>1` ask which.

## Verified

In a container against a real backend, all three cases:

| projects | `--json` on stdout |
| --- | --- |
| 0 | `[]` |
| 1 | `[{"organization_name": "agent-eval", "project_name": "my-first-app"}]` |
| 2 | both, sorted |

and `logfire projects list` with no flag still prints the same table to stderr.

`tests/test_cli.py tests/test_configure.py`: **314 passed**, including two new tests covering stdout-vs-stderr separation and the empty case.

## Context

Same motivation as #2274 / #2275: our docs' "copy AI prompt" is designed to be pasted into a coding agent, and agent shells are non-interactive. That PR is about `logfire auth`; this one is independent of it (different file, no conflict) and can land on its own.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

