### PR TITLE
Update docs to use Gateway endpoint terminology

### DIFF
--- a/docs/reference/advanced/gateway/embeddings.md
+++ b/docs/reference/advanced/gateway/embeddings.md
@@ -19,7 +19,7 @@ The badge means the provider *can* serve embeddings; which embedding models are 
 
 Each route reports its chat and embedding models separately. List them with `GET /proxy/models`.
 
-The requests on this page need two values. Create or reveal a gateway API key on the **API Keys** tab and use it in place of `<YOUR_GATEWAY_API_KEY>`; for the route, use a provider slug from the **Providers** tab or a Gateway endpoint slug from **Endpoints**. The examples below use `openai`.
+The requests on this page need two values. Create or reveal a gateway API key on the **API Keys** tab and use it in place of `<YOUR_GATEWAY_API_KEY>`; for the route, use a provider slug from the **Providers** tab or a gateway endpoint slug from **Endpoints**. The examples below use `openai`.
 
 ```bash
 curl "https://gateway-us.pydantic.dev/proxy/models?route=openai" \

--- a/docs/reference/advanced/gateway/embeddings.md
+++ b/docs/reference/advanced/gateway/embeddings.md
@@ -19,7 +19,7 @@ The badge means the provider *can* serve embeddings; which embedding models are 
 
 Each route reports its chat and embedding models separately. List them with `GET /proxy/models`.
 
-The requests on this page need two values. Create or reveal a gateway API key on the **API Keys** tab and use it in place of `<YOUR_GATEWAY_API_KEY>`; for the route, use a provider slug from the **Providers** tab (or a routing group slug from **Routing**). The examples below use `openai`.
+The requests on this page need two values. Create or reveal a gateway API key on the **API Keys** tab and use it in place of `<YOUR_GATEWAY_API_KEY>`; for the route, use a provider slug from the **Providers** tab or a Gateway endpoint slug from **Endpoints**. The examples below use `openai`.
 
 ```bash
 curl "https://gateway-us.pydantic.dev/proxy/models?route=openai" \

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -15,7 +15,7 @@ The gateway gives you:
 - **One endpoint, many providers**: call OpenAI, Anthropic, Google, AWS Bedrock, Groq, Mistral, and more through provider-compatible endpoints, using the SDKs you already have.
 - **Key management**: project-scoped and personal API keys with per-key spending limits and expiry, managed in the Logfire UI.
 - **Cost controls**: usage analytics plus daily, weekly, monthly, and total spending caps per key, and per-member limits.
-- **Failover and load balancing**: Gateway endpoints route requests across one or more providers, using priorities and weights.
+- **Failover and load balancing**: gateway endpoints route requests across one or more providers, using priorities and weights.
 - **Observability**: with telemetry enabled, every gateway request is traced into a Logfire project of your choice.
 
 The gateway is configured per **organization** and is available on the Personal, Team, Growth, and Enterprise Cloud plans.
@@ -33,7 +33,7 @@ The recommended setup runs the whole onboarding in one go: it enables the gatewa
 If you prefer to wire things up yourself, **Manual setup** just turns the gateway on and leaves providers, telemetry, and keys to you.
 
 !!! note "Prerequisites"
