### PR TITLE
Document Gateway CLI for self-hosted instances

### DIFF
--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -162,7 +162,7 @@ logfire gateway launch claude
 ```
 
 !!! note
-    For self-hosted Logfire, set `--base-url https://<your-logfire-host>`. Set `--gateway-url https://<your-gateway-host>` only if the Gateway is exposed at a different URL.
+    For self-hosted Logfire, run `logfire --base-url "https://<your-logfire-host>" gateway launch claude`. If the Gateway is exposed at a different URL, append `--gateway-url "https://<your-gateway-host>"`.
 
 Or run just the proxy and configure a tool manually with `logfire gateway serve`. See the [CLI reference](../../cli.md#ai-gateway-gateway) for details.
 

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -161,6 +161,18 @@ pip install "logfire[gateway]"
 logfire gateway launch claude
 ```
 
+For a self-hosted Logfire instance, pass its public URL as `--base-url`:
+
+```bash
+uvx --with 'logfire[gateway]' logfire \
+  --base-url https://<your-logfire-host> \
+  gateway launch claude
+```
+
+The browser opens the instance's normal login and consent flow. The CLI receives a short-lived OAuth credential, so you do not need to put a Gateway API key in an environment variable. The Logfire Helm chart supports this flow in version `0.13.42` and later.
+
+By default, the CLI also sends Gateway requests to the host passed with `--base-url`. If the Gateway is exposed on a different host, add `--gateway-url https://<your-gateway-host>` after `claude`.
+
 Or run just the proxy and configure a tool manually with `logfire gateway serve`. See the [CLI reference](../../cli.md#ai-gateway-gateway) for details.
 
 ## See also

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -161,17 +161,8 @@ pip install "logfire[gateway]"
 logfire gateway launch claude
 ```
 
-For a self-hosted Logfire instance, pass its public URL as `--base-url`:
-
-```bash
-uvx --with 'logfire[gateway]' logfire \
-  --base-url https://<your-logfire-host> \
-  gateway launch claude
-```
-
-The browser opens the instance's normal login and consent flow. The CLI receives a short-lived OAuth credential, so you do not need to put a Gateway API key in an environment variable. The Logfire Helm chart supports this flow in version `0.13.42` and later.
-
-By default, the CLI also sends Gateway requests to the host passed with `--base-url`. If the Gateway is exposed on a different host, add `--gateway-url https://<your-gateway-host>` after `claude`.
+!!! note
+    For self-hosted Logfire, set `--base-url https://<your-logfire-host>`. Set `--gateway-url https://<your-gateway-host>` only if the Gateway is exposed at a different URL.
 
 Or run just the proxy and configure a tool manually with `logfire gateway serve`. See the [CLI reference](../../cli.md#ai-gateway-gateway) for details.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,6 +97,16 @@ Launch a supported integration through the proxy:
 logfire gateway launch claude
 ```
 
+For a self-hosted instance, set its public URL with the global `--base-url` option:
+
+```bash
+uvx --with 'logfire[gateway]' logfire \
+  --base-url https://<your-logfire-host> \
+  gateway launch claude
+```
+
+The CLI uses the same host for Gateway requests by default. If the Gateway is exposed on a different host, add `--gateway-url https://<your-gateway-host>` after `claude`.
+
 You can also run only the proxy and configure a tool manually:
 
 ```bash

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -97,15 +97,8 @@ Launch a supported integration through the proxy:
 logfire gateway launch claude
 ```
 
-For a self-hosted instance, set its public URL with the global `--base-url` option:
-
-```bash
-uvx --with 'logfire[gateway]' logfire \
-  --base-url https://<your-logfire-host> \
-  gateway launch claude
-```
-
-The CLI uses the same host for Gateway requests by default. If the Gateway is exposed on a different host, add `--gateway-url https://<your-gateway-host>` after `claude`.
+!!! note
+    For self-hosted Logfire, set `--base-url https://<your-logfire-host>`. Set `--gateway-url https://<your-gateway-host>` only if the Gateway is exposed at a different URL.
 
 You can also run only the proxy and configure a tool manually:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,7 +98,7 @@ logfire gateway launch claude
 ```
 
 !!! note
-    For self-hosted Logfire, set `--base-url https://<your-logfire-host>`. Set `--gateway-url https://<your-gateway-host>` only if the Gateway is exposed at a different URL.
+    For self-hosted Logfire, run `logfire --base-url "https://<your-logfire-host>" gateway launch claude`. If the Gateway is exposed at a different URL, append `--gateway-url "https://<your-gateway-host>"`.
 
 You can also run only the proxy and configure a tool manually:
 


### PR DESCRIPTION
Documents the `--base-url` and optional `--gateway-url` settings for self-hosted Gateway CLI usage.