### PR TITLE
Add LOGFIRE_BASE_URL support to Gateway CLI

### DIFF
--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -162,7 +162,7 @@ logfire gateway launch claude
 ```
 
 !!! note
-    For self-hosted Logfire, run `logfire --base-url "https://<your-logfire-host>" gateway launch claude`. If the Gateway is exposed at a different URL, append `--gateway-url "https://<your-gateway-host>"`.
+    For self-hosted Logfire, set `LOGFIRE_BASE_URL` to your Logfire URL or pass `--base-url "https://<your-logfire-host>"` before `gateway`. If the Gateway is exposed at a different URL, set `LOGFIRE_GATEWAY_URL` or append `--gateway-url "https://<your-gateway-host>"`.
 
 Or run just the proxy and configure a tool manually with `logfire gateway serve`. See the [CLI reference](../../cli.md#ai-gateway-gateway) for details.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -98,7 +98,7 @@ logfire gateway launch claude
 ```
 
 !!! note
-    For self-hosted Logfire, run `logfire --base-url "https://<your-logfire-host>" gateway launch claude`. If the Gateway is exposed at a different URL, append `--gateway-url "https://<your-gateway-host>"`.
+    For self-hosted Logfire, set `LOGFIRE_BASE_URL` to your Logfire URL or pass `--base-url "https://<your-logfire-host>"` before `gateway`. If the Gateway is exposed at a different URL, set `LOGFIRE_GATEWAY_URL` or append `--gateway-url "https://<your-gateway-host>"`.
 
 You can also run only the proxy and configure a tool manually:
 

--- a/logfire/_internal/cli/gateway.py
+++ b/logfire/_internal/cli/gateway.py
@@ -618,7 +618,7 @@ def parse_gateway(args: argparse.Namespace) -> None:
     context = GatewayCommandContext(
         raw_args=list(args.gateway_args or []),
         region=args.region,
-        logfire_url=args.logfire_url,
+        logfire_url=args.logfire_url or os.getenv('LOGFIRE_BASE_URL'),
     )
     command = parse_gateway_command(context)
     code = execute_gateway_command(command, context)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3965,6 +3965,7 @@ def test_gateway_cli_adapter_exits_for_launch(monkeypatch: pytest.MonkeyPatch) -
         return 0
 
     monkeypatch.setattr(gateway_cli, '_run_launch', run_launch)
+    monkeypatch.setenv('LOGFIRE_BASE_URL', 'https://logfire.example.com')
 
     with pytest.raises(SystemExit) as exc_info:
         main(['--region', 'eu', 'gateway', 'launch', 'claude'])
@@ -3994,6 +3995,30 @@ def test_gateway_cli_adapter_exits_for_serve(monkeypatch: pytest.MonkeyPatch) ->
 
     assert exc_info.value.code == 130
     assert calls == [([], gateway_cli.GatewayCommandContext(raw_args=['serve'], region=None, logfire_url=None))]
+
+
+def test_gateway_cli_uses_logfire_base_url_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[list[str], gateway_cli.GatewayCommandContext]] = []
+
+    def run_launch(raw_args: list[str], context: gateway_cli.GatewayCommandContext) -> int:
+        calls.append((raw_args, context))
+        return 0
+
+    monkeypatch.setenv('LOGFIRE_BASE_URL', 'https://logfire.example.com')
+    monkeypatch.setattr(gateway_cli, '_run_launch', run_launch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        main(['gateway', 'launch', 'claude'])
+
+    assert exc_info.value.code == 0
+    assert calls == [
+        (
+            ['claude'],
+            gateway_cli.GatewayCommandContext(
+                raw_args=['launch', 'claude'], region=None, logfire_url='https://logfire.example.com'
+            ),
+        )
+    ]
 
 
 def test_gateway_optional_dependency_error(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Add support for `LOGFIRE_BASE_URL` in the Gateway CLI.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

