### PR TITLE
Fix docs navigation comment lookup

### DIFF
--- a/.github/workflows/docs-navigation.yml
+++ b/.github/workflows/docs-navigation.yml
@@ -90,8 +90,11 @@ jobs:
           )
 
           # Update an existing navigation or legacy preview comment on reruns.
-          existing=$(gh api --paginate --slurp "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
-            --jq '[.[][] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview"))))][0].url // empty')
+          matching_comments=$(
+            gh api --paginate "repos/${REPO}/issues/${PR_NUMBER}/comments?per_page=100" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and ((.body | startswith("## Docs Navigation Check")) or (.body | startswith("## Docs Preview")))) | .url'
+          )
+          existing=${matching_comments%%$'\n'*}
           if [ -n "$existing" ]; then
             gh api -X PATCH "$existing" -f body="$body"
           else

--- a/.github/workflows/scripts/test_docs_navigation_workflow.py
+++ b/.github/workflows/scripts/test_docs_navigation_workflow.py
@@ -31,7 +31,11 @@ def test_public_comments_describe_data_only_navigation_validation() -> None:
     assert 'Docs Navigation Check — queued' in workflow
     assert 'Navigation validation for commit' in workflow
     assert 'preview URL' not in workflow
-    assert '--paginate --slurp' in workflow
+    assert '--paginate' in workflow
+    assert '--slurp' not in workflow
+    assert 'matching_comments=$(' in workflow
+    assert 'gh api --paginate' in workflow
+    assert "existing=${matching_comments%%$'\\n'*}" in workflow
     assert 'startswith("## Docs Preview")' in workflow
     assert "steps.app-token.outcome == 'failure' || steps.dispatch.outcome == 'failure'" in workflow
     assert "steps.acknowledge.outcome == 'failure'" in workflow


### PR DESCRIPTION
## Summary

Fix the `Docs Navigation Check` dispatcher acknowledgement step so it no longer combines `gh api --slurp` with `--jq`, which the GitHub-hosted runner rejects.

The docs navigation dispatch itself succeeds; the failure is only in the PR comment lookup/update step after dispatch. This keeps the paginated lookup and still updates an existing `Docs Navigation Check` or legacy `Docs Preview` bot comment on reruns.

## Context

This failure is currently blocking docs navigation checks, for example:

- https://github.com/pydantic/logfire/actions/runs/32354276450/job/96379980132?pr=2287

## Validation

- `uv run pytest -q .github/workflows/scripts/test_docs_navigation_workflow.py`
- `uv run ruff format --check .github/workflows/scripts/test_docs_navigation_workflow.py`
- `uv run ruff check .github/workflows/scripts/test_docs_navigation_workflow.py`
- `ruby -ryaml -e 'YAML.load_file(".github/workflows/docs-navigation.yml"); puts "yaml ok"'`
- `bash -n <(ruby -ryaml -e 'puts YAML.load_file(".github/workflows/docs-navigation.yml").fetch("jobs").fetch("dispatch").fetch("steps").find { |s| s["name"] == "Acknowledge on PR" }.fetch("run")')`
- `git diff --check`

Not run locally:

- `actionlint`: not installed in this environment.
