### PR TITLE
logfire-setup: fix the query/UI routing table, both skills exist

### DIFF
--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -37,8 +37,8 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 | App instrumentation | Traces, logs, metrics, and AI/agent spans from application code — Python, JavaScript/TypeScript, Rust, or any OpenTelemetry language | `logfire-instrumentation` |
 | Infrastructure monitoring | Hosts, Docker, Kubernetes, database/queue/cache servers, cloud-provider metrics — no application code | `logfire-infrastructure` |
 | Evals | Score AI/agent output against test-case datasets with `pydantic_evals` | `logfire-evals` |
-| Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | no dedicated skill yet — use a connected Logfire MCP server, or the product's own docs |
-| Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | no dedicated skill yet — see the product's own docs |
+| Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | `logfire-query` — not in this repo; install from [github.com/pydantic/skills](https://github.com/pydantic/skills) or fetch its SKILL.md directly from there |
+| Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | `logfire-ui` — same source as above |
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |
 | AI Gateway | Spend caps, failover, and routing for model calls (`logfire gateway`) | no dedicated skill yet — see the product's own docs |
 

--- a/logfire/.agents/skills/logfire-setup/SKILL.md
+++ b/logfire/.agents/skills/logfire-setup/SKILL.md
@@ -24,8 +24,8 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 | App instrumentation | Traces, logs, metrics, and AI/agent spans from application code — Python, JavaScript/TypeScript, Rust, or any OpenTelemetry language | `logfire-instrumentation` |
 | Infrastructure monitoring | Hosts, Docker, Kubernetes, database/queue/cache servers, cloud-provider metrics — no application code | `logfire-infrastructure` |
 | Evals | Score AI/agent output against test-case datasets with `pydantic_evals` | `logfire-evals` |
-| Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | no dedicated skill yet — use a connected Logfire MCP server, or the product's own docs |
-| Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | no dedicated skill yet — see the product's own docs |
+| Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | `logfire-query` — not in this repo; install from [github.com/pydantic/skills](https://github.com/pydantic/skills) or fetch its SKILL.md directly from there |
+| Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | `logfire-ui` — same source as above |
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |
 | AI Gateway | Spend caps, failover, and routing for model calls (`logfire gateway`) | no dedicated skill yet — see the product's own docs |
 


### PR DESCRIPTION
The hub's routing table said "no dedicated skill yet" for querying telemetry and the live UI. Both exist -- `github.com/pydantic/skills` ships `logfire-query` and `logfire-ui` -- just in a different repo than the other three rows, which point at skills co-located with this hub. Found while investigating why pydantic.dev's `llms.txt` already listed them: this hub told agents the opposite.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

