### PR TITLE
Record #2296 under v4.41.0 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Let `logfire auth` complete without a TTY by @strawgate in [#2275](https://github.com/pydantic/logfire/pull/2275)
 * Add `logfire --non-interactive` by @strawgate in [#2283](https://github.com/pydantic/logfire/pull/2283)
 * Add `logfire projects status` by @strawgate in [#2286](https://github.com/pydantic/logfire/pull/2286)
+* `projects status`: work from a saved read token alone by @strawgate in [#2296](https://github.com/pydantic/logfire/pull/2296)
 
 ## [v4.40.0] (2026-08-05)
 


### PR DESCRIPTION
Adds one line to the `v4.41.0` changelog section, as groundwork for recovering that release.

## Why

v4.41.0 was tagged and GitHub-released, but **never published to PyPI** — the release job failed at the upload step ([run 32387640302](https://github.com/pydantic/logfire/actions/runs/32387640302)):

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Hatchling emits Core Metadata 2.5; the then-pinned `gh-action-pypi-publish@v1.13.0` bundled a twine that predates it. #2297 fixed the pin, but landed *after* the tag, so the tag's own workflow run can't use it and re-running replays the broken file.

Recovering the release means re-tagging `v4.41.0` at a commit carrying that fix. `pyproject.toml` is still `4.41.0` there, so the version check passes untouched — but it also pulls #2296 into the release.

## Why this line belongs in v4.41.0 and not the next release

#2296 refines `logfire projects status`, a command that is itself new in v4.41.0 (#2286) and has never shipped to PyPI — so there is no released behavior for it to change. If the tag moves to include it, that is genuinely where it ships.

It would otherwise go unrecorded entirely: `release/prepare.py` generates each release's notes from `git describe --tags --abbrev=0`, so once `v4.41.0` points at the later commit, the next release generates from *there* onward and #2296 falls into neither range.

#2297 is a CI workflow pin and is left out, per the release README's guidance to curate out changes that don't affect the package.

## Test plan

- [x] Documentation only — one line in `CHANGELOG.md`, no code or version change
- [x] `check_changelog.yml` only enforces its version/changelog pairing when `pyproject.toml` changes, which it does not here
- [x] pre-commit passes

https://claude.ai/code/session_01AaTjMtxFKrx1XQ94gNv7th

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

