### PR TITLE
Add `logfire projects status`

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -183,6 +183,28 @@ logfire projects new <project-name>
 
 Follow the instructions, and you'll have a new project created in no time! :partying_face:
 
+### Status (`projects status`)
+
+To see what telemetry has actually reached the project this directory is linked to, run:
+
+```bash
+logfire projects status
+```
+
+```bash
+Project  my-org/orders
+         https://logfire-us.pydantic.dev/my-org/orders
+
+ Service         | Records | Last seen
+-----------------|---------|---------------------------------
+ orders-web      | 87      | 2026-08-19T01:01:29.717170+00:00
+ orders-worker   | 84      | 2026-08-19T01:01:29.716577+00:00
+```
+
+One row per service, so a partly-instrumented system shows up as one: if you instrumented a web app and a worker but only the web app appears, the worker is not reporting.
+
+This needs a saved read token — see below — and reports the last hour. Add `--json` for machine-readable output.
+
 ## Read tokens (`read-tokens`)
 
 To create a [read token](../how-to-guides/query-api.md) for a project and print it to stdout, run:
@@ -196,6 +218,21 @@ Because the token is printed to stdout, this composes well with other tools, e.g
 ```bash
 claude mcp add logfire -e LOGFIRE_READ_TOKEN=$(logfire read-tokens --project <org>/<project> create) -- uvx logfire-mcp@latest
 ```
+
+### Saving a token instead of printing it
+
+To store the token in the data directory rather than printing it, use `--save`:
+
+```bash
+logfire read-tokens create --save
+```
+
+With no `--project`, this uses the project the current directory is linked to. The token is written to `.logfire/read_token.json`, readable only by you, in the same gitignored directory that already holds your write credentials — and it is never printed, so it cannot end up in your terminal history, a CI log, or a coding agent's transcript.
+
+`logfire projects status` uses this token. A saved token expires after 30 days; run the command again to replace it.
+
+!!! note
+    A read token can read everything in the project, which may include personal data captured in span attributes. Keep `.logfire/` out of version control — the CLI adds a `.gitignore` for you — and use `logfire clean` to remove stored credentials.
 
 ## Run (`run`)
 

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -268,15 +268,22 @@ def _has_git_dir(start: Path) -> bool:
     impossible" from "unconfirmed" without needing a `git` binary at all -- it walks up the
     same way `git` itself resolves a repository root from a working directory.
 
-    Raises `OSError` (permission denied on an intermediate directory, a symlink loop
-    `.resolve()` cannot settle, ...) rather than swallowing it: the caller's whole reason
-    for being here is telling "no repository" from "cannot tell", and silently returning
-    either `True` or `False` on a filesystem error would collapse that distinction right
-    back into a guess.
+    Raises `OSError` (permission denied on an intermediate directory, ...) rather than
+    swallowing it: the caller's whole reason for being here is telling "no repository" from
+    "cannot tell", and silently returning either `True` or `False` on a filesystem error
+    would collapse that distinction right back into a guess. `Path.exists()` itself
+    swallows exactly that kind of error and reports `False` -- confirmed empirically, not
+    merely assumed from its docs -- so this uses `lstat()` directly and treats ONLY
+    `FileNotFoundError` as "confirmed absent"; every other `OSError` (permission denied, a
+    path component that is not a directory, ...) propagates.
     """
     current = start.resolve()
     while True:
-        if (current / '.git').exists():
+        try:
+            (current / '.git').lstat()
+        except FileNotFoundError:
+            pass
+        else:
             return True
         parent = current.parent
         if parent == current:

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -261,6 +261,23 @@ def _read_token_path(data_dir: Path) -> Path:
     return data_dir / READ_TOKEN_FILENAME
 
 
+def _has_git_dir(start: Path) -> bool:
+    """Whether `start` or any of its ancestors contains a `.git` entry.
+
+    A pure filesystem walk, so it can tell "categorically no repository, so tracking is
+    impossible" from "unconfirmed" without needing a `git` binary at all -- it walks up the
+    same way `git` itself resolves a repository root from a working directory.
+    """
+    current = start.resolve()
+    while True:
+        if (current / '.git').exists():
+            return True
+        parent = current.parent
+        if parent == current:
+            return False
+        current = parent
+
+
 def _is_git_tracked(path: Path) -> bool:
     """Whether `path` is tracked by the git repository it sits in, if any.
 
@@ -269,19 +286,35 @@ def _is_git_tracked(path: Path) -> bool:
     writing a real, permanent credential through such a path would make the next `git
     commit -am` publish it.
 
-    No `git` binary anywhere on the machine means no git tracking anywhere either: the
-    threat this guards against is categorically impossible without git, so that case is
-    safe to treat as untracked (and `git ls-files` in a directory that exists but is not a
-    repository fails the SAME way a real "not tracked" answer does -- a plain non-zero
-    exit, not an exception -- so that is handled by the ordinary return below too). A `git`
-    binary that EXISTS but fails to answer -- the check times out, or some other OS-level
-    failure -- is different: tracking might still be real, just unconfirmed, and treating
-    that the same as "definitely untracked" would silently defeat this whole check on
-    exactly the machine states an attacker aiming at this file is most likely to have
-    engineered. That case raises instead, so the caller fails closed rather than guessing.
+    No `.git` anywhere in `path`'s ancestry means no git tracking anywhere either: the
+    threat this guards against is categorically impossible without a repository, so that
+    case is safe to treat as untracked. Checking for `.git` on disk, not merely checking
+    for a `git` BINARY, matters: a repository's index is just files, and can exist -- with
+    this path already tracked in it -- on a machine where `git` itself is not on `PATH`
+    (uninstalled after the commit, a stripped-down `PATH` for this one subprocess call,
+    etc). Trusting the binary's absence as proof of "no repository" would let exactly that
+    machine state slip the write through untracked. Once a `.git` is present, though, a
+    missing `git` binary is treated the same as any other failure to answer below: unconfirmed,
+    not untracked.
+
+    A `git` binary that exists but fails to answer -- the check times out, or some other
+    OS-level failure -- is likewise different from a confirmed "not tracked": tracking might
+    still be real, just unconfirmed, and treating that the same as "definitely untracked"
+    would silently defeat this whole check on exactly the machine states an attacker aiming
+    at this file is most likely to have engineered. Both cases raise, so the caller fails
+    closed rather than guessing. (`git ls-files` in a directory that exists but is not a
+    repository fails the SAME way a real "not tracked" answer does -- a plain non-zero exit,
+    not an exception -- so that case is handled by the ordinary return below.)
     """
     if shutil.which('git') is None:
-        return False
+        if not _has_git_dir(path.parent):
+            return False
+        raise LogfireConfigError(
+            f'Could not confirm whether {path} is already tracked by git (no `git` binary '
+            f'found on PATH, but {path.parent} appears to be inside a git repository); '
+            f'refusing to write a live credential through it without checking. Install git, '
+            f'or resolve whatever is keeping it off PATH here, then try again.'
+        )
     try:
         result = subprocess.run(
             ['git', 'ls-files', '--error-unmatch', '--', path.name],

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import platform
+import shutil
 import subprocess
 import sys
 import warnings
@@ -266,10 +267,21 @@ def _is_git_tracked(path: Path) -> bool:
     `.gitignore` only stops an UNTRACKED file from being added; it does nothing for a path
     already in the index -- committed before this feature existed, or by mistake -- so
     writing a real, permanent credential through such a path would make the next `git
-    commit -am` publish it. Best-effort: git missing, no repository, or the check itself
-    timing out all mean "cannot tell" here, which must not block a working setup over an
-    environment quirk unrelated to the file's own tracked status.
+    commit -am` publish it.
+
+    No `git` binary anywhere on the machine means no git tracking anywhere either: the
+    threat this guards against is categorically impossible without git, so that case is
+    safe to treat as untracked (and `git ls-files` in a directory that exists but is not a
+    repository fails the SAME way a real "not tracked" answer does -- a plain non-zero
+    exit, not an exception -- so that is handled by the ordinary return below too). A `git`
+    binary that EXISTS but fails to answer -- the check times out, or some other OS-level
+    failure -- is different: tracking might still be real, just unconfirmed, and treating
+    that the same as "definitely untracked" would silently defeat this whole check on
+    exactly the machine states an attacker aiming at this file is most likely to have
+    engineered. That case raises instead, so the caller fails closed rather than guessing.
     """
