### PR TITLE
Make docs navigation retries observable

### DIFF
--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -33,6 +33,7 @@ jobs:
 
     steps:
       - name: Verify a maintainer triggered the check
+        id: verify
         env:
           ACTOR: ${{ github.actor }}
           GH_TOKEN: ${{ github.token }}
@@ -102,19 +103,35 @@ jobs:
           fi
 
       - name: Comment failure on PR
-        if: failure() && (steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
+        if: failure() && (steps.verify.outcome == 'failure' || steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          VERIFY_OUTCOME: ${{ steps.verify.outcome }}
+          APP_TOKEN_OUTCOME: ${{ steps.app-token.outcome }}
         run: |
+          if [ "$VERIFY_OUTCOME" = failure ]; then
+            heading='## Docs Navigation Check — permission denied'
+            detail='Only a repository maintainer can request this check. Ask a maintainer to add the `trigger:docs` label.'
+            retry=''
+          elif [ "$APP_TOKEN_OUTCOME" = failure ]; then
+            heading='## Docs Navigation Check — authentication failed'
+            detail='The documentation app token could not be generated.'
+            retry='<sub>Re-add the `trigger:docs` label after the app credentials are fixed.</sub>'
+          else
+            heading='## Docs Navigation Check — dispatch failed'
+            detail='The navigation check could not be queued.'
+            retry='<sub>Re-add the `trigger:docs` label to retry.</sub>'
+          fi
+
           body=$(cat <<EOF
-          ## Docs Navigation Check — dispatch failed
+          ${heading}
 
-          The navigation check could not be queued. See [the workflow run](${RUN_URL}) for details.
+          ${detail} See [the workflow run](${RUN_URL}) for details.
 
-          <sub>Re-add the \`trigger:docs\` label to retry.</sub>
+          ${retry}
           EOF
           )
           gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" -f body="$body"

--- a/.github/workflows/scripts/test_docs_navigation_workflow.py
+++ b/.github/workflows/scripts/test_docs_navigation_workflow.py
@@ -37,5 +37,12 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'gh api --paginate' in workflow
     assert "existing=${matching_comments%%$'\\n'*}" in workflow
     assert 'startswith("## Docs Preview")' in workflow
+    assert "steps.verify.outcome == 'failure'" in workflow
     assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
+    assert 'Docs Navigation Check — permission denied' in workflow
+    assert 'Only a repository maintainer can request this check.' in workflow
+    assert 'Docs Navigation Check — authentication failed' in workflow
+    assert 'The documentation app token could not be generated.' in workflow
+    assert 'Docs Navigation Check — dispatch failed' in workflow
+    assert 'The navigation check could not be queued.' in workflow
     assert "steps.acknowledge.outcome == 'failure'" in workflow


### PR DESCRIPTION
## Summary

- report maintainer-verification failures instead of silently removing the trigger label
- update the newest matching navigation status comment on retries
- add focused regression assertions for both behaviors

Follow-up to #2288, which entered the merge queue before these shared dispatcher findings were applied.

## Verification

- `uv run pytest -q .github/workflows/scripts/test_docs_navigation_workflow.py`
- `uv run ruff check .github/workflows/scripts/test_docs_navigation_workflow.py`
- `uv run ruff format --check .github/workflows/scripts/test_docs_navigation_workflow.py`
- `actionlint .github/workflows/docs-navigation.yml`
- `uvx zizmor .github/workflows/docs-navigation.yml`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

