### PR TITLE
Describe what the Pydantic plugin's include and exclude actually do

### DIFF
--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -73,24 +73,37 @@ imported *after* that call.
 
 ## Advanced
 
-### Third-party modules
+### Choosing which models to instrument
 
-By default the plugin does not instrument third-party modules, to avoid noise. Opt specific ones in
-with the [`include`][logfire.PydanticPlugin.include] setting:
+The plugin instruments **every** Pydantic model in the process, including models defined by the
+libraries you depend on. In an application with a few large dependencies that can be thousands of
+model classes, and with `record='failure'` it also records validations those libraries perform
+deliberately — several use a failed validation as control flow and fall back to another schema, so
+the failure is expected rather than a problem you can act on.
 
-```py skip-run="true" skip-reason="global-instrumentation"
-import logfire
-
-logfire.instrument_pydantic(include={'openai'})
-```
-
-Opt your own modules out with the [`exclude`][logfire.PydanticPlugin.exclude] setting:
+Narrow it to your own code with the [`include`][logfire.PydanticPlugin.include] setting:
 
 ```py skip-run="true" skip-reason="global-instrumentation"
 import logfire
 
-logfire.instrument_pydantic(exclude={'app.api.v1'})
+logfire.instrument_pydantic(include={r'^app\..*'})
 ```
+
+Patterns are regular expressions matched against `<module>::<class name>`, and they are anchored at
+the end but not at the start. `app\..*` on its own therefore also matches `django.apps.config`,
+which is why the example begins with `^`.
+
+Use [`exclude`][logfire.PydanticPlugin.exclude] to leave particular models out. It is checked before
+`include`, so a model matching both is not instrumented:
+
+```py skip-run="true" skip-reason="global-instrumentation"
+import logfire
+
+logfire.instrument_pydantic(exclude={r'^app\.api\.v1\..*'})
+```
+
+Models in `fastapi`, `fastui` and `logfire_backend` are never instrumented, regardless of these
+settings.
 
 ### Per-model configuration
 

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -86,11 +86,11 @@ Narrow it to your own code with the [`include`][logfire.PydanticPlugin.include] 
 ```py skip-run="true" skip-reason="global-instrumentation"
 import logfire
 
-logfire.instrument_pydantic(include={r'^app\..*'})
+logfire.instrument_pydantic(include={r'^apps\..*'})
 ```
 
 Patterns are regular expressions matched against `<module>::<class name>`, and they are anchored at
-the end but not at the start. `app\..*` on its own therefore also matches `django.apps.config`,
+the end but not at the start. `apps\..*` on its own therefore also matches `django.apps.config`,
 which is why the example begins with `^`.
 
 Use [`exclude`][logfire.PydanticPlugin.exclude] to leave particular models out. It is checked before
