### PR TITLE
Let logfire.configure() finish project setup without a TTY

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -115,7 +115,7 @@ from .exporters.remove_pending import RemovePendingSpansExporter
 from .exporters.test import TestExporter
 from .forwarding import OTLPForwardingManager
 from .integrations.executors import instrument_executors
-from .interactive import require_answer
+from .interactive import ask_or_default, ask_required, require_answer
 from .logs import ProxyLoggerProvider
 from .metrics import ProxyMeterProvider
 from .scrubbing import NOOP_SCRUBBER, BaseScrubber, Scrubber, ScrubbingOptions
@@ -2054,10 +2054,13 @@ class LogfireCredentials:
                     f'No {project_message} found for the current user{org_message}.',
                     'logfire projects use PROJECT_NAME --org ORGANIZATION',
                 )
-                expand_search = Prompt.ask(
-                    f'No {project_message} found for the current user{org_message}. Choose from all projects?',
-                    choices=['y', 'n'],
-                    default='y',
+                expand_search = ask_or_default(
+                    lambda: Prompt.ask(
+                        f'No {project_message} found for the current user{org_message}. Choose from all projects?',
+                        choices=['y', 'n'],
+                        default='y',
+                    ),
+                    'y',
                 )
                 if expand_search == 'n':
                     # user didn't want to expand search, print a hint and quit
@@ -2088,10 +2091,13 @@ class LogfireCredentials:
                 f'Several projects are available:\n{project_choices_str}',
                 'logfire projects use PROJECT_NAME --org ORGANIZATION',
             )
-            selected_project_key = Prompt.ask(
-                f"Please select one of the following projects by number (requires the 'write_token' permission):\n{project_choices_str}\n",
-                choices=list(project_choices.keys()),
-                default='1',
+            selected_project_key = ask_or_default(
+                lambda: Prompt.ask(
+                    f"Please select one of the following projects by number (requires the 'write_token' permission):\n{project_choices_str}\n",
+                    choices=list(project_choices.keys()),
+                    default='1',
+                ),
+                '1',
             )
             project_info_tuple: tuple[str, str] = project_choices[selected_project_key]
             organization = project_info_tuple[0]
@@ -2143,11 +2149,15 @@ class LogfireCredentials:
                         'logfire projects new PROJECT_NAME --org ORGANIZATION',
                         'logfire projects new PROJECT_NAME --default-org',
                     )
-                    organization = Prompt.ask(
-                        '\nTo create and use a new project, please provide the following information:\n'
-                        'Select the organization to create the project in',
-                        choices=organizations,
-                        default=user_default_organization_name or organizations[0],
+                    org_default = user_default_organization_name or organizations[0]
+                    organization = ask_or_default(
+                        lambda: Prompt.ask(
+                            '\nTo create and use a new project, please provide the following information:\n'
+                            'Select the organization to create the project in',
+                            choices=organizations,
+                            default=org_default,
+                        ),
+                        org_default,
                     )
             else:
                 organization = organizations[0]
@@ -2159,8 +2169,12 @@ class LogfireCredentials:
                         f'logfire projects new PROJECT_NAME --org {organization}',
                         'logfire projects new PROJECT_NAME --default-org',
                     )
-                    confirm = Confirm.ask(
-                        f'The project will be created in the organization "{organization}". Continue?', default=True
+                    confirm = ask_or_default(
+                        lambda: Confirm.ask(
+                            f'The project will be created in the organization "{organization}". Continue?',
+                            default=True,
+                        ),
+                        True,
                     )
                     if not confirm:
                         sys.exit(1)
@@ -2182,6 +2196,22 @@ class LogfireCredentials:
             """A runnable `projects new`, carrying the organization already settled on."""
             return f'logfire projects new {name} --org {organization}'
 
+        def ask_project_name(prompt: str) -> str:
+            """Ask for a project name, falling back to `project_name_default` on EOF.
+
+            Unless it is the `...` sentinel, in which case there is no safe name to fall
+            back on (see the comment below), so an exhausted stdin gets the same
+            `NonInteractiveError` guidance `--non-interactive` would rather than silently
+            creating a project called Ellipsis.
+            """
+            if project_name_default is ...:  # pyright: ignore[reportUnnecessaryComparison]  # it really can be
+                return ask_required(
+                    lambda: Prompt.ask(prompt, default=project_name_default),
+                    prompt.strip(),
+                    name_remedy('PROJECT_NAME'),
+                )
+            return ask_or_default(lambda: Prompt.ask(prompt, default=project_name_default), project_name_default)
+
         while True:
             if not project_name:
                 # `project_name_prompt` carries WHY a name is being asked for -- it is
@@ -2196,7 +2226,7 @@ class LogfireCredentials:
                     project_name_prompt.strip(),
                     name_remedy('PROJECT_NAME' if name_rejected else project_name_default),
                 )
