### PR TITLE
Recommend one-minute intervals for infrastructure metrics

### DIFF
--- a/docs/guides/web-ui/docker.md
+++ b/docs/guides/web-ui/docker.md
@@ -40,7 +40,7 @@ Containers populate from the standard OpenTelemetry [`docker_stats` receiver](ht
 ```yaml
 receivers:
   docker_stats:
-    collection_interval: 30s
+    collection_interval: 60s
     container_labels_to_metric_labels:   # so the Compose projects tab can group containers
       com.docker.compose.project: compose.project
       com.docker.compose.service: compose.service
@@ -66,6 +66,12 @@ service:
 The receiver reads the local Docker socket (`unix:///var/run/docker.sock` by default) and negotiates the API version automatically; the collector's user just needs permission to read that socket: the `docker` group, or root. The `resourcedetection` processor's `docker` detector reads the host name from that same daemon, so the containers group under their host and link across to the [Hosts view](hosts.md). CPU, memory, network and block-I/O land within a minute or two. For production hardening (memory limiter, batching) see the [OpenTelemetry Collector Overview](../../how-to-guides/otel-collector/otel-collector-overview.md).
 
 The `container_labels_to_metric_labels` mapping is what powers the **Compose projects** tab: `docker_stats` doesn't export container labels on its own, so it lifts Compose's `com.docker.compose.project`/`service` labels into the `compose.project`/`compose.service` attributes the view groups on.
+
+### Control metric volume
+
+Keep `collection_interval: 60s` unless you have a specific need for finer resolution. The receiver defaults to 10 seconds, so setting 60 seconds sends one-sixth as many datapoints while still giving the Docker view a useful operational resolution.
+
+Metric volume scales with the number of containers. Network metrics also split by interface, and block I/O metrics split by device and operation. Leave optional metrics off unless you use them, especially `container.cpu.usage.percpu`, which adds a separate value for every CPU core reported for every container on control groups version 1 (cgroups v1). Use [`excluded_images`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver#configuration) to omit short-lived or irrelevant containers by image, and only promote container labels that you actually group or filter by.
 
 ### Optional extras
 

--- a/docs/guides/web-ui/hosts.md
+++ b/docs/guides/web-ui/hosts.md
@@ -48,7 +48,7 @@ A working setup for a single host (Linux VM, container host, or laptop), exporti
 ```yaml
 receivers:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     # Set root_path: /hostfs when running the collector inside a container
     # with the host filesystem bind-mounted at /hostfs (Linux only).
     scrapers:
@@ -56,7 +56,10 @@ receivers:
       memory: {}
       load:
         cpu_average: true         # normalise load across CPUs
-      disk: {}
+      disk:
+        exclude:
+          devices: ['^(loop|ram)[0-9]+$']
+          match_type: regexp
       filesystem:
         include_virtual_filesystems: false
       network:
@@ -89,6 +92,10 @@ service:
       processors: [memory_limiter, resourcedetection, batch]
       exporters: [otlphttp/logfire]
 ```
+
+Keep the collection interval at 60 seconds unless you have a specific need for finer resolution. Some Collector deployment presets use 10 seconds, which sends six times as many datapoints. The `processes` scraper above is inexpensive because it reports aggregate counts. Do not confuse it with the singular `process` scraper, which reports CPU, memory, and disk metrics for every process ID. Leave `process` off, or filter it to a small set of stable process names. See [Cardinality and cost](../../how-to-guides/otel-collector/host-monitoring.md#cardinality-and-cost) for details.
+
+At a 60-second interval, the **Status** badge has no timing buffer before its one-minute `stale` threshold. Collection, export, or network delays can therefore make a healthy host appear `stale` briefly between samples. Treat short transitions as timing jitter; a sustained `stale` status indicates a collection or export problem. If an uninterrupted `live` badge is operationally important, that is a specific reason to choose a finer interval despite the extra datapoints.
 
 The pipeline shape (`memory_limiter` first, `batch` last, enrichment in the middle) is the same for any other receivers you add. See [OpenTelemetry Collector Overview](../../how-to-guides/otel-collector/otel-collector-overview.md) for the broader patterns and authentication options. If you haven't set anything up, the empty state on the Hosts page also deep-links to the **Everything else** tab of the add-data wizard.
 

--- a/docs/guides/web-ui/hosts.md
+++ b/docs/guides/web-ui/hosts.md
@@ -14,7 +14,7 @@ You'll find Hosts in the project sidebar, between **Services** and **Kubernetes*
 
 Each row is a host, with at-a-glance columns:
 
-- **Status**: `live` if the host emitted a sample in the last minute, `stale` between 1 and 5 minutes, `down` once it's been over 5 minutes since the last sample.
+- **Status**: `live` if the host emitted a sample in the last 2 minutes, `stale` between 2 and 5 minutes, `down` once it's been over 5 minutes since the last sample.
 - **OS** and architecture.
 - **CPU** with an inline sparkline.
 - **Memory** (percent or bytes depending on what the collector reports).
@@ -94,8 +94,6 @@ service:
 ```
 
 Keep the collection interval at 60 seconds unless you have a specific need for finer resolution. Some Collector deployment presets use 10 seconds, which sends six times as many datapoints. The `processes` scraper above is inexpensive because it reports aggregate counts. Do not confuse it with the singular `process` scraper, which reports CPU, memory, and disk metrics for every process ID. Leave `process` off, or filter it to a small set of stable process names. See [Cardinality and cost](../../how-to-guides/otel-collector/host-monitoring.md#cardinality-and-cost) for details.
-
-At a 60-second interval, the **Status** badge has no timing buffer before its one-minute `stale` threshold. Collection, export, or network delays can therefore make a healthy host appear `stale` briefly between samples. Treat short transitions as timing jitter; a sustained `stale` status indicates a collection or export problem. If an uninterrupted `live` badge is operationally important, that is a specific reason to choose a finer interval despite the extra datapoints.
 
 The pipeline shape (`memory_limiter` first, `batch` last, enrichment in the middle) is the same for any other receivers you add. See [OpenTelemetry Collector Overview](../../how-to-guides/otel-collector/otel-collector-overview.md) for the broader patterns and authentication options. If you haven't set anything up, the empty state on the Hosts page also deep-links to the **Everything else** tab of the add-data wizard.
 

--- a/docs/guides/web-ui/kubernetes.md
+++ b/docs/guides/web-ui/kubernetes.md
@@ -44,7 +44,7 @@ Every detail page links into the [Live View](live.md) for the trace investigatio
 
 ## Setting up
 
-The recommended path is the upstream [`opentelemetry-kube-stack`](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) Helm chart. By default it deploys the OpenTelemetry Operator, a DaemonSet `OpenTelemetryCollector` running every preset this view reads from: `kubeletMetrics` (with `metric_groups` already set to `[node, pod, container]`), `clusterMetrics` (`k8s_cluster` with leader election so it only emits from one pod), `hostMetrics`, `kubernetesAttributes` (the trace-enrichment processor), and `kubernetesEvents`, plus the ServiceAccount, RBAC and CRDs it all needs. You just point its OTLP exporter at Logfire:
+The recommended path is the upstream [`opentelemetry-kube-stack`](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) Helm chart. By default it deploys the OpenTelemetry Operator, a DaemonSet `OpenTelemetryCollector` running every preset this view reads from: `kubeletMetrics`, `clusterMetrics` (`k8s_cluster` with leader election so it only emits from one pod), `hostMetrics`, `kubernetesAttributes` (the trace-enrichment processor), and `kubernetesEvents`, plus the ServiceAccount, role-based access control (RBAC), and custom resource definitions (CRDs) it all needs. You point its OpenTelemetry Protocol (OTLP) exporter at Logfire and reduce the default metric volume:
 
 ```yaml
 # values.yaml: Logfire-shaped overrides for opentelemetry-kube-stack.
@@ -67,6 +67,21 @@ extraEnvs:
 collectors:
   daemon:
     config:
+      # These receiver presets currently use 10 or 15 seconds. One minute is
+      # a better default for infrastructure metrics and sends far fewer points.
+      receivers:
+        host_metrics:
+          collection_interval: 60s
+        kubelet_stats:
+          collection_interval: 60s
+          # Add `volume` only if you need persistent-volume metrics.
+          metric_groups: [node, pod, container]
+          # Keep container IDs for correlation, but skip volume metadata.
+          extra_metadata_labels: [container.id]
+        k8s_cluster:
+          collection_interval: 60s
+          node_conditions_to_report: [Ready]
+          allocatable_types_to_report: [cpu, memory]
       exporters:
         otlphttp/logfire:
           endpoint: https://logfire-us.pydantic.dev   # or https://logfire-eu.pydantic.dev
@@ -90,6 +105,8 @@ helm upgrade --install otel-stack open-telemetry/opentelemetry-kube-stack \
 
 Data starts flowing within a minute or two of the daemon pods reaching `Ready`. The chart wires the `k8sattributes` processor into the daemon's trace pipeline so the **drill-down from a pod to the spans that pod emitted** in the [Live View](live.md) works out of the box.
 
+Keep these metric receivers at 60 seconds unless you have a specific need for finer resolution. The chart's shorter preset intervals send four to six times as many datapoints. The example also leaves the kubelet `volume` group off because the current view does not display persistent-volume metrics. Container, pod, volume, interface, and per-process dimensions can multiply metric volume quickly; see [Control Kubernetes metric volume](../../how-to-guides/otel-collector/kubernetes-monitoring.md#control-kubernetes-metric-volume) before enabling more groups or attributes.
+
 For the full per-piece breakdown (RBAC, both collector configs, the `k8sattributes` processor's pod_association chain, and a kind walkthrough), see the [Kubernetes monitoring](../../how-to-guides/otel-collector/kubernetes-monitoring.md) how-to-guide. For an end-to-end article including a real application sending traces and unified dashboards, see [Full-stack Kubernetes observability with Logfire](https://pydantic.dev/articles/kubernetes-cluster-observability-logfire).
 
 If you have not set anything up yet, the empty state on each tab has a **Set up** button that deep-links to the relevant page of the add-data wizard.
@@ -103,7 +120,7 @@ The chart's `kubernetesEvents` preset turns Kubernetes events (pod scheduling, O
 | Symptom | Likely cause |
 |---------|--------------|
 | Clusters tab is empty or shows `pods: 0` | The cluster-scope collector (or the chart's `clusterMetrics` preset) is not running, or `k8s_cluster` is missing from the metrics pipeline. |
-| Nodes tab CPU and memory columns are blank | `kubeletstats` is running with the default `metric_groups: [container, pod]`. Add `node` to the list (the chart preset includes it by default). |
+| Nodes tab CPU and memory columns are blank | A custom `kubeletstats.metric_groups` list omits `node`. Add `node` to the list (the receiver and chart preset include it by default). |
 | Pod row has no traces to drill into | The `k8sattributes` processor is not on the trace pipeline, so spans never get `k8s.pod.name` etc. attached. The chart wires this in by default; if you assembled the setup by hand, see [Kubernetes monitoring](../../how-to-guides/otel-collector/kubernetes-monitoring.md#what-k8sattributesprocessor-actually-does). |
 | Cluster metrics appear duplicated across nodes | `k8s_cluster` is running on every replica without `k8s_leader_elector`. The chart configures the elector; from-scratch setups must add it. |
 | Two clusters collide as one row in the **Clusters** tab | Both clusters report the same `k8s.cluster.name`. Set a unique `clusterName` on each via the chart's top-level `clusterName:` value or the `resource/cluster` processor in a hand-rolled setup. |

--- a/docs/how-to-guides/cloud-metrics.md
+++ b/docs/how-to-guides/cloud-metrics.md
@@ -31,6 +31,8 @@ For example, you don't want to export your application metrics to Logfire and Go
 
 We recommend you export all application metrics to Logfire directly and then use the OpenTelemetry Collector to collect metrics from your cloud provider that are *not* already being exported to Logfire.
 
+Do not collect cloud metrics more often than every 60 seconds unless you have a specific need for finer resolution. The examples below use 60 seconds, but you can keep a receiver's longer default when you do not need one-minute data. For example, the Google Cloud Monitoring receiver defaults to five minutes. Cloud metric volume also grows with the number of resources, regions, and metric names selected, so collect only the metrics you use in dashboards, queries, or alerts.
+
 ## 2. Collecting Metrics from Google Cloud Platform (GCP)
 
 The [Google Cloud Monitoring receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/googlecloudmonitoringreceiver) allows you to collect metrics from Google Cloud Monitoring (formerly Stackdriver) and forward them to Logfire.

--- a/docs/how-to-guides/otel-collector/host-monitoring.md
+++ b/docs/how-to-guides/otel-collector/host-monitoring.md
@@ -13,7 +13,7 @@ This is also the smallest possible working Collector configuration. The same sha
 ```yaml title="otel-collector-config.yaml"
 receivers:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     scrapers:
       cpu:
         metrics:
@@ -25,11 +25,18 @@ receivers:
             enabled: true
       load:
       disk:
+        exclude:
+          devices: ['^(loop|ram)[0-9]+$']
+          match_type: regexp
       filesystem:
+        include_virtual_filesystems: false
         metrics:
           system.filesystem.utilization:
             enabled: true
       network:
+        exclude:
+          interfaces: [lo, 'veth.*']
+          match_type: regexp
       paging:
       processes:
 
@@ -58,9 +65,9 @@ A few things worth calling out:
 
 - **`resourcedetection`** adds the `host.name` (and on cloud VMs, `cloud.provider`, `cloud.region`, etc.) resource attributes to every metric. The Hosts page groups by `host.name`, so a Collector that omits this processor won't appear there.
 - **`*.utilization` metrics are off by default in the receiver**, but the Hosts page expects them. Enabling `system.cpu.utilization`, `system.memory.utilization`, and `system.filesystem.utilization` populates the **CPU**, **Memory**, and disk columns directly instead of requiring a downstream rate calculation.
-- **Scraper list** is the OTel `hostmetricsreceiver` default set. Drop the ones you don't need to reduce cardinality. `processes` in particular emits a series per running process and can be heavy on busy hosts.
+- **Scraper list** is selected explicitly. Drop the scrapers you don't need to reduce metric volume. `processes` reports a few aggregate process counts per host. The similarly named `process` scraper reports metrics for every process ID (PID) and is intentionally not enabled here.
 - The endpoint must match the region your project lives in (`logfire-eu` or `logfire-us`). The token is a Logfire write token; pass it via the `LOGFIRE_TOKEN` environment variable on the Collector workload.
-- `collection_interval` defaults to `1m` in the receiver. `30s` is a good middle ground; anything faster multiplies series volume (and your bill) without telling you much more about a host.
+- **Keep `collection_interval: 60s` unless you have a specific need for finer resolution.** The standalone receiver already defaults to one minute, but some deployment presets override it to 10 seconds. A 10-second interval sends six times as many datapoints as a 60-second interval, which usually adds cost without making host trends more useful.
 
 ## Scraper reference
 
@@ -68,7 +75,7 @@ Each entry under `scrapers:` enables one source of host metrics. Pick the ones y
 
 | Scraper | What it emits | Linux | macOS | Windows |
 |---|---|---|---|---|
-| `cpu` | Per-core CPU time broken down by state (`user`, `system`, `idle`, `iowait`, ...). | yes | yes | yes |
+| `cpu` | CPU time broken down by state (`user`, `system`, `idle`, `iowait`, ...), aggregated across cores by default. Enabling the `cpu` metric attribute splits it per core. | yes | yes | yes |
 | `memory` | Used / free / cached / buffered bytes and memory utilization. | yes | yes | yes |
 | `load` | 1, 5, and 15 minute system load averages. | yes | yes | yes |
 | `disk` | Block-device I/O counters: bytes read/written, operations, weighted I/O time. | yes | yes | yes |
@@ -88,14 +95,16 @@ For the exhaustive list of metric names and attributes each scraper emits, see t
 The `processes` and `process` scrapers are the two you have to think about.
 
 - `processes` emits a handful of aggregate counts per host. It's cheap.
-- `process` emits **one set of series per process PID**: every short-lived `ps`, every Node worker, every `kubectl exec`. On a busy host or build agent this can mean tens of thousands of active series before lunch, and each new PID is a fresh series even if the binary is identical.
+- `process` emits **one set of series per process PID**: every short-lived `ps`, every Node worker, every `kubectl exec`. On Linux, its default metrics produce roughly seven datapoints per PID on every collection, covering CPU states, disk read/write, memory usage, and virtual memory. The resource also includes the PID and can include the executable, command line, and owner. On a busy host or build agent this can create thousands of datapoints per collection, and each new PID is a fresh series even if the binary is identical.
 
-If you turn on `process`, scope it. The receiver supports `include` and `exclude` filters on process name, and you almost always want one or the other:
+Disk, filesystem, and network metrics also multiply by device, mount point, and interface. The minimal configuration filters loop and memory-backed (`ram`) devices, virtual filesystems, the loopback interface, and virtual Ethernet interfaces. Adjust those filters to your environment rather than collecting infrastructure you never query.
+
+If you turn on `process`, scope it. The receiver supports `include` and `exclude` filters on process name; we recommend using one of them. It does not provide a "top N processes" limit.
 
 ```yaml title="otel-collector-config.yaml"
 receivers:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     scrapers:
       process:
         mute_process_name_error: true
@@ -149,21 +158,28 @@ In Kubernetes you want one Collector per node, scraping that node's host metrics
 Three things have to be right:
 
 1. `hostNetwork: true` and `hostPID: true` on the pod, so the network and process scrapers see the node.
-2. Mount the host's `/proc` and `/sys` into the container (read-only is fine).
+2. Mount the host root at `/host`, with the host's `/proc` and `/sys` available below it (read-only is fine).
 3. Set `root_path: /host` on the `hostmetrics` receiver so it reads from those mounts instead of the container root.
 
 ```yaml title="otel-collector-config.yaml"
 receivers:
   hostmetrics:
-    collection_interval: 30s
+    collection_interval: 60s
     root_path: /host
     scrapers:
       cpu:
       memory:
       load:
       disk:
+        exclude:
+          devices: ['^(loop|ram)[0-9]+$']
+          match_type: regexp
       filesystem:
+        include_virtual_filesystems: false
       network:
+        exclude:
+          interfaces: [lo, 'veth.*']
+          match_type: regexp
       paging:
       processes:
 
@@ -232,7 +248,7 @@ spec:
               mountPath: /host/sys
               readOnly: true
             - name: hostfs-root
-              mountPath: /host/root
+              mountPath: /host
               readOnly: true
               mountPropagation: HostToContainer
       volumes:
@@ -254,7 +270,7 @@ A couple of things to be deliberate about:
 
 - `hostNetwork: true` puts the Collector on the node's network namespace, which is what makes the `network` scraper return real interface stats and lets `resourcedetection`'s cloud detectors reach the instance metadata service. It also means the Collector's ports are exposed on the node, so don't bind anything you don't intend to.
 - `hostPID: true` is what lets the `processes` / `process` scrapers see PIDs other than the Collector's own.
-- The `filesystem` scraper needs the host root mounted (commonly at `/host/root` with `mountPropagation: HostToContainer`) to report node disk usage rather than the container's overlay. If you only care about CPU/memory/network, you can omit that mount and drop `filesystem` from the scraper list.
+- The `filesystem` scraper needs the host root mounted at the receiver's `root_path` (here `/host`, with `mountPropagation: HostToContainer`) to report node disk usage rather than the container's overlay. If you only care about CPU/memory/network, you can omit that mount and drop `filesystem` from the scraper list.
 
 ## Running on a bare host
 

--- a/docs/how-to-guides/otel-collector/kubernetes-monitoring.md
+++ b/docs/how-to-guides/otel-collector/kubernetes-monitoring.md
@@ -10,7 +10,7 @@ If you only want one slice of this, jump straight to the relevant section. Every
 
 ## Quickstart: the `opentelemetry-kube-stack` Helm chart
 
-For the fastest path from an empty cluster to a populated [Kubernetes view](../../guides/web-ui/kubernetes.md), use the upstream [`opentelemetry-kube-stack`](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) Helm chart. By default it deploys the OpenTelemetry Operator and a DaemonSet `OpenTelemetryCollector` running every preset the view reads from: `kubeletMetrics` (with `metric_groups: [node, pod, container]`), `clusterMetrics` (`k8s_cluster` with `k8s_leader_elector` so it only emits from one pod), `hostMetrics`, `kubernetesAttributes`, `kubernetesEvents`, plus the ServiceAccount, CRDs and RBAC it all needs. You provide a small `values.yaml` to point its OTLP exporter at Logfire:
+For the fastest path from an empty cluster to a populated [Kubernetes view](../../guides/web-ui/kubernetes.md), use the upstream [`opentelemetry-kube-stack`](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-kube-stack) Helm chart. By default it deploys the OpenTelemetry Operator and a DaemonSet `OpenTelemetryCollector` running every preset the view reads from: `kubeletMetrics`, `clusterMetrics` (`k8s_cluster` with `k8s_leader_elector` so it only emits from one pod), `hostMetrics`, `kubernetesAttributes`, `kubernetesEvents`, plus the ServiceAccount, custom resource definitions (CRDs), and role-based access control (RBAC) it all needs. You provide a small `values.yaml` to point its OpenTelemetry Protocol (OTLP) exporter at Logfire and reduce the default metric volume:
 
 ```yaml
 # values.yaml: Logfire-shaped overrides for opentelemetry-kube-stack.
@@ -31,6 +31,21 @@ extraEnvs:
 collectors:
   daemon:
     config:
+      # These receiver presets currently use 10 or 15 seconds. One minute is
+      # a better default for infrastructure metrics and sends far fewer points.
+      receivers:
+        host_metrics:
+          collection_interval: 60s
+        kubelet_stats:
+          collection_interval: 60s
+          # Add `volume` only if you need persistent-volume metrics.
+          metric_groups: [node, pod, container]
+          # Keep container IDs for correlation, but skip volume metadata.
+          extra_metadata_labels: [container.id]
+        k8s_cluster:
+          collection_interval: 60s
+          node_conditions_to_report: [Ready]
+          allocatable_types_to_report: [cpu, memory]
       exporters:
         otlphttp/logfire:
           endpoint: https://logfire-us.pydantic.dev   # or https://logfire-eu.pydantic.dev
@@ -52,7 +67,7 @@ helm upgrade --install otel-stack open-telemetry/opentelemetry-kube-stack \
   -n observability -f values.yaml
 ```
 
-Data starts flowing within a minute or two of the daemon pods reaching `Ready`. Validated against a 3-node kind cluster with chart 0.15.2 / operator + collector 0.151.0; the daemon collector exports cleanly with no dropped batches, and the `k8s_cluster` receiver completes initial cache sync via leader election.
+Data starts flowing within a minute or two of the daemon pods reaching `Ready`. The chart configures the daemon Collector pipelines and runs the `k8s_cluster` receiver behind leader election so only one Collector exports cluster-wide metrics.
 
 The rest of this page is the **from-scratch walkthrough**: recommended if you want to understand every piece, customise beyond what the chart's value overrides expose, or deploy without the chart's bundled Operator (for example on a managed platform that already provides one). If you took the Helm path above, you can skip directly to [What `k8sattributesprocessor` actually does](#what-k8sattributesprocessor-actually-does) and [Verifying it works on the Logfire side](#verifying-it-works-on-the-logfire-side).
 
@@ -79,6 +94,20 @@ The recommended layout is two Collector workloads sharing one image, one config 
     *"Things about a node, or things sent by Pods on a node"* → DaemonSet.
 
 The two share one ClusterRole and one ServiceAccount because the receivers and processor want the same set of read permissions on the Kubernetes API.
+
+## Control Kubernetes metric volume
+
+Use a 60-second collection interval for `kubeletstats`, `k8s_cluster`, and `hostmetrics` unless you have a specific need for finer resolution. The Helm chart presets currently use 10 seconds for host and cluster metrics and 15 seconds for kubelet metrics. Moving them to 60 seconds sends one-sixth and one-quarter as many datapoints respectively.
+
+The main volume multipliers are:
+
+- **Containers and pods:** `kubeletstats` emits CPU, memory, filesystem, and network series for each container and pod. More replicas produce more datapoints on every collection.
+- **Persistent volumes:** the `volume` metric group adds several series for every volume. The current Logfire Kubernetes view does not display these metrics, so the examples keep this group off. Add it only when you need persistent-volume charts or alerts.
+- **Interfaces and metadata:** leave `collect_all_network_interfaces` at its default of `false`. Enabling it splits network metrics across every interface. Extra metadata such as `container.id` can also create a new series whenever a container restarts. The examples keep the ID for correlation but omit `k8s.volume.type` because volume metrics are off.
+- **Node conditions and allocatable resources:** every entry in `node_conditions_to_report` and `allocatable_types_to_report` adds a value per node. Start with the `Ready` condition and `cpu` and `memory` allocatable types, then add pod or storage capacity deliberately if you use it.
+- **Host processes:** the chart's `hostmetrics` preset does not enable the singular `process` scraper, and neither do the examples on this page. Keep it off unless you need per-process CPU, memory, and disk data. It emits roughly seven datapoints per process ID per collection on Linux. The plural `processes` scraper only emits aggregate counts and is much cheaper.
+
+Also keep cluster-scoped metrics behind leader election or in a single-replica Deployment. Running `k8s_cluster` on every node duplicates the same cluster data once per Collector.
 
 ## Prerequisites: write token and namespace
 
@@ -204,9 +233,9 @@ data:
       # Cluster-level metrics: pod phase, deployment available/desired replicas,
       # node conditions, allocatable cpu/memory, etc.
       k8s_cluster:
-        collection_interval: 30s
-        node_conditions_to_report: [Ready, MemoryPressure, DiskPressure, PIDPressure]
-        allocatable_types_to_report: [cpu, memory, ephemeral-storage, pods]
+        collection_interval: 60s
+        node_conditions_to_report: [Ready]
+        allocatable_types_to_report: [cpu, memory]
 
       # Kubernetes Events as OTel log records.
       # Watch mode keeps a long-lived connection open; pull mode polls.
@@ -344,10 +373,10 @@ metadata:
 data:
   config.yaml: |-
     receivers:
-      # Per-container/pod/node CPU, memory, network, filesystem, volume
+      # Per-container/pod/node CPU, memory, network, and filesystem
       # metrics scraped from the local node's kubelet.
       kubeletstats:
-        collection_interval: 30s
+        collection_interval: 60s
         auth_type: serviceAccount
         endpoint: "https://${env:KUBE_NODE_NAME}:10250"
         # On managed clusters (EKS/GKE/AKS) the kubelet certificate is usually
@@ -356,10 +385,10 @@ data:
         # and you need this set to true. It bypasses TLS verification of the
         # kubelet: fine on a node-local connection, less so over the network.
         insecure_skip_verify: true
-        metric_groups: [node, pod, container, volume]
+        # Add `volume` only if you need persistent-volume metrics.
+        metric_groups: [node, pod, container]
         extra_metadata_labels:
           - container.id
-          - k8s.volume.type
 
       # Tails container stdout/stderr written by the container runtime to
       # /var/log/pods/<namespace>_<pod>_<uid>/<container>/<n>.log.
@@ -396,15 +425,22 @@ data:
       # Node-level metrics from /proc and /sys, mounted from the host.
       # Optional: skip this receiver and its volume mounts if you don't want it.
       hostmetrics:
-        collection_interval: 30s
+        collection_interval: 60s
         root_path: /host
         scrapers:
           cpu:
           memory:
           load:
           disk:
+            exclude:
+              devices: ['^(loop|ram)[0-9]+$']
+              match_type: regexp
           filesystem:
+            include_virtual_filesystems: false
           network:
+            exclude:
+              interfaces: [lo, 'veth.*']
+              match_type: regexp
           paging:
 
       # Apps on this node send OTLP here. Enriching at the agent (not at a

--- a/docs/how-to-guides/otel-collector/otel-collector-overview.md
+++ b/docs/how-to-guides/otel-collector/otel-collector-overview.md
@@ -23,6 +23,12 @@ Use cases for the OpenTelemetry Collector include:
 As Logfire is a fully compliant OpenTelemetry SDK and backend it does not require any special configuration to be used with the OpenTelemetry Collector.
 For more information on the Collector itself please see the [official documentation](https://opentelemetry.io/docs/collector/).
 
+## Metric collection intervals
+
+When a metric receiver or deployment preset collects more often than once a minute, set it to a 60-second interval unless you have a specific need for finer resolution. Moving from 10 seconds to 60 seconds sends one-sixth as many datapoints and is usually enough resolution for infrastructure trends. Do not shorten receivers that default to longer intervals unless you need the additional data.
+
+Interval is only one part of metric volume. Enable only the metrics and attributes you use, and pay particular attention to dimensions that multiply series per process, container, pod, CPU core, disk, filesystem, or network interface. The [host monitoring guide](host-monitoring.md#cardinality-and-cost) explains why the singular `hostmetrics.process` scraper should normally stay disabled, and the [Kubernetes monitoring guide](kubernetes-monitoring.md#control-kubernetes-metric-volume) covers the highest-volume Kubernetes settings.
+
 ## Guides
 
 This section is task-oriented: pick the scenario you're working on.

--- a/docs/integrations/event-streams/airflow.md
+++ b/docs/integrations/event-streams/airflow.md
@@ -62,7 +62,7 @@ otel_on = True
 otel_host = logfire-us.pydantic.dev
 otel_port = 443
 otel_prefix = airflow
-otel_interval_milliseconds = 30000  # The interval between exports, defaults to 60000
+otel_interval_milliseconds = 60000  # One minute, which is also Airflow's default
 otel_ssl_active = True
 
 [traces]
@@ -76,6 +76,8 @@ otel_task_log_event = True
 ```
 
 For the full list of settings, see Airflow's [traces] and [metrics] documentation.
+
+Keep the metrics export interval at 60,000 milliseconds (one minute) unless you have a specific need for finer resolution. Shorter intervals increase datapoint volume across every Airflow metric and usually do not make scheduler or task trends more useful.
 
 ## Verify it worked
 
@@ -167,7 +169,7 @@ otel_on = True
 otel_host = localhost
 otel_port = 4318
 otel_prefix = airflow
-otel_interval_milliseconds = 30000  # The interval between exports, defaults to 60000
+otel_interval_milliseconds = 60000  # One minute, which is also Airflow's default
 otel_ssl_active = False
 
 [traces]

--- a/docs/integrations/no-code/dify.md
+++ b/docs/integrations/no-code/dify.md
@@ -20,12 +20,15 @@ OTLP_BASE_ENDPOINT=https://logfire-us.pydantic.dev
 OTLP_API_KEY=<your-write-token>
 OTEL_EXPORTER_TYPE=otlp
 OTEL_EXPORTER_OTLP_PROTOCOL=http
+OTEL_METRIC_EXPORT_INTERVAL=60000
 OTEL_SAMPLING_RATE=1.0
 ```
 
 For an EU project, use `https://logfire-eu.pydantic.dev`. Leave `OTLP_TRACE_ENDPOINT` and `OTLP_METRIC_ENDPOINT` unset when using the base URL. Dify appends `/v1/traces` and `/v1/metrics`, and sends `OTLP_API_KEY` as a Bearer authorization token.
 
 `OTEL_SAMPLING_RATE=1.0` records every eligible trace and is useful while verifying the connection. Lower it after considering traffic volume and cost.
+
+`OTEL_METRIC_EXPORT_INTERVAL` is in milliseconds. Dify defaults to 60,000 (one minute); setting it makes the intended interval explicit in your deployment. Keep it at one minute unless you have a specific need for finer resolution.
 
 !!! warning "Review captured data"
     Current Dify spans can contain user, tenant, application, and workflow identifiers, plus database and outbound-request metadata. Review this data before enabling production traffic. The Logfire SDK's scrubbing feature does not process telemetry sent directly by Dify. If Dify cannot omit sensitive content before sending it, do not enable this route for workflows whose telemetry must be redacted.

--- a/docs/integrations/no-code/flowise.md
+++ b/docs/integrations/no-code/flowise.md
@@ -6,7 +6,7 @@ integration: otel
 
 # Send Flowise metrics to Logfire
 
-Track Flowise API, flow, prediction, and optional node metrics (numbers tracked over time, like requests per second or CPU load) in Logfire. Flowise sends these metrics using the OpenTelemetry Protocol (OTLP), the standard wire format Logfire uses to receive telemetry. Its current OpenTelemetry support does not send detailed model or tool traces.
+Track Flowise API, flow, and prediction metrics (numbers tracked over time, such as request counts and duration) in Logfire. Flowise sends these metrics using the OpenTelemetry Protocol (OTLP), the standard wire format Logfire uses to receive telemetry. Its current OpenTelemetry support does not send detailed model or tool traces or Node.js process metrics.
 
 This setup requires access to Flowise's runtime configuration and an [OpenTelemetry Collector](../../how-to-guides/otel-collector/otel-collector-overview.md). The Collector is a separate program that sits between Flowise and Logfire, gathering telemetry and forwarding it. It also adds the Logfire authorization header.
 
@@ -17,13 +17,15 @@ Set these values in the Flowise environment:
 ```dotenv
 ENABLE_METRICS=true
 METRICS_PROVIDER=open_telemetry
-METRICS_INCLUDE_NODE_METRICS=true
 METRICS_OPEN_TELEMETRY_METRIC_ENDPOINT=http://otel-collector:4318/v1/metrics
 METRICS_OPEN_TELEMETRY_PROTOCOL=http
 METRICS_OPEN_TELEMETRY_DEBUG=false
 ```
 
 Replace `otel-collector` if the Collector has a different hostname. Restart Flowise after applying the environment.
+
+!!! warning "Flowise exports metrics every five seconds"
+    Flowise currently hard-codes a five-second interval in its OpenTelemetry metrics implementation and does not provide a setting to change it. This sends twelve times as many datapoints as the recommended 60-second interval. Monitor metric usage on busy instances and only enable this integration when you need its metrics. `METRICS_INCLUDE_NODE_METRICS` only affects Flowise's Prometheus provider, so it is intentionally omitted here.
 
 ## Configure the Collector
 

--- a/docs/integrations/no-code/index.md
+++ b/docs/integrations/no-code/index.md
@@ -18,7 +18,7 @@ The configuration location matters. A **runtime configuration** row means you ne
 | Platform | What can be connected | Where it is configured |
 | --- | --- | --- |
 | [Dify](dify.md) | Application and workflow traces and metrics | Dify runtime configuration |
-| [Flowise](flowise.md) | API, flow, prediction, and optional node metrics, but not detailed traces | Flowise runtime and an OpenTelemetry Collector |
+| [Flowise](flowise.md) | API, flow, and prediction metrics, but not detailed traces or Node.js process metrics | Flowise runtime and an OpenTelemetry Collector |
 | [Goose](goose.md) | Agent-session and tool traces | Local settings and environment |
 | [Langflow](langflow.md) | Flow, model, and tool traces | Langflow runtime configuration |
 | [LobeChat](lobe-chat.md) | Request, model, agent, tool traces, and metrics | LobeChat runtime configuration |

--- a/docs/integrations/no-code/lobe-chat.md
+++ b/docs/integrations/no-code/lobe-chat.md
@@ -23,7 +23,7 @@ OTEL_METRICS_EXPORTER_INTERVAL=60000
 
 For an EU project, use `https://logfire-eu.pydantic.dev`. LobeChat sends both signals over OTLP/HTTP and appends the signal paths to the base URL. It currently reports the service as `lobehub`.
 
-The metrics interval is in milliseconds. LobeChat's default is one second; the example changes it to one minute to reduce telemetry volume.
+The metrics interval is in milliseconds. LobeChat's default is one second; the example changes it to one minute, which sends one-sixtieth as many datapoints. Keep the interval at one minute unless you have a specific need for finer resolution.
 
 For a non-production development build, also set `ENABLE_TELEMETRY_IN_DEV=1`. Restart LobeChat after applying the environment.
 

--- a/docs/integrations/no-code/open-webui.md
+++ b/docs/integrations/no-code/open-webui.md
@@ -36,6 +36,8 @@ OTEL_METRICS_EXPORT_INTERVAL_MILLIS=60000
 
 Replace `otel-collector` if the Collector has a different hostname. Restart Open WebUI after applying the environment.
 
+`OTEL_METRICS_EXPORT_INTERVAL_MILLIS` is in milliseconds. Open WebUI defaults to 10,000 milliseconds, so the recommended 60,000-millisecond setting sends one-sixth as many datapoints. Keep it at one minute unless you have a specific need for finer resolution.
+
 ## Configure the Collector
 
 Create a [project write token](../../how-to-guides/create-write-tokens.md), expose the Collector's OTLP receiver using Open WebUI's default gRPC transport, and forward all three signals to Logfire over OTLP using HTTP:

--- a/docs/integrations/system-metrics.md
+++ b/docs/integrations/system-metrics.md
@@ -54,9 +54,9 @@ table (see the [SQL reference](../reference/sql.md)).
 
 ## Verify it worked
 
-Run your program and leave it running for a few seconds, then open the
+Run your program and leave it running for at least a minute, then open the
 [Metrics explorer](../guides/web-ui/metrics-explorer.md) or the [Hosts](../guides/web-ui/hosts.md)
-view. Within a few seconds you'll see your machine appear with CPU and memory charts.
+view. After the next export you'll see your machine appear with CPU and memory charts.
 
 ## Troubleshooting
 
@@ -74,6 +74,8 @@ as `process.*` or cloud metadata). See the [SQL reference](../reference/sql.md#r
 and query resource attributes.
 
 ### Choosing which metrics to collect
+
+By default, Logfire uses OpenTelemetry's 60-second metrics export interval. Keep that interval unless you have a specific need for finer resolution. Exporting every 10 seconds sends six times as many datapoints from every instrumented process, while host trends are usually clear at one-minute resolution.
 
 By default, `instrument_system_metrics` collects only the metrics it needs to display the 'Basic System Metrics (Logfire)' dashboard. You can choose exactly which metrics to collect and how much data to collect about each metric. The default is equivalent to this:
 
@@ -106,6 +108,8 @@ To collect lots of detailed data about all available metrics, use `logfire.instr
     The most expensive metrics are `system.cpu.utilization/time` which collect data for each core and each mode,
     and `system.disk.*` which collect data for each disk device. The exact number depends on the machine hardware,
     but this can result in hundreds of data points per minute from each instrumented host.
+
+    The `process.*` metrics in this integration describe only the instrumented Python process. They do not scan every process ID on the host. The Collector's singular `hostmetrics.process` scraper does scan every process and has a much higher volume risk; see [Cardinality and cost](../how-to-guides/otel-collector/host-monitoring.md#cardinality-and-cost).
 
 `logfire.instrument_system_metrics(base='full')` is equivalent to:
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -2,6 +2,8 @@
 
 import gc
 import os
+import re
+from pathlib import Path
 
 import pydantic
 import pytest
@@ -35,6 +37,12 @@ SKIP_RUN_TAGS = ['skip', 'skip-run']
 SKIP_LINT_TAGS = ['skip', 'skip-lint']
 """Tags to skip linting the example with pytest-examples."""
 
+COLLECTION_INTERVAL_PATTERN = re.compile(r'\bcollection_interval:\s*["\']?(\d+(?:\.\d+)?)(ms|s|m)\b')
+MILLISECOND_METRIC_INTERVAL_PATTERNS = (
+    re.compile(r'\botel_interval_milliseconds\s*=\s*(\d+)\b'),
+    re.compile(r'\bOTEL_METRICS?_EXPORT(?:ER)?_INTERVAL(?:_MILLIS)?=(\d+)\b'),
+)
+
 
 def set_eval_config(eval_example: EvalExample):
     """Set the evaluation configuration."""
@@ -60,6 +68,32 @@ def test_formatting(eval_example: EvalExample):
             eval_example.format(example)
         else:
             eval_example.lint_ruff(example)
+
+
+def test_documented_metric_intervals_are_at_least_one_minute():
+    """Prevent examples from accidentally recommending high-volume metric intervals."""
+    short_intervals: list[str] = []
+
+    for path in Path('docs').rglob('*.md'):
+        source = path.read_text()
+        matches_with_seconds = [
+            (
+                match,
+                float(match.group(1)) * {'ms': 0.001, 's': 1, 'm': 60}[match.group(2)],
+            )
+            for match in COLLECTION_INTERVAL_PATTERN.finditer(source)
+        ]
+        for pattern in MILLISECOND_METRIC_INTERVAL_PATTERNS:
+            matches_with_seconds.extend((match, int(match.group(1)) / 1000) for match in pattern.finditer(source))
+
+        for match, seconds in matches_with_seconds:
+            if seconds < 60:
+                line_number = source.count('\n', 0, match.start()) + 1
+                short_intervals.append(f'{path}:{line_number}: {match.group(0)}')
+
+    assert not short_intervals, 'Metric examples must use intervals of at least 60 seconds:\n' + '\n'.join(
+        short_intervals
+    )
 
 
 def _get_runnable_examples():


### PR DESCRIPTION
## Summary

- recommend 60-second metric intervals across host, Docker, Kubernetes, cloud, Airflow, and no-code OpenTelemetry setup docs
- call out high-volume dimensions explicitly, especially per-process, per-container, per-interface, per-device, and optional per-core metrics
- reduce the Kubernetes Helm example to the metric groups and metadata used by the current Logfire view
- add a documentation regression test that rejects metric interval examples shorter than one minute

## Verification

- `uv run pytest tests/test_docs.py` (127 passed)
- `uv run ruff check tests/test_docs.py`
- `uv run pyright tests/test_docs.py`
- `git diff --check`
- rendered the documented values against `opentelemetry-kube-stack` 0.20.4 and inspected the final Collector resource
- parsed the host, Docker, and Kubernetes receiver examples with the OpenTelemetry Collector Contrib 0.128.0 image
- cross-checked interval defaults and high-volume behavior against current receiver and integration source code

## Related product change

- [pydantic/platform#35892](https://github.com/pydantic/platform/pull/35892) updates the Hosts status tolerance so 60-second reporters remain live through one delayed collection cycle. It is queued ahead of this documentation change.

## Scope notes

- Prometheus scrape configuration changes are deliberately out of scope.
- Flowise currently hard-codes a five-second OpenTelemetry metric export interval, so its page documents the limitation instead of showing a setting that does not exist.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
