### PR TITLE
Bump gh-action-pypi-publish to v1.14.2, fixing a broken release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,7 +263,7 @@ jobs:
         run: uv build --all
 
       - name: Publish logfire and logfire-api to PyPI
-        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # v1.13.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
         with:
           skip-existing: true
           verbose: true


### PR DESCRIPTION
## Summary

The v4.41.0 release job failed at the PyPI-upload step:

```
Checking dist/logfire-4.41.0-py3-none-any.whl: ERROR InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

(https://github.com/pydantic/logfire/actions/runs/32387640302)

`hatchling` (this repo's build backend) emits Core Metadata version 2.5. The pinned `gh-action-pypi-publish@v1.13.0` bundles a Twine version that predates support for it, so `verify-metadata` rejects the wheel and the whole publish step fails. **v4.41.0 is not currently published to PyPI** (still shows 4.40.0 as latest).

v1.14.2's own release notes confirm this is exactly the fix:

> So what most people will find useful is @takluyver's update of Twine to v7 that we use internally. This version will let them upload their sdists and wheels containing core packaging metadata v2.5 to (Test)PyPI.

## Fix

Bump the pin from `v1.13.0` to `v1.14.2` (commit SHA verified independently via both the tag object and the `/commits/{ref}` endpoint, matching this file's existing pin-to-SHA-with-version-comment convention).

## Note

This fixes future releases. It does not retroactively publish v4.41.0 — that tag's workflow run used the old pinned action, so republishing v4.41.0 (or cutting a new patch version) is a separate decision for whoever owns the PyPI release.

## Test plan

- [x] `pre-commit run --files .github/workflows/main.yml` passes (including `zizmor`)
- [x] SHA independently verified against both `git/refs/tags`→`git/tags` and `/commits/{ref}`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