-    - You need to be an **organization admin** to enable the gateway and manage providers, Gateway endpoints, and spending. Non-admin members see the **Connect** and **API Keys** tabs only.
+    - You need to be an **organization admin** to enable the gateway and manage providers, gateway endpoints, and spending. Non-admin members see the **Connect** and **API Keys** tabs only.
     - The organization needs at least one **project**: API keys and telemetry are scoped to a project.
     - On the Personal, Team, and Growth plans, built-in providers are billed against a prepaid balance and require a payment method; the exact fees and initial balance are shown during activation. You can skip this entirely by adding your own provider credentials instead (see [Providers](#providers)).
 
@@ -51,7 +51,7 @@ The gateway base URL depends on your Logfire region:
 | EU | `https://gateway-eu.pydantic.dev/proxy` |
 | Self-hosted | `https://<your-logfire-host>/proxy` |
 
-Requests are addressed to `<gateway-base-url>/<route>`, where `<route>` is a provider slug from the **Providers** tab or a Gateway endpoint slug from the **Endpoints** tab. Authenticate the request with an `Authorization: Bearer` header carrying your gateway API key.
+Requests are addressed to `<gateway-base-url>/<route>`, where `<route>` is a provider slug from the **Providers** tab or a gateway endpoint slug from the **Endpoints** tab. Authenticate the request with an `Authorization: Bearer` header carrying your gateway API key.
 
 For example, with an OpenAI-compatible provider whose slug is `openai`, in the US region:
 
@@ -138,7 +138,7 @@ Each key can have an expiry date and its own **spending limits**: daily, weekly,
 
 ### Gateway endpoints
 
-A Gateway endpoint routes requests across one or more providers under a single slug. Manage Gateway endpoints on the **Endpoints** tab. Each provider assigned to a Gateway endpoint has a **priority** (failover order) and a **weight** (load balancing between providers at the same priority level). Use the Gateway endpoint's slug in place of a provider slug in your request URL.
+A gateway endpoint routes requests across one or more providers under a single slug. Manage gateway endpoints on the **Endpoints** tab. Each provider assigned to a gateway endpoint has a **priority** (failover order) and a **weight** (load balancing between providers at the same priority level). Use the gateway endpoint's slug in place of a provider slug in your request URL.
 
 ### Spending limits and balance
 

--- a/docs/reference/advanced/gateway/index.md
+++ b/docs/reference/advanced/gateway/index.md
@@ -15,7 +15,7 @@ The gateway gives you:
 - **One endpoint, many providers**: call OpenAI, Anthropic, Google, AWS Bedrock, Groq, Mistral, and more through provider-compatible endpoints, using the SDKs you already have.
 - **Key management**: project-scoped and personal API keys with per-key spending limits and expiry, managed in the Logfire UI.
 - **Cost controls**: usage analytics plus daily, weekly, monthly, and total spending caps per key, and per-member limits.
-- **Failover and load balancing**: routing groups let you group providers with priorities and weights.
+- **Failover and load balancing**: Gateway endpoints route requests across one or more providers, using priorities and weights.
 - **Observability**: with telemetry enabled, every gateway request is traced into a Logfire project of your choice.
 
 The gateway is configured per **organization** and is available on the Personal, Team, Growth, and Enterprise Cloud plans.
@@ -33,11 +33,11 @@ The recommended setup runs the whole onboarding in one go: it enables the gatewa
 If you prefer to wire things up yourself, **Manual setup** just turns the gateway on and leaves providers, telemetry, and keys to you.
 
 !!! note "Prerequisites"
-    - You need to be an **organization admin** to enable the gateway and manage providers, routing, and spending. Non-admin members see the **Connect** and **API Keys** tabs only.
+    - You need to be an **organization admin** to enable the gateway and manage providers, Gateway endpoints, and spending. Non-admin members see the **Connect** and **API Keys** tabs only.
     - The organization needs at least one **project**: API keys and telemetry are scoped to a project.
     - On the Personal, Team, and Growth plans, built-in providers are billed against a prepaid balance and require a payment method; the exact fees and initial balance are shown during activation. You can skip this entirely by adding your own provider credentials instead (see [Providers](#providers)).
 
-Once enabled, the Gateway page has these tabs: **Overview**, **Connect**, **API Keys**, **Providers**, **Routing**, **Spending**, and **Settings**.
+Once enabled, the Gateway page has these tabs: **Overview**, **Connect**, **API Keys**, **Providers**, **Endpoints**, **Spending**, and **Settings**.
 
 ### Connect an SDK
 
@@ -51,7 +51,7 @@ The gateway base URL depends on your Logfire region:
 | EU | `https://gateway-eu.pydantic.dev/proxy` |
 | Self-hosted | `https://<your-logfire-host>/proxy` |
 
-Requests are addressed to `<gateway-base-url>/<route>`, where `<route>` is a provider slug (or routing group slug) from your **Providers** tab, and authenticated with an `Authorization: Bearer` header carrying your gateway API key.
+Requests are addressed to `<gateway-base-url>/<route>`, where `<route>` is a provider slug from the **Providers** tab or a Gateway endpoint slug from the **Endpoints** tab. Authenticate the request with an `Authorization: Bearer` header carrying your gateway API key.
 
 For example, with an OpenAI-compatible provider whose slug is `openai`, in the US region:
 
@@ -136,9 +136,9 @@ Gateway API keys authenticate requests to the gateway. Keys are scoped to a proj
 
 Each key can have an expiry date and its own **spending limits**: daily, weekly, monthly, and total. The recommended setup creates a first project key named **Quick Start**.
 
-### Routing groups
+### Gateway endpoints
 
-Routing groups (the **Routing** tab) let you define fallback strategies by grouping multiple providers under a single slug. Each member provider has a **priority** (failover order) and a **weight** (load balancing between members at the same priority level). Use the group's slug in place of a provider slug in your request URL to route through the group.
+A Gateway endpoint routes requests across one or more providers under a single slug. Manage Gateway endpoints on the **Endpoints** tab. Each provider assigned to a Gateway endpoint has a **priority** (failover order) and a **weight** (load balancing between providers at the same priority level). Use the Gateway endpoint's slug in place of a provider slug in your request URL.
 
 ### Spending limits and balance
 

--- a/docs/reference/advanced/gateway/integrations/index.md
+++ b/docs/reference/advanced/gateway/integrations/index.md
@@ -10,7 +10,7 @@ Connect the framework, prompts, tools, and agent workflow you already use to the
 !!! note "Gateway vs. instrument"
     These guides **route** your model calls through the gateway for spending caps, failover, and shared keys. If you only want to **see and debug** the calls you already make, you don't need the gateway: [instrument a framework](../../../../integrations/llms/index.md) instead.
 
-Each guide shows the two client settings you need to change: the API key and gateway URL. You can point them at one model provider or at a [routing group](../index.md#routing-groups), which can fail over to another provider or distribute requests across several providers.
+Each guide shows the two client settings you need to change: the API key and gateway URL. You can point them at one model provider or a [Gateway endpoint](../index.md#gateway-endpoints), which can fail over to another provider or distribute requests across several providers.
 
 ## Before you start
 
@@ -26,7 +26,7 @@ Each guide shows the two client settings you need to change: the API key and gat
 
 The examples use the OpenAI-compatible route for the US region, `https://gateway-us.pydantic.dev/proxy/openai`. For the EU region, use `gateway-eu` instead. For a self-hosted organization, copy the URL from the **Connect** tab.
 
-Most examples use an OpenAI-compatible client. The provider or routing group you select must support the OpenAI request format and the model name in the example. Provider-native APIs, such as Anthropic Messages, require that provider's client. See [Connect an SDK](../index.md#connect-an-sdk) for both patterns.
+Most examples use an OpenAI-compatible client. The provider or Gateway endpoint you select must support the OpenAI request format and the model name in the example. Provider-native APIs, such as Anthropic Messages, require that provider's client. See [Connect an SDK](../index.md#connect-an-sdk) for both patterns.
 
 !!! note "Model data passes through Logfire"
     These settings send prompts, tool inputs, and model responses through the Logfire AI Gateway and the selected model provider. If gateway telemetry is enabled, Logfire records the model, latency, token usage, and conversation content in your selected project. Calls to built-in providers count toward your gateway spend.
@@ -54,4 +54,4 @@ Most examples use an OpenAI-compatible client. The provider or routing group you
 
 ## Next steps
 
-Read the [AI Gateway overview](../index.md) to learn how providers, routing groups, spending limits, and telemetry work together.
+Read the [AI Gateway overview](../index.md) to learn how providers, Gateway endpoints, spending limits, and telemetry work together.

--- a/docs/reference/advanced/gateway/integrations/index.md
+++ b/docs/reference/advanced/gateway/integrations/index.md
@@ -10,7 +10,7 @@ Connect the framework, prompts, tools, and agent workflow you already use to the
 !!! note "Gateway vs. instrument"
     These guides **route** your model calls through the gateway for spending caps, failover, and shared keys. If you only want to **see and debug** the calls you already make, you don't need the gateway: [instrument a framework](../../../../integrations/llms/index.md) instead.
 
-Each guide shows the two client settings you need to change: the API key and gateway URL. You can point them at one model provider or a [Gateway endpoint](../index.md#gateway-endpoints), which can fail over to another provider or distribute requests across several providers.
+Each guide shows the two client settings you need to change: the API key and gateway URL. You can point them at one model provider or a [gateway endpoint](../index.md#gateway-endpoints), which can fail over to another provider or distribute requests across several providers.
 
 ## Before you start
 
@@ -26,7 +26,7 @@ Each guide shows the two client settings you need to change: the API key and gat
 
 The examples use the OpenAI-compatible route for the US region, `https://gateway-us.pydantic.dev/proxy/openai`. For the EU region, use `gateway-eu` instead. For a self-hosted organization, copy the URL from the **Connect** tab.
 
-Most examples use an OpenAI-compatible client. The provider or Gateway endpoint you select must support the OpenAI request format and the model name in the example. Provider-native APIs, such as Anthropic Messages, require that provider's client. See [Connect an SDK](../index.md#connect-an-sdk) for both patterns.
+Most examples use an OpenAI-compatible client. The provider or gateway endpoint you select must support the OpenAI request format and the model name in the example. Provider-native APIs, such as Anthropic Messages, require that provider's client. See [Connect an SDK](../index.md#connect-an-sdk) for both patterns.
 
 !!! note "Model data passes through Logfire"
     These settings send prompts, tool inputs, and model responses through the Logfire AI Gateway and the selected model provider. If gateway telemetry is enabled, Logfire records the model, latency, token usage, and conversation content in your selected project. Calls to built-in providers count toward your gateway spend.
@@ -54,4 +54,4 @@ Most examples use an OpenAI-compatible client. The provider or Gateway endpoint 
 
 ## Next steps
 
-Read the [AI Gateway overview](../index.md) to learn how providers, Gateway endpoints, spending limits, and telemetry work together.
+Read the [AI Gateway overview](../index.md) to learn how providers, gateway endpoints, spending limits, and telemetry work together.


### PR DESCRIPTION
## Summary

- replace the retired routing-group UI terminology with Gateway endpoints
- update the Gateway tab name and cross-page anchors
- qualify endpoint references so they are distinct from generic HTTP endpoints

## Checks

- pre-commit hooks run by `git commit`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