-            project_name = project_name or Prompt.ask(project_name_prompt, default=project_name_default)
+            project_name = project_name or ask_project_name(project_name_prompt)
             while project_name and not re.match(PROJECT_NAME_PATTERN, project_name):
                 # A name that was SUPPLIED and is malformed skips the guard above, so
                 # without this the recovery prompt below reads stdin and hangs.
@@ -2206,13 +2236,12 @@ class LogfireCredentials:
                     'a hyphen.',
                     name_remedy('PROJECT_NAME'),
                 )
-                project_name = Prompt.ask(
+                project_name = ask_project_name(
                     "\nThe project name you've entered is invalid. Valid project names:\n"
                     '  * may contain lowercase alphanumeric characters\n'
                     '  * may contain single hyphens\n'
                     '  * may not start or end with a hyphen\n\n'
-                    'Enter the project name you want to use:',
-                    default=project_name_default,
+                    'Enter the project name you want to use:'
                 )
 
             try:
@@ -2262,7 +2291,12 @@ class LogfireCredentials:
 
         projects = client.get_user_projects()
         if projects:
-            use_existing_projects = Confirm.ask('Do you want to use one of your existing projects? ', default=True)
+            # `default=True` already says what "no answer" means, same as a real person
+            # pressing Enter would give -- an exhausted stdin gets that same outcome
+            # rather than an EOFError traceback (see `ask_or_default`).
+            use_existing_projects = ask_or_default(
+                lambda: Confirm.ask('Do you want to use one of your existing projects? ', default=True), True
+            )
             if use_existing_projects:  # pragma: no branch
                 credentials = cls.use_existing_project(client=client, projects=projects)
 
@@ -2271,10 +2305,17 @@ class LogfireCredentials:
 
         try:
             result = cls(**credentials, logfire_api_url=client.base_url)
-            Prompt.ask(
-                f'Project initialized successfully. You will be able to view it at: {result.project_url}\n'
-                'Press Enter to continue'
-            )
+            # This prompt exists to give a person a beat before moving on -- nothing is
+            # done with the answer either way. When there is no one to press the key,
+            # there is no beat to give, so an exhausted stdin just continues rather than
+            # raising an EOFError traceback after the project was already created.
+            try:
+                Prompt.ask(
+                    f'Project initialized successfully. You will be able to view it at: {result.project_url}\n'
+                    'Press Enter to continue'
+                )
+            except EOFError:
+                pass
             return result
         except TypeError as e:  # pragma: no cover
             raise LogfireConfigError(f'Invalid credentials, when initializing project: {e}') from e

--- a/logfire/_internal/interactive.py
+++ b/logfire/_internal/interactive.py
@@ -35,8 +35,8 @@ class NonInteractiveError(LogfireConfigError):
     Carries the guidance the user needs rather than a traceback: the CLI catches this and
     prints `message` before exiting non-zero. Raised either because `--non-interactive`
     said so up front (`require_answer`), or because stdin ran out before an answer arrived
-    (`ask_required`) -- the same message either way, since both mean the same thing to
-    whoever reads it.
+    (`ask_required`) -- the same question/remedy structure either way (only the reason
+    line differs), since both mean the same thing to whoever reads it.
     """
 
 
@@ -102,8 +102,10 @@ def ask_required(ask: Callable[[], T], question: str, remedy: str, *more_remedie
     The reactive half of `require_answer`'s proactive check: that covers a caller who
     declared `--non-interactive` up front, this covers one that did not but ran out of
     input anyway -- a command copied out of the docs into an agent, mid-conversation.
-    Raises the identical `NonInteractiveError` message either way, since both mean the
-    same thing to whoever reads it: there was no answer, and here is how to supply one.
+    Raises the same `NonInteractiveError` structure `require_answer` would -- question,
+    then reason, then remedies -- with a reason line naming stdin instead of the flag,
+    since both mean the same thing to whoever reads it: there was no answer, and here is
+    how to supply one.
     """
     try:
         return ask()

--- a/logfire/_internal/interactive.py
+++ b/logfire/_internal/interactive.py
@@ -12,20 +12,31 @@ cannot cover that case; declaring intent up front can, because nothing has to be
 
 The two are complements. EOF handling still covers callers that cannot be changed (a
 command copied out of the docs into an agent), and this covers callers that can say so.
+`ask_or_default`/`ask_required` below are the EOF-handling half: they let a prompt whose
+stdin genuinely runs dry (rather than merely being non-interactive by declaration) reach
+the same outcome, instead of an unhandled `EOFError` traceback.
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import TypeVar
+
 from logfire.exceptions import LogfireConfigError
+
+T = TypeVar('T')
 
 _non_interactive = False
 
 
 class NonInteractiveError(LogfireConfigError):
-    """A prompt was needed, but `--non-interactive` says nobody can answer it.
+    """A prompt was needed, but nobody could answer it.
 
     Carries the guidance the user needs rather than a traceback: the CLI catches this and
-    prints `message` before exiting non-zero.
+    prints `message` before exiting non-zero. Raised either because `--non-interactive`
+    said so up front (`require_answer`), or because stdin ran out before an answer arrived
+    (`ask_required`) -- the same message either way, since both mean the same thing to
+    whoever reads it.
     """
 
 
@@ -38,6 +49,19 @@ def set_non_interactive(value: bool) -> None:
 def is_non_interactive() -> bool:
     """Whether the caller declared that it cannot answer prompts."""
     return _non_interactive
+
+
+def _cannot_answer(question: str, reason: str, remedy: str, more_remedies: tuple[str, ...]) -> NonInteractiveError:
+    return NonInteractiveError(
+        '\n'.join(
+            [
+                question,
+                reason,
+                'Supply it instead with:',
+                *(f'  {r}' for r in (remedy, *more_remedies)),
+            ]
+        )
+    )
 
 
 def require_answer(question: str, remedy: str, *more_remedies: str) -> None:
@@ -53,15 +77,37 @@ def require_answer(question: str, remedy: str, *more_remedies: str) -> None:
         more_remedies: further suggestions. Each is printed on its own line, so each must
             be individually pasteable -- `--org a|b` is a shell pipeline, not a suggestion.
     """
-    if not _non_interactive:
-        return
-    raise NonInteractiveError(
-        '\n'.join(
-            [
-                question,
-                'Cannot prompt because --non-interactive was passed.',
-                'Supply it instead with:',
-                *(f'  {r}' for r in (remedy, *more_remedies)),
-            ]
-        )
-    )
+    if _non_interactive:
+        raise _cannot_answer(question, 'Cannot prompt because --non-interactive was passed.', remedy, more_remedies)
+
+
+def ask_or_default(ask: Callable[[], T], default: T) -> T:
+    """Run a prompt, falling back to `default` when stdin runs out before an answer does.
+
+    Mirrors accepting a blank Enter keypress: the caller already declared what "no answer"
+    means by passing this SAME value as the prompt's own `default=`, so an exhausted stdin
+    reaches the outcome a person pressing Enter would, rather than an `EOFError` traceback.
+    Only for prompts where that default is genuinely safe to assume -- see `ask_required`
+    for one that has no safe default to fall back on.
+    """
+    try:
+        return ask()
+    except EOFError:
+        return default
+
+
+def ask_required(ask: Callable[[], T], question: str, remedy: str, *more_remedies: str) -> T:
+    """Run a prompt that has no safe default, raising if stdin runs out before an answer does.
+
+    The reactive half of `require_answer`'s proactive check: that covers a caller who
+    declared `--non-interactive` up front, this covers one that did not but ran out of
+    input anyway -- a command copied out of the docs into an agent, mid-conversation.
+    Raises the identical `NonInteractiveError` message either way, since both mean the
+    same thing to whoever reads it: there was no answer, and here is how to supply one.
+    """
+    try:
+        return ask()
+    except EOFError:
+        raise _cannot_answer(
+            question, 'Cannot prompt because there is nothing left to read from stdin.', remedy, more_remedies
+        ) from None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3405,6 +3405,130 @@ def test_projects_use_wrong_project(
         }
 
 
+def test_projects_use_expands_search_with_no_tty(
+    tmp_dir_cwd: Path, default_credentials: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """ "Choose from all projects?" already has `default='y'` -- the same outcome a person
+
+    pressing Enter would get -- so an exhausted stdin reaches that same outcome (and then
+    continues into project-by-number selection) instead of an `EOFError` traceback.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        prompt_mock = stack.enter_context(patch('rich.prompt.Prompt.ask', side_effect=[EOFError, '1']))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/writable-projects/',
+            json=[{'organization_name': 'fake_org', 'project_name': 'myproject'}],
+        )
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/organizations/fake_org/projects/myproject/write-tokens/',
+            [create_project_response],
+        )
+
+        main(['projects', 'use', 'wrong-project', '--org', 'fake_org'])
+
+        assert prompt_mock.mock_calls == [
+            call(
+                'No projects with name `wrong-project` found for the current user in organization `fake_org`. Choose from all projects?',
+                choices=['y', 'n'],
+                default='y',
+            ),
+            call(
+                "Please select one of the following projects by number (requires the 'write_token' permission):\n1. fake_org/myproject\n",
+                choices=['1'],
+                default='1',
+            ),
+        ]
+
+        output = capsys.readouterr().err
+        assert output == snapshot('Project configured successfully. You will be able to view it at: fake_project_url\n')
+
+        assert json.loads((tmp_dir_cwd / '.logfire/logfire_credentials.json').read_text()) == {
+            **create_project_response['json'],
+            'logfire_api_url': 'https://logfire-us.pydantic.dev',
+        }
+
+
+def test_projects_use_selects_by_number_with_no_tty(
+    tmp_dir_cwd: Path, default_credentials: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The project-by-number prompt already has `default='1'` -- the first listed project,
+
+    same as a person pressing Enter would get -- so an exhausted stdin picks that project
+    instead of raising an `EOFError` traceback.
+    """
+    with ExitStack() as stack:
+        stack.enter_context(
+            patch(
+                'logfire._internal.auth.UserTokenCollection.get_token',
+                return_value=UserToken(
+                    token='', base_url='https://logfire-us.pydantic.dev', expiration='2099-12-31T23:59:59'
+                ),
+            )
+        )
+        prompt_mock = stack.enter_context(patch('rich.prompt.Prompt.ask', side_effect=[EOFError]))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/writable-projects/',
+            json=[
+                {'organization_name': 'fake_org', 'project_name': 'myproject'},
+                {'organization_name': 'fake_org', 'project_name': 'otherproject'},
+            ],
+        )
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/organizations/fake_org/projects/myproject/write-tokens/',
+            [create_project_response],
+        )
+
+        main(['projects', 'use'])
+
+        assert prompt_mock.mock_calls == [
+            call(
+                (
+                    "Please select one of the following projects by number (requires the 'write_token' permission):\n"
+                    '1. fake_org/myproject\n'
+                    '2. fake_org/otherproject\n'
+                ),
+                choices=['1', '2'],
+                default='1',
+            )
+        ]
+
+        output = capsys.readouterr().err
+        assert output == snapshot('Project configured successfully. You will be able to view it at: fake_project_url\n')
+
+        assert json.loads((tmp_dir_cwd / '.logfire/logfire_credentials.json').read_text()) == {
+            **create_project_response['json'],
+            'logfire_api_url': 'https://logfire-us.pydantic.dev',
+        }
+
+
 def test_projects_use_wrong_project_give_up(
     tmp_dir_cwd: Path, default_credentials: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -82,6 +82,7 @@ from logfire._internal.exporters.quiet_metrics import QuietMetricExporter
 from logfire._internal.exporters.remove_pending import RemovePendingSpansExporter
 from logfire._internal.forwarding import OTLPForwardingManager
 from logfire._internal.integrations.executors import deserialize_config, serialize_config
+from logfire._internal.interactive import NonInteractiveError
 from logfire._internal.tracer import PendingSpanProcessor
 from logfire._internal.utils import SeededRandomIdGenerator, get_version
 from logfire.exceptions import LogfireConfigError
@@ -1986,6 +1987,223 @@ def test_initialize_project_create_project_default_organization(tmp_dir_cwd: Pat
                 'Project initialized successfully. You will be able to view it at: fake_project_url\nPress Enter to continue'
             ),
         ]
