### PR TITLE
Limit HTTP connection attempts to three seconds

### DIFF
--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -10,11 +10,12 @@ from logfire.exceptions import LogfireConfigError
 from logfire.version import VERSION
 
 from .auth import UserToken, UserTokenCollection
+from .constants import HTTP_CONNECT_TIMEOUT
 from .server_response import ServerResponseCallback, install_logfire_response_hook
 from .utils import UnexpectedResponse
 
 UA_HEADER = f'logfire/{VERSION}'
-_REQUEST_TIMEOUT = 30
+_REQUEST_TIMEOUT = (HTTP_CONNECT_TIMEOUT, 30)
 
 
 class ProjectAlreadyExists(Exception):

--- a/logfire/_internal/constants.py
+++ b/logfire/_internal/constants.py
@@ -179,4 +179,7 @@ MESSAGE_FORMATTED_VALUE_LENGTH_LIMIT = 128
 
 ONE_SECOND_IN_NANOSECONDS = 1_000_000_000
 
+HTTP_CONNECT_TIMEOUT = 3
+"""Maximum time in seconds to wait for each HTTP connection attempt."""
+
 ATTRIBUTES_EXCEPTION_FINGERPRINT_KEY = 'logfire.exception.fingerprint'

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -24,6 +24,7 @@ from requests import Session
 
 import logfire
 
+from ..constants import HTTP_CONNECT_TIMEOUT
 from ..utils import logger, platform_is_emscripten
 from .wrapper import WrapperLogExporter, WrapperSpanExporter
 
@@ -67,6 +68,10 @@ class OTLPExporterHttpSession(Session):
     """A requests.Session subclass that defers failed requests to a DiskRetryer."""
 
     def post(self, url: str, data: bytes, **kwargs: Any):  # pyright: ignore[reportIncompatibleMethodOverride]
+        timeout = kwargs.get('timeout')
+        if isinstance(timeout, (int, float)):
+            kwargs['timeout'] = (min(HTTP_CONNECT_TIMEOUT, timeout), timeout)
+
         start_time = time.time()
         try:
             return self._post(url, data, **kwargs)

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -67,10 +67,19 @@ class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
 class OTLPExporterHttpSession(Session):
     """A requests.Session subclass that defers failed requests to a DiskRetryer."""
 
-    def post(self, url: str, data: bytes, **kwargs: Any):  # pyright: ignore[reportIncompatibleMethodOverride]
+    @staticmethod
+    def _configure_timeout(kwargs: dict[str, Any]) -> None:
         timeout = kwargs.get('timeout')
         if isinstance(timeout, (int, float)):
             kwargs['timeout'] = (min(HTTP_CONNECT_TIMEOUT, timeout), timeout)
+
+    def request(self, method: str, url: str, **kwargs: Any):  # pyright: ignore[reportIncompatibleMethodOverride]
+        self._configure_timeout(kwargs)
+        return super().request(method, url, **kwargs)
+
+    def post(self, url: str, data: bytes, **kwargs: Any):  # pyright: ignore[reportIncompatibleMethodOverride]
+        # Configure this before calling `_post` so disk retries preserve the split timeout.
+        self._configure_timeout(kwargs)
 
         start_time = time.time()
         try:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -60,9 +60,10 @@ def test_connect_timeout(timeout: float | tuple[float, float], expected: tuple[f
     adapter = SinkHTTPAdapter()
     session.mount('http://', adapter)
 
+    session.get('http://example.com', timeout=timeout)
     session.post('http://example.com', data=b'', timeout=timeout)
 
-    assert adapter.timeouts == [expected]
+    assert adapter.timeouts == [expected, expected]
 
 
 def test_connect_timeout_is_preserved_for_disk_retry(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -36,10 +36,47 @@ from tests.test_configure import get_span_processors, wait_for_check_token_threa
 class SinkHTTPAdapter(HTTPAdapter):
     """An HTTPAdapter that consumes all data sent to it."""
 
+    def __init__(self) -> None:
+        super().__init__()
+        self.timeouts: list[float | tuple[float, float] | None] = []
+
     def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
+        self.timeouts.append(kwargs.get('timeout'))
         resp = Response()
         resp.status_code = 200
         return resp
+
+
+@pytest.mark.parametrize(
+    ('timeout', 'expected'),
+    [
+        (30, (3, 30)),
+        (2, (2, 2)),
+        ((1, 30), (1, 30)),
+    ],
+)
+def test_connect_timeout(timeout: float | tuple[float, float], expected: tuple[float, float]) -> None:
+    session = OTLPExporterHttpSession()
+    adapter = SinkHTTPAdapter()
+    session.mount('http://', adapter)
+
+    session.post('http://example.com', data=b'', timeout=timeout)
+
+    assert adapter.timeouts == [expected]
+
+
+def test_connect_timeout_is_preserved_for_disk_retry(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = OTLPExporterHttpSession()
+    request_error = requests.exceptions.RequestException('request failed')
+    monkeypatch.setattr(session, '_post', Mock(side_effect=request_error))
+    add_task = Mock()
+    monkeypatch.setattr(session, '_add_task', add_task)
+    monkeypatch.setattr('time.time', Mock(side_effect=[0, 11]))
+
+    with pytest.raises(requests.exceptions.RequestException, match='request failed'):
+        session.post('http://example.com', data=b'data', timeout=30)
+
+    add_task.assert_called_once_with(b'data', 'http://example.com', {'timeout': (3, 30)}, request_error)
 
 
 def test_max_body_size_bytes() -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,7 +29,7 @@ def test_requests_send_a_timeout() -> None:
         client._put_raw('/v1/anything', body={})  # pyright: ignore[reportPrivateUsage]
 
     assert [(request.method, request.timeout) for request in m.request_history] == [
-        ('GET', 30),
-        ('POST', 30),
-        ('PUT', 30),
+        ('GET', (3, 30)),
+        ('POST', (3, 30)),
+        ('PUT', (3, 30)),
     ]


### PR DESCRIPTION
## Summary

- cap each Logfire HTTP connection attempt at three seconds while retaining existing read/export timeouts
- apply the split timeout to Logfire API requests and OTLP trace, metric, and log exports
- preserve the split timeout when failed OTLP payloads enter the disk retry path

## Root cause

Requests/urllib3 tries resolved addresses sequentially. When a network advertises an unusable IPv6 route before a working IPv4 route, a scalar 30-second timeout can make each new connection wait roughly 30 seconds before falling back to IPv4. Short scripts can consequently spend most of shutdown waiting for telemetry and token-validation requests that ultimately succeed.

Using Requests' `(connect, read)` timeout form limits the failed address attempt without reducing the existing allowance for uploading telemetry or reading a response. The OTLP connection timeout is also clipped to the exporter's remaining deadline.

## Impact

Networks with a blackholed address family fall back to the next resolved address after at most three seconds per address. If all addresses are unavailable, the existing Logfire retry and disk-queue behavior remains in place.

## Validation

- `uv run pytest tests/exporters/test_otlp_session.py tests/test_internal_forwarding.py tests/test_client.py tests/test_configure.py` (168 passed)
- pre-commit Ruff, formatting, and pyright checks
