### PR TITLE
Add OpenTelemetry Collector transport torture tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,10 +184,37 @@ jobs:
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 
+  test-otel-collector:
+    name: test against OpenTelemetry Collector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8.0.0
+        with:
+          version: "0.11.1"
+          enable-cache: true  # zizmor: ignore[cache-poisoning] -- Job does not produce release artifacts and does not have sensitive permissions
+
+      - run: uv sync --python 3.12 --frozen
+      - run: mkdir collector-test-artifacts
+      - run: make test-otel-collector
+        env:
+          LOGFIRE_OTEL_COLLECTOR_ARTIFACTS: collector-test-artifacts
+
+      - name: Upload Collector test artifacts
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: otel-collector-test-artifacts
+          path: collector-test-artifacts
+
   # https://github.com/marketplace/actions/alls-green#why used for branch protection checks
   check:
     if: always()
-    needs: [ lint, minimal-install, test, coverage, test-pyodide ]
+    needs: [ lint, minimal-install, test, coverage, test-pyodide, test-otel-collector ]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ typecheck:
 test:
 	uv run --no-sync pytest -n logical --dist=loadgroup
 
+.PHONY: test-otel-collector
+test-otel-collector:
+	LOGFIRE_OTEL_COLLECTOR_TESTS=1 uv run --no-sync pytest -n 0 tests/otel_collector
+
 .PHONY: test-update-examples  # Update the examples in the documentation
 test-update-examples:
 	uv run pytest --update-examples -k test_docs

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -31,6 +31,7 @@ from ..auth import HOME_LOGFIRE
 from ..client import UA_HEADER, LogfireClient
 from ..config import REGIONS, LogfireCredentials, get_base_url_from_token
 from ..config_params import ParamManager
+from ..http_transport import install_connection_policy
 from ..interactive import NonInteractiveError, is_non_interactive, require_answer, set_non_interactive
 from ..server_response import install_logfire_response_hook
 from ..tracer import SDKTracerProvider
@@ -1041,6 +1042,7 @@ def _main(args: list[str] | None = None) -> None:
         namespace.func(namespace)
     else:
         with tracer.start_as_current_span('logfire._internal.cli'), requests.Session() as session:
+            install_connection_policy(session)
             context = get_context()
             session.hooks = {'response': [functools.partial(log_trace_id, context=context)]}
             session.headers.update(context)

--- a/logfire/_internal/client.py
+++ b/logfire/_internal/client.py
@@ -12,6 +12,7 @@ from logfire.version import VERSION
 
 from .auth import UserToken, UserTokenCollection
 from .constants import HTTP_CONNECT_TIMEOUT
+from .http_transport import install_connection_policy
 from .server_response import ServerResponseCallback, install_logfire_response_hook
 from .utils import UnexpectedResponse
 
@@ -47,6 +48,7 @@ class LogfireClient:
         self.base_url = user_token.base_url
         self._token = user_token.token
         self._session = Session()
+        install_connection_policy(self._session)
         self._session.headers.update({'Authorization': self._token, 'User-Agent': UA_HEADER})
         install_logfire_response_hook(self._session, server_response_hook)
 

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -114,6 +114,7 @@ from .exporters.quiet_metrics import QuietMetricExporter
 from .exporters.remove_pending import RemovePendingSpansExporter
 from .exporters.test import TestExporter
 from .forwarding import OTLPForwardingManager
+from .http_transport import install_connection_policy
 from .integrations.executors import instrument_executors
 from .interactive import require_answer
 from .logs import ProxyLoggerProvider
@@ -1739,6 +1740,7 @@ class LogfireConfig(_LogfireConfigData):
 
     def _initialize_credentials_from_token(self, token: str) -> LogfireCredentials | None:
         session = requests.Session()
+        install_connection_policy(session)
         install_logfire_response_hook(session, self.advanced.server_response_hook)
         # This runs in the background `check_logfire_token` thread, where a warning would be
         # attributed to the thread rather than to the user's `configure()` call and so wouldn't

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -25,6 +25,7 @@ from requests import Session
 import logfire
 
 from ..constants import HTTP_CONNECT_TIMEOUT
+from ..http_transport import install_connection_policy
 from ..utils import logger, platform_is_emscripten
 from .wrapper import WrapperLogExporter, WrapperSpanExporter
 
@@ -66,6 +67,10 @@ class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
 
 class OTLPExporterHttpSession(Session):
     """A requests.Session subclass that defers failed requests to a DiskRetryer."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        install_connection_policy(self)
 
     @staticmethod
     def _configure_timeout(kwargs: dict[str, Any]) -> None:
@@ -165,6 +170,7 @@ class DiskRetryer:
         # because thread safety of Session is questionable.
         # This assumes that the only important state is the headers.
         self.session = Session()
+        install_connection_policy(self.session)
         self.session.headers.update(headers)
 
         # The directory where the export files are stored.

--- a/logfire/_internal/http_transport.py
+++ b/logfire/_internal/http_transport.py
@@ -11,8 +11,8 @@ second stall surfaced as `Read timed out`.
 Every session Logfire creates therefore gets two measures:
 
 - **TCP keepalive**, so an idle connection keeps producing traffic and the flow is not reclaimed.
-- **An idle recycle window**, so a session unused for longer than the window drops its pooled
-  connections and reconnects rather than gambling on one that may already be dead.
+- **An idle recycle window**, so a pooled connection unused for longer than the window is closed
+  and reconnected rather than gambling on one that may already be dead.
 
 This applies only to sessions Logfire itself creates. Clients belonging to the user are
 instrumented, never reconfigured.
@@ -26,13 +26,15 @@ from typing import Any
 
 from requests import Session
 from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
-from urllib3.connection import HTTPConnection
-from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3 import connection as urllib3_connection
+from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.poolmanager import PoolManager
 
 _now = time.monotonic
+"""Indirection so tests can drive the clock without touching the one `urllib3` itself uses."""
 
 IDLE_CONNECTION_RECYCLE_SECONDS = 30
-"""Drop pooled connections when the session has gone unused for longer than this.
+"""Close a pooled connection that has sat unused for longer than this.
 
 Chosen to sit below the things that would otherwise reclaim the connection first: the default
 60 second metric export interval (`OTEL_METRIC_EXPORT_INTERVAL`), and the idle timeouts of
@@ -54,29 +56,33 @@ def keepalive_socket_options() -> list[tuple[int, int, int | bytes]]:
     """`urllib3`'s default socket options plus TCP keepalive.
 
     Building on `HTTPConnection.default_socket_options` keeps `TCP_NODELAY`, which `urllib3` sets
-    and which we have no reason to drop.
+    and which we have no reason to drop. The class is read off the module at call time because
+    `urllib3` swaps it out under Pyodide, for an Emscripten connection that talks over `fetch()`
+    and so has neither a socket nor any default options.
     """
-    options: list[tuple[int, int, int | bytes]] = [
-        *HTTPConnection.default_socket_options,
-        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
-    ]
+    defaults = getattr(urllib3_connection.HTTPConnection, 'default_socket_options', None)
+    options: list[tuple[int, int, int | bytes]] = [*(defaults or [])]
 
-    def add_if_supported(name: str, value: int) -> bool:
+    def add_if_supported(level: int, name: str, value: int) -> bool:
         # Looked up by name because these constants are platform specific: referring to them
         # directly would not type check on a platform that lacks them.
         option = getattr(socket, name, None)
         if option is None:
             return False
-        options.append((socket.IPPROTO_TCP, option, value))
+        options.append((level, option, value))
         return True
+
+    if not add_if_supported(socket.SOL_SOCKET, 'SO_KEEPALIVE', 1):
+        # Nothing to keep alive, so none of the knobs below mean anything either.
+        return options
 
     # How long a connection may be idle before probing starts. Without this the system default
     # applies, which is two hours on most platforms and so useless against a NAT timeout.
     # Linux (and recent Windows) call it TCP_KEEPIDLE; macOS calls the same thing TCP_KEEPALIVE.
-    if not add_if_supported('TCP_KEEPIDLE', TCP_KEEPALIVE_IDLE_SECONDS):
-        add_if_supported('TCP_KEEPALIVE', TCP_KEEPALIVE_IDLE_SECONDS)
-    add_if_supported('TCP_KEEPINTVL', TCP_KEEPALIVE_INTERVAL_SECONDS)
-    add_if_supported('TCP_KEEPCNT', TCP_KEEPALIVE_FAILED_PROBES)
+    if not add_if_supported(socket.IPPROTO_TCP, 'TCP_KEEPIDLE', TCP_KEEPALIVE_IDLE_SECONDS):
+        add_if_supported(socket.IPPROTO_TCP, 'TCP_KEEPALIVE', TCP_KEEPALIVE_IDLE_SECONDS)
+    add_if_supported(socket.IPPROTO_TCP, 'TCP_KEEPINTVL', TCP_KEEPALIVE_INTERVAL_SECONDS)
+    add_if_supported(socket.IPPROTO_TCP, 'TCP_KEEPCNT', TCP_KEEPALIVE_FAILED_PROBES)
 
     return options
 
@@ -104,22 +110,32 @@ class _IdleRecyclingPoolMixin(HTTPConnectionPool):
 
     def _get_conn(self, timeout: float | None = None) -> Any:
         conn = super()._get_conn(timeout)
+        # Absent on a connection this pool has never handed back, i.e. a brand new one.
         idle_since = getattr(conn, '_logfire_idle_since', None)
         if idle_since is not None and _now() - idle_since > self.idle_recycle_seconds:
             conn.close()
         return conn
 
 
-def _pool_classes(idle_recycle_seconds: float) -> dict[str, type[Any]]:
-    """Pool classes bound to one recycle window.
+def _recycling_pool_class(base: type[HTTPConnectionPool], idle_recycle_seconds: float) -> type[HTTPConnectionPool]:
+    return type(
+        f'IdleRecycling{base.__name__}', (_IdleRecyclingPoolMixin, base), {'idle_recycle_seconds': idle_recycle_seconds}
+    )
 
-    Built per adapter rather than passed through `connection_pool_kw`, because `urllib3` feeds
-    that mapping to its pool-key normalizer, which rejects keys it does not know.
+
+def _install_recycling_pools(manager: PoolManager, idle_recycle_seconds: float) -> None:
+    """Point a pool manager at recycling versions of the pool classes it already uses.
+
+    Derived from whatever the manager has rather than named outright, because the classes vary:
+    a SOCKS proxy manager brings its own, and Pyodide swaps in others again. Installed on the
+    manager rather than passed through `connection_pool_kw`, because `urllib3` feeds that mapping
+    to its pool-key normalizer, which rejects keys it does not know.
     """
-    namespace = {'idle_recycle_seconds': idle_recycle_seconds}
-    return {
-        'http': type('LogfireHTTPConnectionPool', (_IdleRecyclingPoolMixin, HTTPConnectionPool), namespace),
-        'https': type('LogfireHTTPSConnectionPool', (_IdleRecyclingPoolMixin, HTTPSConnectionPool), namespace),
+    manager.pool_classes_by_scheme = {
+        # `requests` hands back a proxy manager it has already built, so the classes may be ours
+        # from an earlier call; subclassing again each time would nest them without end.
+        scheme: cls if issubclass(cls, _IdleRecyclingPoolMixin) else _recycling_pool_class(cls, idle_recycle_seconds)
+        for scheme, cls in manager.pool_classes_by_scheme.items()
     }
 
 
@@ -143,9 +159,15 @@ class LogfireHTTPAdapter(HTTPAdapter):
     ) -> None:
         pool_kwargs.setdefault('socket_options', keepalive_socket_options())
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
-        # `getattr` because unpickling restores attributes in an order we do not control.
-        window = getattr(self, '_idle_recycle_seconds', IDLE_CONNECTION_RECYCLE_SECONDS)
-        self.poolmanager.pool_classes_by_scheme = _pool_classes(window)
+        _install_recycling_pools(self.poolmanager, self._idle_recycle_seconds)
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: Any) -> Any:
+        # A proxied request goes through a manager of its own, built here rather than by
+        # `init_poolmanager`, so the policy has to be applied again as each one appears.
+        proxy_kwargs.setdefault('socket_options', keepalive_socket_options())
+        manager = super().proxy_manager_for(proxy, **proxy_kwargs)
+        _install_recycling_pools(manager, self._idle_recycle_seconds)
+        return manager
 
 
 def install_connection_policy(session: Session, *, idle_recycle_seconds: float | None = None) -> None:

