### PR TITLE
Preserve legacy capture headers docs route

### DIFF
--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -281,6 +281,7 @@ navigation:
             slug: "integrations/web-frameworks"
             aliases:
               - "integrations/use-cases/web-frameworks"
+              - "guides/advanced/capture_headers"
           - page: "FastAPI"
             path: "integrations/web-frameworks/fastapi.md"
             slug: "integrations/web-frameworks/fastapi"


### PR DESCRIPTION
## Summary

- preserve the retired `guides/advanced/capture_headers` URL with a source-owned navigation alias
- redirect existing links to the current Web Frameworks documentation

## Validation

- compiled with a production unified-docs build using this local checkout
- verified the generated exact and trailing-slash redirects
- verified the navigation diff against the current `main` branch


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

