### PR TITLE
Spell out what counts as a third-party module for the pydantic plugin (after #2054) [murmur:logfire-sdk/handle-pr-comments]

### DIFF
--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -86,6 +86,12 @@ import logfire
 logfire.instrument_pydantic(include={'openai'})
 ```
 
+!!! note
+    This is about where a module's file lives, not who wrote it. If you install your own application
+    into `site-packages` — which a container image does whenever it runs `pip install .` — then your
+    models are third-party by this rule, and you'll see no validations at all until you name your own
+    package in `include`.
+
 Opt your own modules out with the [`exclude`][logfire.PydanticPlugin.exclude] setting:
 
 ```py skip-run="true" skip-reason="global-instrumentation"

--- a/docs/integrations/pydantic.md
+++ b/docs/integrations/pydantic.md
@@ -75,8 +75,10 @@ imported *after* that call.
 
 ### Third-party modules
 
-By default the plugin does not instrument third-party modules, to avoid noise. Opt specific ones in
-with the [`include`][logfire.PydanticPlugin.include] setting:
+By default the plugin does not instrument third-party modules, to avoid noise. A module counts as
+third-party if it was imported from the standard library or from an installed package (somewhere like
+`site-packages`) rather than from your own source code. Opt specific ones in with the
+[`include`][logfire.PydanticPlugin.include] setting:
 
 ```py skip-run="true" skip-reason="global-instrumentation"
 import logfire


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft: do not merge before #2054.** This documents behavior that #2054 implements.

The Pydantic Validation page says third-party modules aren't instrumented by default, but never says how the plugin decides what "third-party" means. That's what confused the reporter of #2053, so this adds one sentence naming the rule: the module's file being in the standard library or an installed package rather than in your own source.

The rule itself is implemented in #2054, which rewrites `_include_model` to skip modules whose `__file__` is in a non-user location. Until that merges, this sentence is aspirational — as, for that matter, is the sentence already on `main` that it clarifies, which is exactly what #2053 reports.

It is a separate PR only because #2054 branches from before the docs restructure that landed yesterday, so the two edits to this file conflict and the merge that would resolve it can't be pushed to the contributor's fork from here.

[Created via Murmur](https://cloud.murmur.dev/github_app/pydantic/task/github_app%2Fpydantic%2Fw%2Flogfire-sdk%2Fgithub_oauth%2Falexmojaki%2Fhandle-pr-comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)