### PR TITLE
docs: fix typo in collect_package_info docstring

### DIFF
--- a/logfire/_internal/collect_system_info.py
+++ b/logfire/_internal/collect_system_info.py
@@ -9,7 +9,7 @@ def collect_package_info() -> dict[str, str]:
     """Retrieve the package information for all installed packages.
 
     Returns:
-        A dicts with the package name and version.
+        A dict with the package name and version.
     """
     try:
         distributions = list(metadata.distributions())


### PR DESCRIPTION
### Summary
- Fix minor grammatical typo in `collect_package_info` docstring (`A dicts with` -> `A dict with`).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

