### PR TITLE
logfire-instrumentation skill: drop stale gRPC/protocol claim

### DIFF
--- a/logfire/.agents/skills/logfire-instrumentation/SKILL.md
+++ b/logfire/.agents/skills/logfire-instrumentation/SKILL.md
@@ -132,7 +132,7 @@ Always call `shutdown_handler.shutdown()` before program exit to flush data.
 
 ### Other Languages (Go, Java, .NET, PHP, Ruby, ...)
 
-No dedicated Logfire SDK — install that language's own OpenTelemetry SDK and point its OTLP exporter at Logfire: [Alternative clients](https://pydantic.dev/docs/logfire/guides/alternative-clients/) has the exact endpoint, protocol (`http/protobuf`, not the gRPC default some exporters ship with), and header format.
+No dedicated Logfire SDK — install that language's own OpenTelemetry SDK and point its OTLP exporter at Logfire: [Alternative clients](https://pydantic.dev/docs/logfire/guides/alternative-clients/) has the exact endpoint and header format. Logfire accepts OTLP over both gRPC and HTTP, so an exporter that defaults to gRPC (Java, .NET) needs no protocol override.
 
 For the write token that endpoint needs, see [Authenticate and Select the Exact Project](./references/auth.md)'s "If the calling skill needs a write token" section — for local development, reuse the token `projects use` already put in `.logfire/logfire_credentials.json` rather than assuming a fresh one has to come from the UI.
 

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -187,7 +187,7 @@ Always call `shutdown_handler.shutdown()` before program exit to flush data.
 
 ### Other Languages (Go, Java, .NET, PHP, Ruby, ...)
 
-No dedicated Logfire SDK — install that language's own OpenTelemetry SDK and point its OTLP exporter at Logfire: [Alternative clients](https://pydantic.dev/docs/logfire/guides/alternative-clients/) has the exact endpoint, protocol (`http/protobuf`, not the gRPC default some exporters ship with), and header format.
+No dedicated Logfire SDK — install that language's own OpenTelemetry SDK and point its OTLP exporter at Logfire: [Alternative clients](https://pydantic.dev/docs/logfire/guides/alternative-clients/) has the exact endpoint and header format. Logfire accepts OTLP over both gRPC and HTTP, so an exporter that defaults to gRPC (Java, .NET) needs no protocol override.
 
 For the write token that endpoint needs, see [Authenticate and Select the Exact Project](./references/auth.md)'s "If the calling skill needs a write token" section — for local development, reuse the token `projects use` already put in `.logfire/logfire_credentials.json` rather than assuming a fresh one has to come from the UI.
 


### PR DESCRIPTION
The logfire-instrumentation skill's "Other Languages" line claimed Logfire's protocol is `http/protobuf, not the gRPC default some exporters ship with`. That's wrong: Logfire accepts OTLP over both gRPC and HTTP, so an exporter defaulting to gRPC (Java, .NET) needs no protocol override. Updated the line and regenerated the offline skill bundle to match.