+    if shutil.which('git') is None:
+        return False
     try:
         result = subprocess.run(
             ['git', 'ls-files', '--error-unmatch', '--', path.name],
@@ -277,8 +289,12 @@ def _is_git_tracked(path: Path) -> bool:
             capture_output=True,
             timeout=5,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+    except (OSError, subprocess.TimeoutExpired) as e:
+        raise LogfireConfigError(
+            f'Could not confirm whether {path} is already tracked by git ({e}); refusing to '
+            f'write a live credential through it without checking. Resolve whatever is '
+            f'blocking `git ls-files` here, then try again.'
+        ) from e
     return result.returncode == 0
 
 

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import platform
+import subprocess
 import sys
 import warnings
 from collections.abc import Sequence
@@ -259,6 +260,28 @@ def _read_token_path(data_dir: Path) -> Path:
     return data_dir / READ_TOKEN_FILENAME
 
 
+def _is_git_tracked(path: Path) -> bool:
+    """Whether `path` is tracked by the git repository it sits in, if any.
+
+    `.gitignore` only stops an UNTRACKED file from being added; it does nothing for a path
+    already in the index -- committed before this feature existed, or by mistake -- so
+    writing a real, permanent credential through such a path would make the next `git
+    commit -am` publish it. Best-effort: git missing, no repository, or the check itself
+    timing out all mean "cannot tell" here, which must not block a working setup over an
+    environment quirk unrelated to the file's own tracked status.
+    """
+    try:
+        result = subprocess.run(
+            ['git', 'ls-files', '--error-unmatch', '--', path.name],
+            cwd=path.parent,
+            capture_output=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
 def _save_read_token(
     data_dir: Path, *, token: str, base_url: str, organization: str, project_name: str, expires_at: datetime
 ) -> Path:
@@ -277,6 +300,12 @@ def _save_read_token(
     """
     ensure_data_dir_exists(data_dir)
     path = _read_token_path(data_dir)
+    if _is_git_tracked(path):
+        raise LogfireConfigError(
+            f'{path} is already tracked by git, so .gitignore does not protect it. Writing '
+            f'the token there risks it reaching a commit. Untrack it first '
+            f'(`git rm --cached {path}`) or remove it, then try again.'
+        )
     payload = {
         'token': token,
         'base_url': base_url,
@@ -348,8 +377,18 @@ def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: s
         return None
     if data.get('organization') != organization or data.get('project_name') != project_name:
         return None
-    expires_at = data.get('expires_at')
-    if isinstance(expires_at, str):
+    # Absent means unbounded -- this CLI always writes the key, so a file without it was
+    # written by a different version or edited by hand, and the expiry exists to bound a
+    # leak rather than to gate the happy path. PRESENT but not a string is different: this
+    # file always writes a string, so `null`/a number/etc. did not come from a normal run,
+    # and skipping the check for it (the same way absence does) would let a tampered file
+    # defeat the TTL entirely instead of just losing it. `'expires_at' in data`, not
+    # `data.get('expires_at') is not None`: the key present with a JSON `null` and the key
+    # truly absent both read back as `None` from `.get()`, and only one of those is fine.
+    if 'expires_at' in data:
+        expires_at = data['expires_at']
+        if not isinstance(expires_at, str):
+            return None
         try:
             expiry = datetime.fromisoformat(expires_at)
         except ValueError:
@@ -488,8 +527,12 @@ def parse_project_status(args: argparse.Namespace) -> None:
         )
         return
 
-    sys.stderr.write(f'Project  {organization}/{credentials.project_name}\n')
-    sys.stderr.write(f'         {credentials.project_url}\n\n')
+    # `credentials` came from a file inside the project this command runs in (the same
+    # threat model `_save_read_token`'s docstring covers), so its fields get the same
+    # stripping as a service name -- not the JSON branch above, which is already safe
+    # because `json.dumps` escapes control characters by construction.
+    sys.stderr.write(f'Project  {_printable(organization)}/{_printable(credentials.project_name)}\n')
+    sys.stderr.write(f'         {_printable(credentials.project_url)}\n\n')
     if not services:
         # Deliberately not phrased as failure. Data takes a moment to arrive, and the
         # common case for someone running this during setup is "not yet", not "broken".

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -6,13 +6,16 @@ import argparse
 import functools
 import json
 import logging
+import os
 import platform
 import sys
 import warnings
 from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
 from operator import itemgetter
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple, cast
+from urllib.parse import urlparse
 
 import requests
 from opentelemetry import trace
@@ -23,12 +26,13 @@ from logfire.propagate import ContextCarrier, get_context
 
 from ...version import VERSION
 from ..auth import HOME_LOGFIRE
-from ..client import LogfireClient
+from ..client import UA_HEADER, LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
 from ..interactive import NonInteractiveError, is_non_interactive, require_answer, set_non_interactive
 from ..server_response import install_logfire_response_hook
 from ..tracer import SDKTracerProvider
+from ..utils import READ_TOKEN_FILENAME, ensure_data_dir_exists
 from .auth import parse_auth, parse_logout
 from .prompt import parse_prompt
 from .run import collect_instrumentation_context, parse_run, print_otel_summary
@@ -90,13 +94,9 @@ def parse_whoami(args: argparse.Namespace) -> None:
         username = current_user['name']
         sys.stderr.write(f'Logged in as: {username}\n')
 
-    credentials = LogfireCredentials.load_creds_file(data_dir)
-    if credentials is None:
-        sys.stderr.write(f'No Logfire credentials found in {data_dir.resolve()}\n')
-        sys.exit(1)
-    else:
-        sys.stderr.write(f'Credentials loaded from data dir: {data_dir.resolve()}\n\n')
-        credentials.print_token_summary()
+    credentials = _load_credentials_or_exit(data_dir)
+    sys.stderr.write(f'Credentials loaded from data dir: {data_dir.resolve()}\n\n')
+    credentials.print_token_summary()
 
 
 def parse_clean(args: argparse.Namespace) -> None:
@@ -112,6 +112,9 @@ def parse_clean(args: argparse.Namespace) -> None:
 
     files_to_delete.append(data_dir / '.gitignore')
     files_to_delete.append(data_dir / 'logfire_credentials.json')
+    # The saved read token is a credential too, and leaving it behind would mean a
+    # "cleaned" data directory still holds something that can read the whole project.
+    files_to_delete.append(data_dir / READ_TOKEN_FILENAME)
 
     files_to_display = '\n'.join([str(file) for file in files_to_delete if file.exists()])
     if not args.yes:
@@ -202,11 +205,371 @@ def parse_create_new_project(args: argparse.Namespace) -> None:
     sys.stderr.write(f'Project created successfully. You will be able to view it at: {credentials.project_url}\n')
 
 
+STATUS_LOOKBACK = timedelta(hours=1)
+"""How far back `projects status` looks. Long enough to cover a setup session, short
+enough that the answer is about what you just did rather than about last week."""
+
+STATUS_MAX_ROWS = 10_000
+"""A ceiling on the rows this asks for, so it cannot become an enormous query.
+
+It should not bind in practice -- the result is one row per service -- but the command is
+run against someone else's project and an unbounded query is not worth the surprise.
+"""
+
+
+def _status_sql() -> str:
+    """One row per service: how much arrived and when it last did.
+
+    Aggregated by the backend rather than by pulling rows down and counting here: a
+    project with real traffic would make that unusable, and the answer (a few services) is
+    far smaller than the input.
+
+    Counts RECORDS, not spans: the table holds spans and logs together. Filtering to spans
+    would be the wrong fix -- a service that only logs would then vanish from a command
+    whose entire job is answering "is anything arriving from this service?". So the count
+    stays inclusive and the column says what it actually is.
+    """
+    return (
+        'SELECT service_name, count(*) AS records, max(start_timestamp) AS last_seen FROM records GROUP BY service_name'
+    )
+
+
+def _printable(value: object) -> str:
+    """A value from telemetry, safe to write to a terminal.
+
+    `service_name` is submitted by whoever sends the data, so it can carry ANSI escapes or
+    other control characters. Written straight to stderr those can clear the screen,
+    reposition the cursor, or forge lines of output in a table an operator is reading to
+    decide whether their setup worked.
+    """
+    return ''.join(ch if ch.isprintable() or ch == ' ' else '�' for ch in str(value))
+
+
+READ_TOKEN_TTL = timedelta(days=30)
+"""How long a SAVED read token lasts.
+
+Only tokens this CLI writes to disk get an expiry. The CLI cannot revoke a token, so one
+sitting in a file needs some end; a token printed for the caller to paste elsewhere does
+not get one, because we do not know what it was wired into and silently breaking it later
+would be worse than leaving it.
+"""
+
+
+def _read_token_path(data_dir: Path) -> Path:
+    return data_dir / READ_TOKEN_FILENAME
+
+
+def _save_read_token(
+    data_dir: Path, *, token: str, base_url: str, organization: str, project_name: str, expires_at: datetime
+) -> Path:
+    """Write a read token into the data directory, readable only by its owner.
+
+    The data directory already holds the write token and is gitignored (`.gitignore` of
+    `*`, seeded by `ensure_data_dir_exists`), so this adds a second credential to a place
+    already treated as secret rather than introducing a new one.
+
+    `base_url` is the host the CREATE request actually used -- `client.base_url` after
+    `LogfireClient.from_url(args.logfire_url)`, which comes from `--base-url`/`--region`
+    flags or the user's own `~/.logfire/default.toml`, never from anything inside the
+    project this command runs in. Saving it here is what lets `projects status` use it
+    later without re-deriving a host from anything the repository could have tampered
+    with -- see `_load_saved_read_token`.
+    """
+    ensure_data_dir_exists(data_dir)
+    path = _read_token_path(data_dir)
+    payload = {
+        'token': token,
+        'base_url': base_url,
+        # Recorded so the token is never used for a project it was not issued for -- see
+        # `_load_saved_read_token`.
+        'organization': organization,
+        'project_name': project_name,
+        'expires_at': expires_at.isoformat(),
+    }
+    # O_NOFOLLOW, because this path is inside the user's repository: someone who can get a
+    # symlink committed there -- or who lands one any other way -- would otherwise have
+    # O_TRUNC and the mode change below applied to whatever it points at.
+    # O_NOFOLLOW does not exist on Windows, where symlinks need a privilege to create.
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | getattr(os, 'O_NOFOLLOW', 0)
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError as e:
+        raise LogfireConfigError(f'Could not write the read token to {path}: {e}') from e
+    try:
+        # BEFORE any bytes are written. The mode passed to `os.open` applies only when it
+        # creates the file, so an existing file keeps whatever permissions it had and the
+        # token would land in a world-readable one, restricted only afterwards.
+        os.fchmod(fd, 0o600)
+        handle = os.fdopen(fd, 'w')
+    except BaseException:  # pragma: no cover
+        # Only while the descriptor is still ours; once `fdopen` succeeds the file object
+        # owns it and closing here too would be a double close.
+        os.close(fd)
+        raise
+    with handle as f:
+        json.dump(payload, f, indent=2)
+        f.write('\n')
+    return path
+
+
+class SavedReadToken(NamedTuple):
+    token: str
+    # The host this token is valid against, recorded when it was created -- see
+    # `_save_read_token`. Using this instead of deriving a host from the token's shape or
+    # from `logfire_credentials.json` is what makes self-hosted deployments work: their
+    # base URL cannot be recovered from the token, only from where it was actually minted.
+    base_url: str
+
+
+def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: str) -> SavedReadToken | None:
+    """A saved read token for THIS project, if there is one and it is still usable.
+
+    Returns None rather than raising for every failure mode -- missing, unreadable,
+    corrupt, expired, belonging to a different project, or missing the host it is valid
+    against. The caller turns that into one message naming the command to run, which is
+    more useful than five ways to fail.
+
+    The project check matters: `logfire projects use` repoints the directory, and a token
+    left over from the previous project would otherwise be sent for the new one and
+    produce a confusing 401 or, worse, another project's data.
+    """
+    try:
+        raw: Any = json.loads(_read_token_path(data_dir).read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    data = cast('dict[str, Any]', raw)
+    token = data.get('token')
+    if not isinstance(token, str) or not token:
+        return None
+    base_url = data.get('base_url')
+    if not isinstance(base_url, str) or not base_url:
+        return None
+    if data.get('organization') != organization or data.get('project_name') != project_name:
+        return None
+    expires_at = data.get('expires_at')
+    if isinstance(expires_at, str):
+        try:
+            expiry = datetime.fromisoformat(expires_at)
+        except ValueError:
+            return None
+        # A naive timestamp would raise when compared against an aware one; treat it as
+        # UTC, which is what this file is always written with.
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        if expiry <= datetime.now(tz=timezone.utc):
+            return None
+    return SavedReadToken(token=token, base_url=base_url)
+
+
+def _load_credentials_or_exit(data_dir: Path, remedy: str | None = None) -> LogfireCredentials:
+    """The project this folder is linked to, or a clean exit saying so.
+
+    Shared with `whoami`, which had this block verbatim. `remedy` is what to run to fix
+    it, for callers that know -- `whoami` deliberately passes nothing, because "you are
+    not linked" is the answer it exists to give rather than a failure to recover from.
+    """
+    credentials = LogfireCredentials.load_creds_file(data_dir)
+    if credentials is None:
+        sys.stderr.write(f'No Logfire credentials found in {data_dir.resolve()}\n')
+        if remedy:
+            sys.stderr.write(f'{remedy}\n')
+        sys.exit(1)
+    return credentials
+
+
+def _organization_from_project_url(project_url: str) -> str | None:
+    """The organization a project URL belongs to, or None if it does not look like one.
+
+    The credentials file stores the project URL but not the organization, and the
+    read-token endpoint needs both. Project URLs end in `<organization>/<project>`, so the
+    organization is the second-to-last path segment.
+
+    Pure, and separated out because it is the only part of `projects status` with edge
+    cases worth enumerating -- a URL with no path, one segment, or a trailing slash. The
+    rest of that command is I/O.
+    """
+    parts = [part for part in urlparse(project_url).path.split('/') if part]
+    return parts[-2] if len(parts) >= 2 else None
+
+
+def parse_project_status(args: argparse.Namespace) -> None:
+    """Show what telemetry has reached the current project."""
+    data_dir = Path(args.data_dir)
+    credentials = _load_credentials_or_exit(
+        data_dir, remedy='Run `logfire projects use PROJECT_NAME --org ORGANIZATION` first.'
+    )
+
+    organization = _organization_from_project_url(credentials.project_url)
+    if organization is None:
+        sys.stderr.write(f'Cannot tell which organization {credentials.project_url} belongs to.\n')
+        sys.exit(1)
+
+    # Reuse the token saved next to the write credentials rather than creating one here.
+    # An earlier version of this command minted a read token per invocation, which is a
+    # PERMANENT credential the CLI cannot revoke -- and this command is built to be run
+    # repeatedly while waiting for data, so polling four times left four behind.
+    saved = _load_saved_read_token(data_dir, organization=organization, project_name=credentials.project_name)
+    if saved is None:
+        sys.stderr.write(
+            f'No usable read token for {organization}/{credentials.project_name}.\n'
+            'Run `logfire read-tokens create --save` to create one, then try again.\n'
+        )
+        sys.exit(1)
+
+    # The host the token was CREATED against, not `credentials.logfire_api_url`. That field
+    # comes from `logfire_credentials.json`, which lives in the project this command runs
+    # inside -- a tampered repository could point it at an attacker's server and this
+    # command would hand over the read token in the Authorization header of the next
+    # request. An earlier version derived the host from the token's own region prefix
+    # instead, which closed that hole but broke self-hosted deployments: their base URL is
+    # not recoverable from the token, only from where it was actually minted, which is what
+    # `saved.base_url` records -- see `_save_read_token`.
+    try:
+        # Over `requests`, like every other call this CLI makes. `logfire.query_client`
+        # would be the obvious choice, but it needs httpx, an optional extra rather than a
+        # dependency -- so using it here would break this command on a plain install.
+        response = requests.post(
+            f'{saved.base_url}/v2/query',
+            headers={'Authorization': saved.token, 'User-Agent': UA_HEADER},
+            json={
+                'sql': _status_sql(),
+                'min_timestamp': (datetime.now(tz=timezone.utc) - STATUS_LOOKBACK).isoformat(),
+                'limit': STATUS_MAX_ROWS,
+            },
+            timeout=30,
+        )
+    except requests.RequestException as e:
+        # A DNS failure, timeout, or refused connection raises here rather than returning a
+        # response, and would otherwise print a raw traceback instead of this message.
+        sys.stderr.write(f'Could not reach {saved.base_url}: {e}\n')
+        sys.exit(1)
+    # Exactly 200, not `response.ok`: a 204 or 3xx is "not an error" by that test and
+    # would then fail in `.json()` with a decode error instead of this message.
+    if response.status_code != 200:
+        sys.stderr.write(f'Could not read the project: {response.status_code} {response.text}\n')
+        sys.exit(1)
+    try:
+        # A 200 with a body that is not JSON, or JSON shaped unlike the query response, can
+        # happen without the backend ever seeing the request -- a proxy or WAF intercepting
+        # it -- and would otherwise fail below with a raw traceback instead of this message.
+        raw_data: Any = response.json()['data']
+        if not isinstance(raw_data, list):
+            raise TypeError('"data" is not a list')
+        rows = cast('list[Any]', raw_data)
+        if not all(isinstance(row, dict) for row in rows):
+            raise TypeError('"data" is not a list of objects')
+        services = cast('list[dict[str, Any]]', rows)
+    except (ValueError, KeyError, TypeError) as e:
+        sys.stderr.write(f'Could not read the project: unexpected response shape ({e}).\n')
+        sys.exit(1)
+    services.sort(key=lambda r: str(r.get('service_name') or ''))
+
+    if args.json:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    'organization': organization,
+                    'project_name': credentials.project_name,
+                    'project_url': credentials.project_url,
+                    'lookback_hours': STATUS_LOOKBACK.total_seconds() / 3600,
+                    'services': [
+                        {
+                            'service_name': row.get('service_name'),
+                            'records': row.get('records'),
+                            'last_seen': row.get('last_seen'),
+                        }
+                        for row in services
+                    ],
+                }
+            )
+            + '\n'
+        )
+        return
+
+    sys.stderr.write(f'Project  {organization}/{credentials.project_name}\n')
+    sys.stderr.write(f'         {credentials.project_url}\n\n')
+    if not services:
+        # Deliberately not phrased as failure. Data takes a moment to arrive, and the
+        # common case for someone running this during setup is "not yet", not "broken".
+        sys.stderr.write(
+            f'No telemetry in the last {int(STATUS_LOOKBACK.total_seconds() // 3600)}h.\n'
+            'Run the application so it sends something, then try again.\n'
+        )
+        return
+    sys.stderr.write(
+        _pretty_table(
+            ['Service', 'Records', 'Last seen'],
+            [
+                [
+                    _printable(row.get('service_name') or '(unnamed)'),
+                    _printable(row.get('records') or 0),
+                    _printable(row.get('last_seen') or '-'),
+                ]
+                for row in services
+            ],
+        )
+    )
+
+
 def parse_create_read_token(args: argparse.Namespace) -> None:
     """Create a read token for a project."""
+    save: bool = getattr(args, 'save', False)
+    data_dir = Path(getattr(args, 'data_dir', '.logfire'))
+    organization: str | None = getattr(args, 'organization', None)
+    project_name: str | None = getattr(args, 'project', None)
+
+    if organization is None or project_name is None:
+        # No `--project`, so fall back to whatever this directory is linked to. That is
+        # what makes `logfire read-tokens create --save` work with no arguments at all,
+        # which is the case this option exists for.
+        credentials = _load_credentials_or_exit(
+            data_dir,
+            remedy='Pass --project <org>/<project>, or run `logfire projects use PROJECT_NAME --org ORGANIZATION` first.',
+        )
+        organization = organization or _organization_from_project_url(credentials.project_url)
+        project_name = project_name or credentials.project_name
+        if organization is None:
+            sys.stderr.write(f'Cannot tell which organization {credentials.project_url} belongs to.\n')
+            sys.exit(1)
+
     client = LogfireClient.from_url(args.logfire_url)
-    response = client.create_read_token(args.organization, args.project)
-    sys.stdout.write(response['token'] + '\n')
+    expires_at = datetime.now(tz=timezone.utc) + READ_TOKEN_TTL if save else None
+    response = client.create_read_token(organization, project_name, expires_at=expires_at)
+
+    if not save:
+        sys.stdout.write(response['token'] + '\n')
+        return
+
+    assert expires_at is not None
+    try:
+        path = _save_read_token(
+            data_dir,
+            token=response['token'],
+            # `client.base_url` is the host the CREATE request actually used -- resolved
+            # from `--base-url`/`--region` flags or the user's own `~/.logfire/default.toml`,
+            # never from anything inside the project this command runs in. Recording it
+            # here is what lets `projects status` reuse a trustworthy host later. Works for
+            # self-hosted deployments too, since it is whatever URL the mint request was
+            # really sent to.
+            base_url=client.base_url,
+            organization=organization,
+            project_name=project_name,
+            expires_at=expires_at,
+        )
+    except LogfireConfigError as e:
+        # A symlinked destination or a read-only data directory raises here, and would
+        # otherwise print a raw traceback -- worse, one AFTER a token was already minted,
+        # leaving the caller unsure whether anything happened.
+        sys.stderr.write(f'{e}\n')
+        sys.exit(1)
+    # To STDERR, and without the token. The whole point of `--save` is that the credential
+    # never reaches a terminal, a log, or an agent's transcript.
+    sys.stderr.write(
+        f'Read token for {organization}/{project_name} saved to {path}.\n'
+        f'It expires in {READ_TOKEN_TTL.days} days. `logfire projects status` will use it.\n'
+    )
 
 
 def parse_use_project(args: argparse.Namespace) -> None:
@@ -400,6 +763,13 @@ def _main(args: list[str] | None = None) -> None:
     )
     cmd_projects_new.set_defaults(func=parse_create_new_project)
 
+    cmd_projects_status = projects_subparsers.add_parser(
+        'status', help='show what telemetry has reached the current project'
+    )
+    cmd_projects_status.add_argument('--data-dir', default='.logfire')
+    cmd_projects_status.add_argument('--json', action='store_true', help='output JSON to stdout instead of a table')
+    cmd_projects_status.set_defaults(func=parse_project_status)
+
     cmd_projects_use = projects_subparsers.add_parser('use', help='use a project')
     cmd_projects_use.add_argument('project_name', nargs='?', help='project name')
     cmd_projects_use.add_argument('--org', help='project organization')
@@ -408,12 +778,20 @@ def _main(args: list[str] | None = None) -> None:
 
     cmd_read_tokens = subparsers.add_parser('read-tokens', help='Manage read tokens for a project')
     cmd_read_tokens.add_argument('--project', action=OrgProjectAction, help='project in the format <org>/<project>')
-    cmd_read_tokens.set_defaults(func=lambda _: cmd_read_tokens.print_help())  # pyright: ignore[reportUnknownLambdaType]
+    # `OrgProjectAction` only sets `organization` when `--project` is given, so without a
+    # default the attribute is missing entirely and reading it raises `AttributeError`.
+    cmd_read_tokens.set_defaults(func=lambda _: cmd_read_tokens.print_help(), organization=None)  # pyright: ignore[reportUnknownLambdaType]
     read_tokens_subparsers = cmd_read_tokens.add_subparsers()
 
     # With this command you can do:
     # claude mcp add logfire -e LOGFIRE_READ_TOKEN=$(logfire read-tokens --project kludex/potato create) -- uvx logfire-mcp@latest
     cmd_read_tokens_create = read_tokens_subparsers.add_parser('create', help=parse_create_read_token.__doc__)
+    cmd_read_tokens_create.add_argument(
+        '--save',
+        action='store_true',
+        help='save the token into the data directory instead of printing it, for `logfire projects status`',
+    )
+    cmd_read_tokens_create.add_argument('--data-dir', default='.logfire')
     cmd_read_tokens_create.set_defaults(func=parse_create_read_token)
 
     cmd_prompt = subparsers.add_parser('prompt', help=parse_prompt.__doc__)

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -267,6 +267,12 @@ def _has_git_dir(start: Path) -> bool:
     A pure filesystem walk, so it can tell "categorically no repository, so tracking is
     impossible" from "unconfirmed" without needing a `git` binary at all -- it walks up the
     same way `git` itself resolves a repository root from a working directory.
+
+    Raises `OSError` (permission denied on an intermediate directory, a symlink loop
+    `.resolve()` cannot settle, ...) rather than swallowing it: the caller's whole reason
+    for being here is telling "no repository" from "cannot tell", and silently returning
+    either `True` or `False` on a filesystem error would collapse that distinction right
+    back into a guess.
     """
     current = start.resolve()
     while True:
@@ -307,7 +313,16 @@ def _is_git_tracked(path: Path) -> bool:
     not an exception -- so that case is handled by the ordinary return below.)
     """
     if shutil.which('git') is None:
-        if not _has_git_dir(path.parent):
+        try:
+            has_repo = _has_git_dir(path.parent)
+        except OSError as e:
+            raise LogfireConfigError(
+                f'Could not confirm whether {path} is already tracked by git (looking for a '
+                f'repository above {path.parent} failed: {e}); refusing to write a live '
+                f'credential through it without checking. Resolve whatever is blocking that '
+                f'lookup, then try again.'
+            ) from e
+        if not has_repo:
             return False
         raise LogfireConfigError(
             f'Could not confirm whether {path} is already tracked by git (no `git` binary '
@@ -410,9 +425,28 @@ def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: s
     The project check matters: `logfire projects use` repoints the directory, and a token
     left over from the previous project would otherwise be sent for the new one and
     produce a confusing 401 or, worse, another project's data.
+
+    Also refuses a symlink, or a file the git-tracking check from `_save_read_token` would
+    have refused to write in the first place: `_save_read_token` only guards its OWN
+    writes, so a `read_token.json` that arrived some other way -- committed into the repo
+    by someone else, force-added, or dropped in as a symlink -- has never been through that
+    check. Trusting it here would trust its `base_url` too, and that field is sent straight
+    into the next request's target and `Authorization` header: an attacker who can land
+    such a file controls where this command sends the token it then reads back as project
+    telemetry. `_is_git_tracked` raising (tracking status unconfirmed) is treated the same
+    as "tracked" here -- unlike at `_save_read_token`, failing closed on THIS call site
+    means falling back to "no usable token", not blocking anything.
     """
+    path = _read_token_path(data_dir)
+    if path.is_symlink():
+        return None
     try:
-        raw: Any = json.loads(_read_token_path(data_dir).read_text())
+        if _is_git_tracked(path):
+            return None
+    except LogfireConfigError:
+        return None
+    try:
+        raw: Any = json.loads(path.read_text())
     except (OSError, ValueError):
         return None
     if not isinstance(raw, dict):

--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 from urllib.parse import urljoin
 
@@ -147,11 +148,21 @@ class LogfireClient:
             error_message='Error creating project write token',
         )
 
-    def create_read_token(self, organization: str, project_name: str) -> dict[str, Any]:
-        """Create a read token for the given project in the given organization."""
+    def create_read_token(
+        self, organization: str, project_name: str, expires_at: datetime | None = None
+    ) -> dict[str, Any]:
+        """Create a read token for the given project in the given organization.
+
+        `expires_at` bounds how long the token stays valid. The CLI has no way to revoke
+        one, so a token it stores on disk gets an expiry; a token it prints for the caller
+        to place somewhere else does not, because we do not know what it was used for.
+        """
+        body: dict[str, Any] = {'description': 'Created by Logfire CLI'}
+        if expires_at is not None:
+            body['expires_at'] = expires_at.isoformat()
         return self._post(
             f'/v1/organizations/{organization}/projects/{project_name}/read-tokens',
-            body={'description': 'Created by Logfire CLI'},
+            body=body,
             error_message='Error creating project read token',
         )
 

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -211,8 +211,22 @@ class UnexpectedResponse(RequestException):
             raise cls(response)
 
 
-DATA_DIR_FILENAMES = {'.gitignore', 'logfire_credentials.json'}
-"""The files that Logfire itself writes into a data directory."""
+READ_TOKEN_FILENAME = 'read_token.json'
+"""Where `logfire read-tokens create --save` stores a read token.
+
+Deliberately NOT a new key inside `logfire_credentials.json`: that file is loaded with
+`LogfireCredentials(**data)`, so an unrecognised key raises `LogfireConfigError` in every
+SDK version released before it. A separate file cannot break an older reader.
+"""
+
+DATA_DIR_FILENAMES = {'.gitignore', 'logfire_credentials.json', READ_TOKEN_FILENAME}
+"""The files that Logfire itself writes into a data directory.
+
+Membership is load-bearing beyond bookkeeping: `ensure_data_dir_exists` only seeds the
+`.gitignore` when the directory holds nothing else, so a file omitted here would stop the
+ignore rule being restored for a directory containing it -- and this one holds a
+credential.
+"""
 
 
 def ensure_data_dir_exists(data_dir: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from logfire._internal.cli import (
     STATUS_MAX_ROWS,
     OrgProjectAction,
     SplitArgs,
+    _has_git_dir,  # pyright: ignore[reportPrivateUsage]
     _is_git_tracked,  # pyright: ignore[reportPrivateUsage]
     _load_saved_read_token,  # pyright: ignore[reportPrivateUsage]
     _organization_from_project_url,  # pyright: ignore[reportPrivateUsage]
@@ -2607,6 +2608,25 @@ def test_is_git_tracked_fails_closed_when_git_binary_is_missing_but_a_repo_exist
         pytest.raises(LogfireConfigError, match='Could not confirm whether'),
     ):
         _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME)
+
+
+def test_has_git_dir_fails_closed_on_a_real_permission_error(tmp_dir_cwd: Path) -> None:
+    """`Path.exists()` swallows a permission-denied ancestor and reports "not found" --
+    confirmed empirically against this Python's actual behavior, not merely assumed from
+    its docs. `_has_git_dir` must not inherit that through a plain `.exists()` call: an
+    inaccessible ancestor reading as "no repository" is exactly the state most likely on a
+    machine that has been tampered with, not evidence that no repository is there.
+    """
+    locked = tmp_dir_cwd / 'locked'
+    locked.mkdir()
+    inner = locked / 'inner'
+    inner.mkdir()
+    os.chmod(locked, 0o000)
+    try:
+        with pytest.raises(PermissionError):
+            _has_git_dir(inner)
+    finally:
+        os.chmod(locked, 0o755)
 
 
 def test_is_git_tracked_fails_closed_when_the_repository_walk_itself_fails(tmp_dir_cwd: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from logfire._internal.cli import (
     STATUS_MAX_ROWS,
     OrgProjectAction,
     SplitArgs,
+    _is_git_tracked,  # pyright: ignore[reportPrivateUsage]
     _load_saved_read_token,  # pyright: ignore[reportPrivateUsage]
     _organization_from_project_url,  # pyright: ignore[reportPrivateUsage]
     main,
@@ -2518,6 +2519,20 @@ def test_read_token_save_refuses_a_git_tracked_destination(
     assert exc_info.value.code == 1
     assert 'already tracked by git' in capsys.readouterr().err
     assert path.read_text() == '{}', 'the tracked file was written through'
+
+
+def test_is_git_tracked_is_best_effort_when_git_itself_is_unavailable(tmp_dir_cwd: Path) -> None:
+    """git missing, no repository, or the check timing out all mean "cannot tell".
+
+    None of those may block a working setup over an environment quirk unrelated to the
+    file's own tracked status -- a machine without git installed must still be able to
+    save a read token.
+    """
+    with patch('logfire._internal.cli.subprocess.run', side_effect=FileNotFoundError('git not found')):
+        assert _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME) is False
+
+    with patch('logfire._internal.cli.subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='git', timeout=5)):
+        assert _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME) is False
 
 
 def test_read_token_save_narrows_an_existing_permissive_file(tmp_dir_cwd: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2521,15 +2521,31 @@ def test_read_token_save_refuses_a_git_tracked_destination(
     assert path.read_text() == '{}', 'the tracked file was written through'
 
 
-def test_is_git_tracked_treats_no_git_binary_as_untracked(tmp_dir_cwd: Path) -> None:
-    """No git anywhere on the machine means no git tracking anywhere either.
+def test_is_git_tracked_treats_no_git_binary_and_no_repo_as_untracked(tmp_dir_cwd: Path) -> None:
+    """No `git` binary, and no `.git` anywhere in the path's ancestry either.
 
     The threat this check guards against -- a path already in git's index -- is
-    categorically impossible without git installed, so a machine without it must still be
+    categorically impossible without a repository, so a machine with neither must still be
     able to save a read token rather than being blocked over an unrelated environment gap.
     """
     with patch('logfire._internal.cli.shutil.which', return_value=None):
         assert _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME) is False
+
+
+def test_is_git_tracked_fails_closed_when_git_binary_is_missing_but_a_repo_exists(tmp_dir_cwd: Path) -> None:
+    """No `git` binary is not proof that no repository exists.
+
+    A repository's index is just files on disk, and can already track this path on a
+    machine where `git` itself is missing or off `PATH` for this one call -- exactly the
+    condition `shutil.which` alone cannot distinguish from "no repository at all". Once a
+    `.git` is visibly present, that gap must fail closed, not silently permit the write.
+    """
+    (tmp_dir_cwd / '.git').mkdir()
+    with (
+        patch('logfire._internal.cli.shutil.which', return_value=None),
+        pytest.raises(LogfireConfigError, match='Could not confirm whether'),
+    ):
+        _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME)
 
 
 def test_is_git_tracked_fails_closed_when_git_exists_but_cannot_answer(tmp_dir_cwd: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,8 +18,9 @@ import types
 import webbrowser
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Coroutine, Generator
 from contextlib import ExitStack, asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import IO, Any, cast
 from unittest.mock import Mock, call, patch
 from urllib.parse import parse_qs, urlparse
 
@@ -36,7 +37,15 @@ import logfire._internal.cli.gateway as gateway_cli
 import logfire._internal.cli.gateway_auth as gateway_auth
 from logfire import VERSION
 from logfire._internal.auth import UserToken
-from logfire._internal.cli import OrgProjectAction, SplitArgs, main
+from logfire._internal.cli import (
+    READ_TOKEN_TTL,
+    STATUS_MAX_ROWS,
+    OrgProjectAction,
+    SplitArgs,
+    _load_saved_read_token,  # pyright: ignore[reportPrivateUsage]
+    _organization_from_project_url,  # pyright: ignore[reportPrivateUsage]
+    main,
+)
 from logfire._internal.cli.run import (
     InstrumentationRecommendation,
     collect_instrumentation_context,
@@ -46,6 +55,7 @@ from logfire._internal.cli.run import (
     instrumented_packages_text,
 )
 from logfire._internal.config import LogfireConfigWarning, LogfireCredentials, sanitize_project_name
+from logfire._internal.utils import READ_TOKEN_FILENAME
 from logfire.exceptions import LogfireConfigError
 from tests.import_used_for_tests import run_script_test
 
@@ -926,6 +936,282 @@ def test_non_interactive_remedies_are_pasteable() -> None:
         assert not set(suggestion) & set('<>|&;$`()'), f'not pasteable: {suggestion!r}'
 
 
+def _status_credentials(tmp_dir_cwd: Path, *, read_token: bool = True) -> Path:
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                'project_url': 'https://logfire-us.pydantic.dev/test-org/orders',
+                'logfire_api_url': 'https://logfire-us.pydantic.dev',
+            }
+        )
+    )
+    if read_token:
+        _save_fake_read_token(data_dir)
+    return data_dir
+
+
+def _save_fake_read_token(
+    data_dir: Path,
+    *,
+    token: str = 'fake_read_token',
+    base_url: str = 'https://logfire-us.pydantic.dev',
+    organization: str = 'test-org',
+    project_name: str = 'orders',
+    expires_at: str | None = None,
+) -> Path:
+    """The file `read-tokens create --save` writes, which `projects status` now reads."""
+    path = data_dir / READ_TOKEN_FILENAME
+    path.write_text(
+        json.dumps(
+            {
+                'token': token,
+                'base_url': base_url,
+                'organization': organization,
+                'project_name': project_name,
+                'expires_at': expires_at or (datetime.now(tz=timezone.utc) + timedelta(days=30)).isoformat(),
+            }
+        )
+    )
+    return path
+
+
+def _mock_status_backend(m: requests_mock.Mocker, rows: list[dict[str, Any]]) -> None:
+    """The only call `projects status` makes: the query itself.
+
+    It deliberately does NOT mock the read-tokens endpoint. `projects status` must use the
+    saved token rather than creating one, and a mock here would hide a regression back to
+    minting per invocation -- requests_mock raises `NoMockAddress` for the unregistered
+    POST, so that regression fails loudly instead of passing.
+
+    The response is the WIRE shape -- `{"schema": {...}, "data": [...]}` -- not the
+    columns/rows shape the query client maps it to. Returning the mapped shape would make
+    the test pass against a body the server never sends.
+    """
+    m.post(
+        'https://logfire-us.pydantic.dev/v2/query',
+        json={
+            # Mirrors the real body, verified against staging: fields carry `nullable`
+            # and the schema carries `metadata`, even though this command reads neither.
+            'schema': {
+                'fields': [{'name': k, 'data_type': 'Utf8', 'nullable': False} for k in (rows[0] if rows else {})],
+                'metadata': {},
+            },
+            'data': rows,
+        },
+    )
+
+
+def test_projects_status_reports_what_arrived(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """One row per service, so a partly-instrumented system is visible as such.
+
+    This is the case the command exists for: an agent that instrumented the web app and
+    forgot the worker sees `orders-worker` missing, which no amount of "no errors in the
+    log" would have told it.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(
+            m,
+            [
+                {'service_name': 'orders-web', 'records': 12, 'last_seen': '2026-08-18T20:00:00Z'},
+                {'service_name': 'orders-worker', 'records': 3, 'last_seen': '2026-08-18T20:00:05Z'},
+            ],
+        )
+
+        main(['projects', 'status'])
+
+    query = next(r for r in m.request_history if r.path.endswith('/v2/query'))
+    body = query.json()
+    sql = body['sql']
+    assert 'GROUP BY service_name' in sql, sql
+    assert 'count(*)' in sql, sql
+    # A time bound, so a long-lived project does not scan its whole history.
+    assert body.get('min_timestamp'), body
+    # And a ceiling, so this cannot become an enormous query on a busy project.
+    assert body['limit'] == STATUS_MAX_ROWS, body
+
+    err = capsys.readouterr().err
+    assert 'test-org/orders' in err
+    assert 'orders-web' in err
+    assert 'orders-worker' in err
+    assert '12' in err
+    # The read token is minted to run the query and must never be shown: putting a live
+    # credential in the caller's output is the thing this command exists to avoid.
+    assert 'fake_read_token' not in err
+
+
+def test_projects_status_says_nothing_yet_rather_than_failing(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No data during setup usually means "not yet", not "broken"."""
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(m, [])
+
+        main(['projects', 'status'])
+
+    err = capsys.readouterr().err
+    assert 'No telemetry' in err
+    assert 'Run the application' in err
+
+
+def test_projects_status_json_is_machine_readable(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """`--json` on stdout, so an agent can branch on it without parsing a table."""
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(m, [{'service_name': 'orders-web', 'records': 12, 'last_seen': '2026-08-18T20:00:00Z'}])
+
+        main(['projects', 'status', '--json'])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload['organization'] == 'test-org'
+    assert payload['project_name'] == 'orders'
+    assert payload['services'] == [{'service_name': 'orders-web', 'records': 12, 'last_seen': '2026-08-18T20:00:00Z'}]
+    assert 'fake_read_token' not in captured.out
+    assert 'fake_read_token' not in captured.err
+
+
+def test_projects_status_without_credentials_says_what_to_run(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main(['projects', 'status'])
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert 'No Logfire credentials found' in err
+    # Runnable as printed: `<name>` would be shell input redirection.
+    assert 'logfire projects use PROJECT_NAME --org ORGANIZATION' in err
+
+
+@pytest.mark.parametrize(
+    ('project_url', 'expected'),
+    [
+        # The shape the CLI actually writes into the credentials file.
+        ('https://logfire-us.pydantic.dev/test-org/orders', 'test-org'),
+        ('https://logfire-eu.pydantic.dev/test-org/orders', 'test-org'),
+        # Self-hosted, where the deployment lives under a path prefix.
+        ('https://logfire.example.com/logfire/acme/orders', 'acme'),
+        # A trailing slash must not shift the answer by one segment.
+        ('https://logfire-us.pydantic.dev/test-org/orders/', 'test-org'),
+        # Hyphens and digits are legal in both names.
+        ('https://logfire-us.pydantic.dev/acme-2/orders-api', 'acme-2'),
+        # Not enough path to name an organization.
+        ('https://logfire-us.pydantic.dev/orders', None),
+        ('https://logfire-us.pydantic.dev/', None),
+        ('https://logfire-us.pydantic.dev', None),
+        ('', None),
+    ],
+)
+def test_organization_from_project_url(project_url: str, expected: str | None) -> None:
+    """The organization is the second-to-last path segment, or nothing.
+
+    Pure, so every shape is enumerable here rather than through a command with four
+    mocked collaborators. The `None` cases matter: the credentials file is user-editable
+    and `projects status` must say something useful rather than raise IndexError.
+    """
+    assert _organization_from_project_url(project_url) == expected
+
+
+def test_projects_status_when_the_project_url_names_no_organization(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A credentials file that cannot name an organization exits cleanly.
+
+    Reachable in practice: the file is plain JSON in the repo and people edit it. Before
+    this it was the one uncovered branch in the command.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                'project_url': 'https://logfire-us.pydantic.dev/',
+                'logfire_api_url': 'https://logfire-us.pydantic.dev',
+            }
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(['projects', 'status'])
+    assert exc_info.value.code == 1
+    assert 'Cannot tell which organization' in capsys.readouterr().err
+
+
+def test_projects_status_reports_a_failed_query(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A rejected query says what the server said, rather than raising.
+
+    Reachable whenever the read token is refused or the backend is unhappy, and the
+    status code plus body is the only thing that tells someone which it was.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/organizations/test-org/projects/orders/read-tokens',
+            json={'token': 'fake_read_token'},
+        )
+        m.post(
+            'https://logfire-us.pydantic.dev/v2/query',
+            status_code=401,
+            text='Invalid read token',
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['projects', 'status'])
+
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert 'Could not read the project' in err
+    assert '401' in err
+    assert 'Invalid read token' in err
+
+
 def test_auth_temp_failure(tmp_path: Path) -> None:
     auth_file = tmp_path / 'default.toml'
     with ExitStack() as stack:
@@ -1050,7 +1336,7 @@ expiration = "fake_exp"
 
 def test_projects_help(capsys: pytest.CaptureFixture[str]) -> None:
     main(['projects'])
-    assert capsys.readouterr().out.splitlines()[0] == 'usage: logfire projects [-h] {list,new,use} ...'
+    assert capsys.readouterr().out.splitlines()[0] == 'usage: logfire projects [-h] {list,new,status,use} ...'
 
 
 def test_projects_list(default_credentials: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -1741,6 +2027,701 @@ def test_create_read_token(tmp_dir_cwd: Path, default_credentials: Path, capsys:
 
         output = capsys.readouterr().out
         assert output == snapshot('fake_token\n')
+
+    # Without `--save` the token is printed and NOT given an expiry: it is being pasted
+    # into something we do not control, and silently breaking that later is worse than
+    # leaving it.
+    assert 'expires_at' not in m.request_history[-1].json()
+
+
+def _read_token_backend(m: requests_mock.Mocker, token: str = 'saved_read_token') -> None:
+    m.post(
+        'https://logfire-us.pydantic.dev/v1/organizations/test-org/projects/orders/read-tokens',
+        json={'token': token},
+    )
+
+
+def test_projects_status_ignores_a_malicious_logfire_api_url(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The read token must go to the host it was minted against, never wherever the repo
+    file says.
+
+    `logfire_credentials.json` lives inside the project this command runs in, so a
+    malicious or tampered repository can set `logfire_api_url` to anything. If that value
+    controlled where the read token is sent, checking out an untrusted repo and running
+    `projects status` in it would hand the token straight to an attacker.
+
+    The query host comes from the SAVED token file's own `base_url` instead, recorded when
+    the token was created from a trusted source (CLI flags or `~/.logfire/default.toml`,
+    never from anything inside the project) -- see `_save_read_token`. An earlier version
+    derived the host from the token's own region prefix, which also closed this hole but
+    broke self-hosted deployments; see `test_projects_status_uses_a_self_hosted_read_token`.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                'project_url': 'https://logfire-us.pydantic.dev/test-org/orders',
+                # The attack: a tampered repo pointing this at a server it controls.
+                'logfire_api_url': 'https://attacker.example.com',
+            }
+        )
+    )
+    # Saved with the REAL host, as it would be by a legitimate `--save` run -- proving the
+    # query follows this recorded value rather than the credentials file.
+    _save_fake_read_token(data_dir)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        # Only the REAL host is registered. If the code used `logfire_api_url` instead,
+        # the POST would target `attacker.example.com` and requests_mock would raise
+        # `NoMockAddress` -- so this test fails loudly rather than passing if the
+        # vulnerability comes back.
+        _mock_status_backend(m, [{'service_name': 'orders-web', 'records': 1, 'last_seen': '2026-08-18T20:00:00Z'}])
+
+        main(['projects', 'status'])
+
+    query = next(r for r in m.request_history if r.path.endswith('/v2/query'))
+    assert query.hostname == 'logfire-us.pydantic.dev'
+    assert 'attacker.example.com' not in {r.hostname for r in m.request_history}
+    assert 'orders-web' in capsys.readouterr().err
+
+
+def test_projects_status_uses_a_self_hosted_read_token(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A self-hosted deployment's read token must go to the self-hosted host.
+
+    Self-hosted instances (`logfire --base-url=https://logfire.example.com auth`) use an
+    arbitrary URL that cannot be recovered from a token's shape -- an earlier version of
+    the exfiltration fix derived the query host from the token's own region prefix, which
+    would have silently sent a self-hosted token to the hosted US service instead: the
+    right server for nobody, and a leak to a real host, not just a broken command.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                'project_url': 'https://logfire.example.com/test-org/orders',
+                'logfire_api_url': 'https://logfire.example.com',
+            }
+        )
+    )
+    _save_fake_read_token(data_dir, base_url='https://logfire.example.com')
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire.example.com', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire.example.com/v2/query',
+            json={
+                'schema': {'fields': [{'name': 'service_name', 'data_type': 'Utf8', 'nullable': False}]},
+                'data': [{'service_name': 'orders-web', 'records': 1, 'last_seen': '2026-08-18T20:00:00Z'}],
+            },
+        )
+
+        main(['projects', 'status'])
+
+    query = next(r for r in m.request_history if r.path.endswith('/v2/query'))
+    assert query.hostname == 'logfire.example.com'
+    assert 'orders-web' in capsys.readouterr().err
+
+
+def test_read_token_save_writes_the_file_and_prints_nothing(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--save` exists so the credential never reaches a terminal or a transcript.
+
+    The measured failure it fixes: agents told to verify their own work ran
+    `read-tokens create`, which writes the token to stdout, and every one of them ended up
+    with a live credential in the transcript that ships to a model provider.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m)
+
+        # No `--project`: it should fall back to the linked project, which is the whole
+        # point of the no-argument form.
+        main(['read-tokens', 'create', '--save'])
+
+    captured = capsys.readouterr()
+    assert captured.out == '', 'the token must never reach stdout'
+    assert 'saved_read_token' not in captured.err, 'nor stderr'
+    assert 'test-org/orders' in captured.err
+
+    saved = json.loads((data_dir / READ_TOKEN_FILENAME).read_text())
+    assert saved['token'] == 'saved_read_token'
+    assert saved['organization'] == 'test-org'
+    assert saved['project_name'] == 'orders'
+    # The host the CREATE request actually used, not read back from anywhere in the
+    # project -- this is what lets `projects status` trust it later. See
+    # test_projects_status_ignores_a_malicious_logfire_api_url.
+    assert saved['base_url'] == 'https://logfire-us.pydantic.dev'
+
+    # An expiry, because the CLI cannot revoke a token it has written to disk.
+    requested = m.request_history[-1].json()
+    assert requested['expires_at'], requested
+    expiry = datetime.fromisoformat(saved['expires_at'])
+    assert timedelta(days=READ_TOKEN_TTL.days - 1) < expiry - datetime.now(tz=timezone.utc) <= READ_TOKEN_TTL
+
+    # Owner-only: this file holds a credential that can read the whole project.
+    assert (data_dir / READ_TOKEN_FILENAME).stat().st_mode & 0o077 == 0
+
+
+def test_read_token_save_with_explicit_project_needs_no_linked_directory(tmp_dir_cwd: Path) -> None:
+    """`--project` bypasses the linked-directory fallback entirely.
+
+    Every other `--save` test relies on `_status_credentials` linking the directory.
+    `--project` is the OTHER way to reach `parse_create_read_token`'s org/project
+    resolution -- no `logfire_credentials.json` needed at all -- and that branch was
+    otherwise never exercised for the `--save` path, only for plain `create`.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/organizations/other-org/projects/other-project/read-tokens',
+            json={'token': 'explicit_project_token'},
+        )
+
+        main(['read-tokens', '--project', 'other-org/other-project', 'create', '--save'])
+
+    saved = json.loads((tmp_dir_cwd / '.logfire' / READ_TOKEN_FILENAME).read_text())
+    assert saved['organization'] == 'other-org'
+    assert saved['project_name'] == 'other-project'
+    assert saved['token'] == 'explicit_project_token'
+
+
+def test_read_token_create_without_save_writes_no_file(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Printed mode must not ALSO persist a copy to disk.
+
+    `--save` is what makes a token durable; without it, nothing should be left behind for
+    `projects status` to pick up later, since the caller asked for the token in hand, not
+    stored.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m, token='printed_token')
+
+        main(['read-tokens', 'create'])
+
+    assert capsys.readouterr().out == 'printed_token\n'
+    assert not (data_dir / READ_TOKEN_FILENAME).exists()
+
+
+def test_read_token_save_rotates_a_previously_saved_token(tmp_dir_cwd: Path) -> None:
+    """Running `--save` again must replace the old token, not merge with it.
+
+    The realistic workflow is re-running this to get a fresh token before an old one
+    expires; a loader that somehow preferred stale data over the new file would silently
+    defeat that.
+
+    The stale token is padded far longer than the fresh one on purpose: writing without
+    truncating (no `O_TRUNC`) would leave the old file's tail bytes after the new, shorter
+    JSON document, and a same-or-shorter stale value would not expose that -- this makes a
+    dropped `O_TRUNC` produce genuinely invalid JSON instead of silently still parsing.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    _save_fake_read_token(data_dir, token='stale_token_' + 'x' * 200)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m, token='fresh_token')
+
+        main(['read-tokens', 'create', '--save'])
+
+    saved = json.loads((data_dir / READ_TOKEN_FILENAME).read_text())
+    assert saved['token'] == 'fresh_token'
+    loaded = _load_saved_read_token(data_dir, organization='test-org', project_name='orders')
+    assert loaded is not None and loaded.token == 'fresh_token'
+
+
+def test_projects_status_json_output_escapes_control_characters(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--json` is safe for the same attacker-controlled service name, but for a different
+    reason than the table is.
+
+    The table needs `_printable` to strip control characters explicitly. `--json` does not
+    call it -- `json.dumps` already escapes control characters inside a JSON string
+    (`\\u001b`, not a literal ESC byte), so the raw value is safe by construction. This
+    pins that: nobody should "fix" this by routing JSON output through `_printable` too
+    (which would mangle legitimate unicode service names for no reason), and if the output
+    ever moves off `json.dumps` the replacement needs the same guarantee.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(
+            m, [{'service_name': 'evil\x1b[2K\rorders-web', 'records': 1, 'last_seen': '2026-08-18T20:00:00Z'}]
+        )
+
+        main(['projects', 'status', '--json'])
+
+    out = capsys.readouterr().out
+    assert '\x1b' not in out
+    assert '\\u001b' in out
+    payload = json.loads(out)
+    assert payload['services'][0]['service_name'] == 'evil\x1b[2K\rorders-web'
+
+
+def test_read_token_save_keeps_the_data_dir_gitignored(tmp_dir_cwd: Path) -> None:
+    """The saved token must not be the thing that leaves a data directory untracked-but-visible.
+
+    `ensure_data_dir_exists` only seeds `.gitignore` when the directory holds nothing but
+    the files Logfire writes itself, so a filename missing from `DATA_DIR_FILENAMES`
+    would silently stop that rule being restored -- for a directory that now contains a
+    read token.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    (data_dir / '.gitignore').unlink(missing_ok=True)
+    _save_fake_read_token(data_dir)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m)
+        main(['read-tokens', 'create', '--save'])
+
+    assert (data_dir / '.gitignore').read_text() == '*'
+
+
+def test_projects_status_without_a_saved_token_says_what_to_run(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No token: one message naming the command, and no silent minting.
+
+    The command used to create a read token per invocation. Those are permanent and the
+    CLI cannot revoke them, so a user polling "has my data arrived yet?" four times left
+    four live credentials behind.
+    """
+    _status_credentials(tmp_dir_cwd, read_token=False)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        # Nothing registered at all: any request whatsoever fails the test.
+        with pytest.raises(SystemExit) as exc_info:
+            main(['projects', 'status'])
+
+    assert exc_info.value.code == 1
+    assert m.request_history == [], 'it must not call the API without a token'
+    err = capsys.readouterr().err
+    assert 'read-tokens create --save' in err
+
+
+_REMOVE_KEY = object()
+"""Marker for "delete this field", which a plain override dict cannot express."""
+
+
+@pytest.mark.parametrize(
+    'override,reason',
+    [
+        ({'organization': 'other-org'}, 'issued for a different organization'),
+        ({'project_name': 'other-project'}, 'issued for a different project'),
+        ({'expires_at': (datetime.now(tz=timezone.utc) - timedelta(days=1)).isoformat()}, 'already expired'),
+        ({'expires_at': 'not a timestamp'}, 'unparseable expiry'),
+        ({'token': ''}, 'empty token'),
+        ({'token': 123}, 'token is not a string'),
+        ({'token': _REMOVE_KEY}, 'no token key'),
+        ({'base_url': ''}, 'empty base_url'),
+        ({'base_url': _REMOVE_KEY}, 'no base_url key -- an older saved-token file'),
+    ],
+)
+def test_saved_read_token_is_rejected_when_unusable(tmp_dir_cwd: Path, override: dict[str, Any], reason: str) -> None:
+    """A saved token is only used for the project it was issued for, and only while valid.
+
+    `logfire projects use` repoints a directory; a token left from the previous project
+    would otherwise be sent for the new one and produce a baffling 401 -- or, if the two
+    happened to be in the same org, somebody else's data.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    path = _save_fake_read_token(data_dir)
+    data: dict[str, Any] = json.loads(path.read_text())
+    for key, value in override.items():
+        if value is _REMOVE_KEY:
+            data.pop(key, None)
+        else:
+            data[key] = value
+    path.write_text(json.dumps(data))
+
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None, reason
+
+
+def test_saved_read_token_survives_a_naive_expiry(tmp_dir_cwd: Path) -> None:
+    """A timestamp without a timezone must not blow up the comparison.
+
+    This file is always written with an aware timestamp, but it is a plain JSON file a
+    user can edit, and `datetime` raises rather than coerces when comparing naive to
+    aware.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    _save_fake_read_token(
+        data_dir, expires_at=(datetime.now(tz=timezone.utc) + timedelta(days=1)).replace(tzinfo=None).isoformat()
+    )
+    loaded = _load_saved_read_token(data_dir, organization='test-org', project_name='orders')
+    assert loaded is not None and loaded.token == 'fake_read_token'
+
+
+def test_read_token_save_refuses_to_follow_a_symlink(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """A symlink at the destination must not be followed, and the refusal must be clean.
+
+    The data directory lives inside the user's repository, so a symlink can arrive by
+    being committed to it. Following one would apply `O_TRUNC` and an ownership-only mode
+    change to whatever it points at -- destroying that file and handing the write to
+    somewhere the user did not choose. The refusal itself must not ALSO be a raw
+    traceback: `_save_read_token` raises `LogfireConfigError` for this, and an earlier
+    version of `parse_create_read_token` let that escape uncaught -- worse than most such
+    bugs, because it happens AFTER a token has already been minted, leaving the caller
+    unsure whether anything happened.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    victim = tmp_dir_cwd / 'victim.txt'
+    victim.write_text('important')
+    (data_dir / READ_TOKEN_FILENAME).symlink_to(victim)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['read-tokens', 'create', '--save'])
+
+    assert exc_info.value.code == 1
+    assert victim.read_text() == 'important', 'the symlink target was written through'
+    err = capsys.readouterr().err
+    assert 'Could not write the read token' in err
+    assert 'saved_read_token' not in err, 'the already-minted token must not leak into the error either'
+
+
+def test_read_token_save_narrows_an_existing_permissive_file(tmp_dir_cwd: Path) -> None:
+    """An existing world-readable file must be restricted BEFORE the token is written.
+
+    The mode passed to `os.open` applies only when it creates the file, so without an
+    explicit `fchmod` the token would be written into a file others can read and only
+    locked down afterwards.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    path = data_dir / READ_TOKEN_FILENAME
+    path.write_text('{}')
+    path.chmod(0o644)
+
+    observed: list[int] = []
+    real_fdopen = os.fdopen
+
+    def spy(fd: int, *args: Any, **kwargs: Any) -> IO[Any]:
+        # The mode at the moment the file becomes writable, which is what matters.
+        observed.append(os.fstat(fd).st_mode & 0o777)
+        return cast('IO[Any]', real_fdopen(fd, *args, **kwargs))
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        stack.enter_context(patch('logfire._internal.cli.os.fdopen', spy))
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m)
+        main(['read-tokens', 'create', '--save'])
+
+    assert observed == [0o600], 'the token was written while the file was still permissive'
+    assert path.stat().st_mode & 0o077 == 0
+
+
+def test_projects_status_rejects_a_non_200_response(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """204 is not an error by `response.ok`, but it has no body to parse.
+
+    Without an exact status check this failed with a JSON decode error instead of the
+    command's own message.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post('https://logfire-us.pydantic.dev/v2/query', status_code=204, text='')
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['projects', 'status'])
+
+    assert exc_info.value.code == 1
+    assert 'Could not read the project: 204' in capsys.readouterr().err
+
+
+def test_projects_status_reports_a_network_failure_cleanly(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A timeout, DNS failure, or refused connection must not print a raw traceback.
+
+    `requests.post` raises `RequestException` for these rather than returning a response,
+    so the non-200 branch alone does not catch them.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post('https://logfire-us.pydantic.dev/v2/query', exc=requests.exceptions.ConnectTimeout)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['projects', 'status'])
+
+    assert exc_info.value.code == 1
+    assert 'Could not reach https://logfire-us.pydantic.dev' in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    'body,reason',
+    [
+        ('not json at all', 'not JSON -- a proxy or WAF page instead of the real backend'),
+        ('{"no_data_key": []}', 'JSON but missing "data"'),
+        ('{"data": "not a list"}', '"data" is a string, not a list'),
+        ('{"data": ["not", "objects"]}', '"data" is a list of strings, not row objects'),
+    ],
+)
+def test_projects_status_rejects_a_malformed_200_response(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str], body: str, reason: str
+) -> None:
+    """A 200 whose body does not look like the query response must not crash.
+
+    A 200 status does not guarantee the real backend produced the body -- a proxy or WAF
+    can intercept the request and answer with its own page. Without this, a malformed body
+    fails several lines further down with a raw `JSONDecodeError`, `KeyError`, or
+    `AttributeError` instead of this command's own message.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post('https://logfire-us.pydantic.dev/v2/query', status_code=200, text=body)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['projects', 'status'])
+
+    assert exc_info.value.code == 1, reason
+    assert 'Could not read the project: unexpected response shape' in capsys.readouterr().err, reason
+
+
+def test_projects_status_strips_control_characters_from_service_names(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A service name is submitted telemetry, so it is attacker-controlled text.
+
+    Written raw to a terminal it could clear the screen or forge rows in the very table
+    someone is reading to decide whether their setup worked.
+    """
+    _status_credentials(tmp_dir_cwd)
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(
+            m,
+            [{'service_name': 'evil\x1b[2K\rorders-web', 'records': 1, 'last_seen': '2026-08-18T20:00:00Z'}],
+        )
+        main(['projects', 'status'])
+
+    err = capsys.readouterr().err
+    assert '\x1b' not in err, 'an ANSI escape reached the terminal'
+    assert '\r' not in err
+
+
+def test_saved_read_token_without_an_expiry_is_still_usable(tmp_dir_cwd: Path) -> None:
+    """No `expires_at` means unbounded, not invalid.
+
+    This CLI always writes one, so a file without it was written by a different version
+    or edited by hand. Refusing it would break a working setup over a field we added;
+    the expiry exists to bound a leak, not to gate the happy path.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    path = _save_fake_read_token(data_dir)
+    data: dict[str, Any] = json.loads(path.read_text())
+    del data['expires_at']
+    path.write_text(json.dumps(data))
+
+    loaded = _load_saved_read_token(data_dir, organization='test-org', project_name='orders')
+    assert loaded is not None and loaded.token == 'fake_read_token'
+
+
+def test_read_token_save_when_the_project_url_names_no_organization(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`--save` needs an organization, and the credentials file does not store one.
+
+    It is recovered from the project URL, so a URL that does not carry one has to fail
+    with something better than an `IndexError`.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                # One path segment, so there is no organization to take.
+                'project_url': 'https://logfire-us.pydantic.dev/orders',
+                'logfire_api_url': 'https://logfire-us.pydantic.dev',
+            }
+        )
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(['read-tokens', 'create', '--save'])
+
+    assert exc_info.value.code == 1
+    assert 'Cannot tell which organization' in capsys.readouterr().err
+
+
+def test_clean_removes_the_saved_read_token(tmp_dir_cwd: Path) -> None:
+    """`logfire clean` must not leave a credential behind.
+
+    It deletes the write credentials, so a data directory that still held a read token
+    afterwards would be "cleaned" while retaining something that can read the whole
+    project.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd)
+    assert (data_dir / READ_TOKEN_FILENAME).exists()
+
+    main(['clean', '--yes'])
+
+    assert not (data_dir / READ_TOKEN_FILENAME).exists()
+    assert not (data_dir / 'logfire_credentials.json').exists()
+
+
+def test_saved_read_token_survives_a_corrupt_file(tmp_dir_cwd: Path) -> None:
+    """Unreadable is treated as absent, so the caller gives the one useful instruction."""
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    (data_dir / READ_TOKEN_FILENAME).write_text('{not json')
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
+
+    (data_dir / READ_TOKEN_FILENAME).write_text('["a list"]')
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
 
 
 def test_get_prompt(tmp_dir_cwd: Path, default_credentials: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2623,6 +2623,16 @@ def test_has_git_dir_fails_closed_on_a_real_permission_error(tmp_dir_cwd: Path) 
     inner.mkdir()
     os.chmod(locked, 0o000)
     try:
+        # Running as root, or with CAP_DAC_OVERRIDE, bypasses permission bits entirely --
+        # confirming the lock actually took effect before relying on it, rather than
+        # asserting straight into `_has_git_dir`, is what keeps this a real test of the
+        # fix instead of a false failure wherever it does not.
+        try:
+            inner.stat()
+        except PermissionError:
+            pass
+        else:
+            pytest.skip('permission bits are not enforced in this environment (root or CAP_DAC_OVERRIDE)')
         with pytest.raises(PermissionError):
             _has_git_dir(inner)
     finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2432,6 +2432,67 @@ def test_saved_read_token_is_rejected_when_unusable(tmp_dir_cwd: Path, override:
     assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None, reason
 
 
+def test_load_saved_read_token_refuses_a_symlink(tmp_dir_cwd: Path) -> None:
+    """A symlinked `read_token.json` must not be trusted, even with valid-looking content.
+
+    `_save_read_token` refuses to write through a symlink, but that only protects writes
+    THIS command makes -- a symlink planted some other way (committed to the repo, dropped
+    in by another tool) never goes through that check. Following it here would hand
+    whatever `base_url` and `token` the symlink target holds straight into the next
+    request's URL and `Authorization` header: an attacker who can plant the symlink chooses
+    where this command sends that token.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    victim = tmp_dir_cwd / 'victim.json'
+    victim.write_text(
+        json.dumps(
+            {
+                'token': 'read-token',
+                'base_url': 'http://169.254.169.254',
+                'organization': 'test-org',
+                'project_name': 'orders',
+            }
+        )
+    )
+    (data_dir / READ_TOKEN_FILENAME).symlink_to(victim)
+
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
+
+
+def test_load_saved_read_token_refuses_a_git_tracked_file(tmp_dir_cwd: Path) -> None:
+    """A `read_token.json` already in the git index must not be trusted either.
+
+    `.gitignore` only stops an untracked file from being added -- it does nothing for one
+    already in the index, so an attacker with commit access (or a malicious PR) can ship a
+    tracked `read_token.json` naming their own `base_url`. `_save_read_token` refuses to
+    write through a tracked path, but a file that arrived via a commit was never written by
+    this command at all, so that check never ran against it.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    path = _save_fake_read_token(data_dir, base_url='http://169.254.169.254')
+    subprocess.run(['git', 'init', '--quiet'], cwd=tmp_dir_cwd, check=True)
+    subprocess.run(['git', 'add', '--force', str(path)], cwd=tmp_dir_cwd, check=True)
+
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
+
+
+def test_load_saved_read_token_treats_unconfirmed_tracking_as_unusable(tmp_dir_cwd: Path) -> None:
+    """An ambiguous git-tracking check must fail this call closed too, but by returning
+    "no usable token" rather than raising -- unlike `_save_read_token`, where the safe
+    outcome is to BLOCK. Here the safe outcome is to fall back to the same "no token saved"
+    path an absent file already takes, which the caller turns into one clean message
+    naming `read-tokens create --save`, not a crash.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    _save_fake_read_token(data_dir)
+
+    with patch(
+        'logfire._internal.cli._is_git_tracked',
+        side_effect=LogfireConfigError('could not confirm'),
+    ):
+        assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
+
+
 def test_saved_read_token_survives_a_naive_expiry(tmp_dir_cwd: Path) -> None:
     """A timestamp without a timezone must not blow up the comparison.
 
@@ -2543,6 +2604,24 @@ def test_is_git_tracked_fails_closed_when_git_binary_is_missing_but_a_repo_exist
     (tmp_dir_cwd / '.git').mkdir()
     with (
         patch('logfire._internal.cli.shutil.which', return_value=None),
+        pytest.raises(LogfireConfigError, match='Could not confirm whether'),
+    ):
+        _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME)
+
+
+def test_is_git_tracked_fails_closed_when_the_repository_walk_itself_fails(tmp_dir_cwd: Path) -> None:
+    """A filesystem error while looking for `.git` must not escape as a raw traceback.
+
+    Walking up for a repository can hit a permission-denied intermediate directory or a
+    symlink loop `.resolve()` cannot settle -- `OSError`, not a clean "no repository here".
+    Letting that propagate unchanged would break the one contract every other failure mode
+    in this function honors: a clean `LogfireConfigError`, not a bare traceback, and it
+    would do so on exactly the kind of filesystem state most likely to be the OS itself
+    refusing to answer, not proof of anything about the file's tracked status.
+    """
+    with (
+        patch('logfire._internal.cli.shutil.which', return_value=None),
+        patch('logfire._internal.cli._has_git_dir', side_effect=PermissionError('denied')),
         pytest.raises(LogfireConfigError, match='Could not confirm whether'),
     ):
         _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1192,10 +1192,10 @@ def test_projects_status_reports_a_failed_query(tmp_dir_cwd: Path, capsys: pytes
         )
         m = requests_mock.Mocker()
         stack.enter_context(m)
-        m.post(
-            'https://logfire-us.pydantic.dev/v1/organizations/test-org/projects/orders/read-tokens',
-            json={'token': 'fake_read_token'},
-        )
+        # No read-tokens mock: `_status_credentials`'s default `read_token=True` already
+        # saves one, so `projects status` uses that and never mints -- registering a
+        # read-tokens mock here would sit dead, and a regression back to minting per
+        # invocation would pass this test instead of failing it.
         m.post(
             'https://logfire-us.pydantic.dev/v2/query',
             status_code=401,
@@ -2481,9 +2481,43 @@ def test_read_token_save_refuses_to_follow_a_symlink(tmp_dir_cwd: Path, capsys: 
 
     assert exc_info.value.code == 1
     assert victim.read_text() == 'important', 'the symlink target was written through'
-    err = capsys.readouterr().err
-    assert 'Could not write the read token' in err
-    assert 'saved_read_token' not in err, 'the already-minted token must not leak into the error either'
+
+
+def test_read_token_save_refuses_a_git_tracked_destination(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`.gitignore` does not protect an already-tracked file.
+
+    A `read_token.json` committed before this feature existed -- or by mistake, since
+    `.gitignore` only stops NEW files from being added -- would otherwise get a live,
+    permanent credential written straight into it, and the next `git commit -am` would
+    publish it. Refuse rather than write.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    path = data_dir / READ_TOKEN_FILENAME
+    path.write_text('{}')
+    subprocess.run(['git', 'init', '--quiet'], cwd=tmp_dir_cwd, check=True)
+    subprocess.run(['git', 'add', '--force', str(path)], cwd=tmp_dir_cwd, check=True)
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _read_token_backend(m)
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(['read-tokens', 'create', '--save'])
+
+    assert exc_info.value.code == 1
+    assert 'already tracked by git' in capsys.readouterr().err
+    assert path.read_text() == '{}', 'the tracked file was written through'
 
 
 def test_read_token_save_narrows_an_existing_permissive_file(tmp_dir_cwd: Path) -> None:
@@ -2652,6 +2686,48 @@ def test_projects_status_strips_control_characters_from_service_names(
     assert '\r' not in err
 
 
+def test_projects_status_strips_control_characters_from_the_header(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`organization`/`project_name`/`project_url` come from `logfire_credentials.json`,
+    a file inside the project this command runs in -- the same threat model
+    `_save_read_token`'s docstring covers for the read token itself. Written raw to the
+    `Project  <org>/<name>` header they are just as attacker-controlled as a service name.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'evil\x1b[2Korders',
+                'project_url': 'https://logfire-us.pydantic.dev/evil\x1b[2Korg/evil\x1b[2Korders',
+                'logfire_api_url': 'https://logfire-us.pydantic.dev',
+            }
+        )
+    )
+    # Matches what `_organization_from_project_url` derives from the malicious
+    # `project_url` above -- the saved token is scoped to org/project, and a mismatch
+    # would fail with "no usable read token" before the header is ever printed.
+    _save_fake_read_token(data_dir, organization='evil\x1b[2Korg', project_name='evil\x1b[2Korders')
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(m, [])
+        main(['projects', 'status'])
+
+    assert '\x1b' not in capsys.readouterr().err, 'an ANSI escape reached the terminal'
+
+
 def test_saved_read_token_without_an_expiry_is_still_usable(tmp_dir_cwd: Path) -> None:
     """No `expires_at` means unbounded, not invalid.
 
@@ -2721,6 +2797,31 @@ def test_saved_read_token_survives_a_corrupt_file(tmp_dir_cwd: Path) -> None:
     assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
 
     (data_dir / READ_TOKEN_FILENAME).write_text('["a list"]')
+    assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
+
+
+def test_saved_read_token_rejects_a_non_string_expiry(tmp_dir_cwd: Path) -> None:
+    """A PRESENT but wrongly-typed `expires_at` must not be treated as absent.
+
+    Absence means unbounded -- this CLI always writes the key, so a missing one came from
+    an older version or a hand-edited file, and the expiry exists to bound a leak rather
+    than to gate the happy path. `null`/a number/etc. are different: this file always
+    writes a string, so a non-string value did not come from a normal run, and treating it
+    the same as absence (as `isinstance(expires_at, str)` alone does) lets a tampered file
+    defeat the TTL entirely instead of merely losing it.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    (data_dir / READ_TOKEN_FILENAME).write_text(
+        json.dumps(
+            {
+                'token': 'fake_read_token',
+                'base_url': 'https://logfire-us.pydantic.dev',
+                'organization': 'test-org',
+                'project_name': 'orders',
+                'expires_at': None,
+            }
+        )
+    )
     assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2521,18 +2521,31 @@ def test_read_token_save_refuses_a_git_tracked_destination(
     assert path.read_text() == '{}', 'the tracked file was written through'
 
 
-def test_is_git_tracked_is_best_effort_when_git_itself_is_unavailable(tmp_dir_cwd: Path) -> None:
-    """git missing, no repository, or the check timing out all mean "cannot tell".
+def test_is_git_tracked_treats_no_git_binary_as_untracked(tmp_dir_cwd: Path) -> None:
+    """No git anywhere on the machine means no git tracking anywhere either.
 
-    None of those may block a working setup over an environment quirk unrelated to the
-    file's own tracked status -- a machine without git installed must still be able to
-    save a read token.
+    The threat this check guards against -- a path already in git's index -- is
+    categorically impossible without git installed, so a machine without it must still be
+    able to save a read token rather than being blocked over an unrelated environment gap.
     """
-    with patch('logfire._internal.cli.subprocess.run', side_effect=FileNotFoundError('git not found')):
+    with patch('logfire._internal.cli.shutil.which', return_value=None):
         assert _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME) is False
 
-    with patch('logfire._internal.cli.subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='git', timeout=5)):
-        assert _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME) is False
+
+def test_is_git_tracked_fails_closed_when_git_exists_but_cannot_answer(tmp_dir_cwd: Path) -> None:
+    """git present but unable to answer must NOT be treated the same as "untracked".
+
+    Silently proceeding here would defeat the whole check on exactly the machine states an
+    attacker aiming at this file is best positioned to engineer -- the check itself timing
+    out, or some other OS-level failure -- so this raises and blocks the write instead of
+    guessing safe.
+    """
+    with (
+        patch('logfire._internal.cli.shutil.which', return_value='/usr/bin/git'),
+        patch('logfire._internal.cli.subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='git', timeout=5)),
+        pytest.raises(LogfireConfigError, match='Could not confirm whether'),
+    ):
+        _is_git_tracked(tmp_dir_cwd / READ_TOKEN_FILENAME)
 
 
 def test_read_token_save_narrows_an_existing_permissive_file(tmp_dir_cwd: Path) -> None:


### PR DESCRIPTION
Adds `logfire projects status`: what telemetry has actually reached the project this folder is linked to, one row per service.

```console
$ logfire projects status
Project  acme/orders
         https://logfire-us.pydantic.dev/acme/orders

 Service         | Records | Last seen
-----------------|---------|----------------------------------
 orders-web      | 12      | 2026-08-18T21:39:15.388096+00:00
 orders-worker   | 3       | 2026-08-18T21:39:17.902441+00:00
```

`whoami` proves you're pointed at a project; it can't tell you anything arrived. The per-service breakdown catches the common failure of instrumenting one service and stopping — a missing row says so immediately. `--json` gives the same thing on stdout.

Reading your own data needs a read token, and `logfire read-tokens create` prints it to stdout — which is a problem for anyone following our setup prompt's instruction to verify their own work and never print a token. So `read-tokens create --save` stores the token in `.logfire/` instead of printing it, and `projects status` reads it from there. Both take no arguments.

Security-relevant details:
- The token is saved with `O_NOFOLLOW` + `0600` before any bytes are written, expires after 30 days, is scoped to the org/project that issued it, and is removed by `logfire clean`.
- The query goes to the host the token was created against (recorded at `--save` time), never to `logfire_credentials.json`'s URL — that file lives in the project and could be tampered with. This also keeps self-hosted deployments working, since their URL can't be recovered from the token itself.
- Control characters in service names are stripped before reaching the terminal; a network failure or a malformed response (a proxy/WAF page instead of the real backend) exits cleanly instead of printing a traceback.

Counts records rather than spans, since the table holds both and a log-only service shouldn't disappear from the output.

## Open questions

- **Name.** `projects status` fits the existing group; `project status` (singular) reads better for "the current one" but would be the only singular command.
- **Scope.** Records only for now — metrics is the obvious next column.
- **A server-side endpoint** would avoid storing a token at all. The CLI's `logfire auth` token can't query directly, but `require_sdk_or_api_project_auth` + `FusionFireServiceFactory` already accept it and mint an ephemeral token server-side — `logfire prompt` does exactly this. Worth doing separately; not blocking this PR.
