### PR TITLE
Update managed variable MCP tools in the tool table

### DIFF
--- a/docs/how-to-guides/mcp-server.md
+++ b/docs/how-to-guides/mcp-server.md
@@ -353,5 +353,25 @@ The table below lists the full tool set for the `/mcp` endpoint.
 | Notification channels | Create and manage organization-level destinations for alert notifications (for example webhooks/Opsgenie). | `channel_create_webhook`, `channel_create_opsgenie`, `channel_list`, `channel_get`, `channel_update_webhook`, `channel_update_opsgenie`, `channel_delete` |
 | Notification schedules | Create and manage schedule windows that gate alert notification delivery. | `schedule_create`, `schedule_list`, `schedule_get`, `schedule_update`, `schedule_delete` |
 | Issue tracking | List tracked exception issues and triage them by state. | `issue_list`, `issue_set_states` |
-| Managed variables (feature flags) | Create and manage variables, versions, labels, and rollout behavior. | `variable_create`, `variable_list`, `variable_get`, `variable_list_versions`, `variable_update`, `variable_delete`, `variable_update_rollout`, `variable_create_version`, `variable_assign_label` |
+| Managed variables (feature flags) | Create and manage variables, versions, labels, and rollout behavior. | `variable_list`, `variable_get`, `variable_resolve`, `variable_manage`, `variable_delete` |
 | Local development bootstrap | Create a local dev session (including token/env setup) for sending telemetry. | `local_dev_session` |
+
+### Managed variable tools
+
+The managed variable write tools are consolidated, so one tool covers several operations through a
+dispatch parameter:
+
+- `variable_manage` performs every non-destructive write, selected with its `action` parameter:
+  `create`, `update`, `create_version`, `update_rollout`, and `assign_label`. Each action takes the
+  one argument bundle it needs (`metadata`, `version`, `rollout`, or `label`).
+- `variable_delete` performs the destructive operations, selected with its `target` parameter:
+  `variable` (the whole variable, the default), `version` (a single version), or `label` (a label,
+  leaving its versions intact).
+
+Keeping the destructive operations in their own tool lets clients rely on the `destructiveHint`
+annotation, which agents use to decide when to ask for confirmation.
+
+On the read side, `variable_get` returns versions, rollout change history, and the assignment
+history of a label through its `include` parameter (`"versions"`, `"routing_history"`, and
+`"label_history"`, the last of which also needs `label`). `variable_resolve` returns the value a
+given evaluation context would be served.


### PR DESCRIPTION
The managed variable MCP write tools are consolidated: `variable_manage` covers
the non-destructive operations through its `action` parameter, and
`variable_delete` covers the destructive ones through its `target` parameter.
`variable_resolve` was added on the read side.

The tool table in `docs/how-to-guides/mcp-server.md` still lists the previous
per-operation names (`variable_create`, `variable_update`,
`variable_update_rollout`, `variable_create_version`, `variable_assign_label`,
`variable_list_versions`), and does not mention `variable_manage` or
`variable_resolve`.

This updates the row to the current tool names and adds a short section below
the table describing the two dispatch parameters, plus the `include` parameter
on `variable_get` that now returns versions and history. Without that section a
reader who knew the old names has no way to find where those operations went.

Docs only, no code changes.

Verified against a live MCP server: `variable_list_versions` is now rejected as
an unknown tool, `variable_get` accepts and validates `include`, and
`variable_resolve` is present.