### PR TITLE
Add `logfire --non-interactive`

### DIFF
--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -26,7 +26,7 @@ from ..auth import HOME_LOGFIRE
 from ..client import LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
-from ..interactive import NonInteractiveError, set_non_interactive
+from ..interactive import NonInteractiveError, is_non_interactive, require_answer, set_non_interactive
 from ..server_response import install_logfire_response_hook
 from ..tracer import SDKTracerProvider
 from .auth import parse_auth, parse_logout
@@ -114,7 +114,14 @@ def parse_clean(args: argparse.Namespace) -> None:
     files_to_delete.append(data_dir / 'logfire_credentials.json')
 
     files_to_display = '\n'.join([str(file) for file in files_to_delete if file.exists()])
-    confirm = input(f'The following files will be deleted:\n{files_to_display}\nAre you sure? [N/y]')
+    if not args.yes:
+        require_answer(
+            f'This would delete:\n{files_to_display}',
+            'logfire clean --yes',
+        )
+    confirm = (
+        'y' if args.yes else input(f'The following files will be deleted:\n{files_to_display}\nAre you sure? [N/y]')
+    )
     if confirm.lower() in ('yes', 'y'):
         for file in files_to_delete:
             file.unlink(missing_ok=True)
@@ -362,6 +369,7 @@ def _main(args: list[str] | None = None) -> None:
     cmd_clean.set_defaults(func=parse_clean)
     cmd_clean.add_argument('--data-dir', default='.logfire')
     cmd_clean.add_argument('--logs', action='store_true', default=False, help='remove the Logfire logs')
+    cmd_clean.add_argument('--yes', '-y', action='store_true', default=False, help='do not ask for confirmation')
 
     cmd_gateway = subparsers.add_parser('gateway', help=_parse_gateway.__doc__)
     cmd_gateway.add_argument('gateway_args', nargs=argparse.REMAINDER)
@@ -480,6 +488,7 @@ def main(args: list[str] | None = None) -> None:
     file_handler.setLevel(logging.DEBUG)
     logging.basicConfig(handlers=[file_handler], level=logging.DEBUG)
 
+    previous_non_interactive = is_non_interactive()
     try:
         _main(args)
     except KeyboardInterrupt:
@@ -490,4 +499,8 @@ def main(args: list[str] | None = None) -> None:
         sys.stderr.write(f'{e}\n')
         sys.exit(1)
     finally:
+        # Restore rather than clear: `main()` is importable and an application may call it
+        # in-process, where leaving the switch set would silently stop every later prompt
+        # -- including ones in `logfire.configure()`, which this flag does not govern.
+        set_non_interactive(previous_non_interactive)
         file_handler.close()

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -26,6 +26,7 @@ from ..auth import HOME_LOGFIRE
 from ..client import LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
+from ..interactive import NonInteractiveError, set_non_interactive
 from ..server_response import install_logfire_response_hook
 from ..tracer import SDKTracerProvider
 from .auth import parse_auth, parse_logout
@@ -335,6 +336,11 @@ def _main(args: list[str] | None = None) -> None:
 
     parser.add_argument('--version', action='store_true', help='show the version and exit')
     global_opts = parser.add_argument_group(title='global options')
+    global_opts.add_argument(
+        '--non-interactive',
+        action='store_true',
+        help='never prompt; fail with guidance if an answer would be required',
+    )
     url_or_region_grp = global_opts.add_mutually_exclusive_group()
     url_or_region_grp.add_argument('--logfire-url', help=argparse.SUPPRESS)
     url_or_region_grp.add_argument(
@@ -434,6 +440,7 @@ def _main(args: list[str] | None = None) -> None:
         namespace.script_and_args = unknown_args + (namespace.script_and_args or [])
     else:
         namespace = parser.parse_args(args)
+    set_non_interactive(namespace.non_interactive)
 
     if namespace.logfire_url:
         warnings.warn(
@@ -477,6 +484,10 @@ def main(args: list[str] | None = None) -> None:
         _main(args)
     except KeyboardInterrupt:
         sys.stderr.write('User cancelled.\n')
+        sys.exit(1)
+    except NonInteractiveError as e:
+        # The whole point is guidance instead of a traceback, so it must not escape.
+        sys.stderr.write(f'{e}\n')
         sys.exit(1)
     finally:
         file_handler.close()

--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from ...exceptions import LogfireConfigError
 from ..auth import DEFAULT_FILE, UserTokenCollection, poll_for_token, request_device_code
 from ..config import REGIONS
+from ..interactive import require_answer
 
 
 def _read_line(prompt: str = '') -> str | None:
@@ -57,6 +58,10 @@ def parse_auth(args: argparse.Namespace) -> None:
         )
     )
     if not logfire_url:
+        require_answer(
+            'Logfire is available in multiple data regions and no region was selected.',
+            *(f'logfire --region {region_id} auth' for region_id in REGIONS),
+        )
         selected_region = -1
         while not (1 <= selected_region <= len(REGIONS)):
             sys.stderr.write('Logfire is available in multiple data regions. Please select one:\n')

--- a/logfire/_internal/cli/auth.py
+++ b/logfire/_internal/cli/auth.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from ...exceptions import LogfireConfigError
 from ..auth import DEFAULT_FILE, UserTokenCollection, poll_for_token, request_device_code
 from ..config import REGIONS