--- a/logfire/_internal/http_transport.py
+++ b/logfire/_internal/http_transport.py
@@ -1,0 +1,139 @@
+"""Connection reuse policy for the HTTP sessions Logfire owns.
+
+`requests` and `urllib3` pool connections indefinitely: there is no maximum age and no idle
+expiry. `urllib3` discards a pooled connection only when it can *see* that the peer closed it
+(`is_connection_dropped` spots a FIN or RST). A connection dropped silently while idle — a NAT
+or stateful firewall reclaiming the flow, which is common on container platforms — still looks
+healthy from this side, so the next export writes into it and then blocks until the read
+timeout expires. For the metrics exporter, which exports once a minute by default, that is a ten
+second stall surfaced as `Read timed out`.
+
+Every session Logfire creates therefore gets two measures:
+
+- **TCP keepalive**, so an idle connection keeps producing traffic and the flow is not reclaimed.
+- **An idle recycle window**, so a session unused for longer than the window drops its pooled
+  connections and reconnects rather than gambling on one that may already be dead.
+
+This applies only to sessions Logfire itself creates. Clients belonging to the user are
+instrumented, never reconfigured.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import time
+from typing import Any
+
+from requests import Session
+from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
+from urllib3.connection import HTTPConnection
+
+IDLE_CONNECTION_RECYCLE_SECONDS = 30
+"""Drop pooled connections when the session has gone unused for longer than this.
+
+Chosen to sit below the things that would otherwise reclaim the connection first: the default
+60 second metric export interval (`OTEL_METRIC_EXPORT_INTERVAL`), and the idle timeouts of
+typical NAT and load balancer hops, which start around 60 seconds. For reference `httpx`
+defaults to 5 seconds and Go's `http.Transport` to 90.
+"""
+
+TCP_KEEPALIVE_IDLE_SECONDS = 30
+"""Start sending keepalive probes once the connection has been idle this long."""
+
+TCP_KEEPALIVE_INTERVAL_SECONDS = 10
+"""Gap between individual keepalive probes."""
+
+TCP_KEEPALIVE_FAILED_PROBES = 3
+"""Unanswered probes before the connection is considered dead."""
+
+
+def keepalive_socket_options() -> list[tuple[int, int, int | bytes]]:
+    """`urllib3`'s default socket options plus TCP keepalive.
+
+    Building on `HTTPConnection.default_socket_options` keeps `TCP_NODELAY`, which `urllib3` sets
+    and which we have no reason to drop.
+    """
+    options: list[tuple[int, int, int | bytes]] = [
+        *HTTPConnection.default_socket_options,
+        (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+    ]
+
+    def add_if_supported(name: str, value: int) -> bool:
+        # Looked up by name because these constants are platform specific: referring to them
+        # directly would not type check on a platform that lacks them.
+        option = getattr(socket, name, None)
+        if option is None:
+            return False
+        options.append((socket.IPPROTO_TCP, option, value))
+        return True
+
+    # How long a connection may be idle before probing starts. Without this the system default
+    # applies, which is two hours on most platforms and so useless against a NAT timeout.
+    # Linux (and recent Windows) call it TCP_KEEPIDLE; macOS calls the same thing TCP_KEEPALIVE.
+    if not add_if_supported('TCP_KEEPIDLE', TCP_KEEPALIVE_IDLE_SECONDS):
+        add_if_supported('TCP_KEEPALIVE', TCP_KEEPALIVE_IDLE_SECONDS)
+    add_if_supported('TCP_KEEPINTVL', TCP_KEEPALIVE_INTERVAL_SECONDS)
+    add_if_supported('TCP_KEEPCNT', TCP_KEEPALIVE_FAILED_PROBES)
+
+    return options
+
+
+class LogfireHTTPAdapter(HTTPAdapter):
+    """A `requests` adapter that enables TCP keepalive and recycles idle pooled connections."""
+
+    # `_recycle_lock` holds a lock, which cannot be pickled, so it is rebuilt in `__setstate__`
+    # rather than listed here.
+    __attrs__ = [*HTTPAdapter.__attrs__, '_idle_recycle_seconds']
+
+    def __init__(
+        self,
+        *args: Any,
+        idle_recycle_seconds: float = IDLE_CONNECTION_RECYCLE_SECONDS,
+        **kwargs: Any,
+    ) -> None:
+        # Set before `super().__init__`, which calls `init_poolmanager`.
+        self._idle_recycle_seconds = idle_recycle_seconds
+        self._recycle_lock = threading.Lock()
+        self._last_used = time.monotonic()
+        super().__init__(*args, **kwargs)
+
+    def init_poolmanager(
+        self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: Any
+    ) -> None:
+        pool_kwargs.setdefault('socket_options', keepalive_socket_options())
+        super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self._recycle_lock = threading.Lock()
+        self._last_used = time.monotonic()
+        state.setdefault('_idle_recycle_seconds', IDLE_CONNECTION_RECYCLE_SECONDS)
+        super().__setstate__(state)  # type: ignore[misc]
+
+    def send(self, *args: Any, **kwargs: Any) -> Any:
+        with self._recycle_lock:
+            if time.monotonic() - self._last_used > self._idle_recycle_seconds:
+                # Only idle connections sit in the pool. Anything in flight has been checked out
+                # and is untouched by this, so concurrent requests are not disturbed.
+                self.poolmanager.clear()
+            self._last_used = time.monotonic()
+        try:
+            return super().send(*args, **kwargs)
+        finally:
+            # Stamp again on the way out so that a slow or streaming response does not make the
+            # *next* request look as though it followed an idle gap.
+            with self._recycle_lock:
+                self._last_used = time.monotonic()
+
+
+def install_connection_policy(session: Session, *, idle_recycle_seconds: float | None = None) -> None:
+    """Apply the keepalive and idle recycle policy to a session Logfire owns.
+
+    A single adapter serves both schemes so that idleness is tracked per session rather than per
+    scheme; a session that talks only HTTPS would otherwise leave the HTTP adapter's clock
+    permanently stale.
+    """
+    kwargs: dict[str, Any] = {} if idle_recycle_seconds is None else {'idle_recycle_seconds': idle_recycle_seconds}
+    adapter = LogfireHTTPAdapter(**kwargs)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)

--- a/logfire/_internal/http_transport.py
+++ b/logfire/_internal/http_transport.py
@@ -33,13 +33,24 @@ from urllib3.poolmanager import PoolManager
 _now = time.monotonic
 """Indirection so tests can drive the clock without touching the one `urllib3` itself uses."""
 
-IDLE_CONNECTION_RECYCLE_SECONDS = 30
+IDLE_CONNECTION_RECYCLE_SECONDS = 90
 """Close a pooled connection that has sat unused for longer than this.
 
-Chosen to sit below the things that would otherwise reclaim the connection first: the default
-60 second metric export interval (`OTEL_METRIC_EXPORT_INTERVAL`), and the idle timeouts of
-typical NAT and load balancer hops, which start around 60 seconds. For reference `httpx`
-defaults to 5 seconds and Go's `http.Transport` to 90.
+`urllib3` pools from a LIFO queue, so idle time is sharply bimodal rather than spread evenly:
+one connection serves nearly everything with sub-second gaps, while any extra connection opened
+during a moment of concurrency sinks to the bottom of the stack and is left there indefinitely.
+Measured on a traces-plus-metrics workload, 98 of 99 requests went to a single connection. Any
+window catches that abandoned tail, because its idle time is unbounded, so the exact value is
+not what decides correctness there.
+
+What the value does decide is the session whose only user is the metric exporter, where the one
+hot connection has 60 second gaps. Below that interval every export would reconnect, giving up
+keep-alive entirely for a fresh handshake each time; 90 seconds keeps the reuse. It stays well
+under the idle timeouts of the hops in between, which run to several minutes (AWS NAT gateways
+350s, Azure 4 minutes, GCP Cloud NAT 20 minutes). TCP keepalive is the real defence against the
+flow being reclaimed, and this window is the backstop for when it does not apply, so it is
+cheap to leave it long. For reference `httpx` defaults to 5 seconds and Go's `http.Transport`
+to 90.
 """
 
 TCP_KEEPALIVE_IDLE_SECONDS = 30
@@ -95,6 +106,13 @@ class _IdleRecyclingPoolMixin(HTTPConnectionPool):
     Logfire, where one session carries traces, metrics and logs from different threads, so a
     steady trace stream keeps the session active while the connection that last served a metric
     export waits out the full export interval.
+
+    `urllib3` pools from a LIFO queue, which makes this sharper than steady-state staleness.
+    Sequential traffic reuses the connection on top of the stack, so a connection opened during
+    a brief overlap is used once and then left at the bottom, idle for as long as the workload
+    stays sequential. It is handed back out at the next overlap, which is exactly when a request
+    is least able to tolerate a dead socket. Recycling on the way out of the pool is what catches
+    that connection before it is used.
 
     `urllib3` already drops a pooled connection it can see was closed. This extends that to the
     case it cannot see, closing on the way out of the pool and letting `urllib3` reconnect

--- a/logfire/_internal/http_transport.py
+++ b/logfire/_internal/http_transport.py
@@ -21,13 +21,15 @@ instrumented, never reconfigured.
 from __future__ import annotations
 
 import socket
-import threading
 import time
 from typing import Any
 
 from requests import Session
 from requests.adapters import DEFAULT_POOLBLOCK, HTTPAdapter
 from urllib3.connection import HTTPConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+
+_now = time.monotonic
 
 IDLE_CONNECTION_RECYCLE_SECONDS = 30
 """Drop pooled connections when the session has gone unused for longer than this.
@@ -79,11 +81,51 @@ def keepalive_socket_options() -> list[tuple[int, int, int | bytes]]:
     return options
 
 
+class _IdleRecyclingPoolMixin(HTTPConnectionPool):
+    """Closes a pooled connection that has sat idle longer than the recycle window.
+
+    The unit that goes stale is one connection, not the session: a session can be busy
+    continuously while an individual pooled connection sits unused. That is the normal shape for
+    Logfire, where one session carries traces, metrics and logs from different threads, so a
+    steady trace stream keeps the session active while the connection that last served a metric
+    export waits out the full export interval.
+
+    `urllib3` already drops a pooled connection it can see was closed. This extends that to the
+    case it cannot see, closing on the way out of the pool and letting `urllib3` reconnect
+    lazily, exactly as it does for a connection it detected as dropped.
+    """
+
+    idle_recycle_seconds: float = IDLE_CONNECTION_RECYCLE_SECONDS
+
+    def _put_conn(self, conn: Any) -> Any:
+        if conn is not None:
+            conn._logfire_idle_since = _now()
+        return super()._put_conn(conn)
+
+    def _get_conn(self, timeout: float | None = None) -> Any:
+        conn = super()._get_conn(timeout)
+        idle_since = getattr(conn, '_logfire_idle_since', None)
+        if idle_since is not None and _now() - idle_since > self.idle_recycle_seconds:
+            conn.close()
+        return conn
+
+
+def _pool_classes(idle_recycle_seconds: float) -> dict[str, type[Any]]:
+    """Pool classes bound to one recycle window.
+
+    Built per adapter rather than passed through `connection_pool_kw`, because `urllib3` feeds
+    that mapping to its pool-key normalizer, which rejects keys it does not know.
+    """
+    namespace = {'idle_recycle_seconds': idle_recycle_seconds}
+    return {
+        'http': type('LogfireHTTPConnectionPool', (_IdleRecyclingPoolMixin, HTTPConnectionPool), namespace),
+        'https': type('LogfireHTTPSConnectionPool', (_IdleRecyclingPoolMixin, HTTPSConnectionPool), namespace),
+    }
+
+
 class LogfireHTTPAdapter(HTTPAdapter):
     """A `requests` adapter that enables TCP keepalive and recycles idle pooled connections."""
 
-    # `_recycle_lock` holds a lock, which cannot be pickled, so it is rebuilt in `__setstate__`
-    # rather than listed here.
     __attrs__ = [*HTTPAdapter.__attrs__, '_idle_recycle_seconds']
 
     def __init__(
@@ -94,8 +136,6 @@ class LogfireHTTPAdapter(HTTPAdapter):
     ) -> None:
         # Set before `super().__init__`, which calls `init_poolmanager`.
         self._idle_recycle_seconds = idle_recycle_seconds
-        self._recycle_lock = threading.Lock()
-        self._last_used = time.monotonic()
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(
@@ -103,36 +143,13 @@ class LogfireHTTPAdapter(HTTPAdapter):
     ) -> None:
         pool_kwargs.setdefault('socket_options', keepalive_socket_options())
         super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
-
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        self._recycle_lock = threading.Lock()
-        self._last_used = time.monotonic()
-        state.setdefault('_idle_recycle_seconds', IDLE_CONNECTION_RECYCLE_SECONDS)
-        super().__setstate__(state)  # type: ignore[misc]
-
-    def send(self, *args: Any, **kwargs: Any) -> Any:
-        with self._recycle_lock:
-            if time.monotonic() - self._last_used > self._idle_recycle_seconds:
-                # Only idle connections sit in the pool. Anything in flight has been checked out
-                # and is untouched by this, so concurrent requests are not disturbed.
-                self.poolmanager.clear()
-            self._last_used = time.monotonic()
-        try:
-            return super().send(*args, **kwargs)
-        finally:
-            # Stamp again on the way out so that a slow or streaming response does not make the
-            # *next* request look as though it followed an idle gap.
-            with self._recycle_lock:
-                self._last_used = time.monotonic()
+        # `getattr` because unpickling restores attributes in an order we do not control.
+        window = getattr(self, '_idle_recycle_seconds', IDLE_CONNECTION_RECYCLE_SECONDS)
+        self.poolmanager.pool_classes_by_scheme = _pool_classes(window)
 
 
 def install_connection_policy(session: Session, *, idle_recycle_seconds: float | None = None) -> None:
-    """Apply the keepalive and idle recycle policy to a session Logfire owns.
-
-    A single adapter serves both schemes so that idleness is tracked per session rather than per
-    scheme; a session that talks only HTTPS would otherwise leave the HTTP adapter's clock
-    permanently stale.
-    """
+    """Apply the keepalive and idle recycle policy to a session Logfire owns."""
     kwargs: dict[str, Any] = {} if idle_recycle_seconds is None else {'idle_recycle_seconds': idle_recycle_seconds}
     adapter = LogfireHTTPAdapter(**kwargs)
     session.mount('http://', adapter)

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -270,6 +270,26 @@ class LogfireRemoteVariableProvider(VariableProvider):
         with suppress_instrumentation():
             self._sse_listener_loop()
 
+    def _new_sse_session(self) -> Session:
+        """Build the session for a single SSE connection attempt.
+
+        Separate from the polling session so that reconnecting cannot disturb polling, and
+        separate from the loop below so the connection policy on this stream, the longest-lived
+        connection the SDK opens, can be asserted without driving the loop.
+        """
+        session = Session()
+        install_connection_policy(session)
+        session.headers.update(
+            {
+                'Authorization': f'bearer {self._token}',
+                'User-Agent': UA_HEADER,
+                'Accept': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+            }
+        )
+        install_logfire_response_hook(session, self._server_response_hook)
+        return session
+
     def _sse_listener_loop(self):  # pragma: no cover
         """Connect to the SSE endpoint, reconnecting with backoff until shutdown."""
         sse_url = urljoin(self._base_url, '/v1/variable-updates/')
@@ -278,19 +298,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
 
         while not self._shutdown:
             try:
-                # Use a separate session for SSE to avoid conflicts with polling
-                with Session() as sse_session:
-                    install_connection_policy(sse_session)
-                    sse_session.headers.update(
-                        {
-                            'Authorization': f'bearer {self._token}',
-                            'User-Agent': UA_HEADER,
-                            'Accept': 'text/event-stream',
-                            'Cache-Control': 'no-cache',
-                        }
-                    )
-                    install_logfire_response_hook(sse_session, self._server_response_hook)
-
+                with self._new_sse_session() as sse_session:
                     # Open streaming connection
                     response = sse_session.get(sse_url, stream=True, timeout=(10, None))
                     if response.status_code != 200:

--- a/logfire/variables/remote.py
+++ b/logfire/variables/remote.py
@@ -19,6 +19,7 @@ from requests import RequestException, Session
 
 from logfire._internal.client import UA_HEADER
 from logfire._internal.config import VariablesOptions
