### PR TITLE
Warn for unknown token regions outside configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ assert ... == snapshot({
 
 Use `@pytest.mark.anyio` for async tests.
 
+Emitting a warning is safe even though the test suite converts warnings to errors. When a warning is intentional, update affected tests to expect it or narrow their warning filters instead of suppressing the warning in production code. Suppress a warning at a call site only when it would be a known duplicate or is intentionally irrelevant there.
+
 Some tests are decorated with `@pytest.mark.vcr()` and use `pytest-recording` to record HTTP interactions. Existing VCR cassette files should suffice. When creating a new test like this, run `uv run pytest -k test_my_thing --inline-snapshot=fix --record-mode=rewrite`.
 
 Tests should use user-facing APIs as much as possible. Minimize mocking and reaching into internals.

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -278,9 +278,8 @@ class AdvancedOptions:
     def generate_base_url(self, token: str, warn_unknown_region: bool = True) -> str:
         """Resolve the base API URL for `token`, honouring an explicitly configured `base_url`.
 
-        Every caller of this method is part of configuration, so unknown regions warn by default
-        here. Runtime helpers (the query/API clients and the CLI) call `get_base_url_from_token`
-        directly instead, which stays silent so they can't raise under warnings-as-errors.
+        Unknown regions warn by default. The background credential check opts out because the
+        synchronous exporter setup has already emitted the same warning.
         """
         if self.base_url is not None:
             return self.base_url
@@ -2252,15 +2251,14 @@ def _get_creds_file(creds_dir: Path) -> Path:
     return creds_dir / CREDENTIALS_FILENAME
 
 
-def get_base_url_from_token(token: str, warn_unknown_region: bool = False) -> str:
+def get_base_url_from_token(token: str, warn_unknown_region: bool = True) -> str:
     """Get the base API URL from the token's region.
 
     Args:
         token: The Logfire token to read the region from.
         warn_unknown_region: Whether to emit a `LogfireConfigWarning` when the token's region is
-            unrecognised and the US region is used as a fallback. This is off by default so that
-            runtime helpers (e.g. the query/API clients and the CLI) never raise under
-            warnings-as-errors; it's enabled during configuration, where the warning is actionable.
+            unrecognised and the US region is used as a fallback. This is on by default for every
+            caller; disable it only when the same token has already produced the warning.
     """
     # default to US for tokens that were created before regions were added:
     region = 'us'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,7 @@ from logfire._internal.cli.run import (
     instrument_packages,
     instrumented_packages_text,
 )
-from logfire._internal.config import LogfireCredentials, sanitize_project_name
+from logfire._internal.config import LogfireConfigWarning, LogfireCredentials, sanitize_project_name
 from logfire.exceptions import LogfireConfigError
 from tests.import_used_for_tests import run_script_test
 
@@ -100,6 +100,23 @@ def test_whoami_eu_token_env_var(capsys: pytest.CaptureFixture[str]) -> None:
         )
 
         main(['whoami'])
+
+        assert len(request_mocker.request_history) == 1
+        assert capsys.readouterr().err == 'Logfire project URL: fake_project_url\n'
+
+
+def test_whoami_unknown_token_region(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch.dict(os.environ, {'LOGFIRE_TOKEN': 'pylf_v1_unknownregion_foobar'}),
+        requests_mock.Mocker() as request_mocker,
+    ):
+        request_mocker.get(
+            'https://logfire-us.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+
+        with pytest.warns(LogfireConfigWarning, match="Unknown region 'unknownregion'"):
+            main(['whoami'])
 
         assert len(request_mocker.request_history) == 1
         assert capsys.readouterr().err == 'Logfire project URL: fake_project_url\n'

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2125,7 +2125,7 @@ def test_send_to_logfire_if_token_present_in_logfire_dir(tmp_path: Path, capsys:
         assert len(request_mocker.request_history) == 1
 
 
-def test_configure_unknown_token_region(capsys: pytest.CaptureFixture[str]) -> None:
+def test_configure_unknown_token_region(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     # Should default to us:
     with requests_mock.Mocker() as request_mocker:
         request_mocker.get(
@@ -2133,7 +2133,7 @@ def test_configure_unknown_token_region(capsys: pytest.CaptureFixture[str]) -> N
             json={'project_name': 'myproject', 'project_url': 'https://logfire-us.pydantic.dev'},
         )
         with pytest.warns(LogfireConfigWarning) as warns:
-            configure(send_to_logfire='if-token-present', token='pylf_v1_unknownregion_foobarbaz')
+            configure(send_to_logfire='if-token-present', token='pylf_v1_unknownregion_foobarbaz', data_dir=tmp_path)
             # Inside the `pytest.warns` block so that any warning from the background
             # token-checking thread would be caught too: the token must warn exactly once.
             wait_for_check_token_thread()
@@ -3141,24 +3141,18 @@ def test_staging_token_regions():
 def test_known_token_regions_do_not_warn():
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        assert (
-            get_base_url_from_token('pylf_v1_us_123456', warn_unknown_region=True) == 'https://logfire-us.pydantic.dev'
-        )
-        assert (
-            get_base_url_from_token('pylf_v1_eu_123456', warn_unknown_region=True) == 'https://logfire-eu.pydantic.dev'
-        )
+        assert get_base_url_from_token('pylf_v1_us_123456') == 'https://logfire-us.pydantic.dev'
+        assert get_base_url_from_token('pylf_v1_eu_123456') == 'https://logfire-eu.pydantic.dev'
         # Tokens predating regions have no region segment and must keep working silently.
-        assert (
-            get_base_url_from_token('legacy_token_no_region', warn_unknown_region=True)
-            == 'https://logfire-us.pydantic.dev'
-        )
+        assert get_base_url_from_token('legacy_token_no_region') == 'https://logfire-us.pydantic.dev'
 
 
-def test_unknown_token_region_does_not_warn_by_default():
-    # Runtime helpers (query/API clients, CLI) must never raise under warnings-as-errors.
-    with warnings.catch_warnings():
-        warnings.simplefilter('error')
-        assert get_base_url_from_token('pylf_v1_unknownregion_123456') == 'https://logfire-us.pydantic.dev'
+def test_unknown_token_region_warns_by_default():
+    with pytest.warns(LogfireConfigWarning) as warns:
+        assert get_base_url_from_token('pylf_v1_unknownregion_123456') == snapshot('https://logfire-us.pydantic.dev')
+    assert str(warns[0].message) == snapshot(
+        "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
+    )
 
 
 def test_generate_base_url_warns_about_unknown_region_by_default():
@@ -3182,14 +3176,13 @@ def test_generate_base_url_with_explicit_base_url_does_not_warn():
         assert advanced.generate_base_url('pylf_v1_unknownregion_123456') == 'https://my-proxy.example.com'
 
 
-def test_unknown_token_region_warns_when_opted_in():
-    with pytest.warns(LogfireConfigWarning) as warns:
-        assert get_base_url_from_token('pylf_v1_unknownregion_123456', warn_unknown_region=True) == snapshot(
-            'https://logfire-us.pydantic.dev'
+def test_unknown_token_region_warning_can_be_disabled():
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        assert (
+            get_base_url_from_token('pylf_v1_unknownregion_123456', warn_unknown_region=False)
+            == 'https://logfire-us.pydantic.dev'
         )
-    assert str(warns[0].message) == snapshot(
-        "Unknown region 'unknownregion' in Logfire token, falling back to the US region. Known regions: eu, us."
-    )
 
 
 def test_multiple_tokens_list(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_query_client.py
+++ b/tests/test_query_client.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 import pytest
 from inline_snapshot import snapshot
 
+from logfire._internal.config import LogfireConfigWarning
 from logfire.query_client import AsyncLogfireQueryClient, LogfireQueryClient
 
 # This file is intended to be updated by the Logfire developers, with the development platform running locally.
@@ -53,6 +54,15 @@ def test_infers_base_url_from_token(
 ):
     client = client_class(read_token=token)
     assert client.base_url == expected
+
+
+@pytest.mark.parametrize('client_class', [AsyncLogfireQueryClient, LogfireQueryClient])
+def test_infers_base_url_from_unknown_token_region(
+    client_class: type[AsyncLogfireQueryClient | LogfireQueryClient],
+):
+    with pytest.warns(LogfireConfigWarning, match="Unknown region 'unknownregion'"):
+        client = client_class(read_token='pylf_v1_unknownregion_123456')
+    assert client.base_url == 'https://logfire-us.pydantic.dev'
 
 
 def test_info_sync():


### PR DESCRIPTION
Follow-up to #2229.

## What changed

- Make unknown token regions warn by default for every `get_base_url_from_token()` caller, including the query/API clients and CLI.
- Keep the background credential validation call silent because synchronous exporter setup has already emitted the same warning.
- Cover the direct resolver, public sync/async query clients, CLI, and the single-warning `configure()` path.
- Isolate the configuration test from developer-machine credentials.
- Document in the repository's agent instructions that intentional warnings remain valid when tests convert warnings to errors.

## Why

PR #2229 limited warnings to configuration after warnings-as-errors was treated as a reason runtime callers could not safely warn. Warnings are intentional API behavior; tests that promote them to errors should assert or filter them where appropriate.

## Validation

- `uv run pytest tests/test_configure.py -k 'unknown_token_region or known_token_regions' tests/test_query_client.py -k 'unknown_token_region or known_token_regions or infers_base_url'`
- `uv run pytest tests/test_cli.py -k 'whoami_unknown_token_region'`
- `uv run ruff check logfire/_internal/config.py tests/test_configure.py tests/test_query_client.py tests/test_cli.py`
- `uv run pyright logfire/_internal/config.py tests/test_configure.py tests/test_query_client.py tests/test_cli.py`
- pre-commit hooks via `gcap`
