### PR TITLE
Run test matrix on GitHub-hosted runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,20 +68,7 @@ jobs:
 
   test:
     name: test on Python ${{ matrix.python-version }}, pydantic ${{ matrix.pydantic-version }}, otel ${{ matrix.otel-version }}
-    # Use Ubicloud premium 4-core runners for maintainer PRs and merge queue runs (faster
-    # CPUs/more cores); fork PRs run on standard GitHub runners
-    # During a runner-provider outage, set the FAST_RUNNERS_DISABLED repository variable to
-    # 'true' to force standard GitHub runners everywhere
-    runs-on: >-
-      ${{
-        vars.FAST_RUNNERS_DISABLED != 'true'
-        && (
-          github.event_name == 'merge_group'
-          || github.event.pull_request.head.repo.full_name == github.repository
-        )
-        && 'ubicloud-premium-4'
-        || 'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- run the Python test matrix on `ubuntu-latest`
- remove the Ubicloud-specific routing expression and outage override

## Why

Logfire is a public repository, so its standard GitHub-hosted Linux runners do not consume paid Actions minutes. Using the standard runner removes an unnecessary third-party runner dependency while preserving the existing test matrix and xdist parallelism.

## Validation

- `pre-commit run --files .github/workflows/main.yml`
- `actionlint` reports only the pre-existing `test-pyodide` `matrix.python-version` warning, identical on `origin/main`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

