### PR TITLE
projects status: work from a saved read token alone

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -185,7 +185,7 @@ Follow the instructions, and you'll have a new project created in no time! :part
 
 ### Status (`projects status`)
 
-To see what telemetry has actually reached the project this directory is linked to, run:
+To see what telemetry has actually reached a project, run:
 
 ```bash
 logfire projects status
@@ -203,7 +203,11 @@ Project  my-org/orders
 
 One row per service, so a partly-instrumented system shows up as one: if you instrumented a web app and a worker but only the web app appears, the worker is not reporting.
 
-This needs a saved read token — see below — and reports the last hour. Add `--json` for machine-readable output.
+This needs a saved read token — see below — and reports the last hour. Write credentials
+(`projects use`/`new`) are not required: a saved read token already records which project
+it belongs to, so `read-tokens --project ORGANIZATION/PROJECT_NAME create --save` on its
+own is enough. If this directory IS linked to a project, the saved token must match it.
+Add `--json` for machine-readable output.
 
 ## Read tokens (`read-tokens`)
 

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -419,19 +419,32 @@ class SavedReadToken(NamedTuple):
     # from `logfire_credentials.json` is what makes self-hosted deployments work: their
     # base URL cannot be recovered from the token, only from where it was actually minted.
     base_url: str
+    # The project the token was minted for, recorded alongside it -- see `_save_read_token`.
+    # Exposed so a caller with no linked project (no `logfire_credentials.json` at all) can
+    # still say which project it is reporting on, using the token's own identity rather
+    # than one it has no other way to name.
+    organization: str
+    project_name: str
 
 
-def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: str) -> SavedReadToken | None:
-    """A saved read token for THIS project, if there is one and it is still usable.
+def _load_saved_read_token(
+    data_dir: Path, *, organization: str | None = None, project_name: str | None = None
+) -> SavedReadToken | None:
+    """A saved read token, if there is one and it is still usable.
 
     Returns None rather than raising for every failure mode -- missing, unreadable,
     corrupt, expired, belonging to a different project, or missing the host it is valid
     against. The caller turns that into one message naming the command to run, which is
     more useful than five ways to fail.
 
-    The project check matters: `logfire projects use` repoints the directory, and a token
+    `organization`/`project_name` given means there IS a linked project to check the token
+    against, and it must match: `logfire projects use` repoints the directory, and a token
     left over from the previous project would otherwise be sent for the new one and
-    produce a confusing 401 or, worse, another project's data.
+    produce a confusing 401 or, worse, another project's data. Omitted (both, together --
+    there is no reading with only one of a project's two identifying halves) means there is
+    no local link at all to check against, so the token's OWN recorded organization and
+    project name are trusted directly -- read-only access should not require ever having
+    held write credentials, and a saved token is already self-describing.
 
     Also refuses a symlink, or a file the git-tracking check from `_save_read_token` would
     have refused to write in the first place: `_save_read_token` only guards its OWN
@@ -465,7 +478,15 @@ def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: s
     base_url = data.get('base_url')
     if not isinstance(base_url, str) or not base_url:
         return None
-    if data.get('organization') != organization or data.get('project_name') != project_name:
+    token_organization = data.get('organization')
+    token_project_name = data.get('project_name')
+    if not isinstance(token_organization, str) or not token_organization:
+        return None
+    if not isinstance(token_project_name, str) or not token_project_name:
+        return None
+    if organization is not None and token_organization != organization:
+        return None
+    if project_name is not None and token_project_name != project_name:
         return None
     # Absent means unbounded -- this CLI always writes the key, so a file without it was
     # written by a different version or edited by hand, and the expiry exists to bound a
@@ -489,7 +510,9 @@ def _load_saved_read_token(data_dir: Path, *, organization: str, project_name: s
             expiry = expiry.replace(tzinfo=timezone.utc)
         if expiry <= datetime.now(tz=timezone.utc):
             return None
-    return SavedReadToken(token=token, base_url=base_url)
+    return SavedReadToken(
+        token=token, base_url=base_url, organization=token_organization, project_name=token_project_name
+    )
 
 
 def _load_credentials_or_exit(data_dir: Path, remedy: str | None = None) -> LogfireCredentials:
@@ -524,28 +547,53 @@ def _organization_from_project_url(project_url: str) -> str | None:
 
 
 def parse_project_status(args: argparse.Namespace) -> None:
-    """Show what telemetry has reached the current project."""
+    """Show what telemetry has reached the current project.
+
+    Does NOT require write credentials (`logfire_credentials.json`) to exist -- only a
+    saved read token, which is self-describing (it records which organization and project
+    it was minted for -- see `_save_read_token`) and is all this command actually sends.
+    Requiring write credentials too would mean a read-only workflow -- `read-tokens
+    --project ORG/PROJECT create --save` on a directory that never ran `projects use` --
+    could never use this command at all, for a linkage this command has no other need of.
+    When write credentials DO exist, the saved token must still match the linked project,
+    for the reason `_load_saved_read_token` documents.
+    """
     data_dir = Path(args.data_dir)
-    credentials = _load_credentials_or_exit(
-        data_dir, remedy='Run `logfire projects use PROJECT_NAME --org ORGANIZATION` first.'
-    )
-
-    organization = _organization_from_project_url(credentials.project_url)
-    if organization is None:
-        sys.stderr.write(f'Cannot tell which organization {credentials.project_url} belongs to.\n')
-        sys.exit(1)
-
-    # Reuse the token saved next to the write credentials rather than creating one here.
-    # An earlier version of this command minted a read token per invocation, which is a
-    # PERMANENT credential the CLI cannot revoke -- and this command is built to be run
-    # repeatedly while waiting for data, so polling four times left four behind.
-    saved = _load_saved_read_token(data_dir, organization=organization, project_name=credentials.project_name)
-    if saved is None:
-        sys.stderr.write(
-            f'No usable read token for {organization}/{credentials.project_name}.\n'
-            'Run `logfire read-tokens create --save` to create one, then try again.\n'
+    credentials = LogfireCredentials.load_creds_file(data_dir)
+    saved: SavedReadToken | None
+    if credentials is None:
+        # Reuse the token saved next to write credentials rather than creating one here.
+        # An earlier version of this command minted a read token per invocation, which is a
+        # PERMANENT credential the CLI cannot revoke -- and this command is built to be run
+        # repeatedly while waiting for data, so polling four times left four behind.
+        saved = _load_saved_read_token(data_dir)
+        if saved is None:
+            sys.stderr.write(
+                'No usable read token.\n'
+                'Run `logfire read-tokens --project ORGANIZATION/PROJECT_NAME create --save` to create one '
+                '(or run `logfire projects use PROJECT_NAME --org ORGANIZATION` first, then `logfire '
+                'read-tokens create --save`), then try again.\n'
+            )
+            sys.exit(1)
+        project_url = f'{saved.base_url}/{saved.organization}/{saved.project_name}'
+    else:
+        linked_organization = _organization_from_project_url(credentials.project_url)
+        if linked_organization is None:
+            sys.stderr.write(f'Cannot tell which organization {credentials.project_url} belongs to.\n')
+            sys.exit(1)
+        saved = _load_saved_read_token(
+            data_dir, organization=linked_organization, project_name=credentials.project_name
         )