+
+
+def test_initialize_project_completes_with_no_tty_at_the_final_prompt(tmp_dir_cwd: Path, tmp_path: Path):
+    """`configure()` finishes even when stdin runs out at the very last prompt.
+
+    That final "Press Enter to continue" discards its answer either way -- it exists to
+    give a person a beat before moving on -- so an `EOFError` there must not turn an
+    already-completed setup into a crash. This is the exact shape of a real failure: an
+    agent piping just enough answers to satisfy the prompts it can see ahead of time
+    (`printf 'y\\n1\\n' | python -c 'import logfire; logfire.configure()'`) and hitting an
+    unhandled traceback on the one prompt it had no way to anticipate.
+    """
+    auth_file = tmp_path / 'default.toml'
+    auth_file.write_text(
+        '[tokens."https://logfire-api.pydantic.dev"]\ntoken = "fake_user_token"\nexpiration = "2099-12-31T23:59:59"'
+    )
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        confirm_mock = stack.enter_context(mock.patch('rich.prompt.Confirm.ask', side_effect=[True, True]))
+        # Only two real answers, same as `printf 'y\n1\n'` -- the third prompt (the final
+        # "Press Enter to continue") has nothing left to read.
+        prompt_mock = stack.enter_context(mock.patch('rich.prompt.Prompt.ask', side_effect=['1', EOFError]))
+
+        request_mocker = requests_mock.Mocker()
+        stack.enter_context(request_mocker)
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/writable-projects/',
+            json=[{'organization_name': 'fake_org', 'project_name': 'fake_project'}],
+        )
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        request_mocker.post(
+            'https://logfire-api.pydantic.dev/v1/organizations/fake_org/projects/fake_project/write-tokens/',
+            [create_project_response],
+        )
+
+        logfire.configure(send_to_logfire=True)
+        wait_for_check_token_thread()
+
+        assert confirm_mock.mock_calls == [call('Do you want to use one of your existing projects? ', default=True)]
+        assert prompt_mock.mock_calls == [
+            call(
+                "Please select one of the following projects by number (requires the 'write_token' permission):\n1. fake_org/fake_project\n",
+                choices=['1'],
+                default='1',
+            ),
+            call(
+                'Project initialized successfully. You will be able to view it at: fake_project_url\nPress Enter to continue',
+            ),
+        ]
+        assert json.loads((tmp_dir_cwd / '.logfire/logfire_credentials.json').read_text()) == {
+            **create_project_response['json'],
+            'logfire_api_url': 'https://logfire-api.pydantic.dev',
+        }
+
+
+def test_initialize_project_uses_existing_projects_with_no_tty(tmp_dir_cwd: Path, tmp_path: Path):
+    """ "Do you want to use one of your existing projects?" already has `default=True` --
+
+    the same outcome a person pressing Enter would get -- so an exhausted stdin reaches
+    that same outcome (and then continues into `use_existing_project`) instead of an
+    `EOFError` traceback on the very first prompt of the whole flow.
+    """
+    auth_file = tmp_path / 'default.toml'
+    auth_file.write_text(
+        '[tokens."https://logfire-api.pydantic.dev"]\ntoken = "fake_user_token"\nexpiration = "2099-12-31T23:59:59"'
+    )
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        confirm_mock = stack.enter_context(mock.patch('rich.prompt.Confirm.ask', side_effect=EOFError))
+        prompt_mock = stack.enter_context(mock.patch('rich.prompt.Prompt.ask', side_effect=['1', EOFError]))
+
+        request_mocker = requests_mock.Mocker()
+        stack.enter_context(request_mocker)
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/writable-projects/',
+            json=[{'organization_name': 'fake_org', 'project_name': 'fake_project'}],
+        )
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        request_mocker.post(
+            'https://logfire-api.pydantic.dev/v1/organizations/fake_org/projects/fake_project/write-tokens/',
+            [create_project_response],
+        )
+
+        logfire.configure(send_to_logfire=True)
+        wait_for_check_token_thread()
+
+        # The `use_existing_project` prompt was still reached, proving the first Confirm
+        # defaulted to True rather than skipping straight to project creation.
+        assert prompt_mock.mock_calls[0] == call(
+            "Please select one of the following projects by number (requires the 'write_token' permission):\n1. fake_org/fake_project\n",
+            choices=['1'],
+            default='1',
+        )
+        assert confirm_mock.mock_calls == [call('Do you want to use one of your existing projects? ', default=True)]
+
+
+def test_create_new_project_confirms_the_organization_with_no_tty(tmp_dir_cwd: Path, tmp_path: Path):
+    """The organization-creation "Continue?" confirm already has `default=True` -- the
+
+    exact prompt a real user copying `logfire auth && python -c '...configure()'` out of
+    the docs would hit with no terminal attached. An exhausted stdin reaches the same
+    outcome pressing Enter would (create it) instead of an `EOFError` traceback.
+    """
+    auth_file = tmp_path / 'default.toml'
+    auth_file.write_text(
+        '[tokens."https://logfire-api.pydantic.dev"]\ntoken = "fake_user_token"\nexpiration = "2099-12-31T23:59:59"'
+    )
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        # Only the first Confirm ("use one of your existing projects?") has a real
+        # answer; there are no existing projects, so it is never asked. The "Continue?"
+        # confirm that matters here has nothing to read.
+        confirm_mock = stack.enter_context(mock.patch('rich.prompt.Confirm.ask', side_effect=EOFError))
+        prompt_mock = stack.enter_context(mock.patch('rich.prompt.Prompt.ask', side_effect=['myproject', EOFError]))
+
+        request_mocker = requests_mock.Mocker()
+        stack.enter_context(request_mocker)
+        request_mocker.get('https://logfire-api.pydantic.dev/v1/writable-projects/', json=[])
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/organizations/available-for-projects/',
+            json=[{'organization_name': 'fake_org'}],
+        )
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        request_mocker.post(
+            'https://logfire-api.pydantic.dev/v1/organizations/fake_org/projects', [create_project_response]
+        )
+
+        logfire.configure(send_to_logfire=True)
+        wait_for_check_token_thread()
+
+        assert confirm_mock.mock_calls == [
+            call('The project will be created in the organization "fake_org". Continue?', default=True),
+        ]
+        assert prompt_mock.mock_calls == [
+            call('Enter the project name', default=sanitize_project_name(tmp_dir_cwd.name)),
+            call(
+                'Project initialized successfully. You will be able to view it at: fake_project_url\nPress Enter to continue'
+            ),
+        ]
+        assert json.loads((tmp_dir_cwd / '.logfire/logfire_credentials.json').read_text()) == {
+            **create_project_response['json'],
+            'logfire_api_url': 'https://logfire-api.pydantic.dev',
+        }
+
+
+def test_project_name_prompt_with_no_safe_default_and_no_tty_fails_with_guidance(tmp_dir_cwd: Path, tmp_path: Path):
+    """A rejected project name has NO safe default left to fall back on ("Ellipsis" is a
+
+    sentinel meaning "an answer is required", not a suggestion -- see the comment beside
+    `project_name_default = ...`). So once the first name is rejected, an exhausted stdin
+    must raise the same guidance `--non-interactive` would rather than silently retrying
+    with a project literally named "Ellipsis".
+    """
+    auth_file = tmp_path / 'default.toml'
+    auth_file.write_text(
+        '[tokens."https://logfire-api.pydantic.dev"]\ntoken = "fake_user_token"\nexpiration = "2099-12-31T23:59:59"'
+    )
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(mock.patch('rich.prompt.Confirm.ask', side_effect=[True]))
+        stack.enter_context(mock.patch('rich.prompt.Prompt.ask', side_effect=['existingprojectname', EOFError]))
+
+        request_mocker = requests_mock.Mocker()
+        stack.enter_context(request_mocker)
+        request_mocker.get('https://logfire-api.pydantic.dev/v1/writable-projects/', json=[])
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/organizations/available-for-projects/',
+            json=[{'organization_name': 'fake_org'}],
+        )
+        request_mocker.post(
+            'https://logfire-api.pydantic.dev/v1/organizations/fake_org/projects',
+            [{'status_code': 409}],
+        )
+
+        with pytest.raises(NonInteractiveError) as exc_info:
+            logfire.configure(send_to_logfire=True)
+        wait_for_check_token_thread()
+
+        message = str(exc_info.value)
+        assert "A project with the name 'existingprojectname' already exists" in message
+        assert 'Cannot prompt because there is nothing left to read from stdin.' in message
+        assert 'logfire projects new PROJECT_NAME --org fake_org' in message
+
+        # No retry with the rejected name's sentinel default -- only the one doomed POST.
+        create_requests = [r for r in request_mocker.request_history if r.method == 'POST']
+        assert len(create_requests) == 1
+        assert not (tmp_dir_cwd / '.logfire/logfire_credentials.json').exists()
 
 
 def test_send_to_logfire_true(tmp_path: Path) -> None:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1989,6 +1989,74 @@ def test_initialize_project_create_project_default_organization(tmp_dir_cwd: Pat
         ]
 
 
