### PR TITLE
Release v4.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Release Notes
 
+## [v4.41.0] (2026-08-19)
+
+* Add `logfire --non-interactive` by @strawgate in [#2283](https://github.com/pydantic/logfire/pull/2283)
+* Let `logfire auth` complete without a TTY by @strawgate in [#2275](https://github.com/pydantic/logfire/pull/2275)
+* Add `logfire projects list --json` by @strawgate in [#2280](https://github.com/pydantic/logfire/pull/2280)
+* Add `system.cpu.load_average.1m` and `system.processes.count` by @strawgate in [#2014](https://github.com/pydantic/logfire/pull/2014)
+* Warn for unknown token regions outside configuration by @alexmojaki in [#2281](https://github.com/pydantic/logfire/pull/2281)
+* Warn when a token's region is unrecognised instead of silently defaulting to US by @Pager-dot in [#2229](https://github.com/pydantic/logfire/pull/2229)
+* Limit HTTP connection attempts to three seconds by @alexmojaki in [#2282](https://github.com/pydantic/logfire/pull/2282)
+* fix(auth,client): add timeout to outbound HTTP session requests by @bunlongheng in [#2217](https://github.com/pydantic/logfire/pull/2217)
+* Restore the async metric polling loop by @dmontagu in [#2261](https://github.com/pydantic/logfire/pull/2261)
+* fix: keep the data directory gitignored after logfire clean by @snehankekre in [#2173](https://github.com/pydantic/logfire/pull/2173)
+* Speed up default scrubbing pattern matching by @strawgate in [#2190](https://github.com/pydantic/logfire/pull/2190)
+* fix(db_statement_summary): bound INSERT summary length like the SELECT path by @chuenchen309 in [#2084](https://github.com/pydantic/logfire/pull/2084)
+* Parent slow-async-callback spans to the running task by @jirikuncar in [#2209](https://github.com/pydantic/logfire/pull/2209)
+* Fix two races in Claude Agent SDK tool-use hook instrumentation by @dmontagu in [#2194](https://github.com/pydantic/logfire/pull/2194)
+
 ## [v4.40.0] (2026-08-05)
 
 * fix(google-genai): break circular reference in span event body by @dmontagu in [#2157](https://github.com/pydantic/logfire/pull/2157)

--- a/logfire-api/logfire_api/_internal/config.pyi
+++ b/logfire-api/logfire_api/_internal/config.pyi
@@ -76,7 +76,13 @@ class AdvancedOptions:
     emit_configuration_span: bool | None = ...
     server_response_hook: ServerResponseCallback | None = ...
     resource_detectors: Sequence[ResourceDetector | str] | None = ...
-    def generate_base_url(self, token: str) -> str: ...
+    def generate_base_url(self, token: str, warn_unknown_region: bool = True) -> str:
+        """Resolve the base API URL for `token`, honouring an explicitly configured `base_url`.
+
+        Every caller of this method is part of configuration, so unknown regions warn by default
+        here. Runtime helpers (the query/API clients and the CLI) call `get_base_url_from_token`
+        directly instead, which stays silent so they can't raise under warnings-as-errors.
+        """
 
 @dataclass
 class PydanticPlugin:
@@ -416,8 +422,16 @@ class LogfireCredentials:
     def print_token_summary(self) -> None:
         """Print a summary of the existing project."""
 
-def get_base_url_from_token(token: str) -> str:
-    """Get the base API URL from the token's region."""
+def get_base_url_from_token(token: str, warn_unknown_region: bool = False) -> str:
+    """Get the base API URL from the token's region.
+
+    Args:
+        token: The Logfire token to read the region from.
+        warn_unknown_region: Whether to emit a `LogfireConfigWarning` when the token's region is
+            unrecognised and the US region is used as a fallback. This is off by default so that
+            runtime helpers (e.g. the query/API clients and the CLI) never raise under
+            warnings-as-errors; it's enabled during configuration, where the warning is actionable.
+    """
 def get_git_revision_hash() -> str:
     """Get the current git commit hash."""
 def sanitize_project_name(name: str) -> str:

--- a/logfire-api/logfire_api/_internal/integrations/claude_agent_sdk.pyi
+++ b/logfire-api/logfire_api/_internal/integrations/claude_agent_sdk.pyi
@@ -4,6 +4,7 @@ from claude_agent_sdk.types import HookContext, SyncHookJSONOutput
 from contextlib import AbstractContextManager
 from logfire._internal.integrations.llm_providers.semconv import CONVERSATION_ID as CONVERSATION_ID, ChatMessage as ChatMessage, ERROR_TYPE as ERROR_TYPE, INPUT_MESSAGES as INPUT_MESSAGES, MessagePart as MessagePart, OPERATION_NAME as OPERATION_NAME, OUTPUT_MESSAGES as OUTPUT_MESSAGES, OutputMessage as OutputMessage, PROVIDER_NAME as PROVIDER_NAME, REQUEST_MODEL as REQUEST_MODEL, RESPONSE_MODEL as RESPONSE_MODEL, ReasoningPart as ReasoningPart, SYSTEM as SYSTEM, SYSTEM_INSTRUCTIONS as SYSTEM_INSTRUCTIONS, TOOL_CALL_ARGUMENTS as TOOL_CALL_ARGUMENTS, TOOL_CALL_ID as TOOL_CALL_ID, TOOL_CALL_RESULT as TOOL_CALL_RESULT, TOOL_NAME as TOOL_NAME, TextPart as TextPart, ToolCallPart as ToolCallPart, ToolCallResponsePart as ToolCallResponsePart
 from logfire._internal.main import Logfire as Logfire, LogfireSpan as LogfireSpan
+from logfire._internal.stack_info import get_user_stack_info as get_user_stack_info
 from logfire._internal.utils import handle_internal_errors as handle_internal_errors
 from typing import Any
 
@@ -35,7 +36,19 @@ class _ConversationState:
     root_span: Incomplete
     active_tool_spans: dict[str, LogfireSpan]
     model: str | None
+    announced_tool_ids: set[str]
+    tool_announcement_timeout: float
+    code_attrs: Incomplete
     def __init__(self, *, logfire: Logfire, root_span: LogfireSpan, input_messages: list[ChatMessage], system_instructions: list[TextPart] | None = None) -> None: ...
+    async def wait_for_tool_announcement(self, tool_use_id: str) -> None:
+        """Wait until the assistant message announcing `tool_use_id` has been handled.
+
+        The CLI sends the assistant message (containing the `tool_use` block) before it
+        invokes the PreToolUse hook, but hooks run in separate anyio tasks, so the hook
+        can be scheduled before the main task has applied that message to this state.
+        Closing the chat span at that point would lose its output and model attributes.
+        The timeout is a safety valve for tool calls that are never announced.
+        """
     def add_tool_result(self, tool_use_id: str, tool_name: str, result: Any) -> None:
         """Record a tool result to include in the next chat span's input messages."""
     def open_chat_span(self) -> None:

--- a/logfire-api/logfire_api/_internal/utils.pyi
+++ b/logfire-api/logfire_api/_internal/utils.pyi
@@ -78,6 +78,8 @@ class UnexpectedResponse(RequestException):
     def raise_for_status(cls, response: Response) -> None:
         """Like the requests method, but raises a more informative exception."""
 
+DATA_DIR_FILENAMES: Incomplete
+
 def ensure_data_dir_exists(data_dir: Path) -> None: ...
 def get_version(version: str) -> Version:
     """Return a packaging.version.Version object from a version string.

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "4.40.0"
+version = "4.41.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "4.40.0"
+version = "4.41.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.10"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -47,7 +47,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "caio", version = "0.9.25", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
 wheels = [
@@ -76,7 +76,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "caio", version = "0.12.2", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/14/31/edb06aabd8f8f0b56d659f30800795f40b93cba96be946ce179f6931e3a5/aiofile-3.12.3.tar.gz", hash = "sha256:caa6aa746b5e47e2165f7abd741b6415e49cf4d44fddc0f61844612cc3924d41", size = 21600, upload-time = "2026-08-04T22:59:27.171Z" }
 wheels = [
@@ -1342,9 +1342,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version < '3.12'" },
-    { name = "sqlparse", marker = "python_full_version < '3.12'" },
-    { name = "tzdata", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d5/d8/43e9d000519adceb189620b6869ff88031e046df91c2e9da72f8f6918399/django-5.2.17.tar.gz", hash = "sha256:9d4d93be539a18ab80d058eb515900e10951e04c537c5a6b394fc49528d3251f", size = 10889740, upload-time = "2026-08-04T15:04:03.173Z" }
 wheels = [
@@ -1370,9 +1370,9 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "asgiref", marker = "python_full_version >= '3.12'" },
-    { name = "sqlparse", marker = "python_full_version >= '3.12'" },
-    { name = "tzdata", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "asgiref" },
+    { name = "sqlparse" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/42/6cb20996733984c1f6661daeda3877990836c76c633c6c8879d39f7120eb/django-6.1.tar.gz", hash = "sha256:86a2aacd59b817e4d6ac2ebfe22356c58f66f7b24e503f71b7c2fead677ee48b", size = 11223034, upload-time = "2026-08-05T19:21:53.789Z" }
 wheels = [
@@ -2755,7 +2755,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "4.40.0"
+version = "4.41.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -2900,7 +2900,6 @@ dev = [
     { name = "mysql-connector-python" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_version < '0'" },
     { name = "openai" },
     { name = "openai-agents", extra = ["voice"] },
     { name = "openinference-instrumentation-dspy" },
@@ -3117,7 +3116,7 @@ dev = [
 
 [[package]]
 name = "logfire-api"
-version = "4.40.0"
+version = "4.41.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]
@@ -4500,10 +4499,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -4578,10 +4577,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -6267,8 +6266,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
-    { name = "jeepney", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

No unreleased 4.41.0 has ever shipped, so anyone pinning against a released
version misses everything merged since v4.40.0 (2026-08-05) -- including
`logfire --non-interactive` (#2283) and the earlier TTY fix it builds on
(#2275), which non-interactive/agent callers of `logfire auth` currently
have no released version of.

- Bump `pyproject.toml` and `logfire-api/pyproject.toml` to 4.41.0
- Regenerate `logfire-api`'s stubs (`make generate-stubs`) to pick up the
  API surface that changed since 4.40.0 (`config.py`'s region-warning
  changes, the Claude Agent SDK race fixes)
- `uv lock`
- CHANGELOG entry covering the user-facing PRs merged in that range

## Test plan

- [x] `make generate-stubs` runs clean (stable on a second run, no further
      diff)
- [x] `uv lock` resolves with no changes beyond the version bump

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