+from logfire._internal.http_transport import install_connection_policy
 from logfire._internal.server_response import ServerResponseCallback, install_logfire_response_hook
 from logfire._internal.utils import UnexpectedResponse, suppress_instrumentation
 from logfire.variables.abstract import (
@@ -91,6 +92,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
         self._token = token
         self._server_response_hook = server_response_hook
         self._session = Session()
+        install_connection_policy(self._session)
         self._session.headers.update({'Authorization': f'bearer {token}', 'User-Agent': UA_HEADER})
         install_logfire_response_hook(self._session, server_response_hook)
         self._timeout = options.timeout
@@ -278,6 +280,7 @@ class LogfireRemoteVariableProvider(VariableProvider):
             try:
                 # Use a separate session for SSE to avoid conflicts with polling
                 with Session() as sse_session:
+                    install_connection_policy(sse_session)
                     sse_session.headers.update(
                         {
                             'Authorization': f'bearer {self._token}',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,9 @@ venv = ".venv"
 
 [tool.pytest.ini_options]
 xfail_strict = true
+markers = [
+    "otel_collector: requires Docker and runs against a pinned OpenTelemetry Collector",
+]
 # The langsmith pytest plugin messes with test_langchain.py
 addopts = "-p no:langsmith_plugin"
 filterwarnings = [

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import socket
 import subprocess
 import sys
 import textwrap
@@ -25,7 +26,9 @@ from logfire._internal.exporters.otlp import (
     BodyTooLargeError,
     DiskRetryer,
     OTLPExporterHttpSession,
+    SuppressedConnectionError,
     cleanup_disk_retryers,
+    raise_for_retryable_status,
 )
 from logfire._internal.exporters.remove_pending import RemovePendingSpansExporter
 from logfire._internal.exporters.wrapper import WrapperSpanExporter
@@ -64,6 +67,35 @@ def test_connect_timeout(timeout: float | tuple[float, float], expected: tuple[f
     session.post('http://example.com', data=b'', timeout=timeout)
 
     assert adapter.timeouts == [expected, expected]
+
+
+@pytest.mark.parametrize(
+    ('status_code', 'is_retryable'),
+    [
+        (200, False),
+        (400, False),
+        (401, False),
+        (403, False),
+        (404, False),
+        (408, True),
+        (429, True),
+        (499, False),
+        (500, True),
+        (502, True),
+        (503, True),
+        (504, True),
+        (599, True),
+    ],
+)
+def test_retryable_http_status_classification(status_code: int, is_retryable: bool) -> None:
+    response = Response()
+    response.status_code = status_code
+
+    if is_retryable:
+        with pytest.raises(requests.exceptions.HTTPError):
+            raise_for_retryable_status(response)
+    else:
+        assert raise_for_retryable_status(response) is None
 
 
 def test_connect_timeout_is_preserved_for_disk_retry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -243,6 +275,28 @@ def test_disk_retryer_cleanup_after_logfire_shutdown(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert marker_file.read_text() == str(retryer_dir)
     assert not retryer_dir.exists()
+
+
+def test_closing_the_session_discards_pending_disk_retries() -> None:
+    """Characterize the current durability boundary: the disk queue does not survive process exit."""
+    session = OTLPExporterHttpSession()
+    try:
+        with socket.socket() as unavailable_server:
+            unavailable_server.bind(('127.0.0.1', 0))
+            endpoint = f'http://127.0.0.1:{unavailable_server.getsockname()[1]}'
+            with pytest.raises((SuppressedConnectionError, requests.exceptions.ReadTimeout)):
+                session.post(endpoint, data=b'data', timeout=0.2)
+
+        retryer = session.retryer
+        retry_thread = retryer.thread
+        assert retry_thread is not None
+
+        session.close()
+        retry_thread.join(timeout=5)
+        assert not retry_thread.is_alive()
+        assert not retryer.dir.exists()
+    finally:
+        session.close()
 
 
 def test_cleanup_disk_retryers_skips_dead_weakrefs(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/otel_collector/README.md
+++ b/tests/otel_collector/README.md
@@ -1,0 +1,53 @@
+# OpenTelemetry Collector conformance tests
+
+These tests exercise Logfire's OpenTelemetry Protocol (OTLP) HTTP transport against a real,
+digest-pinned OpenTelemetry Collector. They are separate from the default test run because they
+require Docker:
+
+```bash
+make test-otel-collector
+```
+
+The harness uses this path for HTTP traffic:
+
+```text
+Logfire SDK -> stable local gateway -> OpenTelemetry Collector -> protobuf capture server
+```
+
+The gateway keeps the software development kit (SDK) endpoint stable while a test destroys and
+recreates the Collector. The capture server parses the exported protobuf messages and lets tests
+reconcile uniquely identified traces, metric points, and log records. HTTPS goes directly to a
+second Collector receiver using a fresh, explicitly trusted test certificate.
+
+Programmable local proxies cover transport failures that stopping the Collector cannot model:
+silently orphaned pooled connections, retryable and terminal HTTP responses, lost response
+acknowledgements, ordinary forward-proxy traffic, and HTTPS tunnels created with `CONNECT`.
+
+The Collector exporter's queue and retry behavior are disabled. This keeps the Collector from
+hiding whether the SDK retried a request.
+
+## Delivery contract
+
+The tests distinguish these outcomes:
+
+- A request that cannot reach the stopped Collector must be replayed from the SDK's disk queue.
+  Every identified record must arrive exactly once after the replacement Collector is healthy.
+- If the Collector accepts a request but its acknowledgement is lost, the SDK retries the same
+  request. Every record must arrive, but duplicate delivery is expected because OTLP does not
+  provide exactly-once acknowledgement semantics.
+- Retryable status codes must make a second attempt. Terminal client errors must not loop.
+- The disk queue is process-local scratch space, not durable storage. Closing the session discards
+  pending retries; a fast exporter characterization test outside this Docker suite makes that
+  boundary explicit.
+
+## Connection policy contract
+
+- A silently orphaned direct, forward-proxy, or HTTPS tunnel connection must be recycled before
+  reuse once its idle window expires. The direct, forward-proxy, and HTTPS `CONNECT` regression
+  cases first prove that an ordinary `requests` session stalls against the same fault.
+- The separate disk-retry session must use the same recycling policy as the main exporter session.
+- A fast companion transport test verifies that a real connected socket has TCP keepalive enabled
+  with every tuning option exposed by the host platform.
+
+Collector logs, rendered configuration, the test certificate, and captured OTLP JSON are uploaded
+by CI on every run. The generated private key is removed before artifact upload.

--- a/tests/otel_collector/__init__.py
+++ b/tests/otel_collector/__init__.py
@@ -1,0 +1,1 @@
+"""OpenTelemetry Collector conformance and transport tests."""

--- a/tests/otel_collector/conftest.py
+++ b/tests/otel_collector/conftest.py
@@ -1,0 +1,389 @@
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import threading
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, ClassVar, cast
+
+import pytest
+from google.protobuf.json_format import MessageToDict
+from google.protobuf.message import Message
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest, ExportLogsServiceResponse
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import (
+    ExportMetricsServiceRequest,
+    ExportMetricsServiceResponse,
+)
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+    ExportTraceServiceResponse,
+)
+
+from tests.otel_collector.faults import HTTPFaultProxy
+
+COLLECTOR_IMAGE = (
+    'otel/opentelemetry-collector:0.159.0@sha256:7725a7a10c87d8853208bdd4bb3439ad3c0d7b32b4292b9300ac07c8daba14a2'
+)
+
+
+class CaptureStore:
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self.traces: list[ExportTraceServiceRequest] = []
+        self.metrics: list[ExportMetricsServiceRequest] = []
+        self.logs: list[ExportLogsServiceRequest] = []
+
+    def add(self, request: Message) -> None:
+        with self._condition:
+            if isinstance(request, ExportTraceServiceRequest):
+                self.traces.append(request)
+            elif isinstance(request, ExportMetricsServiceRequest):
+                self.metrics.append(request)
+            elif isinstance(request, ExportLogsServiceRequest):
+                self.logs.append(request)
+            else:  # pragma: no cover - request types are fixed by CaptureRequestHandler
+                raise TypeError(f'unsupported request type: {type(request)!r}')
+            self._condition.notify_all()
+
+    def wait_until(self, predicate: Callable[[CaptureStore], bool], description: str, timeout: float = 10) -> None:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while not predicate(self):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError(f'timed out waiting for {description}')
+                self._condition.wait(remaining)
+
+    def dump(self, path: Path) -> None:
+        output = {
+            'traces': [MessageToDict(request, preserving_proto_field_name=True) for request in self.traces],
+            'metrics': [MessageToDict(request, preserving_proto_field_name=True) for request in self.metrics],
+            'logs': [MessageToDict(request, preserving_proto_field_name=True) for request in self.logs],
+        }
+        path.write_text(json.dumps(output, indent=2, sort_keys=True))
+
+
+class CaptureServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self) -> None:
+        super().__init__(('0.0.0.0', 0), CaptureRequestHandler)
+        self.store = CaptureStore()
+
+
+class CaptureRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+
+    request_types: ClassVar[dict[str, tuple[type[Message], type[Message]]]] = {
+        '/v1/traces': (ExportTraceServiceRequest, ExportTraceServiceResponse),
+        '/v1/metrics': (ExportMetricsServiceRequest, ExportMetricsServiceResponse),
+        '/v1/logs': (ExportLogsServiceRequest, ExportLogsServiceResponse),
+    }
+
+    def do_POST(self) -> None:
+        try:
+            request_type, response_type = self.request_types[self.path]
+        except KeyError:
+            self.send_error(404)
+            return
+
+        body = self.rfile.read(int(self.headers['Content-Length']))
+        if self.headers.get('Content-Encoding') == 'gzip':
+            body = gzip.decompress(body)
+
+        request = request_type()
+        request.ParseFromString(body)
+        cast(CaptureServer, self.server).store.add(request)
+
+        response = response_type().SerializeToString()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/x-protobuf')
+        self.send_header('Content-Length', str(len(response)))
+        self.end_headers()
+        try:
+            self.wfile.write(response)
+        except BrokenPipeError:
+            # The capture is the acceptance boundary. A deliberately faulted caller may stop
+            # waiting for the acknowledgement after the request has already arrived.
+            pass
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+class CollectorHarness:
+    def __init__(
+        self,
+        gateway: HTTPFaultProxy,
+        tls_endpoint: str,
+        certificate_path: Path,
+        capture: CaptureStore,
+        container_name: str,
+        artifacts_dir: Path,
+        docker_command: list[str],
+        host: str,
+        http_port: int,
+        tls_host: str,
+        tls_port: int,
+    ) -> None:
+        self._gateway = gateway
+        self.endpoint = gateway.endpoint
+        self.tls_endpoint = tls_endpoint
+        self.certificate_path = certificate_path
+        self.capture = capture
+        self.container_name = container_name
+        self.artifacts_dir = artifacts_dir
+        self._docker_command = docker_command
+        self._restart_count = 0
+        self.host = host
+        self.http_port = http_port
+        self.tls_host = tls_host
+        self.tls_port = tls_port
+
+    def stop(self) -> None:
+        subprocess.run(
+            ['docker', 'stop', '--time', '0', self.container_name], capture_output=True, text=True, check=True
+        )
+
+    def restart(self) -> None:
+        self._restart_count += 1
+        logs = subprocess.run(['docker', 'logs', self.container_name], capture_output=True, text=True)
+        (self.artifacts_dir / f'collector-before-restart-{self._restart_count}.log').write_text(
+            logs.stdout + logs.stderr
+        )
+        subprocess.run(['docker', 'rm', '--force', self.container_name], capture_output=True, text=True, check=True)
+        run = subprocess.run(self._docker_command, capture_output=True, text=True)
+        if run.returncode != 0:
+            raise RuntimeError(f'failed to restart Collector:\n{run.stdout}\n{run.stderr}')
+
+        self.host, self.http_port, self.tls_host, self.tls_port = _collector_addresses(self.container_name)
+        _wait_for_port(self.host, self.http_port, timeout=10, container_name=self.container_name)
+        _wait_for_tls_port(
+            self.tls_host,
+            self.tls_port,
+            certificate_path=self.certificate_path,
+            timeout=10,
+            container_name=self.container_name,
+        )
+        self._gateway.set_upstream(f'http://{self.host}:{self.http_port}')
+        self.tls_endpoint = f'https://{self.tls_host}:{self.tls_port}'
+
+
+@pytest.fixture(scope='session', autouse=True)
+def require_collector_tests_enabled() -> None:
+    if os.getenv('LOGFIRE_OTEL_COLLECTOR_TESTS') != '1':
+        pytest.skip('set LOGFIRE_OTEL_COLLECTOR_TESTS=1 to run tests that require Docker')
+
+
+def _wait_for_port(host: str, port: int, *, timeout: float, container_name: str) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.2):
+                return
+        except OSError:
+            state = subprocess.run(
+                ['docker', 'inspect', '--format', '{{.State.Running}}', container_name],
+                capture_output=True,
+                text=True,
+            )
+            if state.returncode != 0 or state.stdout.strip() != 'true':
+                logs = subprocess.run(['docker', 'logs', container_name], capture_output=True, text=True)
+                raise RuntimeError(f'Collector exited before becoming ready:\n{logs.stdout}\n{logs.stderr}')
+            time.sleep(0.05)
+    raise TimeoutError(f'Collector did not listen on {host}:{port} within {timeout}s')
+
+
+def _wait_for_tls_port(host: str, port: int, *, certificate_path: Path, timeout: float, container_name: str) -> None:
+    context = ssl.create_default_context(cafile=certificate_path)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=0.2) as connection:
+                with context.wrap_socket(connection, server_hostname=host):
+                    return
+        except OSError:
+            state = subprocess.run(
+                ['docker', 'inspect', '--format', '{{.State.Running}}', container_name],
+                capture_output=True,
+                text=True,
+            )
+            if state.returncode != 0 or state.stdout.strip() != 'true':
+                logs = subprocess.run(['docker', 'logs', container_name], capture_output=True, text=True)
+                raise RuntimeError(f'Collector exited before becoming ready:\n{logs.stdout}\n{logs.stderr}')
+            time.sleep(0.05)
+    raise TimeoutError(f'Collector did not negotiate TLS on {host}:{port} within {timeout}s')
+
+
+def _collector_addresses(container_name: str) -> tuple[str, int, str, int]:
+    http_port_result = subprocess.run(
+        ['docker', 'port', container_name, '4318/tcp'], capture_output=True, text=True, check=True
+    )
+    tls_port_result = subprocess.run(
+        ['docker', 'port', container_name, '4319/tcp'], capture_output=True, text=True, check=True
+    )
+    host, http_port_text = http_port_result.stdout.strip().rsplit(':', 1)
+    tls_host, tls_port_text = tls_port_result.stdout.strip().rsplit(':', 1)
+    return host, int(http_port_text), tls_host, int(tls_port_text)
+
+
+@pytest.fixture(scope='session')
+def collector_harness(tmp_path_factory: pytest.TempPathFactory) -> Iterator[CollectorHarness]:
+    if shutil.which('docker') is None:
+        pytest.fail('Docker is required when LOGFIRE_OTEL_COLLECTOR_TESTS=1')
+    if shutil.which('openssl') is None:
+        pytest.fail('OpenSSL is required when LOGFIRE_OTEL_COLLECTOR_TESTS=1')
+
+    capture_server = CaptureServer()
+    capture_thread = threading.Thread(target=capture_server.serve_forever, daemon=True)
+    capture_thread.start()
+
+    artifacts_env = os.getenv('LOGFIRE_OTEL_COLLECTOR_ARTIFACTS')
+    artifacts_dir = Path(artifacts_env) if artifacts_env else tmp_path_factory.mktemp('otel-collector-artifacts')
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    config_path = artifacts_dir / 'collector.yaml'
+    certificate_path = artifacts_dir / 'certificate.pem'
+    key_path = artifacts_dir / 'key.pem'
+    container_name = f'logfire-otel-conformance-{uuid.uuid4().hex}'
+    gateway: HTTPFaultProxy | None = None
+    try:
+        certificate = subprocess.run(
+            [
+                'openssl',
+                'req',
+                '-x509',
+                '-newkey',
+                'rsa:2048',
+                '-nodes',
+                '-keyout',
+                str(key_path),
+                '-out',
+                str(certificate_path),
+                '-days',
+                '1',
+                '-subj',
+                '/CN=localhost',
+                '-addext',
+                'subjectAltName=DNS:localhost,IP:127.0.0.1',
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if certificate.returncode != 0:
+            pytest.fail(f'failed to generate Collector certificate:\n{certificate.stdout}\n{certificate.stderr}')
+        key_path.chmod(0o644)
+        capture_port = capture_server.server_address[1]
+        config_path.write_text(
+            f"""receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+  otlp/tls:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4319
+        tls:
+          cert_file: /test-artifacts/certificate.pem
+          key_file: /test-artifacts/key.pem
+
+exporters:
+  otlp_http/capture:
+    endpoint: http://host.docker.internal:{capture_port}
+    compression: none
+    sending_queue:
+      enabled: false
+    retry_on_failure:
+      enabled: false
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp, otlp/tls]
+      exporters: [otlp_http/capture]
+    metrics:
+      receivers: [otlp, otlp/tls]
+      exporters: [otlp_http/capture]
+    logs:
+      receivers: [otlp, otlp/tls]
+      exporters: [otlp_http/capture]
+"""
+        )
+
+        docker_command = [
+            'docker',
+            'run',
+            '--detach',
+            '--name',
+            container_name,
+            '--add-host',
+            'host.docker.internal:host-gateway',
+            '--publish',
+            '127.0.0.1::4318',
+            '--publish',
+            '127.0.0.1::4319',
+            '--volume',
+            f'{config_path.resolve()}:/etc/otelcol/config.yaml:ro',
+            '--volume',
+            f'{certificate_path.resolve()}:/test-artifacts/certificate.pem:ro',
+            '--volume',
+            f'{key_path.resolve()}:/test-artifacts/key.pem:ro',
+            COLLECTOR_IMAGE,
+            '--config=/etc/otelcol/config.yaml',
+        ]
+        run = subprocess.run(docker_command, capture_output=True, text=True)
+        if run.returncode != 0:
+            pytest.fail(f'failed to start Collector:\n{run.stdout}\n{run.stderr}')
+
+        host, http_port, tls_host, tls_port = _collector_addresses(container_name)
+        _wait_for_port(host, http_port, timeout=10, container_name=container_name)
+        _wait_for_tls_port(
+            tls_host,
+            tls_port,
+            certificate_path=certificate_path,
+            timeout=10,
+            container_name=container_name,
+        )
+        gateway = HTTPFaultProxy(f'http://{host}:{http_port}', [])
+        yield CollectorHarness(
+            gateway=gateway,
+            tls_endpoint=f'https://{tls_host}:{tls_port}',
+            certificate_path=certificate_path,
+            capture=capture_server.store,
+            container_name=container_name,
+            artifacts_dir=artifacts_dir,
+            docker_command=docker_command,
+            host=host,
+            http_port=http_port,
+            tls_host=tls_host,
+            tls_port=tls_port,
+        )
+    finally:
+        try:
+            logs = subprocess.run(['docker', 'logs', container_name], capture_output=True, text=True)
+            if logs.returncode == 0:
+                (artifacts_dir / 'collector.log').write_text(logs.stdout + logs.stderr)
+            capture_server.store.dump(artifacts_dir / 'captured-otlp.json')
+        finally:
+            try:
+                if gateway is not None:
+                    gateway.close()
+            finally:
+                try:
+                    subprocess.run(['docker', 'rm', '--force', container_name], capture_output=True)
+                finally:
+                    try:
+                        key_path.unlink(missing_ok=True)
+                    finally:
+                        capture_server.shutdown()
+                        capture_server.server_close()
+                        capture_thread.join(timeout=5)

--- a/tests/otel_collector/conftest.py
+++ b/tests/otel_collector/conftest.py
@@ -231,9 +231,17 @@ def _collector_addresses(container_name: str) -> tuple[str, int, str, int]:
     tls_port_result = subprocess.run(
         ['docker', 'port', container_name, '4319/tcp'], capture_output=True, text=True, check=True
     )
-    host, http_port_text = http_port_result.stdout.strip().rsplit(':', 1)
-    tls_host, tls_port_text = tls_port_result.stdout.strip().rsplit(':', 1)
-    return host, int(http_port_text), tls_host, int(tls_port_text)
+    host, http_port = _ipv4_collector_address(http_port_result.stdout, '4318/tcp')
+    tls_host, tls_port = _ipv4_collector_address(tls_port_result.stdout, '4319/tcp')
+    return host, http_port, tls_host, tls_port
+
+
+def _ipv4_collector_address(output: str, container_port: str) -> tuple[str, int]:
+    for mapping in output.splitlines():
+        host, host_port = mapping.strip().rsplit(':', 1)
+        if host == '127.0.0.1':
+            return host, int(host_port)
+    raise RuntimeError(f'Docker did not publish an IPv4 mapping for Collector port {container_port}: {output!r}')
 
 
 @pytest.fixture(scope='session')

--- a/tests/otel_collector/faults.py
+++ b/tests/otel_collector/faults.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import http.client
+import socket
+import threading
+import time
+from collections import deque
+from collections.abc import Iterable
+from contextlib import closing
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, ClassVar, Literal, cast
+from urllib.parse import urlsplit
+
+FaultAction = int | Literal['drop_response']
+
+
+class StaleConnectionProxy:
+    """A TCP proxy that can blackhole existing connections while keeping new ones healthy."""
+
+    def __init__(self, upstream_host: str, upstream_port: int, *, accept_connect: bool = False) -> None:
+        self._upstream = (upstream_host, upstream_port)
+        self._accept_connect = accept_connect
+        self._listener = socket.socket()
+        self._listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._listener.bind(('127.0.0.1', 0))
+        self._listener.listen()
+        self._listener.settimeout(0.1)
+        self.endpoint = f'http://127.0.0.1:{self._listener.getsockname()[1]}'
+        self._lock = threading.Lock()
+        self._next_connection_id = 0
+        self._orphan_through = 0
+        self._closed = threading.Event()
+        self._sockets: list[socket.socket] = []
+        self._threads = [threading.Thread(target=self._accept, daemon=True)]
+        self._threads[0].start()
+
+    def _accept(self) -> None:
+        while not self._closed.is_set():
+            try:
+                client = self._listener.accept()[0]
+            except TimeoutError:
+                continue
+            except OSError:
+                return
+            # CONNECT headers can arrive over multiple packets. Give the proxy a
+            # realistic handshake deadline, then switch to short polling once the
+            # tunnel is established so shutdown remains responsive.
+            client.settimeout(2 if self._accept_connect else 0.1)
+            upstream: socket.socket | None = None
+            try:
+                initial_upstream_data = self._read_connect_request(client) if self._accept_connect else b''
+                upstream = socket.create_connection(self._upstream, timeout=2)
+                upstream.settimeout(0.1)
+                if self._accept_connect:
+                    client.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+                if initial_upstream_data:
+                    upstream.sendall(initial_upstream_data)
+                client.settimeout(0.1)
+            except (OSError, ValueError):
+                client.close()
+                if upstream is not None:
+                    upstream.close()
+                continue
+            with self._lock:
+                self._next_connection_id += 1
+                connection_id = self._next_connection_id
+                self._sockets.extend((client, upstream))
+            for source, destination in ((client, upstream), (upstream, client)):
+                thread = threading.Thread(target=self._forward, args=(connection_id, source, destination), daemon=True)
+                self._threads.append(thread)
+                thread.start()
+
+    def _read_connect_request(self, client: socket.socket) -> bytes:
+        request = b''
+        while b'\r\n\r\n' not in request:
+            chunk = client.recv(65536)
+            if not chunk:
+                raise ValueError('client closed before completing CONNECT request')
+            request += chunk
+            if len(request) > 65536:
+                raise ValueError('CONNECT request headers exceeded 64 KiB')
+
+        headers, initial_upstream_data = request.split(b'\r\n\r\n', 1)
+        request_line = headers.split(b'\r\n', 1)[0]
+        try:
+            method, _authority, version = request_line.split(b' ', 2)
+        except ValueError as exc:
+            raise ValueError(f'invalid proxy request line: {request_line!r}') from exc
+        if method != b'CONNECT' or not version.startswith(b'HTTP/'):
+            raise ValueError(f'expected CONNECT request, got: {request_line!r}')
+
+        return initial_upstream_data
+
+    def _forward(self, connection_id: int, source: socket.socket, destination: socket.socket) -> None:
+        try:
+            while not self._closed.is_set():
+                try:
+                    data = source.recv(65536)
+                except TimeoutError:
+                    continue
+                if not data:
+                    break
+                with self._lock:
+                    orphaned = connection_id <= self._orphan_through
+                if not orphaned:
+                    destination.sendall(data)
+        except OSError:
+            pass
+        finally:
+            if not self._closed.is_set():
+                with closing(source), closing(destination):
+                    pass
+
+    def orphan_existing_connections(self) -> None:
+        with self._lock:
+            self._orphan_through = self._next_connection_id
+
+    @property
+    def connection_count(self) -> int:
+        with self._lock:
+            return self._next_connection_id
+
+    def close(self) -> None:
+        self._closed.set()
+        self._listener.close()
+        with self._lock:
+            sockets = list(self._sockets)
+        for sock in sockets:
+            with closing(sock):
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                except OSError:
+                    pass
+        deadline = time.monotonic() + 2
+        for thread in self._threads:
+            thread.join(timeout=max(0, deadline - time.monotonic()))
+        if live_threads := [thread.name for thread in self._threads if thread.is_alive()]:
+            raise AssertionError(f'stale connection proxy threads did not stop: {live_threads}')
+
+
+class HTTPFaultServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, upstream_endpoint: str, actions: Iterable[FaultAction]) -> None:
+        upstream = urlsplit(upstream_endpoint)
+        if upstream.scheme != 'http' or upstream.hostname is None or upstream.port is None:
+            raise ValueError(f'expected an HTTP upstream with an explicit port, got {upstream_endpoint!r}')
+        self._upstream = (upstream.hostname, upstream.port)
+        self._upstream_lock = threading.Lock()
+        self._condition = threading.Condition()
+        self._actions = deque(actions)
+        self.attempts = 0
+        super().__init__(('127.0.0.1', 0), HTTPFaultRequestHandler)
+
+    def set_upstream(self, upstream_endpoint: str) -> None:
+        upstream = urlsplit(upstream_endpoint)
+        if upstream.scheme != 'http' or upstream.hostname is None or upstream.port is None:
+            raise ValueError(f'expected an HTTP upstream with an explicit port, got {upstream_endpoint!r}')
+        with self._upstream_lock:
+            self._upstream = (upstream.hostname, upstream.port)
+
+    def upstream(self) -> tuple[str, int]:
+        with self._upstream_lock:
+            return self._upstream
+
+    def next_action(self) -> FaultAction | None:
+        with self._condition:
+            self.attempts += 1
+            action = self._actions.popleft() if self._actions else None
+            self._condition.notify_all()
+            return action
+
+    def wait_for_attempts(self, attempts: int, timeout: float = 10) -> None:
+        deadline = time.monotonic() + timeout
+        with self._condition:
+            while self.attempts < attempts:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise AssertionError(f'timed out waiting for {attempts} attempts; observed {self.attempts}')
+                self._condition.wait(remaining)
+
+
+class HTTPFaultRequestHandler(BaseHTTPRequestHandler):
+    protocol_version = 'HTTP/1.1'
+    hop_by_hop_headers: ClassVar[set[str]] = {
+        'connection',
+        'content-length',
+        'host',
+        'keep-alive',
+        'proxy-authenticate',
+        'proxy-authorization',
+        'te',
+        'trailer',
+        'transfer-encoding',
+        'upgrade',
+    }
+
+    def do_POST(self) -> None:
+        server = cast(HTTPFaultServer, self.server)
+        body = self.rfile.read(int(self.headers['Content-Length']))
+        action = server.next_action()
+
+        if isinstance(action, int):
+            self.send_response(action)
+            self.send_header('Content-Length', '0')
+            self.end_headers()
+            return
+
+        headers = {key: value for key, value in self.headers.items() if key.lower() not in self.hop_by_hop_headers}
+        upstream = http.client.HTTPConnection(*server.upstream(), timeout=2)
+        try:
+            try:
+                upstream.request('POST', self.path, body=body, headers=headers)
+                response = upstream.getresponse()
+                response_body = response.read()
+                response_headers = response.getheaders()
+            except (OSError, http.client.HTTPException):
+                self._drop_connection()
+                return
+        finally:
+            upstream.close()
+
+        if action == 'drop_response':
+            self._drop_connection()
+            return
+
+        self.send_response(response.status)
+        for key, value in response_headers:
+            if key.lower() not in self.hop_by_hop_headers:
+                self.send_header(key, value)
+        self.send_header('Content-Length', str(len(response_body)))
+        self.end_headers()
+        self.wfile.write(response_body)
+
+    def _drop_connection(self) -> None:
+        self.close_connection = True
+        with closing(self.connection):
+            try:
+                self.connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+
+    def log_message(self, format: str, *args: Any) -> None:
+        pass
+
+
+class HTTPFaultProxy:
+    """A programmable reverse proxy for deterministic response and disconnect faults."""
+
+    def __init__(self, upstream_endpoint: str, actions: Iterable[FaultAction]) -> None:
+        self._server = HTTPFaultServer(upstream_endpoint, actions)
+        self.endpoint = f'http://127.0.0.1:{self._server.server_address[1]}'
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    @property
+    def attempts(self) -> int:
+        return self._server.attempts
+
+    def wait_for_attempts(self, attempts: int, timeout: float = 10) -> None:
+        self._server.wait_for_attempts(attempts, timeout)
+
+    def set_upstream(self, upstream_endpoint: str) -> None:
+        self._server.set_upstream(upstream_endpoint)
+
+    def close(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)

--- a/tests/otel_collector/faults.py
+++ b/tests/otel_collector/faults.py
@@ -42,6 +42,8 @@ class StaleConnectionProxy:
                 continue
             except OSError:
                 return
+            with self._lock:
+                self._sockets.append(client)
             # CONNECT headers can arrive over multiple packets. Give the proxy a
             # realistic handshake deadline, then switch to short polling once the
             # tunnel is established so shutdown remains responsive.
@@ -50,6 +52,8 @@ class StaleConnectionProxy:
             try:
                 initial_upstream_data = self._read_connect_request(client) if self._accept_connect else b''
                 upstream = socket.create_connection(self._upstream, timeout=2)
+                with self._lock:
+                    self._sockets.append(upstream)
                 upstream.settimeout(0.1)
                 if self._accept_connect:
                     client.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
@@ -61,13 +65,21 @@ class StaleConnectionProxy:
                 if upstream is not None:
                     upstream.close()
                 continue
+            if self._closed.is_set():
+                client.close()
+                upstream.close()
+                return
             with self._lock:
                 self._next_connection_id += 1
                 connection_id = self._next_connection_id
-                self._sockets.extend((client, upstream))
-            for source, destination in ((client, upstream), (upstream, client)):
-                thread = threading.Thread(target=self._forward, args=(connection_id, source, destination), daemon=True)
-                self._threads.append(thread)
+                threads: list[threading.Thread] = []
+                for source, destination in ((client, upstream), (upstream, client)):
+                    thread = threading.Thread(
+                        target=self._forward, args=(connection_id, source, destination), daemon=True
+                    )
+                    self._threads.append(thread)
+                    threads.append(thread)
+            for thread in threads:
                 thread.start()
 
     def _read_connect_request(self, client: socket.socket) -> bytes:
@@ -132,9 +144,12 @@ class StaleConnectionProxy:
                 except OSError:
                     pass
         deadline = time.monotonic() + 2
-        for thread in self._threads:
+        self._threads[0].join(timeout=max(0, deadline - time.monotonic()))
+        with self._lock:
+            threads = list(self._threads)
+        for thread in threads[1:]:
             thread.join(timeout=max(0, deadline - time.monotonic()))
-        if live_threads := [thread.name for thread in self._threads if thread.is_alive()]:
+        if live_threads := [thread.name for thread in threads if thread.is_alive()]:
             raise AssertionError(f'stale connection proxy threads did not stop: {live_threads}')
 
 

--- a/tests/otel_collector/scenario.py
+++ b/tests/otel_collector/scenario.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+
+from opentelemetry._logs import SeverityNumber, get_logger
+
+import logfire
+from logfire._internal.config import LogfireConfig
+
+
+def _skip_credentials_check(self: LogfireConfig, token: str) -> None:
+    del self, token
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--endpoint', required=True)
+    parser.add_argument('--run-id', required=True)
+    args = parser.parse_args()
+
+    # Credential validation is a separate HTTP API concern. Keep this process focused on the
+    # exporter path so its background request cannot race the transport scenario.
+    LogfireConfig._initialize_credentials_from_token = _skip_credentials_check  # pyright: ignore[reportPrivateUsage]
+
+    logfire.configure(
+        send_to_logfire=True,
+        token='collector-conformance-token',
+        service_name='logfire-collector-conformance',
+        console=False,
+        inspect_arguments=False,
+        advanced=logfire.AdvancedOptions(base_url=args.endpoint),
+    )
+
+    with logfire.span('collector.conformance.parent', **{'test.run_id': args.run_id}):
+        logfire.info('collector conformance log', **{'test.run_id': args.run_id})
+        get_logger('collector.conformance').emit(
+            body='collector conformance otel log',
+            severity_text='INFO',
+            severity_number=SeverityNumber.INFO,
+            attributes={'test.run_id': args.run_id},
+        )
+
+    counter = logfire.metric_counter('collector.conformance.counter', unit='1')
+    counter.add(7, {'test.run_id': args.run_id})
+
+    if not logfire.force_flush(timeout_millis=10_000):
+        raise RuntimeError('Logfire force_flush timed out')
+    if not logfire.shutdown(timeout_millis=10_000):
+        raise RuntimeError('Logfire shutdown timed out')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/otel_collector/test_conformance.py
+++ b/tests/otel_collector/test_conformance.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from collections.abc import Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+import requests
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+
+from logfire._internal.exporters.otlp import DiskRetryer, OTLPExporterHttpSession
+from logfire._internal.http_transport import (
+    LogfireHTTPAdapter,
+    install_connection_policy,
+)
+from tests.otel_collector.conftest import CaptureStore, CollectorHarness
+from tests.otel_collector.faults import StaleConnectionProxy
+
+pytestmark = pytest.mark.otel_collector
+
+
+def _string_attribute(attributes: Iterable[KeyValue], key: str) -> str | None:
+    for attribute in attributes:
+        if attribute.key != key:
+            continue
+        value = attribute.value
+        if value.WhichOneof('value') == 'string_value':
+            return value.string_value
+    return None
+
+
+def _signals_captured_for_run(capture: CaptureStore, run_id: str) -> set[str]:
+    signals: set[str] = set()
+    if any(
+        _string_attribute(span.attributes, 'test.run_id') == run_id
+        for request in capture.traces
+        for resource_spans in request.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for span in scope_spans.spans
+    ):
+        signals.add('traces')
+    if any(
+        _string_attribute(record.attributes, 'test.run_id') == run_id
+        for request in capture.logs
+        for resource_logs in request.resource_logs
+        for scope_logs in resource_logs.scope_logs
+        for record in scope_logs.log_records
+    ):
+        signals.add('logs')
+    if any(
+        _string_attribute(point.attributes, 'test.run_id') == run_id
+        for request in capture.metrics
+        for resource_metrics in request.resource_metrics
+        for scope_metrics in resource_metrics.scope_metrics
+        for metric in scope_metrics.metrics
+        if metric.name == 'collector.conformance.counter'
+        for point in metric.sum.data_points
+    ):
+        signals.add('metrics')
+    return signals
+
+
+def test_logfire_exports_all_signals_through_the_collector(collector_harness: CollectorHarness) -> None:
+    run_id = uuid.uuid4().hex
+    scenario = Path(__file__).with_name('scenario.py')
+    result = subprocess.run(
+        [sys.executable, str(scenario), '--endpoint', collector_harness.endpoint, '--run-id', run_id],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    collector_harness.capture.wait_until(
+        lambda capture: _signals_captured_for_run(capture, run_id) == {'traces', 'metrics', 'logs'},
+        f'all signals for run {run_id}',
+    )
+
+    spans = [
+        span
+        for request in collector_harness.capture.traces
+        for resource_spans in request.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for span in scope_spans.spans
+        if _string_attribute(span.attributes, 'test.run_id') == run_id
+    ]
+    assert {span.name for span in spans} >= {'collector.conformance.parent', 'collector conformance log'}
+
+    log_records = [
+        record
+        for request in collector_harness.capture.logs
+        for resource_logs in request.resource_logs
+        for scope_logs in resource_logs.scope_logs
+        for record in scope_logs.log_records
+        if _string_attribute(record.attributes, 'test.run_id') == run_id
+    ]
+    assert any(record.body.string_value == 'collector conformance otel log' for record in log_records)
+
+    metrics = [
+        metric
+        for request in collector_harness.capture.metrics
+        for resource_metrics in request.resource_metrics
+        for scope_metrics in resource_metrics.scope_metrics
+        for metric in scope_metrics.metrics
+        if metric.name == 'collector.conformance.counter'
+    ]
+    assert metrics
+    points = [point for metric in metrics for point in metric.sum.data_points]
+    assert any(point.as_int == 7 and _string_attribute(point.attributes, 'test.run_id') == run_id for point in points)
+
+
+@pytest.fixture
+def stale_connection_proxy(collector_harness: CollectorHarness) -> Iterator[StaleConnectionProxy]:
+    proxy = StaleConnectionProxy(collector_harness.host, collector_harness.http_port)
+    try:
+        yield proxy
+    finally:
+        proxy.close()
+
+
+def _post_empty_trace(
+    session: requests.Session,
+    endpoint: str,
+    timeout: float,
+    *,
+    proxies: dict[str, str] | None = None,
+    verify: bool | str = True,
+) -> requests.Response:
+    return session.post(
+        f'{endpoint}/v1/traces',
+        data=ExportTraceServiceRequest().SerializeToString(),
+        headers={'Content-Type': 'application/x-protobuf'},
+        timeout=timeout,
+        proxies=proxies,
+        verify=verify,
+    )
+
+
+def _post_empty_trace_without_application_retry(
+    session: OTLPExporterHttpSession,
+    endpoint: str,
+    timeout: float,
+    *,
+    proxies: dict[str, str] | None = None,
+    verify: bool | str = True,
+) -> requests.Response:
+    return requests.Session.post(
+        session,
+        f'{endpoint}/v1/traces',
+        data=ExportTraceServiceRequest().SerializeToString(),
+        headers={'Content-Type': 'application/x-protobuf'},
+        timeout=timeout,
+        proxies=proxies,
+        verify=verify,
+    )
+
+
+def test_https_pool_can_export_to_a_tls_collector(collector_harness: CollectorHarness) -> None:
+    with OTLPExporterHttpSession() as session:
+        response = session.post(
+            f'{collector_harness.tls_endpoint}/v1/traces',
+            data=ExportTraceServiceRequest().SerializeToString(),
+            headers={'Content-Type': 'application/x-protobuf'},
+            timeout=1,
+            verify=collector_harness.certificate_path,
+        )
+
+    assert response.status_code == 200
+
+
+def test_an_idle_stale_connection_is_recycled_before_reuse(stale_connection_proxy: StaleConnectionProxy) -> None:
+    # Negative control: a normal requests session reuses the silently orphaned connection and
+    # stalls until its read timeout. This proves the fixture distinguishes the regression.
+    with requests.Session() as control:
+        assert _post_empty_trace(control, stale_connection_proxy.endpoint, timeout=1).status_code == 200
+        stale_connection_proxy.orphan_existing_connections()
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            _post_empty_trace(control, stale_connection_proxy.endpoint, timeout=0.2)
+
+    recycle_seconds = 0.1
+    with OTLPExporterHttpSession() as session:
+        install_connection_policy(session, idle_recycle_seconds=recycle_seconds)
+        assert (
+            _post_empty_trace_without_application_retry(session, stale_connection_proxy.endpoint, timeout=1).status_code
+            == 200
+        )
+        stale_connection_proxy.orphan_existing_connections()
+        time.sleep(recycle_seconds + 0.05)
+
+        response = _post_empty_trace_without_application_retry(session, stale_connection_proxy.endpoint, timeout=1)
+
+    assert response.status_code == 200
+
+
+def test_disk_retryer_session_recycles_an_idle_stale_connection(
+    stale_connection_proxy: StaleConnectionProxy,
+) -> None:
+    retryer = DiskRetryer({})
+    try:
+        adapter = retryer.session.get_adapter(stale_connection_proxy.endpoint)
+        assert isinstance(adapter, LogfireHTTPAdapter)
+        for pool_class in adapter.poolmanager.pool_classes_by_scheme.values():
+            pool_class.idle_recycle_seconds = 0.1
+
+        assert _post_empty_trace(retryer.session, stale_connection_proxy.endpoint, timeout=1).status_code == 200
+        stale_connection_proxy.orphan_existing_connections()
+        time.sleep(0.15)
+
+        response = _post_empty_trace(retryer.session, stale_connection_proxy.endpoint, timeout=1)
+    finally:
+        retryer.close()
+
+    assert response.status_code == 200
+
+
+def test_idle_stale_connection_is_recycled_through_a_forward_proxy(
+    collector_harness: CollectorHarness, stale_connection_proxy: StaleConnectionProxy
+) -> None:
+    target = f'http://{collector_harness.host}:{collector_harness.http_port}'
+    proxies = {'http': stale_connection_proxy.endpoint}
+
+    # Negative control: without Logfire's proxy-manager policy, requests reuses the silently
+    # orphaned connection to the forward proxy and waits for the read timeout.
+    with requests.Session() as control:
+        assert _post_empty_trace(control, target, timeout=1, proxies=proxies).status_code == 200
+        stale_connection_proxy.orphan_existing_connections()
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            _post_empty_trace(control, target, timeout=0.2, proxies=proxies)
+
+    recycle_seconds = 0.1
+    with OTLPExporterHttpSession() as session:
+        install_connection_policy(session, idle_recycle_seconds=recycle_seconds)
+        assert (
+            _post_empty_trace_without_application_retry(session, target, timeout=1, proxies=proxies).status_code == 200
+        )
+        stale_connection_proxy.orphan_existing_connections()
+        time.sleep(recycle_seconds + 0.05)
+
+        response = _post_empty_trace_without_application_retry(session, target, timeout=1, proxies=proxies)
+
+    assert response.status_code == 200
+
+
+def test_idle_stale_tls_tunnel_is_recycled_through_a_connect_proxy(
+    collector_harness: CollectorHarness,
+) -> None:
+    proxy = StaleConnectionProxy(collector_harness.tls_host, collector_harness.tls_port, accept_connect=True)
+    try:
+        proxies = {'https': proxy.endpoint}
+        verify = str(collector_harness.certificate_path)
+
+        with requests.Session() as control:
+            assert (
+                _post_empty_trace(
+                    control, collector_harness.tls_endpoint, timeout=1, proxies=proxies, verify=verify
+                ).status_code
+                == 200
+            )
+            proxy.orphan_existing_connections()
+            with pytest.raises(requests.exceptions.ReadTimeout):
+                _post_empty_trace(control, collector_harness.tls_endpoint, timeout=0.2, proxies=proxies, verify=verify)
+
+        recycle_seconds = 0.1
+        with OTLPExporterHttpSession() as session:
+            install_connection_policy(session, idle_recycle_seconds=recycle_seconds)
+            assert (
+                _post_empty_trace_without_application_retry(
+                    session, collector_harness.tls_endpoint, timeout=1, proxies=proxies, verify=verify
+                ).status_code
+                == 200
+            )
+            proxy.orphan_existing_connections()
+            time.sleep(recycle_seconds + 0.05)
+
+            response = _post_empty_trace_without_application_retry(
+                session, collector_harness.tls_endpoint, timeout=1, proxies=proxies, verify=verify
+            )
+    finally:
+        proxy.close()
+
+    assert response.status_code == 200
+
+
+def test_concurrent_idle_stale_connections_are_recycled(stale_connection_proxy: StaleConnectionProxy) -> None:
+    concurrency = 8
+    recycle_seconds = 0.1
+    with OTLPExporterHttpSession() as session:
+        install_connection_policy(session, idle_recycle_seconds=recycle_seconds)
+
+        def request_wave() -> list[requests.Response]:
+            barrier = threading.Barrier(concurrency)
+
+            def send(_: int) -> requests.Response:
+                barrier.wait(timeout=2)
+                return _post_empty_trace_without_application_retry(session, stale_connection_proxy.endpoint, timeout=1)
+
+            with ThreadPoolExecutor(max_workers=concurrency) as executor:
+                return list(executor.map(send, range(concurrency)))
+
+        assert all(response.status_code == 200 for response in request_wave())
+        assert stale_connection_proxy.connection_count > 1
+        stale_connection_proxy.orphan_existing_connections()
+        time.sleep(recycle_seconds + 0.05)
+
+        assert all(response.status_code == 200 for response in request_wave())

--- a/tests/otel_collector/test_resilience.py
+++ b/tests/otel_collector/test_resilience.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import uuid
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+import pytest
+import requests
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+
+from logfire._internal.exporters.otlp import OTLPExporterHttpSession, SuppressedConnectionError
+from tests.otel_collector.conftest import CaptureStore, CollectorHarness
+from tests.otel_collector.faults import HTTPFaultProxy
+
+pytestmark = pytest.mark.otel_collector
+
+Signal = Literal['traces', 'metrics', 'logs']
+
+
+@dataclass(frozen=True)
+class OTLPRequest:
+    signal: Signal
+    path: str
+    body: bytes
+    event_ids: frozenset[str]
+
+
+def _attribute(event_id: str) -> KeyValue:
+    return KeyValue(key='test.event_id', value=AnyValue(string_value=event_id))
+
+
+def _requests(run_id: str, count: int) -> list[OTLPRequest]:
+    event_ids = frozenset(f'{run_id}:{index}' for index in range(count))
+
+    traces = ExportTraceServiceRequest()
+    spans = traces.resource_spans.add().scope_spans.add().spans
+    for event_id in event_ids:
+        span = spans.add()
+        span.name = 'collector.torture.trace'
+        span.trace_id = uuid.uuid4().bytes
+        span.span_id = uuid.uuid4().bytes[:8]
+        span.start_time_unix_nano = 1
+        span.end_time_unix_nano = 2
+        span.attributes.append(_attribute(event_id))
+
+    logs = ExportLogsServiceRequest()
+    log_records = logs.resource_logs.add().scope_logs.add().log_records
+    for event_id in event_ids:
+        record = log_records.add()
+        record.time_unix_nano = 1
+        record.body.string_value = 'collector torture log'
+        record.attributes.append(_attribute(event_id))
+
+    metrics = ExportMetricsServiceRequest()
+    metric = metrics.resource_metrics.add().scope_metrics.add().metrics.add()
+    metric.name = 'collector.torture.gauge'
+    for event_id in event_ids:
+        point = metric.gauge.data_points.add()
+        point.time_unix_nano = 1
+        point.as_int = 1
+        point.attributes.append(_attribute(event_id))
+
+    return [
+        OTLPRequest('traces', '/v1/traces', traces.SerializeToString(), event_ids),
+        OTLPRequest('metrics', '/v1/metrics', metrics.SerializeToString(), event_ids),
+        OTLPRequest('logs', '/v1/logs', logs.SerializeToString(), event_ids),
+    ]
+
+
+def _event_id(attributes: Iterable[KeyValue]) -> str | None:
+    for attribute in attributes:
+        if attribute.key == 'test.event_id' and attribute.value.WhichOneof('value') == 'string_value':
+            return attribute.value.string_value
+    return None
+
+
+def _captured_event_ids(capture: CaptureStore) -> dict[Signal, list[str]]:
+    traces = [
+        event_id
+        for request in capture.traces
+        for resource_spans in request.resource_spans
+        for scope_spans in resource_spans.scope_spans
+        for span in scope_spans.spans
+        if span.name == 'collector.torture.trace'
+        if (event_id := _event_id(span.attributes)) is not None
+    ]
+    logs = [
+        event_id
+        for request in capture.logs
+        for resource_logs in request.resource_logs
+        for scope_logs in resource_logs.scope_logs
+        for record in scope_logs.log_records
+        if record.body.string_value == 'collector torture log'
+        if (event_id := _event_id(record.attributes)) is not None
+    ]
+    metrics = [
+        event_id
+        for request in capture.metrics
+        for resource_metrics in request.resource_metrics
+        for scope_metrics in resource_metrics.scope_metrics
+        for metric in scope_metrics.metrics
+        if metric.name == 'collector.torture.gauge'
+        for point in metric.gauge.data_points
+        if (event_id := _event_id(point.attributes)) is not None
+    ]
+    return {'traces': traces, 'metrics': metrics, 'logs': logs}
+
+
+def _post(
+    session: OTLPExporterHttpSession, endpoint: str, request: OTLPRequest, *, timeout: float = 1
+) -> requests.Response:
+    return session.post(
+        f'{endpoint}{request.path}',
+        data=request.body,
+        headers={'Content-Type': 'application/x-protobuf'},
+        timeout=timeout,
+    )
+
+
+def _wait_for_requests(capture: CaptureStore, requests_: list[OTLPRequest], timeout: float = 20) -> None:
+    expected: dict[Signal, frozenset[str]] = {request.signal: request.event_ids for request in requests_}
+
+    def all_received(store: CaptureStore) -> bool:
+        actual = _captured_event_ids(store)
+        return all(event_ids <= set(actual[signal]) for signal, event_ids in expected.items())
+
+    capture.wait_until(all_received, 'all uniquely identified OTLP records', timeout)
+
+
+def test_collector_outage_retries_every_signal_without_loss(collector_harness: CollectorHarness) -> None:
+    requests_ = _requests(uuid.uuid4().hex, count=25)
+
+    with OTLPExporterHttpSession() as session:
+        collector_harness.stop()
+        try:
+            for request in requests_:
+                with pytest.raises((SuppressedConnectionError, requests.exceptions.ReadTimeout)):
+                    _post(session, collector_harness.endpoint, request, timeout=0.2)
+            retry_thread = session.retryer.thread
+            assert retry_thread is not None
+        finally:
+            collector_harness.restart()
+
+        retry_thread.join(timeout=30)
+        assert not retry_thread.is_alive(), 'disk retry queue did not drain after the Collector recovered'
+        _wait_for_requests(collector_harness.capture, requests_)
+
+    captured = _captured_event_ids(collector_harness.capture)
+    for request in requests_:
+        counts = Counter(captured[request.signal])
+        assert {event_id: counts[event_id] for event_id in request.event_ids} == dict.fromkeys(request.event_ids, 1)
+
+
+def test_429_is_retried_inline_before_delivery(collector_harness: CollectorHarness) -> None:
+    request = _requests(uuid.uuid4().hex, count=1)[0]
+    proxy = HTTPFaultProxy(collector_harness.endpoint, [429])
+    try:
+        with OTLPExporterHttpSession() as session:
+            response = _post(session, proxy.endpoint, request)
+
+        assert response.status_code == 200
+        proxy.wait_for_attempts(2)
+        assert proxy.attempts == 2
+        _wait_for_requests(collector_harness.capture, [request])
+    finally:
+        proxy.close()
+
+
+def test_repeated_503_is_replayed_from_the_disk_queue(collector_harness: CollectorHarness) -> None:
+    request = _requests(uuid.uuid4().hex, count=10)[0]
+    proxy = HTTPFaultProxy(collector_harness.endpoint, [503, 503])
+    try:
+        with OTLPExporterHttpSession() as session:
+            with pytest.raises(requests.exceptions.HTTPError):
+                _post(session, proxy.endpoint, request)
+
+            retry_thread = session.retryer.thread
+            assert retry_thread is not None
+            retry_thread.join(timeout=10)
+            assert not retry_thread.is_alive(), 'disk retry queue did not drain after the 503 responses stopped'
+            _wait_for_requests(collector_harness.capture, [request])
+
+        assert proxy.attempts == 3
+    finally:
+        proxy.close()
+
+    counts = Counter(_captured_event_ids(collector_harness.capture)['traces'])
+    assert {event_id: counts[event_id] for event_id in request.event_ids} == dict.fromkeys(request.event_ids, 1)
+
+
+def test_400_is_not_retried(collector_harness: CollectorHarness) -> None:
+    request = _requests(uuid.uuid4().hex, count=1)[0]
+    proxy = HTTPFaultProxy(collector_harness.endpoint, [400])
+    try:
+        with OTLPExporterHttpSession() as session:
+            response = _post(session, proxy.endpoint, request)
+
+        assert response.status_code == 400
+        assert proxy.attempts == 1
+        assert request.event_ids.isdisjoint(_captured_event_ids(collector_harness.capture)['traces'])
+    finally:
+        proxy.close()
+
+
+def test_lost_success_response_retries_without_loss_but_may_duplicate(collector_harness: CollectorHarness) -> None:
+    request = _requests(uuid.uuid4().hex, count=10)[0]
+    proxy = HTTPFaultProxy(collector_harness.endpoint, ['drop_response'])
+    try:
+        with OTLPExporterHttpSession() as session:
+            response = _post(session, proxy.endpoint, request)
+
+        assert response.status_code == 200
+        proxy.wait_for_attempts(2)
+        _wait_for_requests(collector_harness.capture, [request])
+    finally:
+        proxy.close()
+
+    counts = Counter(_captured_event_ids(collector_harness.capture)['traces'])
+    assert {event_id: counts[event_id] for event_id in request.event_ids} == dict.fromkeys(request.event_ids, 2)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,7 @@ from logfire._internal.cli.run import (
     instrumented_packages_text,
 )
 from logfire._internal.config import LogfireConfigWarning, LogfireCredentials, sanitize_project_name
+from logfire._internal.http_transport import LogfireHTTPAdapter
 from logfire._internal.utils import READ_TOKEN_FILENAME
 from logfire.exceptions import LogfireConfigError
 from tests.import_used_for_tests import run_script_test
@@ -106,6 +107,27 @@ def test_whoami_token_env_var(capsys: pytest.CaptureFixture[str]) -> None:
 
         assert len(request_mocker.request_history) == 1
         assert capsys.readouterr().err == 'Logfire project URL: fake_project_url\n'
+
+
+def test_cli_owned_session_gets_connection_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    sessions: list[requests.Session] = []
+    install_connection_policy = logfire._internal.cli.install_connection_policy
+
+    def capture_session(session: requests.Session) -> None:
+        install_connection_policy(session)
+        sessions.append(session)
+
+    monkeypatch.setattr(logfire._internal.cli, 'install_connection_policy', capture_session)
+    with patch.dict(os.environ, {'LOGFIRE_TOKEN': 'foobar'}), requests_mock.Mocker() as request_mocker:
+        request_mocker.get(
+            'https://logfire-us.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+
+        main(['whoami'])
+
+    [session] = sessions
+    assert isinstance(session.get_adapter('https://example.com'), LogfireHTTPAdapter)
 
 
 def test_whoami_eu_token_env_var(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -11,9 +11,10 @@ from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.poolmanager import PoolManager
 
+import logfire
 from logfire._internal.auth import UserToken
 from logfire._internal.client import LogfireClient
-from logfire._internal.config import LogfireConfig, LogfireCredentials, VariablesOptions
+from logfire._internal.config import LogfireCredentials, VariablesOptions
 from logfire._internal.exporters.otlp import OTLPExporterHttpSession
 from logfire._internal.http_transport import (
     IDLE_CONNECTION_RECYCLE_SECONDS,
@@ -348,7 +349,9 @@ def _assert_connection_policy(session: requests.Session) -> None:
     assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)
 
 
-def test_credentials_check_session_gets_the_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_credentials_check_session_gets_the_policy(
+    monkeypatch: pytest.MonkeyPatch, config_kwargs: dict[str, Any]
+) -> None:
     captured_session: list[requests.Session] = []
 
     def from_token(cls: type[LogfireCredentials], token: str, session: requests.Session, base_url: str) -> None:
@@ -358,7 +361,8 @@ def test_credentials_check_session_gets_the_policy(monkeypatch: pytest.MonkeyPat
 
     monkeypatch.setattr(LogfireCredentials, 'from_token', classmethod(from_token))
 
-    assert LogfireConfig()._initialize_credentials_from_token('test-token') is None  # pyright: ignore[reportPrivateUsage]
+    config_kwargs.update(send_to_logfire=True, token='test-token')
+    logfire.configure(**config_kwargs)
     [session] = captured_session
     _assert_connection_policy(session)
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -159,6 +159,11 @@ def test_a_busy_session_still_recycles_a_connection_that_sat_idle(pool: Any, clo
     One Logfire session carries traces, metrics and logs from different threads. A steady trace
     stream keeps the session busy while the connection that last served a metric export waits out
     the whole export interval, so a session-level clock would never fire for it.
+
+    This is the LIFO shape that makes the window matter: sequential traffic reuses whatever sits
+    on top of the stack, so a connection opened during a brief overlap is left underneath and
+    goes cold, then gets handed back out at the next overlap. Measured on a real session, 98 of
+    99 requests went to one connection while another was used once and abandoned.
     """
     idle_conn, busy_conn = Mock(name='idle'), Mock(name='busy')
     pool._put_conn(idle_conn)  # parked at the bottom of the LIFO pool

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -29,6 +29,7 @@ from logfire._internal.http_transport import (
     keepalive_socket_options,
 )
 from logfire.variables.remote import LogfireRemoteVariableProvider
+from tests.test_configure import wait_for_check_token_thread
 
 
 def test_keepalive_socket_options_enable_keepalive_and_keep_urllib3_defaults() -> None:
@@ -363,6 +364,7 @@ def test_credentials_check_session_gets_the_policy(
 
     config_kwargs.update(send_to_logfire=True, token='test-token')
     logfire.configure(**config_kwargs)
+    wait_for_check_token_thread()
     [session] = captured_session
     _assert_connection_policy(session)
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -13,11 +13,13 @@ from urllib3.poolmanager import PoolManager
 
 from logfire._internal.auth import UserToken
 from logfire._internal.client import LogfireClient
-from logfire._internal.config import VariablesOptions
+from logfire._internal.config import LogfireConfig, LogfireCredentials, VariablesOptions
 from logfire._internal.exporters.otlp import OTLPExporterHttpSession
 from logfire._internal.http_transport import (
     IDLE_CONNECTION_RECYCLE_SECONDS,
+    TCP_KEEPALIVE_FAILED_PROBES,
     TCP_KEEPALIVE_IDLE_SECONDS,
+    TCP_KEEPALIVE_INTERVAL_SECONDS,
     LogfireHTTPAdapter,
     _IdleRecyclingPoolMixin,  # pyright: ignore[reportPrivateUsage]
     _install_recycling_pools,  # pyright: ignore[reportPrivateUsage]
@@ -45,6 +47,21 @@ def test_keepalive_idle_option_is_set_on_platforms_that_have_one() -> None:
     idle_options = {getattr(socket, name) for name in names}
     values = [value for (_level, option, value) in keepalive_socket_options() if option in idle_options]
     assert values == [TCP_KEEPALIVE_IDLE_SECONDS]
+
+
+@pytest.mark.parametrize(
+    ('option_name', 'expected'),
+    [
+        ('TCP_KEEPINTVL', TCP_KEEPALIVE_INTERVAL_SECONDS),
+        ('TCP_KEEPCNT', TCP_KEEPALIVE_FAILED_PROBES),
+    ],
+)
+def test_keepalive_probe_options_are_tuned_when_supported(option_name: str, expected: int) -> None:
+    option = getattr(socket, option_name, None)
+    if option is None:  # pragma: no cover
+        pytest.skip(f'platform exposes no {option_name}')
+
+    assert (socket.IPPROTO_TCP, option, expected) in keepalive_socket_options()
 
 
 def test_the_macos_spelling_of_the_idle_option_is_used_when_it_is_the_only_one(
@@ -87,6 +104,31 @@ def test_a_connection_class_without_default_socket_options(monkeypatch: pytest.M
 def test_adapter_passes_socket_options_to_the_pool() -> None:
     adapter = LogfireHTTPAdapter()
     assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in adapter.poolmanager.connection_pool_kw['socket_options']
+
+
+def test_connected_socket_has_tuned_tcp_keepalive() -> None:
+    with socket.socket() as listener:
+        listener.bind(('127.0.0.1', 0))
+        listener.listen()
+
+        adapter = LogfireHTTPAdapter()
+        pool: Any = adapter.poolmanager.connection_from_host('127.0.0.1', listener.getsockname()[1], scheme='http')
+        connection = pool._new_conn()
+        connection.connect()
+        try:
+            client_socket = connection.sock
+            assert client_socket is not None
+            assert client_socket.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE) == 1
+
+            idle_option = getattr(socket, 'TCP_KEEPIDLE', None) or getattr(socket, 'TCP_KEEPALIVE', None)
+            if idle_option is not None:
+                assert client_socket.getsockopt(socket.IPPROTO_TCP, idle_option) == TCP_KEEPALIVE_IDLE_SECONDS
+            if interval_option := getattr(socket, 'TCP_KEEPINTVL', None):
+                assert client_socket.getsockopt(socket.IPPROTO_TCP, interval_option) == TCP_KEEPALIVE_INTERVAL_SECONDS
+            if probe_option := getattr(socket, 'TCP_KEEPCNT', None):
+                assert client_socket.getsockopt(socket.IPPROTO_TCP, probe_option) == TCP_KEEPALIVE_FAILED_PROBES
+        finally:
+            connection.close()
 
 
 def test_explicit_socket_options_are_not_overridden() -> None:
@@ -300,6 +342,27 @@ def _remote_variables_session() -> requests.Session:
     return provider._session  # pyright: ignore[reportPrivateUsage]
 
 
+def _assert_connection_policy(session: requests.Session) -> None:
+    adapter = session.get_adapter('https://example.com')
+    assert isinstance(adapter, LogfireHTTPAdapter)
+    assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)
+
+
+def test_credentials_check_session_gets_the_policy(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_session: list[requests.Session] = []
+
+    def from_token(cls: type[LogfireCredentials], token: str, session: requests.Session, base_url: str) -> None:
+        assert token == 'test-token'
+        assert base_url == 'https://logfire-us.pydantic.dev'
+        captured_session.append(session)
+
+    monkeypatch.setattr(LogfireCredentials, 'from_token', classmethod(from_token))
+
+    assert LogfireConfig()._initialize_credentials_from_token('test-token') is None  # pyright: ignore[reportPrivateUsage]
+    [session] = captured_session
+    _assert_connection_policy(session)
+
+
 def test_the_sse_stream_session_gets_the_policy() -> None:
     """The SSE stream is the longest-lived connection the SDK opens, so it matters most there.
 
@@ -309,9 +372,7 @@ def test_the_sse_stream_session_gets_the_policy() -> None:
     provider = LogfireRemoteVariableProvider(base_url='https://x', token='t', options=VariablesOptions())
 
     with provider._new_sse_session() as session:  # pyright: ignore[reportPrivateUsage]
-        adapter = session.get_adapter('https://example.com')
-        assert isinstance(adapter, LogfireHTTPAdapter)
-        assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)
+        _assert_connection_policy(session)
         # Still the SSE session, not the polling one.
         assert session.headers['Accept'] == 'text/event-stream'
 
@@ -326,7 +387,4 @@ def test_the_sse_stream_session_gets_the_policy() -> None:
 )
 def test_sessions_logfire_owns_get_the_policy(make_session: Any) -> None:
     session = make_session()
-    adapter = session.get_adapter('https://example.com')
-
-    assert isinstance(adapter, LogfireHTTPAdapter)
-    assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)
+    _assert_connection_policy(session)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -7,7 +7,6 @@ from unittest.mock import Mock
 
 import pytest
 import requests
-from requests.adapters import HTTPAdapter
 from urllib3.connection import HTTPConnection
 
 from logfire._internal.auth import UserToken
@@ -18,6 +17,8 @@ from logfire._internal.http_transport import (
     IDLE_CONNECTION_RECYCLE_SECONDS,
     TCP_KEEPALIVE_IDLE_SECONDS,
     LogfireHTTPAdapter,
+    _IdleRecyclingPoolMixin,  # pyright: ignore[reportPrivateUsage]
+    _pool_classes,  # pyright: ignore[reportPrivateUsage]
     install_connection_policy,
     keepalive_socket_options,
 )
@@ -55,70 +56,96 @@ def test_explicit_socket_options_are_not_overridden() -> None:
     assert adapter.poolmanager.connection_pool_kw['socket_options'] == []
 
 
+def test_adapter_registers_the_recycling_pools() -> None:
+    adapter = LogfireHTTPAdapter(idle_recycle_seconds=11)
+    classes = adapter.poolmanager.pool_classes_by_scheme
+
+    for scheme in ('http', 'https'):
+        assert issubclass(classes[scheme], _IdleRecyclingPoolMixin)
+        assert classes[scheme].idle_recycle_seconds == 11
+
+
 @pytest.fixture
 def clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
     now = [1000.0]
-    monkeypatch.setattr('logfire._internal.http_transport.time.monotonic', lambda: now[0])
+    # Patch the module's own indirection rather than `time.monotonic`, which urllib3 shares.
+    monkeypatch.setattr('logfire._internal.http_transport._now', lambda: now[0])
     return now
 
 
+def make_pool(monkeypatch: pytest.MonkeyPatch, idle_recycle_seconds: float) -> Any:
+    def not_dropped(conn: Any) -> bool:
+        return False
+
+    # Mock connections are not real sockets, so urllib3's own liveness check must stand aside.
+    monkeypatch.setattr('urllib3.connectionpool.is_connection_dropped', not_dropped)
+    pool = _pool_classes(idle_recycle_seconds)['https']('example.com', maxsize=5)
+    # urllib3 pre-fills the pool with `None` placeholders; drain them so seeded connections are
+    # not discarded as "pool is full".
+    while not pool.pool.empty():
+        pool.pool.get(block=False)
+    return pool
+
+
 @pytest.fixture
-def make_adapter(monkeypatch: pytest.MonkeyPatch, clock: list[float]):
-    """Build a real adapter whose network send is stubbed and whose pool clears are recorded."""
-
-    def factory(*, send_duration: float = 0.0, **kwargs: Any) -> LogfireHTTPAdapter:
-        def fake_send(self: HTTPAdapter, *args: Any, **kw: Any) -> Any:
-            clock[0] += send_duration
-            return Mock()
-
-        monkeypatch.setattr(HTTPAdapter, 'send', fake_send)
-        adapter = LogfireHTTPAdapter(**kwargs)
-        adapter.poolmanager = Mock(wraps=adapter.poolmanager)
-        return adapter
-
-    return factory
+def pool(monkeypatch: pytest.MonkeyPatch, clock: list[float]) -> Any:
+    return make_pool(monkeypatch, IDLE_CONNECTION_RECYCLE_SECONDS)
 
 
-def test_pool_is_not_cleared_within_the_idle_window(make_adapter: Any, clock: list[float]) -> None:
-    adapter = make_adapter()
+def test_connection_used_within_the_window_is_reused(pool: Any, clock: list[float]) -> None:
+    conn = Mock()
+    pool._put_conn(conn)
+
     clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS - 1
-    adapter.send(Mock())
-    adapter.poolmanager.clear.assert_not_called()
+
+    assert pool._get_conn() is conn
+    conn.close.assert_not_called()
 
 
-def test_pool_is_cleared_after_the_idle_window(make_adapter: Any, clock: list[float]) -> None:
-    adapter = make_adapter()
+def test_connection_idle_beyond_the_window_is_closed(pool: Any, clock: list[float]) -> None:
+    conn = Mock()
+    pool._put_conn(conn)
+
     clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS + 1
-    adapter.send(Mock())
-    adapter.poolmanager.clear.assert_called_once()
+
+    # urllib3 reconnects lazily, so the connection is still handed back, just closed first.
+    assert pool._get_conn() is conn
+    conn.close.assert_called_once()
 
 
-def test_steady_use_never_clears_the_pool(make_adapter: Any, clock: list[float]) -> None:
-    """A session used more often than the window keeps its connections."""
-    adapter = make_adapter()
-    for _ in range(10):
+def test_a_busy_session_still_recycles_a_connection_that_sat_idle(pool: Any, clock: list[float]) -> None:
+    """Idleness is per connection, not per session.
+
+    One Logfire session carries traces, metrics and logs from different threads. A steady trace
+    stream keeps the session busy while the connection that last served a metric export waits out
+    the whole export interval, so a session-level clock would never fire for it.
+    """
+    idle_conn, busy_conn = Mock(name='idle'), Mock(name='busy')
+    pool._put_conn(idle_conn)  # parked at the bottom of the LIFO pool
+    pool._put_conn(busy_conn)
+
+    # Traffic keeps cycling the top connection well inside the window.
+    for _ in range(5):
         clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS / 2
-        adapter.send(Mock())
-    adapter.poolmanager.clear.assert_not_called()
+        assert pool._get_conn() is busy_conn
+        pool._put_conn(busy_conn)
+    busy_conn.close.assert_not_called()
+
+    # The one underneath has been idle the whole time and must not be trusted.
+    assert pool._get_conn() is busy_conn
+    assert pool._get_conn() is idle_conn
+    idle_conn.close.assert_called_once()
 
 
-def test_a_slow_response_does_not_count_as_idleness(make_adapter: Any, clock: list[float]) -> None:
-    """The clock is stamped on completion, so a long read must not trigger the next clear."""
-    adapter = make_adapter(send_duration=IDLE_CONNECTION_RECYCLE_SECONDS * 3)
+def test_recycle_window_is_configurable(monkeypatch: pytest.MonkeyPatch, clock: list[float]) -> None:
+    pool = make_pool(monkeypatch, idle_recycle_seconds=5)
+    conn = Mock()
+    pool._put_conn(conn)
 
-    adapter.send(Mock())
-    adapter.poolmanager.clear.assert_not_called()
-
-    clock[0] += 1
-    adapter.send(Mock())
-    adapter.poolmanager.clear.assert_not_called()
-
-
-def test_idle_recycle_seconds_is_configurable(make_adapter: Any, clock: list[float]) -> None:
-    adapter = make_adapter(idle_recycle_seconds=5)
     clock[0] += 6
-    adapter.send(Mock())
-    adapter.poolmanager.clear.assert_called_once()
+
+    pool._get_conn()
+    conn.close.assert_called_once()
 
 
 def test_install_connection_policy_mounts_both_schemes() -> None:
@@ -127,18 +154,16 @@ def test_install_connection_policy_mounts_both_schemes() -> None:
 
     http, https = session.get_adapter('http://x'), session.get_adapter('https://x')
     assert isinstance(https, LogfireHTTPAdapter)
-    # One adapter for both schemes, so idleness is tracked per session.
+    # One adapter for both schemes, so a session has a single pool manager.
     assert http is https
 
 
 def test_adapter_survives_pickling() -> None:
-    """`requests.Session` is picklable and the lock is not, so it must be rebuilt on unpickling."""
+    """`requests.Session` is picklable, so the adapter must rebuild its pools on unpickling."""
     restored = pickle.loads(pickle.dumps(LogfireHTTPAdapter(idle_recycle_seconds=7)))
 
     assert isinstance(restored, LogfireHTTPAdapter)
-    assert restored._idle_recycle_seconds == 7  # pyright: ignore[reportPrivateUsage]
-    # Without a rebuilt lock this would raise AttributeError rather than reach the stubbed send.
-    assert restored._recycle_lock is not None  # pyright: ignore[reportPrivateUsage]
+    assert restored.poolmanager.pool_classes_by_scheme['https'].idle_recycle_seconds == 7
 
 
 def _otlp_exporter_session() -> requests.Session:
@@ -165,4 +190,7 @@ def _remote_variables_session() -> requests.Session:
 )
 def test_sessions_logfire_owns_get_the_policy(make_session: Any) -> None:
     session = make_session()
-    assert isinstance(session.get_adapter('https://example.com'), LogfireHTTPAdapter)
+    adapter = session.get_adapter('https://example.com')
+
+    assert isinstance(adapter, LogfireHTTPAdapter)
+    assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -300,6 +300,22 @@ def _remote_variables_session() -> requests.Session:
     return provider._session  # pyright: ignore[reportPrivateUsage]
 
 
+def test_the_sse_stream_session_gets_the_policy() -> None:
+    """The SSE stream is the longest-lived connection the SDK opens, so it matters most there.
+
+    It is built by its own session rather than the polling one, so covering the provider's
+    polling session says nothing about it.
+    """
+    provider = LogfireRemoteVariableProvider(base_url='https://x', token='t', options=VariablesOptions())
+
+    with provider._new_sse_session() as session:  # pyright: ignore[reportPrivateUsage]
+        adapter = session.get_adapter('https://example.com')
+        assert isinstance(adapter, LogfireHTTPAdapter)
+        assert issubclass(adapter.poolmanager.pool_classes_by_scheme['https'], _IdleRecyclingPoolMixin)
+        # Still the SSE session, not the polling one.
+        assert session.headers['Accept'] == 'text/event-stream'
+
+
 @pytest.mark.parametrize(
     'make_session',
     [

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pickle
+import socket
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.connection import HTTPConnection
+
+from logfire._internal.auth import UserToken
+from logfire._internal.client import LogfireClient
+from logfire._internal.config import VariablesOptions
+from logfire._internal.exporters.otlp import OTLPExporterHttpSession
+from logfire._internal.http_transport import (
+    IDLE_CONNECTION_RECYCLE_SECONDS,
+    TCP_KEEPALIVE_IDLE_SECONDS,
+    LogfireHTTPAdapter,
+    install_connection_policy,
+    keepalive_socket_options,
+)
+from logfire.variables.remote import LogfireRemoteVariableProvider
+
+
+def test_keepalive_socket_options_enable_keepalive_and_keep_urllib3_defaults() -> None:
+    options = keepalive_socket_options()
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in options
+    # TCP_NODELAY is urllib3's own default and must survive.
+    for default in HTTPConnection.default_socket_options:
+        assert default in options
+
+
+def test_keepalive_idle_option_is_set_on_platforms_that_have_one() -> None:
+    names = [name for name in ('TCP_KEEPIDLE', 'TCP_KEEPALIVE') if hasattr(socket, name)]
+    if not names:  # pragma: no cover
+        pytest.skip('platform exposes no keepalive idle option')
+
+    idle_options = {getattr(socket, name) for name in names}
+    values = [value for (_level, option, value) in keepalive_socket_options() if option in idle_options]
+    assert values == [TCP_KEEPALIVE_IDLE_SECONDS]
+
+
+def test_adapter_passes_socket_options_to_the_pool() -> None:
+    adapter = LogfireHTTPAdapter()
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in adapter.poolmanager.connection_pool_kw['socket_options']
+
+
+def test_explicit_socket_options_are_not_overridden() -> None:
+    """`setdefault` semantics: a caller passing their own options keeps them."""
+    adapter = LogfireHTTPAdapter()
+    adapter.init_poolmanager(1, 1, socket_options=[])
+    assert adapter.poolmanager.connection_pool_kw['socket_options'] == []
+
+
+@pytest.fixture
+def clock(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    now = [1000.0]
+    monkeypatch.setattr('logfire._internal.http_transport.time.monotonic', lambda: now[0])
+    return now
+
+
+@pytest.fixture
+def make_adapter(monkeypatch: pytest.MonkeyPatch, clock: list[float]):
+    """Build a real adapter whose network send is stubbed and whose pool clears are recorded."""
+
+    def factory(*, send_duration: float = 0.0, **kwargs: Any) -> LogfireHTTPAdapter:
+        def fake_send(self: HTTPAdapter, *args: Any, **kw: Any) -> Any:
+            clock[0] += send_duration
+            return Mock()
+
+        monkeypatch.setattr(HTTPAdapter, 'send', fake_send)
+        adapter = LogfireHTTPAdapter(**kwargs)
+        adapter.poolmanager = Mock(wraps=adapter.poolmanager)
+        return adapter
+
+    return factory
+
+
+def test_pool_is_not_cleared_within_the_idle_window(make_adapter: Any, clock: list[float]) -> None:
+    adapter = make_adapter()
+    clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS - 1
+    adapter.send(Mock())
+    adapter.poolmanager.clear.assert_not_called()
+
+
+def test_pool_is_cleared_after_the_idle_window(make_adapter: Any, clock: list[float]) -> None:
+    adapter = make_adapter()
+    clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS + 1
+    adapter.send(Mock())
+    adapter.poolmanager.clear.assert_called_once()
+
+
+def test_steady_use_never_clears_the_pool(make_adapter: Any, clock: list[float]) -> None:
+    """A session used more often than the window keeps its connections."""
+    adapter = make_adapter()
+    for _ in range(10):
+        clock[0] += IDLE_CONNECTION_RECYCLE_SECONDS / 2
+        adapter.send(Mock())
+    adapter.poolmanager.clear.assert_not_called()
+
+
+def test_a_slow_response_does_not_count_as_idleness(make_adapter: Any, clock: list[float]) -> None:
+    """The clock is stamped on completion, so a long read must not trigger the next clear."""
+    adapter = make_adapter(send_duration=IDLE_CONNECTION_RECYCLE_SECONDS * 3)
+
+    adapter.send(Mock())
+    adapter.poolmanager.clear.assert_not_called()
+
+    clock[0] += 1
+    adapter.send(Mock())
+    adapter.poolmanager.clear.assert_not_called()
+
+
+def test_idle_recycle_seconds_is_configurable(make_adapter: Any, clock: list[float]) -> None:
+    adapter = make_adapter(idle_recycle_seconds=5)
+    clock[0] += 6
+    adapter.send(Mock())
+    adapter.poolmanager.clear.assert_called_once()
+
+
+def test_install_connection_policy_mounts_both_schemes() -> None:
+    session = requests.Session()
+    install_connection_policy(session)
+
+    http, https = session.get_adapter('http://x'), session.get_adapter('https://x')
+    assert isinstance(https, LogfireHTTPAdapter)
+    # One adapter for both schemes, so idleness is tracked per session.
+    assert http is https
+
+
+def test_adapter_survives_pickling() -> None:
+    """`requests.Session` is picklable and the lock is not, so it must be rebuilt on unpickling."""
+    restored = pickle.loads(pickle.dumps(LogfireHTTPAdapter(idle_recycle_seconds=7)))
+
+    assert isinstance(restored, LogfireHTTPAdapter)
+    assert restored._idle_recycle_seconds == 7  # pyright: ignore[reportPrivateUsage]
+    # Without a rebuilt lock this would raise AttributeError rather than reach the stubbed send.
+    assert restored._recycle_lock is not None  # pyright: ignore[reportPrivateUsage]
+
+
+def _otlp_exporter_session() -> requests.Session:
+    return OTLPExporterHttpSession()
+
+
+def _logfire_client_session() -> requests.Session:
+    token = UserToken(token='abc', base_url='http://localhost', expiration='2099-12-31T23:59:59')
+    return LogfireClient(user_token=token)._session  # pyright: ignore[reportPrivateUsage]
+
+
+def _remote_variables_session() -> requests.Session:
+    provider = LogfireRemoteVariableProvider(base_url='https://x', token='t', options=VariablesOptions())
+    return provider._session  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.parametrize(
+    'make_session',
+    [
+        pytest.param(_otlp_exporter_session, id='otlp-exporter'),
+        pytest.param(_logfire_client_session, id='logfire-client'),
+        pytest.param(_remote_variables_session, id='remote-variables'),
+    ],
+)
+def test_sessions_logfire_owns_get_the_policy(make_session: Any) -> None:
+    session = make_session()
+    assert isinstance(session.get_adapter('https://example.com'), LogfireHTTPAdapter)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -7,8 +7,8 @@ from unittest.mock import Mock
 
 import pytest
 import requests
-from urllib3.connection import HTTPConnection
-from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.poolmanager import PoolManager
 
 from logfire._internal.auth import UserToken
@@ -94,6 +94,32 @@ def test_explicit_socket_options_are_not_overridden() -> None:
     adapter = LogfireHTTPAdapter()
     adapter.init_poolmanager(1, 1, socket_options=[])
     assert adapter.poolmanager.connection_pool_kw['socket_options'] == []
+
+
+@pytest.mark.parametrize(
+    ('base', 'expected_connection', 'expected_scheme'),
+    [
+        (HTTPConnectionPool, HTTPConnection, 'http'),
+        (HTTPSConnectionPool, HTTPSConnection, 'https'),
+    ],
+)
+def test_derived_pools_keep_their_own_connection_class(
+    base: type[HTTPConnectionPool], expected_connection: type[HTTPConnection], expected_scheme: str
+) -> None:
+    """The mixin must not shadow `ConnectionCls`, or HTTPS pools would open plaintext connections.
+
+    It inherits `HTTPConnectionPool` so the `super()` calls resolve for type checking, which
+    raises the fair question of whether an HTTPS pool then builds plain `HTTPConnection`s. It does
+    not: the mixin defines neither `ConnectionCls` nor `scheme` in its own `__dict__`, and
+    attribute lookup walks each class's own `__dict__` along the MRO, so `HTTPSConnectionPool`
+    is the first to supply them.
+    """
+    cls = _recycling_pool_class(base, IDLE_CONNECTION_RECYCLE_SECONDS)
+
+    assert cls.ConnectionCls is expected_connection
+    assert cls.scheme == expected_scheme
+    assert 'ConnectionCls' not in _IdleRecyclingPoolMixin.__dict__
+    assert 'scheme' not in _IdleRecyclingPoolMixin.__dict__
 
 
 def test_adapter_registers_the_recycling_pools() -> None:

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock
 import pytest
 import requests
 from urllib3.connection import HTTPConnection
+from urllib3.connectionpool import HTTPSConnectionPool
+from urllib3.poolmanager import PoolManager
 
 from logfire._internal.auth import UserToken
 from logfire._internal.client import LogfireClient
@@ -18,7 +20,8 @@ from logfire._internal.http_transport import (
     TCP_KEEPALIVE_IDLE_SECONDS,
     LogfireHTTPAdapter,
     _IdleRecyclingPoolMixin,  # pyright: ignore[reportPrivateUsage]
-    _pool_classes,  # pyright: ignore[reportPrivateUsage]
+    _install_recycling_pools,  # pyright: ignore[reportPrivateUsage]
+    _recycling_pool_class,  # pyright: ignore[reportPrivateUsage]
     install_connection_policy,
     keepalive_socket_options,
 )
@@ -42,6 +45,43 @@ def test_keepalive_idle_option_is_set_on_platforms_that_have_one() -> None:
     idle_options = {getattr(socket, name) for name in names}
     values = [value for (_level, option, value) in keepalive_socket_options() if option in idle_options]
     assert values == [TCP_KEEPALIVE_IDLE_SECONDS]
+
+
+def test_the_macos_spelling_of_the_idle_option_is_used_when_it_is_the_only_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Linux calls it TCP_KEEPIDLE, macOS calls the same thing TCP_KEEPALIVE."""
+    monkeypatch.delattr(socket, 'TCP_KEEPIDLE', raising=False)
+    monkeypatch.setattr(socket, 'TCP_KEEPALIVE', 0x10, raising=False)
+
+    assert (socket.IPPROTO_TCP, 0x10, TCP_KEEPALIVE_IDLE_SECONDS) in keepalive_socket_options()
+
+
+def test_a_platform_missing_an_option_still_gets_the_rest(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ('TCP_KEEPIDLE', 'TCP_KEEPALIVE', 'TCP_KEEPINTVL', 'TCP_KEEPCNT'):
+        monkeypatch.delattr(socket, name, raising=False)
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in keepalive_socket_options()
+
+
+def test_a_platform_without_keepalive_leaves_the_defaults_alone(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delattr(socket, 'SO_KEEPALIVE', raising=False)
+
+    assert keepalive_socket_options() == list(HTTPConnection.default_socket_options)
+
+
+def test_a_connection_class_without_default_socket_options(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Under Pyodide `urllib3` swaps in an Emscripten connection that has no defaults at all."""
+
+    class EmscriptenLikeConnection:
+        pass
+
+    monkeypatch.setattr('urllib3.connection.HTTPConnection', EmscriptenLikeConnection)
+    options = keepalive_socket_options()
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in options
+    for default in HTTPConnection.default_socket_options:
+        assert default not in options
 
 
 def test_adapter_passes_socket_options_to_the_pool() -> None:
@@ -79,7 +119,7 @@ def make_pool(monkeypatch: pytest.MonkeyPatch, idle_recycle_seconds: float) -> A
 
     # Mock connections are not real sockets, so urllib3's own liveness check must stand aside.
     monkeypatch.setattr('urllib3.connectionpool.is_connection_dropped', not_dropped)
-    pool = _pool_classes(idle_recycle_seconds)['https']('example.com', maxsize=5)
+    pool: Any = _recycling_pool_class(HTTPSConnectionPool, idle_recycle_seconds)('example.com', maxsize=5)
     # urllib3 pre-fills the pool with `None` placeholders; drain them so seeded connections are
     # not discarded as "pool is full".
     while not pool.pool.empty():
@@ -148,6 +188,54 @@ def test_recycle_window_is_configurable(monkeypatch: pytest.MonkeyPatch, clock: 
     conn.close.assert_called_once()
 
 
+def test_connections_urllib3_never_pooled_are_passed_through(pool: Any) -> None:
+    """`urllib3` puts `None` back after a failed request, and builds fresh connections lazily."""
+    pool._put_conn(None)
+
+    conn = pool._get_conn()
+
+    assert not hasattr(conn, '_logfire_idle_since')
+
+
+def test_recycling_pools_are_derived_from_the_classes_the_manager_already_uses() -> None:
+    """A SOCKS proxy manager brings pool classes of its own, which must not be replaced."""
+
+    class CustomPool(HTTPSConnectionPool):
+        pass
+
+    manager = PoolManager()
+    manager.pool_classes_by_scheme = {'https': CustomPool}  # pyright: ignore[reportAttributeAccessIssue]
+
+    _install_recycling_pools(manager, IDLE_CONNECTION_RECYCLE_SECONDS)
+
+    installed = manager.pool_classes_by_scheme['https']
+    assert issubclass(installed, CustomPool)
+    assert issubclass(installed, _IdleRecyclingPoolMixin)
+
+
+def test_proxied_requests_get_the_policy_too() -> None:
+    """`requests` builds a separate manager per proxy, which `init_poolmanager` never sees."""
+    adapter = LogfireHTTPAdapter(idle_recycle_seconds=13)
+
+    manager = adapter.proxy_manager_for('http://proxy.example.com')
+
+    assert (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in manager.connection_pool_kw['socket_options']
+    pool_class = manager.pool_classes_by_scheme['https']
+    assert issubclass(pool_class, _IdleRecyclingPoolMixin)
+    assert pool_class.idle_recycle_seconds == 13
+
+
+def test_a_reused_proxy_manager_is_not_wrapped_again() -> None:
+    """`requests` caches proxy managers, so re-applying the policy must be a no-op."""
+    adapter = LogfireHTTPAdapter()
+    proxy = 'http://proxy.example.com'
+
+    first = adapter.proxy_manager_for(proxy).pool_classes_by_scheme['https']
+    second = adapter.proxy_manager_for(proxy).pool_classes_by_scheme['https']
+
+    assert first is second
+
+
 def test_install_connection_policy_mounts_both_schemes() -> None:
     session = requests.Session()
     install_connection_policy(session)
@@ -163,6 +251,7 @@ def test_adapter_survives_pickling() -> None:
     restored = pickle.loads(pickle.dumps(LogfireHTTPAdapter(idle_recycle_seconds=7)))
 
     assert isinstance(restored, LogfireHTTPAdapter)
+    assert restored._idle_recycle_seconds == 7  # pyright: ignore[reportPrivateUsage]
     assert restored.poolmanager.pool_classes_by_scheme['https'].idle_recycle_seconds == 7
 
 

--- a/tests/test_otel_collector_faults.py
+++ b/tests/test_otel_collector_faults.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import socket
+import time
+
+from tests.otel_collector.faults import StaleConnectionProxy
+
+
+def test_connect_proxy_allows_headers_to_arrive_in_multiple_packets() -> None:
+    with socket.socket() as upstream:
+        upstream.bind(('127.0.0.1', 0))
+        upstream.listen()
+        proxy = StaleConnectionProxy('127.0.0.1', upstream.getsockname()[1], accept_connect=True)
+        try:
+            with socket.create_connection(('127.0.0.1', int(proxy.endpoint.rsplit(':', 1)[1]))) as client:
+                client.settimeout(1)
+                client.sendall(b'CONNECT localhost:443 HTTP/1.1\r\nHost: local')
+                time.sleep(0.15)
+                client.sendall(b'host:443\r\n\r\n')
+
+                assert client.recv(4096).startswith(b'HTTP/1.1 200 Connection Established\r\n')
+        finally:
+            proxy.close()

--- a/tests/test_otel_collector_harness.py
+++ b/tests/test_otel_collector_harness.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from tests.otel_collector.conftest import CollectorHarness, collector_harness
+
+
+def test_collector_setup_failure_removes_generated_private_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    artifacts_dir = tmp_path / 'artifacts'
+    commands: list[list[str]] = []
+
+    class TempPathFactory:
+        def mktemp(self, basename: str) -> Path:
+            assert basename == 'otel-collector-artifacts'
+            return artifacts_dir
+
+    def run(command: list[str], *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if command[0] == 'openssl':
+            Path(command[command.index('-keyout') + 1]).write_text('private key')
+            return subprocess.CompletedProcess(command, 1, '', 'certificate generation failed')
+        assert command[:2] in (['docker', 'logs'], ['docker', 'rm'])
+        return subprocess.CompletedProcess(command, 1 if command[1] == 'logs' else 0, '', '')
+
+    def which(executable: str) -> str:
+        return f'/usr/bin/{executable}'
+
+    monkeypatch.setattr('shutil.which', which)
+    monkeypatch.setattr('subprocess.run', run)
+
+    fixture = cast(
+        Callable[[pytest.TempPathFactory], Iterator[CollectorHarness]], getattr(collector_harness, '__wrapped__')
+    )
+    generator = fixture(cast(pytest.TempPathFactory, TempPathFactory()))
+    with pytest.raises(pytest.fail.Exception, match='failed to generate Collector certificate'):
+        next(generator)
+
+    assert not (artifacts_dir / 'key.pem').exists()
+    assert (artifacts_dir / 'captured-otlp.json').exists()
+    assert any(command[:3] == ['docker', 'rm', '--force'] for command in commands)


### PR DESCRIPTION
## Summary

- Add a digest-pinned OpenTelemetry Collector conformance suite for traces, metrics, logs, and TLS.
- Exercise stale direct and proxied connections, Collector outages and recovery, HTTP retries, disk replay, data loss, and duplicate delivery after a lost acknowledgement.
- Run the suite as a required CI job and retain Collector logs, configuration, certificate, and captured OTLP payloads for diagnosis.

This is stacked on #2309 so the tests exercise that connection-policy change without duplicating its implementation commits. The suite is deterministic fault injection, not a long-running stochastic soak test.

## Test plan

- [x] `make test-otel-collector` — 12 passed
- [x] Focused transport/exporter/CLI tests — 56 passed
- [x] `uv run pytest` — 2,454 passed, 21 skipped, 2 xfailed
- [x] `uv run pre-commit run --all-files`