### PR TITLE
docs: link the Logfire product pages from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ What sets Logfire apart:
 
 See the [documentation](https://pydantic.dev/docs/logfire/) for more information.
 
+Evaluating observability tools? See what Logfire does for [LLM apps and agents](https://pydantic.dev/logfire/llm-observability?utm_source=github&utm_medium=readme&utm_campaign=logfire), [evals in production](https://pydantic.dev/logfire/evals?utm_source=github&utm_medium=readme&utm_campaign=logfire), and [how it compares to alternatives](https://pydantic.dev/logfire/alternatives?utm_source=github&utm_medium=readme&utm_campaign=logfire).
+
 **Feel free to report issues and ask any questions about Logfire in this repository!**
 
 This repo contains the Python SDK for `logfire` and documentation; the server application for recording and displaying data is closed source.


### PR DESCRIPTION
One line after the documentation link, pointing to the LLM-observability, evals, and comparison pages. UTM pattern matches the existing product links in the pydantic-ai README.

Closes #2300.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

