### PR TITLE
Drop the Beta note from the Docker view docs

### DIFF
--- a/docs/guides/web-ui/docker.md
+++ b/docs/guides/web-ui/docker.md
@@ -4,9 +4,6 @@ description: "Browse every Docker container, image and Compose project shipping 
 ---
 # Docker
 
-!!! note "Beta: feedback welcome"
-    The Docker view is in beta and shipping fixes and improvements quickly. Tell us what's missing or broken in the [Logfire Slack community](https://pydantic.dev/docs/logfire/join-slack/) or email [support@pydantic.dev](mailto:support@pydantic.dev).
-
 The <OpenInLogfire path="docker" variant="inline" label="Docker view" /> shows every Docker container reporting stats to your project (CPU, memory, network and block I/O) alongside the application traces those containers produced. The same stats are folded three ways: by **container**, by **image**, and by **Compose project**.
 
 You'll find Docker in the project sidebar under **Infrastructure**, after **Kubernetes**.


### PR DESCRIPTION
The Docker view is generally available, so the Beta note no longer applies.

Every other page under `docs/guides/web-ui/` goes straight from its heading into the description, and Docker was the only one carrying a Beta admonition. This removes it so the page reads like its siblings.

The Slack and support links it contained are already reachable from the docs navigation, so no contact route is lost.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

