### PR TITLE
Summarize MCP tool-list responses

### DIFF
--- a/logfire/_internal/integrations/mcp.py
+++ b/logfire/_internal/integrations/mcp.py
@@ -12,6 +12,7 @@ from mcp.types import (
     ClientRequest,
     ClientResult,
     ErrorData,
+    ListToolsResult,
     LoggingMessageNotification,
     ServerRequest,
     ServerResult,
@@ -22,7 +23,15 @@ from logfire._internal.utils import handle_internal_errors
 from logfire.propagate import attach_context, get_context
 
 if TYPE_CHECKING:
-    from logfire import LevelName, Logfire
+    from logfire import LevelName, Logfire, LogfireSpan
+
+
+def _set_response_attributes(span: LogfireSpan, response: Any) -> None:
+    root = getattr(response, 'root', response)
+    if isinstance(root, ListToolsResult):
+        span.set_attribute('logfire.mcp.tools.count', len(root.tools))
+    else:
+        span.set_attribute('response', response)
 
 
 def instrument_mcp(logfire_instance: Logfire, propagate_otel_context: bool):
@@ -54,7 +63,7 @@ def instrument_mcp(logfire_instance: Logfire, propagate_otel_context: bool):
         with logfire_instance.span(span_name, **attributes) as span:
             _attach_context_to_request(root)
             result = await original_send_request(self, request, *args, **kwargs)
-            span.set_attribute('response', result)
+            _set_response_attributes(span, result)
             return result
 
     BaseSession.send_request = send_request
@@ -129,7 +138,7 @@ def instrument_mcp(logfire_instance: Logfire, propagate_otel_context: bool):
                     def _respond_with_logging(
                         response: SendResultT | ErrorData, *respond_args: Any, **respond_kwargs: Any
                     ) -> Any:
-                        span.set_attribute('response', response)
+                        _set_response_attributes(span, response)
                         return original_respond(response, *respond_args, **respond_kwargs)
 
                     responder.respond = _respond_with_logging

--- a/tests/otel_integrations/test_openai_agents_mcp.py
+++ b/tests/otel_integrations/test_openai_agents_mcp.py
@@ -135,11 +135,7 @@ async def test_mcp(exporter: TestExporter):
                     'logfire.msg_template': 'MCP server handle request: tools/list',
                     'logfire.msg': 'MCP server handle request: tools/list',
                     'logfire.span_type': 'span',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [IsPartialDict()],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {
@@ -162,11 +158,7 @@ async def test_mcp(exporter: TestExporter):
                     'logfire.msg_template': 'MCP request: tools/list',
                     'logfire.msg': 'MCP request: tools/list',
                     'logfire.span_type': 'span',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [IsPartialDict()],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {
@@ -381,11 +373,7 @@ async def test_mcp(exporter: TestExporter):
                     'logfire.msg_template': 'MCP server handle request: tools/list',
                     'logfire.msg': 'MCP server handle request: tools/list',
                     'logfire.span_type': 'span',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [IsPartialDict()],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {
@@ -405,28 +393,7 @@ async def test_mcp(exporter: TestExporter):
                     'logfire.msg_template': 'MCP request: tools/list',
                     'logfire.span_type': 'span',
                     'logfire.msg': 'MCP request: tools/list',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [
-                            {
-                                'name': 'random_number',
-                                'title': None,
-                                'description': '',
-                                'inputSchema': {'properties': {}, 'title': 'random_numberArguments', 'type': 'object'},
-                                'outputSchema': {
-                                    'properties': {'result': {'title': 'Result', 'type': 'integer'}},
-                                    'required': ['result'],
-                                    'title': 'random_numberOutput',
-                                    'type': 'object',
-                                },
-                                'icons': None,
-                                'annotations': None,
-                                'meta': None,
-                                'execution': None,
-                            }
-                        ],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {

--- a/tests/otel_integrations/test_pydantic_ai_mcp.py
+++ b/tests/otel_integrations/test_pydantic_ai_mcp.py
@@ -101,11 +101,7 @@ Because it found something more "sole-ful!"\
                     'logfire.msg_template': 'MCP server handle request: tools/list',
                     'logfire.msg': 'MCP server handle request: tools/list',
                     'logfire.span_type': 'span',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [IsPartialDict()],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {
@@ -122,11 +118,7 @@ Because it found something more "sole-ful!"\
                     'logfire.msg_template': 'MCP request: tools/list',
                     'logfire.msg': 'MCP request: tools/list',
                     'logfire.span_type': 'span',
-                    'response': {
-                        'meta': None,
-                        'nextCursor': None,
-                        'tools': [IsPartialDict()],
-                    },
+                    'logfire.mcp.tools.count': 1,
                 },
             },
             {


### PR DESCRIPTION
## Summary

- replace full `tools/list` response attributes with `logfire.mcp.tools.count`
- apply the bounded summary to both MCP client and server spans
- preserve response attributes for other MCP methods, including `tools/call`

## Why

Tool catalogs can contain hundreds of kilobytes of schemas and descriptions. Recording the complete catalog on both sides of one request duplicates a large, rarely useful payload on every `tools/list` span.

## Tests

- `uv run pytest tests/otel_integrations/test_openai_agents_mcp.py -q`
- `uv run pytest tests/otel_integrations/test_pydantic_ai_mcp.py -q`
- `make lint`
- `make typecheck`
- pre-commit hooks

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