-        sys.exit(1)
+        if saved is None:
+            sys.stderr.write(
+                f'No usable read token for {linked_organization}/{credentials.project_name}.\n'
+                'Run `logfire read-tokens create --save` to create one, then try again.\n'
+            )
+            sys.exit(1)
+        project_url = credentials.project_url
+
+    organization = saved.organization
+    project_name = saved.project_name
 
     # The host the token was CREATED against, not `credentials.logfire_api_url`. That field
     # comes from `logfire_credentials.json`, which lives in the project this command runs
@@ -600,8 +648,8 @@ def parse_project_status(args: argparse.Namespace) -> None:
             json.dumps(
                 {
                     'organization': organization,
-                    'project_name': credentials.project_name,
-                    'project_url': credentials.project_url,
+                    'project_name': project_name,
+                    'project_url': project_url,
                     'lookback_hours': STATUS_LOOKBACK.total_seconds() / 3600,
                     'services': [
                         {
@@ -617,12 +665,13 @@ def parse_project_status(args: argparse.Namespace) -> None:
         )
         return
 
-    # `credentials` came from a file inside the project this command runs in (the same
-    # threat model `_save_read_token`'s docstring covers), so its fields get the same
-    # stripping as a service name -- not the JSON branch above, which is already safe
-    # because `json.dumps` escapes control characters by construction.
-    sys.stderr.write(f'Project  {_printable(organization)}/{_printable(credentials.project_name)}\n')
-    sys.stderr.write(f'         {_printable(credentials.project_url)}\n\n')
+    # `organization`/`project_name`/`project_url` came from a file inside the project this
+    # command runs in -- write credentials or a saved read token, depending on which one
+    # supplied them above (the same threat model `_save_read_token`'s docstring covers) --
+    # so they get the same stripping as a service name. Not the JSON branch above, which is
+    # already safe because `json.dumps` escapes control characters by construction.
+    sys.stderr.write(f'Project  {_printable(organization)}/{_printable(project_name)}\n')
+    sys.stderr.write(f'         {_printable(project_url)}\n\n')
     if not services:
         # Deliberately not phrased as failure. Data takes a moment to arrive, and the
         # common case for someone running this during setup is "not yet", not "broken".

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -444,7 +444,10 @@ def _load_saved_read_token(
     there is no reading with only one of a project's two identifying halves) means there is
     no local link at all to check against, so the token's OWN recorded organization and
     project name are trusted directly -- read-only access should not require ever having
-    held write credentials, and a saved token is already self-describing.
+    held write credentials, and a saved token is already self-describing. Exactly one
+    given is rejected outright: it would check the token against half a project identity,
+    accepting one scoped to a same-named project in a different organization (or vice
+    versa) instead of correctly falling back to trusting the token's own identity.
 
     Also refuses a symlink, or a file the git-tracking check from `_save_read_token` would
     have refused to write in the first place: `_save_read_token` only guards its OWN
@@ -457,6 +460,8 @@ def _load_saved_read_token(
     as "tracked" here -- unlike at `_save_read_token`, failing closed on THIS call site
     means falling back to "no usable token", not blocking anything.
     """
+    if (organization is None) != (project_name is None):
+        return None
     path = _read_token_path(data_dir)
     if path.is_symlink():
         return None

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -575,7 +575,6 @@ def parse_project_status(args: argparse.Namespace) -> None:
                 'read-tokens create --save`), then try again.\n'
             )
             sys.exit(1)
-        project_url = f'{saved.base_url}/{saved.organization}/{saved.project_name}'
     else:
         linked_organization = _organization_from_project_url(credentials.project_url)
         if linked_organization is None:
@@ -590,10 +589,15 @@ def parse_project_status(args: argparse.Namespace) -> None:
                 'Run `logfire read-tokens create --save` to create one, then try again.\n'
             )
             sys.exit(1)
-        project_url = credentials.project_url
 
     organization = saved.organization
     project_name = saved.project_name
+    # From `saved`, not `credentials.project_url`: matching organization and project name
+    # does not guarantee matching HOST (self-hosted, or a different region), and the query
+    # below always goes to `saved.base_url` regardless of which branch loaded `saved` --
+    # this must name the same host, or the displayed URL points somewhere this command
+    # never actually asked.
+    project_url = f'{saved.base_url}/{organization}/{project_name}'
 
     # The host the token was CREATED against, not `credentials.logfire_api_url`. That field
     # comes from `logfire_credentials.json`, which lives in the project this command runs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1090,6 +1090,9 @@ def test_projects_status_works_from_a_saved_read_token_alone(
     err = capsys.readouterr().err
     assert 'alexmojaki/test38' in err
     assert 'orders-web' in err
+    # The read token is minted to run the query and must never be shown: putting a live
+    # credential in the caller's output is the thing this command exists to avoid.
+    assert 'fake_read_token' not in err
 
 
 def test_projects_status_says_nothing_yet_rather_than_failing(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2192,6 +2192,56 @@ def test_projects_status_uses_a_self_hosted_read_token(tmp_dir_cwd: Path, capsys
     assert 'orders-web' in capsys.readouterr().err
 
 
+def test_projects_status_displays_the_host_it_actually_queried(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The displayed project URL must name the host the query actually went to.
+
+    Matching organization and project name does not guarantee a matching host --
+    `logfire_credentials.json` and a saved read token are two separate files, and nothing
+    stops them naming different deployments for what happens to be the same org/project
+    pair. The query always goes to `saved.base_url`; showing `credentials.project_url`
+    instead would tell the user a host their request never touched.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir(exist_ok=True)
+    (data_dir / 'logfire_credentials.json').write_text(
+        json.dumps(
+            {
+                'token': 'fake_write_token',
+                'project_name': 'orders',
+                'project_url': 'https://logfire-us.pydantic.dev/test-org/orders',
+                'logfire_api_url': 'https://logfire-us.pydantic.dev',
+            }
+        )
+    )
+    _save_fake_read_token(data_dir, base_url='https://logfire.example.com')
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire.example.com/v2/query',
+            json={
+                'schema': {'fields': [{'name': 'service_name', 'data_type': 'Utf8', 'nullable': False}]},
+                'data': [],
+            },
+        )
+
+        main(['projects', 'status', '--json'])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload['project_url'] == 'https://logfire.example.com/test-org/orders'
+
+
 def test_read_token_save_writes_the_file_and_prints_nothing(
     tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1056,6 +1056,42 @@ def test_projects_status_reports_what_arrived(tmp_dir_cwd: Path, capsys: pytest.
     assert 'fake_read_token' not in err
 
 
+def test_projects_status_works_from_a_saved_read_token_alone(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No write credentials at all -- only a saved read token -- must still work.
+
+    `read-tokens --project ORGANIZATION/PROJECT_NAME create --save` never touches
+    `logfire_credentials.json`; a directory that only ever ran that command (never
+    `projects use`) is a legitimate, real user-reported state, not an edge case. Before
+    this, `projects status` insisted on write credentials it had no actual use for, and
+    sent a read-only user looking for `projects use` instead of the read-tokens command
+    that would have actually gotten them unstuck.
+    """
+    data_dir = tmp_dir_cwd / '.logfire'
+    data_dir.mkdir()
+    _save_fake_read_token(data_dir, organization='alexmojaki', project_name='test38')
+
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        _mock_status_backend(m, [{'service_name': 'orders-web', 'records': 5, 'last_seen': '2026-08-18T20:00:00Z'}])
+
+        main(['projects', 'status'])
+
+    err = capsys.readouterr().err
+    assert 'alexmojaki/test38' in err
+    assert 'orders-web' in err
+
+
 def test_projects_status_says_nothing_yet_rather_than_failing(
     tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -1111,12 +1147,17 @@ def test_projects_status_json_is_machine_readable(tmp_dir_cwd: Path, capsys: pyt
 def test_projects_status_without_credentials_says_what_to_run(
     tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    """No write credentials and no saved read token: point at minting a read token
+    directly, not at `projects use` -- this command never needs write credentials, so
+    telling a read-only user to go get some would be pointing them at the wrong fix.
+    """
     with pytest.raises(SystemExit) as exc_info:
         main(['projects', 'status'])
     assert exc_info.value.code == 1
     err = capsys.readouterr().err
-    assert 'No Logfire credentials found' in err
+    assert 'No usable read token' in err
     # Runnable as printed: `<name>` would be shell input redirection.
+    assert 'logfire read-tokens --project ORGANIZATION/PROJECT_NAME create --save' in err
     assert 'logfire projects use PROJECT_NAME --org ORGANIZATION' in err
 
 
@@ -2234,6 +2275,26 @@ def test_read_token_save_with_explicit_project_needs_no_linked_directory(tmp_dir
     assert saved['token'] == 'explicit_project_token'
 
 
+def test_read_token_create_without_project_or_linked_directory_says_what_to_run(
+    tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No `--project` and nothing linked: the remedy must name both ways out.
+
+    `parse_create_read_token` falls back to the linked directory when `--project` is
+    omitted, sharing `_load_credentials_or_exit` with `whoami` and (formerly) `projects
+    status` for that. `projects status` reads write credentials directly now, so this is
+    the only remaining caller that passes `_load_credentials_or_exit` a `remedy` -- and
+    without a test here, that branch would go uncovered.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        main(['read-tokens', 'create'])
+    assert exc_info.value.code == 1
+    err = capsys.readouterr().err
+    assert 'No Logfire credentials found' in err
+    assert '--project' in err
+    assert 'logfire projects use PROJECT_NAME --org ORGANIZATION' in err
+
+
 def test_read_token_create_without_save_writes_no_file(tmp_dir_cwd: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Printed mode must not ALSO persist a copy to disk.
 
@@ -2404,6 +2465,11 @@ _REMOVE_KEY = object()
     [
         ({'organization': 'other-org'}, 'issued for a different organization'),
         ({'project_name': 'other-project'}, 'issued for a different project'),
+        ({'organization': ''}, 'empty organization'),
+        ({'organization': 123}, 'organization is not a string'),
+        ({'organization': _REMOVE_KEY}, 'no organization key -- an older saved-token file'),
+        ({'project_name': ''}, 'empty project_name'),
+        ({'project_name': _REMOVE_KEY}, 'no project_name key -- an older saved-token file'),
         ({'expires_at': (datetime.now(tz=timezone.utc) - timedelta(days=1)).isoformat()}, 'already expired'),
         ({'expires_at': 'not a timestamp'}, 'unparseable expiry'),
         ({'token': ''}, 'empty token'),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2613,6 +2613,23 @@ def test_load_saved_read_token_treats_unconfirmed_tracking_as_unusable(tmp_dir_c
         assert _load_saved_read_token(data_dir, organization='test-org', project_name='orders') is None
 
 
+@pytest.mark.parametrize('kwargs', [{'organization': 'test-org'}, {'project_name': 'orders'}])
+def test_load_saved_read_token_rejects_exactly_one_filter(tmp_dir_cwd: Path, kwargs: dict[str, str]) -> None:
+    """Passing only one of `organization`/`project_name` must not check the token against
+    half a project identity.
+
+    A token whose organization matches but whose project does not (or vice versa) would
+    otherwise pass -- matching a same-named project in a different organization, or a
+    different project in the same organization -- neither of which is "the linked
+    project". Both together (a real match check) or neither (trust the token's own
+    identity) are the only valid calls; one alone is a caller bug, not a valid filter.
+    """
+    data_dir = _status_credentials(tmp_dir_cwd, read_token=False)
+    _save_fake_read_token(data_dir, organization='test-org', project_name='orders')
+
+    assert _load_saved_read_token(data_dir, **kwargs) is None
+
+
 def test_saved_read_token_survives_a_naive_expiry(tmp_dir_cwd: Path) -> None:
     """A timestamp without a timezone must not blow up the comparison.
 


### PR DESCRIPTION
## Summary

Real user-reported bug in `logfire projects status`, shipped in v4.41.0: the command unconditionally required local write credentials (`logfire_credentials.json`), even when a valid, self-describing saved read token already existed.

`logfire read-tokens --project ORG/PROJECT create --save` never touches `logfire_credentials.json` — it's a fully read-only workflow. A directory that only ever ran that command (never `projects use`) had a valid saved token sitting right there, and `projects status` refused to use it, pointing the user at `projects use` instead of the read-tokens command that would have actually unblocked them.

## Fix

`_load_saved_read_token` now accepts an optional organization/project filter:
- Given (write credentials exist and are linked): still enforces the match that protects against a stale token left over from a previous `projects use`.
- Omitted (no linked project to check against): trusts the saved token's own recorded organization/project identity directly, which `SavedReadToken` now exposes.

`parse_project_status` no longer hard-requires write credentials; it falls back to the saved token's own identity when there's nothing local to link against, and the "no usable token" message points at `read-tokens --project ORG/PROJECT create --save` as the primary fix rather than `projects use`.

## Test plan

- [x] New test reproduces the exact reported scenario (saved read token, no write credentials) and would fail against the old code (verified via mutation test — reverting the fix reproduces the exact error the user hit).
- [x] Existing match-enforcement behavior (stale token from a previous `projects use`) is unchanged and still covered.
- [x] `coverage report --fail-under 100` passes.
- [x] `ruff check`, `ruff format --check`, `pyright` all pass.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