-from ..interactive import require_answer
+from ..interactive import is_non_interactive, require_answer
 
 
 def _read_line(prompt: str = '') -> str | None:
@@ -104,13 +104,18 @@ def parse_auth(args: argparse.Namespace) -> None:
     # device-code poll simply waits, so a caller can surface the link and the login
     # completes when the user opens it.
     #
-    # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
-    sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
-    if _read_line() is not None:
-        try:
-            webbrowser.open(frontend_auth_url, new=2)
-        except webbrowser.Error:
-            pass
+    # `--non-interactive` is checked BEFORE reading rather than relying on the read
+    # failing, because a read is exactly what it cannot afford: with `--region` supplied
+    # the region prompt is skipped and this is the next stop, so an open, silent stdin
+    # hung here -- the precise failure the flag exists to prevent.
+    if not is_non_interactive():
+        # We are not using the `prompt` parameter from `input` here because we want to write to stderr.
+        sys.stderr.write(f'Press Enter to open {frontend_host} in your browser...\n')
+        if _read_line() is not None:
+            try:
+                webbrowser.open(frontend_auth_url, new=2)
+            except webbrowser.Error:
+                pass
     sys.stderr.writelines(
         (
             f"Please open {frontend_auth_url} in your browser to authenticate if it hasn't already.\n",

--- a/logfire/_internal/cli/gateway.py
+++ b/logfire/_internal/cli/gateway.py
@@ -23,6 +23,7 @@ from rich.prompt import Prompt
 
 from logfire.exceptions import LogfireConfigError
 
+from ..interactive import require_answer
 from .ai_tools import (
     LOCAL_TOKEN_PLACEHOLDER,
     AiToolIntegration,
@@ -446,6 +447,10 @@ def _interactive_integration() -> str:
     if not installed:
         console.print('[red]No supported integration binaries were found on PATH.[/]')
         raise SystemExit(127)
+    require_answer(
+        'No integration was named, and several are installed: ' + ', '.join(installed),
+        *(f'logfire gateway {name}' for name in installed),
+    )
     return Prompt.ask('Launch which integration?', choices=installed, default=installed[0])
 
 

--- a/logfire/_internal/cli/gateway.py
+++ b/logfire/_internal/cli/gateway.py
@@ -448,7 +448,8 @@ def _interactive_integration() -> str:
         console.print('[red]No supported integration binaries were found on PATH.[/]')
         raise SystemExit(127)
     require_answer(
-        'No integration was named, and several are installed: ' + ', '.join(installed),
+        'No integration was named. '
+        + (f'{installed[0]} is installed.' if len(installed) == 1 else f'Installed: {", ".join(installed)}.'),
         *(f'logfire gateway {name}' for name in installed),
     )
     return Prompt.ask('Launch which integration?', choices=installed, default=installed[0])

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -115,7 +115,7 @@ from .exporters.remove_pending import RemovePendingSpansExporter
 from .exporters.test import TestExporter
 from .forwarding import OTLPForwardingManager
 from .integrations.executors import instrument_executors
-from .interactive import is_non_interactive, require_answer
+from .interactive import require_answer
 from .logs import ProxyLoggerProvider
 from .metrics import ProxyMeterProvider
 from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions
@@ -2229,11 +2229,6 @@ class LogfireCredentials:
 
         projects = client.get_user_projects()
         if projects:
-            require_answer(
-                'This folder is not linked to a project, and you have existing projects.',
-                'logfire projects use <name> --org <organization>',
-                'logfire projects new <name> --default-org',
-            )
             use_existing_projects = Confirm.ask('Do you want to use one of your existing projects? ', default=True)
             if use_existing_projects:  # pragma: no branch
                 credentials = cls.use_existing_project(client=client, projects=projects)
@@ -2243,13 +2238,10 @@ class LogfireCredentials:
 
         try:
             result = cls(**credentials, logfire_api_url=client.base_url)
-            message = f'Project initialized successfully. You will be able to view it at: {result.project_url}'
-            if is_non_interactive():
-                # Nothing is being ASKED here -- the keypress is discarded -- so this is
-                # skipped rather than refused. The message still gets printed.
-                print(message)
-            else:
-                Prompt.ask(f'{message}\nPress Enter to continue')
+            Prompt.ask(
+                f'Project initialized successfully. You will be able to view it at: {result.project_url}\n'
+                'Press Enter to continue'
+            )
             return result
         except TypeError as e:  # pragma: no cover
             raise LogfireConfigError(f'Invalid credentials, when initializing project: {e}') from e

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -2169,18 +2169,15 @@ class LogfireCredentials:
         project_name_prompt = 'Enter the project name'
         name_rejected = False
 
-        def name_remedy(name: str) -> str:
-            """A runnable `projects new`, carrying the organization already settled on.
+        # The organization is settled by this point -- every branch above either kept the
+        # one that was passed or assigned one -- so the flag that reproduces it can be
+        # worked out once. Suggestions must carry it: a bare `projects new <name>` handed
+        # to someone who passed `--org` stops at the prompt they had already answered.
+        org_flag = ' --default-org' if default_organization else f' --org {organization}'
 
-            Dropping it would suggest a command that stops at the organization prompt the
-            caller had already answered with `--org` / `--default-org`.
-            """
-            remedy = f'logfire projects new {name}'
-            if default_organization:
-                return remedy + ' --default-org'
-            if organization:
-                return remedy + f' --org {organization}'
-            return remedy
+        def name_remedy(name: str) -> str:
+            """A runnable `projects new`, carrying the organization already settled on."""
+            return f'logfire projects new {name}{org_flag}'
 
         while True:
             if not project_name:

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -2139,7 +2139,7 @@ class LogfireCredentials:
                     organization = user_default_organization_name
                 else:
                     require_answer(
-                        'Several organizations are available and none was selected.',
+                        'Several organizations are available and none was selected: ' + ', '.join(organizations),
                         'logfire projects new <name> --org <organization>',
                         'logfire projects new <name> --default-org',
                     )
@@ -2167,14 +2167,45 @@ class LogfireCredentials:
 
         project_name_default: str = default_project_name()
         project_name_prompt = 'Enter the project name'
+        name_rejected = False
+
+        def name_remedy(name: str) -> str:
+            """A runnable `projects new`, carrying the organization already settled on.
+
+            Dropping it would suggest a command that stops at the organization prompt the
+            caller had already answered with `--org` / `--default-org`.
+            """
+            remedy = f'logfire projects new {name}'
+            if default_organization:
+                return remedy + ' --default-org'
+            if organization:
+                return remedy + f' --org {organization}'
+            return remedy
+
         while True:
             if not project_name:
+                # `project_name_prompt` carries WHY a name is being asked for -- it is
+                # rewritten below when the backend rejects one -- so the refusal repeats
+                # the real reason rather than the generic "none was given".
+                #
+                # Once a name has been rejected there is no good name to suggest: the
+                # default WAS the rejected one, and `project_name_default` is set to `...`
+                # on that path, so suggesting it produces `logfire projects new Ellipsis`
+                # -- which runs, and creates a project called Ellipsis.
                 require_answer(
-                    'No project name was given.',
-                    f'logfire projects new {project_name_default}',
+                    project_name_prompt.strip(),
+                    name_remedy('<name>' if name_rejected else project_name_default),
                 )
             project_name = project_name or Prompt.ask(project_name_prompt, default=project_name_default)
             while project_name and not re.match(PROJECT_NAME_PATTERN, project_name):
+                # A name that was SUPPLIED and is malformed skips the guard above, so
+                # without this the recovery prompt below reads stdin and hangs.
+                require_answer(
+                    f'The project name {project_name!r} is invalid: it may contain lowercase '
+                    'alphanumeric characters and single hyphens, and may not start or end with '
+                    'a hyphen.',
+                    name_remedy('<name>'),
+                )
                 project_name = Prompt.ask(
                     "\nThe project name you've entered is invalid. Valid project names:\n"
                     '  * may contain lowercase alphanumeric characters\n'
@@ -2187,6 +2218,7 @@ class LogfireCredentials:
             try:
                 project = client.create_new_project(organization, project_name)
             except ProjectAlreadyExists:
+                name_rejected = True
                 project_name_default = ...  # pyright: ignore[reportAssignmentType]  # this means the value is required
                 project_name_prompt = (
                     f"\nA project with the name '{project_name}' already exists. Please enter a different project name"
@@ -2194,6 +2226,7 @@ class LogfireCredentials:
                 project_name = None
                 continue
             except InvalidProjectName as exc:
+                name_rejected = True
                 project_name_default = ...  # pyright: ignore[reportAssignmentType]  # this means the value is required
                 project_name_prompt = (
                     f'\nThe project name you entered is invalid:\n{exc.reason}\nPlease enter a different project name'

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -115,6 +115,7 @@ from .exporters.remove_pending import RemovePendingSpansExporter
 from .exporters.test import TestExporter
 from .forwarding import OTLPForwardingManager
 from .integrations.executors import instrument_executors
+from .interactive import is_non_interactive, require_answer
 from .logs import ProxyLoggerProvider
 from .metrics import ProxyMeterProvider
 from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions
@@ -2048,17 +2049,20 @@ class LogfireCredentials:
                     'No projects found for the current user. You can create a new project with `logfire projects new`'
                 )
                 return None
-            elif (
-                Prompt.ask(
+            else:
+                require_answer(
+                    f'No {project_message} found for the current user{org_message}.',
+                    'logfire projects use <name> --org <organization>',
+                )
+                expand_search = Prompt.ask(
                     f'No {project_message} found for the current user{org_message}. Choose from all projects?',
                     choices=['y', 'n'],
                     default='y',
                 )
-                == 'n'
-            ):
-                # user didn't want to expand search, print a hint and quit
-                console.print(f'You can create a new project{org_message} with `logfire projects new{org_flag}`')
-                return None
+                if expand_search == 'n':
+                    # user didn't want to expand search, print a hint and quit
+                    console.print(f'You can create a new project{org_message} with `logfire projects new{org_flag}`')
+                    return None
             # try all projects
             filtered_projects = projects
             organization = None
@@ -2079,6 +2083,10 @@ class LogfireCredentials:
             }
             project_choices_str = '\n'.join(
                 [f'{index}. {item[0]}/{item[1]}' for index, item in project_choices.items()]
+            )
+            require_answer(
+                f'Several projects are available:\n{project_choices_str}',
+                'logfire projects use <name> --org <organization>',
             )
             selected_project_key = Prompt.ask(
                 f"Please select one of the following projects by number (requires the 'write_token' permission):\n{project_choices_str}\n",
@@ -2130,6 +2138,11 @@ class LogfireCredentials:
                 if default_organization and user_default_organization_name:
                     organization = user_default_organization_name
                 else:
+                    require_answer(
+                        'Several organizations are available and none was selected.',
+                        'logfire projects new <name> --org <organization>',
+                        'logfire projects new <name> --default-org',
+                    )
                     organization = Prompt.ask(
                         '\nTo create and use a new project, please provide the following information:\n'
                         'Select the organization to create the project in',
@@ -2139,6 +2152,13 @@ class LogfireCredentials:
             else:
                 organization = organizations[0]
                 if not default_organization:
+                    # Creating a project is a side effect, so this is never assumed --
+                    # `--default-org` is how a caller says yes ahead of time.
+                    require_answer(
+                        f'This would create a project in the organization "{organization}".',
+                        f'logfire projects new <name> --org {organization}',
+                        'logfire projects new <name> --default-org',
+                    )
                     confirm = Confirm.ask(
                         f'The project will be created in the organization "{organization}". Continue?', default=True
                     )
@@ -2148,6 +2168,11 @@ class LogfireCredentials:
         project_name_default: str = default_project_name()
         project_name_prompt = 'Enter the project name'
         while True:
+            if not project_name:
+                require_answer(
+                    'No project name was given.',
+                    f'logfire projects new {project_name_default}',
+                )
             project_name = project_name or Prompt.ask(project_name_prompt, default=project_name_default)
             while project_name and not re.match(PROJECT_NAME_PATTERN, project_name):
                 project_name = Prompt.ask(
@@ -2204,6 +2229,11 @@ class LogfireCredentials:
 
         projects = client.get_user_projects()
         if projects:
+            require_answer(
+                'This folder is not linked to a project, and you have existing projects.',
+                'logfire projects use <name> --org <organization>',
+                'logfire projects new <name> --default-org',
+            )
             use_existing_projects = Confirm.ask('Do you want to use one of your existing projects? ', default=True)
             if use_existing_projects:  # pragma: no branch
                 credentials = cls.use_existing_project(client=client, projects=projects)
@@ -2213,10 +2243,13 @@ class LogfireCredentials:
 
         try:
             result = cls(**credentials, logfire_api_url=client.base_url)
-            Prompt.ask(
-                f'Project initialized successfully. You will be able to view it at: {result.project_url}\n'
-                'Press Enter to continue'
-            )
+            message = f'Project initialized successfully. You will be able to view it at: {result.project_url}'
+            if is_non_interactive():
+                # Nothing is being ASKED here -- the keypress is discarded -- so this is
+                # skipped rather than refused. The message still gets printed.
+                print(message)
+            else:
+                Prompt.ask(f'{message}\nPress Enter to continue')
             return result
         except TypeError as e:  # pragma: no cover
             raise LogfireConfigError(f'Invalid credentials, when initializing project: {e}') from e

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -2052,7 +2052,7 @@ class LogfireCredentials:
             else:
                 require_answer(
                     f'No {project_message} found for the current user{org_message}.',
-                    'logfire projects use <name> --org <organization>',
+                    'logfire projects use PROJECT_NAME --org ORGANIZATION',
                 )
                 expand_search = Prompt.ask(
                     f'No {project_message} found for the current user{org_message}. Choose from all projects?',
@@ -2086,7 +2086,7 @@ class LogfireCredentials:
             )
             require_answer(
                 f'Several projects are available:\n{project_choices_str}',
-                'logfire projects use <name> --org <organization>',
+                'logfire projects use PROJECT_NAME --org ORGANIZATION',
             )
             selected_project_key = Prompt.ask(
                 f"Please select one of the following projects by number (requires the 'write_token' permission):\n{project_choices_str}\n",
@@ -2140,8 +2140,8 @@ class LogfireCredentials:
                 else:
                     require_answer(
                         'Several organizations are available and none was selected: ' + ', '.join(organizations),
-                        'logfire projects new <name> --org <organization>',
-                        'logfire projects new <name> --default-org',
+                        'logfire projects new PROJECT_NAME --org ORGANIZATION',
+                        'logfire projects new PROJECT_NAME --default-org',
                     )
                     organization = Prompt.ask(
                         '\nTo create and use a new project, please provide the following information:\n'
@@ -2156,8 +2156,8 @@ class LogfireCredentials:
                     # `--default-org` is how a caller says yes ahead of time.
                     require_answer(
                         f'This would create a project in the organization "{organization}".',
-                        f'logfire projects new <name> --org {organization}',
-                        'logfire projects new <name> --default-org',
+                        f'logfire projects new PROJECT_NAME --org {organization}',
+                        'logfire projects new PROJECT_NAME --default-org',
                     )
                     confirm = Confirm.ask(
                         f'The project will be created in the organization "{organization}". Continue?', default=True
@@ -2170,14 +2170,17 @@ class LogfireCredentials:
         name_rejected = False
 
         # The organization is settled by this point -- every branch above either kept the
-        # one that was passed or assigned one -- so the flag that reproduces it can be
-        # worked out once. Suggestions must carry it: a bare `projects new <name>` handed
-        # to someone who passed `--org` stops at the prompt they had already answered.
-        org_flag = ' --default-org' if default_organization else f' --org {organization}'
-
+        # one that was passed or assigned one -- so the suggestion can name it outright.
+        # Suggestions must carry it: a bare `projects new PROJECT_NAME` handed to someone
+        # who passed `--org` stops at the prompt they had already answered.
+        #
+        # Always `--org <name>`, never `--default-org`, even when that is how the
+        # organization was chosen. Naming it explicitly reproduces the same result either
+        # way, and it cannot go wrong when BOTH flags were passed -- where `--default-org`
+        # would send the retry to the default organization rather than the requested one.
         def name_remedy(name: str) -> str:
             """A runnable `projects new`, carrying the organization already settled on."""
-            return f'logfire projects new {name}{org_flag}'
+            return f'logfire projects new {name} --org {organization}'
 
         while True:
             if not project_name:
@@ -2191,7 +2194,7 @@ class LogfireCredentials:
                 # -- which runs, and creates a project called Ellipsis.
                 require_answer(
                     project_name_prompt.strip(),
-                    name_remedy('<name>' if name_rejected else project_name_default),
+                    name_remedy('PROJECT_NAME' if name_rejected else project_name_default),
                 )
             project_name = project_name or Prompt.ask(project_name_prompt, default=project_name_default)
             while project_name and not re.match(PROJECT_NAME_PATTERN, project_name):
@@ -2201,7 +2204,7 @@ class LogfireCredentials:
                     f'The project name {project_name!r} is invalid: it may contain lowercase '
                     'alphanumeric characters and single hyphens, and may not start or end with '
                     'a hyphen.',
-                    name_remedy('<name>'),
+                    name_remedy('PROJECT_NAME'),
                 )
                 project_name = Prompt.ask(
                     "\nThe project name you've entered is invalid. Valid project names:\n"

--- a/logfire/_internal/interactive.py
+++ b/logfire/_internal/interactive.py
@@ -40,18 +40,28 @@ def is_non_interactive() -> bool:
     return _non_interactive
 
 
-def require_answer(question: str, *remedies: str) -> None:
+def require_answer(question: str, remedy: str, *more_remedies: str) -> None:
     """Fail instead of prompting, when the caller said it cannot answer.
+
+    At least one remedy is required by the signature: refusing to prompt while offering no
+    way forward just moves the dead end, and telling the caller what to pass is the entire
+    value of failing here rather than blocking.
 
     Args:
         question: what would have been asked, in plain terms.
-        remedies: runnable suggestions. Each is printed on its own line, so they must be
-            individually pasteable -- `--org a|b` is a shell pipeline, not a suggestion.
+        remedy: a runnable suggestion.
+        more_remedies: further suggestions. Each is printed on its own line, so each must
+            be individually pasteable -- `--org a|b` is a shell pipeline, not a suggestion.
     """
     if not _non_interactive:
         return
-    lines = [question, 'Cannot prompt because --non-interactive was passed.']
-    if remedies:
-        lines.append('Supply it instead with:')
-        lines.extend(f'  {r}' for r in remedies)
-    raise NonInteractiveError('\n'.join(lines))
+    raise NonInteractiveError(
+        '\n'.join(
+            [
+                question,
+                'Cannot prompt because --non-interactive was passed.',
+                'Supply it instead with:',
+                *(f'  {r}' for r in (remedy, *more_remedies)),
+            ]
+        )
+    )

--- a/logfire/_internal/interactive.py
+++ b/logfire/_internal/interactive.py
@@ -1,0 +1,57 @@
+"""Whether this process is allowed to stop and ask a person something.
+
+`logfire --non-interactive` says the caller cannot answer prompts. Prompts that need an
+ANSWER then fail with guidance naming the argument that supplies it, instead of blocking.
+Prompts that ask for nothing -- "Press Enter to continue" -- are simply skipped.
+
+WHY A FLAG, when the CLI could just notice that reading fails. Because noticing requires
+a read that RETURNS, and stdin can be open and silent: a CI runner, a supervisor or an
+agent harness that leaves stdin attached to an idle pipe never sends EOF, so `input()`
+waits forever. There is no traceback and no output -- the job just hangs. Detecting EOF
+cannot cover that case; declaring intent up front can, because nothing has to be read.
+
+The two are complements. EOF handling still covers callers that cannot be changed (a
+command copied out of the docs into an agent), and this covers callers that can say so.
+"""
+
+from __future__ import annotations
+
+from logfire.exceptions import LogfireConfigError
+
+_non_interactive = False
+
+
+class NonInteractiveError(LogfireConfigError):
+    """A prompt was needed, but `--non-interactive` says nobody can answer it.
+
+    Carries the guidance the user needs rather than a traceback: the CLI catches this and
+    prints `message` before exiting non-zero.
+    """
+
+
+def set_non_interactive(value: bool) -> None:
+    """Record whether prompts are allowed. Called once, from CLI argument parsing."""
+    global _non_interactive
+    _non_interactive = value
+
+
+def is_non_interactive() -> bool:
+    """Whether the caller declared that it cannot answer prompts."""
+    return _non_interactive
+
+
+def require_answer(question: str, *remedies: str) -> None:
+    """Fail instead of prompting, when the caller said it cannot answer.
+
+    Args:
+        question: what would have been asked, in plain terms.
+        remedies: runnable suggestions. Each is printed on its own line, so they must be
+            individually pasteable -- `--org a|b` is a shell pipeline, not a suggestion.
+    """
+    if not _non_interactive:
+        return
+    lines = [question, 'Cannot prompt because --non-interactive was passed.']
+    if remedies:
+        lines.append('Supply it instead with:')
+        lines.extend(f'  {r}' for r in remedies)
+    raise NonInteractiveError('\n'.join(lines))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -810,6 +810,47 @@ def test_non_interactive_flag_does_not_leak_between_invocations(tmp_path: Path) 
     assert is_non_interactive() is False, 'a later run without the flag must be interactive again'
 
 
+def test_non_interactive_with_a_region_never_reads_stdin(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The path the flag exists for, and the one my own tests missed.
+
+    With `--region` supplied the region prompt is skipped, so "Press Enter to open ... in
+    your browser" is the next stop. It read unconditionally, so an open, silent stdin hung
+    there -- the exact failure this flag is meant to prevent, in the command it is most
+    likely to be used with. Asserting `input` is never called is the only assertion that
+    catches it; an EOF-based test passes either way.
+    """
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        # Not EOFError: a stdin that BLOCKS forever cannot be simulated, so instead this
+        # fails loudly if anything reads at all.
+        mock_input = stack.enter_context(
+            patch('logfire._internal.cli.auth.input', side_effect=AssertionError('read stdin'))
+        )
+        webbrowser_open = stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
+        )
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
+            text='{"token": "fake_token", "expiration": "fake_exp"}',
+        )
+
+        main(['--non-interactive', '--region', 'us', 'auth'])
+
+    mock_input.assert_not_called()
+    webbrowser_open.assert_not_called()
+    assert 'fake_token' in auth_file.read_text()
+    # The URL is still printed: with no browser opened it is the only way to surface the
+    # login to a person.
+    assert 'http://example.com/auth' in capsys.readouterr().err
+
+
 def test_auth_temp_failure(tmp_path: Path) -> None:
     auth_file = tmp_path / 'default.toml'
     with ExitStack() as stack:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -761,55 +761,6 @@ def test_non_interactive_refuses_the_region_without_reading_stdin(
     assert '  logfire --region eu auth' in err
 
 
-def test_non_interactive_does_not_change_the_interactive_path(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
-    """Without the flag, prompting is untouched."""
-    auth_file = tmp_path / 'default.toml'
-    with ExitStack() as stack:
-        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=['1', '']))
-        stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
-
-        m = requests_mock.Mocker()
-        stack.enter_context(m)
-        m.post(
-            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
-            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
-        )
-        m.get(
-            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
-            text='{"token": "fake_token", "expiration": "fake_exp"}',
-        )
-
-        main(['auth'])
-
-    assert 'fake_token' in auth_file.read_text()
-
-
-def test_non_interactive_flag_does_not_leak_between_invocations(tmp_path: Path) -> None:
-    """The switch is process state, so a run that sets it must not affect the next.
-
-    Worth pinning because the failure would be invisible: a later command would simply
-    refuse to prompt, with nothing pointing back at the earlier invocation.
-    """
-    from logfire._internal.interactive import is_non_interactive
-
-    auth_file = tmp_path / 'default.toml'
-    with ExitStack() as stack:
-        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
-        stack.enter_context(patch('logfire._internal.cli.auth.input'))
-        with pytest.raises(SystemExit):
-            main(['--non-interactive', 'auth'])
-
-    assert is_non_interactive() is True, 'sanity: the flag was in force during that run'
-
-    main(['--version'])
-    assert is_non_interactive() is False, 'a later run without the flag must be interactive again'
-
-
 def test_non_interactive_with_a_region_never_reads_stdin(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The path the flag exists for, and the one my own tests missed.
 
@@ -849,6 +800,56 @@ def test_non_interactive_with_a_region_never_reads_stdin(tmp_path: Path, capsys:
     # The URL is still printed: with no browser opened it is the only way to surface the
     # login to a person.
     assert 'http://example.com/auth' in capsys.readouterr().err
+
+
+def test_non_interactive_clean_refuses_instead_of_deleting(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`logfire clean` must not guess an answer either way.
+
+    Assuming its default (N) would do nothing while reporting success; assuming Y would
+    delete credentials nobody confirmed. So it refuses, and `--yes` is how a caller says
+    yes ahead of time.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    (data_dir / 'logfire_credentials.json').write_text('{}')
+
+    with patch('logfire._internal.cli.input', side_effect=AssertionError('read stdin')):
+        with pytest.raises(SystemExit) as exc_info:
+            main(['--non-interactive', 'clean'])
+    assert exc_info.value.code == 1
+
+    err = capsys.readouterr().err
+    assert 'logfire clean --yes' in err
+    # Refused means refused: the file is still there.
+    assert (data_dir / 'logfire_credentials.json').exists()
+
+
+def test_clean_yes_deletes_without_prompting(tmp_dir_cwd: Path) -> None:
+    """`--yes` is the way through, and it must not read stdin to get there."""
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    (data_dir / 'logfire_credentials.json').write_text('{}')
+
+    with patch('logfire._internal.cli.input', side_effect=AssertionError('read stdin')):
+        main(['--non-interactive', 'clean', '--yes'])
+
+    assert not (data_dir / 'logfire_credentials.json').exists()
+
+
+def test_non_interactive_switch_is_restored_after_main_returns() -> None:
+    """`main()` is importable, so the switch must not outlive the call.
+
+    An application that shells through `logfire.cli.main([...])` would otherwise lose
+    prompting everywhere afterwards -- including in `logfire.configure()`, which this flag
+    does not govern at all.
+    """
+    from logfire._internal.interactive import is_non_interactive
+
+    assert is_non_interactive() is False
+    main(['--non-interactive', '--version'])
+    assert is_non_interactive() is False, 'the switch outlived the CLI invocation'
 
 
 def test_auth_temp_failure(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -852,6 +852,80 @@ def test_non_interactive_switch_is_restored_after_main_returns() -> None:
     assert is_non_interactive() is False, 'the switch outlived the CLI invocation'
 
 
+def test_non_interactive_gateway_refuses_instead_of_prompting() -> None:
+    """The gateway refusal, which 100% line coverage did not prove was exercised.
+
+    `require_answer(...)` is one statement, so it counts as covered the moment the
+    surrounding code runs with the flag OFF -- the refusal it performs lives inside the
+    helper. Coverage cannot tell those apart; only driving it with the flag on can.
+    """
+    from logfire._internal.cli.gateway import _interactive_integration  # pyright: ignore[reportPrivateUsage]
+    from logfire._internal.interactive import NonInteractiveError, set_non_interactive
+
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.cli.gateway.ai_tool_names', return_value=['claude', 'codex']))
+        stack.enter_context(
+            patch('logfire._internal.cli.gateway.resolve_ai_tool', return_value=Mock(binary_path=lambda: '/x'))
+        )
+        prompt = stack.enter_context(patch('logfire._internal.cli.gateway.Prompt.ask'))
+
+        set_non_interactive(True)
+        try:
+            with pytest.raises(NonInteractiveError) as exc_info:
+                _interactive_integration()
+        finally:
+            set_non_interactive(False)
+
+    prompt.assert_not_called()
+    message = str(exc_info.value)
+    assert 'Installed: claude, codex' in message
+    assert 'logfire gateway claude' in message
+    assert 'logfire gateway codex' in message
+
+
+def test_non_interactive_gateway_message_matches_how_many_are_installed() -> None:
+    """With one integration the prompt is still reached -- it has a default -- so the
+    refusal must not claim several are available."""
+    from logfire._internal.cli.gateway import _interactive_integration  # pyright: ignore[reportPrivateUsage]
+    from logfire._internal.interactive import NonInteractiveError, set_non_interactive
+
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.cli.gateway.ai_tool_names', return_value=['claude']))
+        stack.enter_context(
+            patch('logfire._internal.cli.gateway.resolve_ai_tool', return_value=Mock(binary_path=lambda: '/x'))
+        )
+        set_non_interactive(True)
+        try:
+            with pytest.raises(NonInteractiveError) as exc_info:
+                _interactive_integration()
+        finally:
+            set_non_interactive(False)
+
+    assert 'claude is installed.' in str(exc_info.value)
+
+
+def test_non_interactive_remedies_are_pasteable() -> None:
+    """Every suggestion must survive being pasted into a shell.
+
+    `<name>` is input redirection and `a|b` is a pipeline, so guidance containing them
+    fails or silently does something else. Both mistakes have already been made once in
+    this PR, which is why this asserts on the whole message rather than one command.
+    """
+    from logfire._internal.interactive import NonInteractiveError, require_answer, set_non_interactive
+
+    set_non_interactive(True)
+    try:
+        with pytest.raises(NonInteractiveError) as exc_info:
+            require_answer('question', 'logfire projects new PROJECT_NAME --org ORGANIZATION')
+    finally:
+        set_non_interactive(False)
+
+    for suggestion in str(exc_info.value).splitlines():
+        if not suggestion.startswith('  logfire'):
+            continue
+        assert not set(suggestion) & set('<>|&;$`()'), f'not pasteable: {suggestion!r}'
+
+
 def test_auth_temp_failure(tmp_path: Path) -> None:
     auth_file = tmp_path / 'default.toml'
     with ExitStack() as stack:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,11 @@ def logfire_credentials() -> LogfireCredentials:
 
 def test_no_args(capsys: pytest.CaptureFixture[str]) -> None:
     main([])
-    assert 'usage: logfire [-h] [--version] [--base-url BASE_URL | --region {us,eu}]  ...' in capsys.readouterr().out
+    # argparse wraps the usage line, so match the parts rather than the layout.
+    out = capsys.readouterr().out
+    assert 'usage: logfire [-h] [--version] [--non-interactive]' in out
+    assert '[--base-url BASE_URL |' in out
+    assert '--region {us,eu}]' in out
 
 
 def test_version(capsys: pytest.CaptureFixture[str]) -> None:
@@ -726,6 +730,84 @@ def test_read_line_returns_none_when_stdin_is_unavailable() -> None:
         assert _read_line('prompt') is None
     finally:
         sys.stdin = original
+
+
+def test_non_interactive_refuses_the_region_without_reading_stdin(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--non-interactive` fails BEFORE reading, which is the whole point.
+
+    Handling EOF only helps when a read returns. Stdin can be open and silent -- a CI
+    runner or a supervisor holding an idle pipe -- and then `input()` waits forever with
+    no output at all. Declaring intent up front is the only thing that catches that, so
+    this asserts nothing is read rather than asserting on the error alone.
+    """
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        mock_input = stack.enter_context(patch('logfire._internal.cli.auth.input'))
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['--non-interactive', 'auth'])
+        assert exc_info.value.code == 1
+
+    mock_input.assert_not_called()
+    err = capsys.readouterr().err
+    assert 'no region was selected' in err
+    assert '--non-interactive' in err
+    # Each suggestion must be runnable as printed.
+    assert '  logfire --region us auth' in err
+    assert '  logfire --region eu auth' in err
+
+
+def test_non_interactive_does_not_change_the_interactive_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Without the flag, prompting is untouched."""
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=['1', '']))
+        stack.enter_context(patch('logfire._internal.cli.auth.webbrowser.open'))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
+        )
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
+            text='{"token": "fake_token", "expiration": "fake_exp"}',
+        )
+
+        main(['auth'])
+
+    assert 'fake_token' in auth_file.read_text()
+
+
+def test_non_interactive_flag_does_not_leak_between_invocations(tmp_path: Path) -> None:
+    """The switch is process state, so a run that sets it must not affect the next.
+
+    Worth pinning because the failure would be invisible: a later command would simply
+    refuse to prompt, with nothing pointing back at the earlier invocation.
+    """
+    from logfire._internal.interactive import is_non_interactive
+
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.input'))
+        with pytest.raises(SystemExit):
+            main(['--non-interactive', 'auth'])
+
+    assert is_non_interactive() is True, 'sanity: the flag was in force during that run'
+
+    main(['--version'])
+    assert is_non_interactive() is False, 'a later run without the flag must be interactive again'
 
 
 def test_auth_temp_failure(tmp_path: Path) -> None:


### PR DESCRIPTION
Adds a global `--non-interactive` flag to the CLI. It never assumes an answer — it **fails with guidance** naming the argument that would have supplied it.

> **Stacked on #2275.** That PR is the first commit on this branch; review/merge it first. This one touches the same region block, so branching off `main` would just conflict.

## Why, when #2275 already handles no-stdin

Because handling `EOFError` only helps when a read **returns**. Stdin can be open and silent — a CI runner, a supervisor, or an agent harness holding an idle pipe — and then `input()` waits forever, with no traceback and no output. The job just stops.

```console
$ sleep 20 | timeout 10 logfire auth                      # killed, still waiting
$ sleep 20 | timeout 10 logfire --non-interactive auth    # exit 1, with guidance
```

Nothing can *detect* that case, because there is nothing to detect. Only declaring intent up front avoids it, since then nothing has to be read.

So the two are complements rather than alternatives:

- **EOF handling** covers callers that cannot be changed — a command copied out of the docs into an agent, which will never know to pass a flag.
- **`--non-interactive`** covers callers that *can* say so, and is the only thing that catches the hang.

Closest precedents: `ssh -o BatchMode=yes`, `pip --no-input`, `terraform -input=false`.

## Behaviour

| Prompt | With `--non-interactive` |
| --- | --- |
| `Press Enter to open <host> in your browser…` | skipped — nothing is being asked |
| `Press Enter to continue` after a project is made | skipped; the message still prints |
| region | error naming `logfire --region us\|eu auth`, one line each |
| organization on `projects new` | error naming `--org` / `--default-org` |
| project name | error naming the positional |
| project selection on `projects use` | error naming the positional |

```console
$ logfire --non-interactive projects new orders
This would create a project in the organization "agent-eval".
Cannot prompt because --non-interactive was passed.
Supply it instead with:
  logfire projects new <name> --org agent-eval
  logfire projects new <name> --default-org
```

**Creating a project is refused, not assumed**, even here. It is a side effect, and `--default-org` is how a caller says yes ahead of time. The flag means "don't ask me", not "do whatever you like".

Without the flag, every prompt behaves exactly as before.

## Verified

In a container against a real backend:

- the hang above, fixed (measured by the CLI's own exit code — wall-clock is the wrong instrument, since `sleep 20 | …` makes the *shell* wait regardless of when the CLI exits);
- each blocking command now exits 1 with guidance and no traceback;
- the already-working paths (`projects use <name> --org <org>`, `projects list`) are unaffected and still exit 0.

Tests: 3 new (refusal without reading stdin, the interactive path unchanged, and that the switch does not leak between invocations — it is process state, and a leak would be invisible). `tests/test_cli.py tests/test_configure.py`: **315 passed**.

One pre-existing failure elsewhere in the suite, `test_log_non_scalar_args[pydantic_file_path]`, reproduces on unmodified `main` and is unrelated.

## Scope

CLI only. `logfire.configure()` — the second half of what our own setup docs tell people to run — is a Python API, so a CLI flag cannot reach it, and it still prompts. Worth saying plainly: this does not finish the job on its own.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