@@ -99,7 +99,7 @@ Use [`exclude`][logfire.PydanticPlugin.exclude] to leave particular models out. 
 ```py skip-run="true" skip-reason="global-instrumentation"
 import logfire
 
-logfire.instrument_pydantic(exclude={r'^app\.api\.v1\..*'})
+logfire.instrument_pydantic(exclude={r'^apps\.api\.v1\..*'})
 ```
 
 Models in `fastapi`, `fastui` and `logfire_backend` are never instrumented, regardless of these

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -309,7 +309,8 @@ class PydanticPlugin:
     r"""Regular expressions for the models to instrument, matched against `<module>::<class name>`.
 
     Empty by default, which instruments every model, including models defined by third-party
-    packages. Patterns are anchored at the end but not at the start, so `apps\..*` also matches
+    packages. Models in `fastapi`, `fastui` and `logfire_backend` are the exception, and are never
+    instrumented. Patterns are anchored at the end but not at the start, so `apps\..*` also matches
     `django.apps.config`; write `^apps\..*` to match from the beginning of the module path.
     """
     exclude: set[str] = field(default_factory=set[str])

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -306,9 +306,17 @@ class PydanticPlugin:
     * `metrics`: Send only metrics.
     """
     include: set[str] = field(default_factory=set[str])
-    """By default, third party modules are not instrumented. This option allows you to include specific modules."""
+    r"""Regular expressions for the models to instrument, matched against `<module>::<class name>`.
+
+    Empty by default, which instruments every model, including models defined by third-party
+    packages. Patterns are anchored at the end but not at the start, so `apps\..*` also matches
+    `django.apps.config`; write `^apps\..*` to match from the beginning of the module path.
+    """
     exclude: set[str] = field(default_factory=set[str])
-    """Exclude specific modules from instrumentation."""
+    """Regular expressions for the models to leave uninstrumented, matched the same way as `include`.
+
+    Checked before `include`, so a model matching both is not instrumented.
+    """
 
 
 @dataclass

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1051,7 +1051,7 @@ class Logfire:
         include: Iterable[str] = (),
         exclude: Iterable[str] = (),
     ) -> None:
-        """Instrument Pydantic model validations.
+        r"""Instrument Pydantic model validations.
 
         This must be called before defining and importing the model classes you want to instrument.
         See the [Pydantic integration guide](https://logfire.pydantic.dev/docs/integrations/pydantic/) for more info.
@@ -1064,9 +1064,13 @@ class Logfire:
                 - `metrics`: Send only metrics.
                 - `off`: Disable instrumentation.
             include:
-                By default, third party modules are not instrumented. This option allows you to include specific modules.
+                Regular expressions for the models to instrument, matched against `<module>::<class name>`.
+                Empty by default, which instruments every model, including models defined by third-party
+                packages. Patterns are anchored at the end but not at the start, so `apps\..*` also matches
+                `django.apps.config`; write `^apps\..*` to match from the beginning of the module path.
             exclude:
-                Exclude specific modules from instrumentation.
+                Regular expressions for the models to leave uninstrumented, matched the same way as `include`.
+                Checked before `include`, so a model matching both is not instrumented.
         """
         # Note that unlike most instrument_* methods, we intentionally don't call
         # _warn_if_not_initialized_for_instrumentation, because this method needs to be called early.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1066,8 +1066,10 @@ class Logfire:
             include:
                 Regular expressions for the models to instrument, matched against `<module>::<class name>`.
                 Empty by default, which instruments every model, including models defined by third-party
-                packages. Patterns are anchored at the end but not at the start, so `apps\..*` also matches
-                `django.apps.config`; write `^apps\..*` to match from the beginning of the module path.
+                packages. Models in `fastapi`, `fastui` and `logfire_backend` are the exception, and are
+                never instrumented. Patterns are anchored at the end but not at the start, so `apps\..*`
+                also matches `django.apps.config`; write `^apps\..*` to match from the beginning of the
+                module path.
             exclude:
                 Regular expressions for the models to leave uninstrumented, matched the same way as `include`.
                 Checked before `include`, so a model matching both is not instrumented.


### PR DESCRIPTION
The docs for `instrument_pydantic` say that third-party modules are not instrumented by default. They are. With `include` empty, which is the default, `_include_model` returns `True` for every model, so every Pydantic class in the process is instrumented, including every model belonging to a dependency. There is no third-party detection anywhere in the decision — only a fixed list of three ignored modules (`fastapi`, `fastui`, `logfire_backend`).

Fixes #2053, which reports 2,221 model classes instrumented at startup in a Django app, the majority from dependencies.

Checked against `main`:

```python
>>> check(include=set(), module='openai._models')      # third-party, no include
True
>>> check(include={r'apps\..*'}, module='django.apps.config')
True                                                   # anchored at the end only
>>> check(include={r'^apps\..*'}, module='django.apps.config')
False
```

This is documentation only. The behaviour may well be the intended one — `include`/`exclude` work fine as an opt-in filter — but the description is the opposite of it, and someone reading it has no reason to pass `include` at all. Changing the default would be a breaking change for anyone relying on models being instrumented without configuration, so this describes what happens instead.

Three things are now stated:

- `include` empty means everything, dependencies included.
- Patterns are matched with `re.search(f'{pattern}$', ...)`, so they are anchored at the end but not at the start. `apps\..*` also matches `django.apps.config`, which is easy to hit and hard to spot. The examples use `^`.
- `exclude` is checked before `include`, so a model matching both is not instrumented.

The docs section also mentions why this is worth configuring rather than leaving alone: with `record='failure'`, libraries that use a failed validation as control flow and fall back to another schema get their expected failures recorded as warnings. The issue gives two concrete cases, in the OpenAI SDK and in Opik.

Every claim added here was verified by calling `_include_model` directly against the current implementation. `make lint`, `make typecheck` and the full suite pass.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