+@pytest.mark.xdist_group(name='sequential')
+def test_create_new_project_selects_organization_with_no_tty(tmp_dir_cwd: Path, tmp_path: Path):
+    """The organization-selection prompt already has `default=user_default_organization_name
+
+    or organizations[0]` -- the same outcome a person pressing Enter would get -- so an
+    exhausted stdin picks that organization instead of raising an `EOFError` traceback.
+    """
+    auth_file = tmp_path / 'default.toml'
+    auth_file.write_text(
+        '[tokens."https://logfire-api.pydantic.dev"]\ntoken = "fake_user_token"\nexpiration = "2099-12-31T23:59:59"'
+    )
+    with ExitStack() as stack:
+        stack.enter_context(mock.patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        prompt_mock = stack.enter_context(
+            mock.patch('rich.prompt.Prompt.ask', side_effect=[EOFError, 'mytestproject1', ''])
+        )
+
+        request_mocker = requests_mock.Mocker()
+        stack.enter_context(request_mocker)
+        request_mocker.get('https://logfire-api.pydantic.dev/v1/writable-projects/', json=[])
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/organizations/available-for-projects/',
+            json=[{'organization_name': 'fake_org'}, {'organization_name': 'fake_org1'}],
+        )
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        request_mocker.get(
+            'https://logfire-api.pydantic.dev/v1/account/me',
+            json={'default_organization': {'organization_name': 'fake_org1'}},
+        )
+
+        create_project_response = {
+            'json': {
+                'project_name': 'myproject',
+                'token': 'fake_token',
+                'project_url': 'fake_project_url',
+            }
+        }
+        # The default (`fake_org1`, from `account/me` above) is where the project must
+        # land -- if the EOF fallback picked the WRONG organization, this mock would 404
+        # instead of the create call succeeding.
+        request_mocker.post(
+            'https://logfire-api.pydantic.dev/v1/organizations/fake_org1/projects',
+            [create_project_response],
+        )
+
+        logfire.configure(send_to_logfire=True)
+        wait_for_check_token_thread()
+
+        assert prompt_mock.mock_calls == [
+            call(
+                '\nTo create and use a new project, please provide the following information:\nSelect the organization to create the project in',
+                choices=['fake_org', 'fake_org1'],
+                default='fake_org1',
+            ),
+            call('Enter the project name', default=sanitize_project_name(tmp_dir_cwd.name)),
+            call(
+                'Project initialized successfully. You will be able to view it at: fake_project_url\nPress Enter to continue'
+            ),
+        ]
+        assert json.loads((tmp_dir_cwd / '.logfire/logfire_credentials.json').read_text()) == {
+            **create_project_response['json'],
+            'logfire_api_url': 'https://logfire-api.pydantic.dev',
+        }
+
+
 def test_initialize_project_completes_with_no_tty_at_the_final_prompt(tmp_dir_cwd: Path, tmp_path: Path):
     """`configure()` finishes even when stdin runs out at the very last prompt.
 


### PR DESCRIPTION
Fixes the `configure()` half of the gap #2275 fixed for `logfire auth`.

## The problem

`logfire auth` was fixed to complete headlessly in #2275. But the prompt shown right after it in our own setup instructions —

```bash
logfire auth && python -c 'import logfire; logfire.configure()'
```

— still crashes with no tty. `logfire.configure()`'s own project-initialization flow (`LogfireCredentials.initialize_project` / `use_existing_project` / `create_new_project`) asks up to three prompts in sequence, and none of them handle `EOFError`:

```console
$ printf 'y\n1\n' | python -c 'import logfire; logfire.configure()'
Do you want to use one of your existing projects?  [y/n] (y): Please select one of the following projects by number...
1. my-org/my-project
 [1] (1): Project initialized successfully. You will be able to view it at: ...
Press Enter to continue: Traceback (most recent call last):
  ...
EOFError: EOF when reading a line
```

Piping in exactly enough answers for the prompts you can see ahead of time still isn't enough — the trailing "Press Enter to continue" (whose answer is never even used) crashes anyway. I found this the same way #2275 was found: running the real CLI in a container with stdin on a pipe, driving it the way our own docs tell an agent to. It's exactly the "a command copied out of the docs into an agent" case `interactive.py`'s own module docstring already calls out as needing this treatment — that half just hadn't been done yet.

## The change

Two new helpers in `interactive.py`, alongside `require_answer`:

- **`ask_or_default(ask, default)`** — runs a prompt, and on `EOFError` returns the SAME value already declared as that prompt's own `default=`. This is exactly the outcome a person pressing Enter would get, so it's a safe fallback for prompts that have a real default: "use one of your existing projects?", "select project by number", "select organization", "create in this org, continue?".
- **`ask_required(ask, question, remedy, *more_remedies)`** — the reactive complement to `require_answer`'s proactive `--non-interactive` check. One prompt has no safe default to fall back on: once a project name is rejected, the suggested default is deliberately the `...` (Ellipsis) sentinel meaning "an answer is required" (see the existing comment beside `project_name_default = ...`) — falling back to it would silently retry with a project literally named `Ellipsis`. This raises the identical `NonInteractiveError` guidance `--non-interactive` already gives, since both cases mean the same thing to whoever reads it.

The final "Press Enter to continue" beat (whose answer is discarded either way, same as `auth`'s own "press enter to open your browser" prompt) just catches `EOFError` and continues.

## Verified

```console
$ printf 'y\n1\n' | python -c 'import logfire; logfire.configure()'
```
now completes instead of crashing on the trailing prompt, and the "no safe default" case now prints actionable guidance and raises cleanly instead of creating a project named `Ellipsis`.

## Tests

Four new tests in `test_configure.py`, one per distinct EOF-handling case:
- `test_initialize_project_completes_with_no_tty_at_the_final_prompt` — the exact repro above; the whole flow completes and credentials are written.
- `test_initialize_project_uses_existing_projects_with_no_tty` — the first Confirm defaults to `True` on EOF and proceeds into `use_existing_project`.
- `test_create_new_project_confirms_the_organization_with_no_tty` — the "Continue?" confirm defaults to `True` on EOF and the project gets created.
- `test_project_name_prompt_with_no_safe_default_and_no_tty_fails_with_guidance` — a rejected name followed by EOF raises `NonInteractiveError` with the right message, and no second project-creation POST happens.

All 399 existing tests in `test_configure.py` + `test_cli.py` still pass unchanged — none of them needed updating, since every EOF fallback is gated on the exact `default=` value each prompt already declared.

`ruff check`, `ruff format --check`, and `pyright` all pass on the changed files.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

