### PR TITLE
Make the `whoami` tests robust to a temp path containing spaces

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -159,7 +159,7 @@ def test_whoami(tmp_dir_cwd: Path, logfire_credentials: LogfireCredentials, caps
         with pytest.warns(
             UserWarning, match='Logfire API returned status code 500, you may have trouble sending data.'
         ):
-            main(shlex.split(f'--base-url=http://localhost:0 whoami --data-dir {tmp_dir_cwd}'))
+            main(['--base-url=http://localhost:0', 'whoami', '--data-dir', str(tmp_dir_cwd)])
 
         assert len(request_mocker.request_history) == 1
         assert capsys.readouterr().err.splitlines() == snapshot(
@@ -207,7 +207,7 @@ def test_whoami_logged_in(
 
         m.get('http://localhost/v1/account/me', json={'name': 'test-user'})
 
-        main(shlex.split(f'--base-url=http://localhost:0 whoami --data-dir {tmp_dir_cwd}'))
+        main(['--base-url=http://localhost:0', 'whoami', '--data-dir', str(tmp_dir_cwd)])
     assert capsys.readouterr().err.splitlines() == snapshot(
         [
             'Logged in as: test-user',


### PR DESCRIPTION
Follow-up to #2232, which fixed the same pattern in the `clean` tests.

The two `whoami` tests build their argv with `shlex.split` on an f-string holding `tmp_dir_cwd`. If that path contains a space, `shlex.split` splits it again, argparse takes the first fragment as `--data-dir`, and the command exits 1. Nothing guards the interpolation, so it is only the default pytest basetemp having no space in it that keeps this from firing.

```
pytest tests/test_cli.py -k whoami --basetemp='.../whoami base'
before: 2 failed, 7 passed
after:  9 passed
```

Both failures are `SystemExit`, at `tests/test_cli.py:162` and `:210`.

The fix passes argv as a list, which is already the dominant style in this file. No production code changes, and no changelog entry, since the change is test-only and `check_changelog` only runs on `pyproject.toml` or `CHANGELOG.md`.

`import shlex` stays for now. The four `clean` call sites on `main` still use it; #2232 converts those, so the import can be dropped once both have landed. The two PRs touch different lines of the same file and should not conflict.

`make format lint typecheck` and `uv run pytest tests/test_cli.py` are clean: 208 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

