### PR TITLE
Refactor dataset retrieval and improve type inference

### DIFF
--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -518,7 +518,9 @@ class _BaseLogfireAPIClient(Generic[T]):
 
         try:
             from pydantic_evals import Dataset
-        except ImportError:
+        except ModuleNotFoundError as e:
+            if e.name != 'pydantic_evals':
+                raise
             raise ImportError(
                 'pydantic-evals is required for this operation. Install with: pip install pydantic-evals'
             ) from None

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -79,8 +79,8 @@ DEFAULT_TIMEOUT = Timeout(30.0)
 
 T = TypeVar('T', bound=BaseClient)
 InputsT = TypeVar('InputsT')
-OutputT = TypeVar('OutputT')
-MetadataT = TypeVar('MetadataT')
+OutputT = TypeVar('OutputT', default=Any)
+MetadataT = TypeVar('MetadataT', default=Any)
 ResponseT = TypeVar('ResponseT')
 
 _UNSET: Any = object()
@@ -255,16 +255,6 @@ def _validate_dataset_name(name: str) -> None:
             f'Invalid dataset name {name!r}. '
             'Names must start with a letter or digit and contain only letters, digits, dots, hyphens, and underscores.'
         )
-
-
-def _import_pydantic_evals() -> tuple[type, type]:
-    """Import pydantic-evals types, raising ImportError if not available."""
-    try:
-        from pydantic_evals import Case, Dataset
-
-        return Dataset, Case
-    except ImportError:
-        raise ImportError('pydantic-evals is required for this operation. Install with: pip install pydantic-evals')
 
 
 @cache
@@ -508,6 +498,33 @@ class _BaseLogfireAPIClient(Generic[T]):
         if response.status_code == 204:
             return None
         return response.json()
+
+    def _get_dataset(
+        self,
+        response: Response,
+        *,
+        input_type: type[InputsT] | None,
+        output_type: type[OutputT] | None,
+        metadata_type: type[MetadataT] | None,
+        include_cases: bool,
+        custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]],
+        custom_report_evaluator_types: Sequence[type[Any]],
+    ) -> Dataset[InputsT, OutputT, MetadataT] | DatasetDetail | ExportedDataset:
+        data = self._handle_response(response)
+        if not include_cases:
+            return _validate_or_warn(_dataset_detail_adapter, data)
+        if input_type is None:
+            return _validate_or_warn(_exported_dataset_adapter, data)
+
+        try:
+            from pydantic_evals import Dataset
+        except ImportError:
+            raise ImportError('pydantic-evals is required for this operation. Install with: pip install pydantic-evals')
+
+        output_type = output_type or Any  # type: ignore
+        metadata_type = metadata_type or Any  # type: ignore
+        typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # type: ignore
+        return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)
 
 
 class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
@@ -1074,19 +1091,19 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
             info = client.get_dataset('qa-dataset', include_cases=False)
             ```
         """
-        if not include_cases:
+        if include_cases:
+            response = self.client.get(f'/v1/datasets/{id_or_name}/export/')
+        else:
             response = self.client.get(f'/v1/datasets/{id_or_name}/')
-            return _validate_or_warn(_dataset_detail_adapter, self._handle_response(response))
-
-        response = self.client.get(f'/v1/datasets/{id_or_name}/export/')
-        data = self._handle_response(response)
-
-        if input_type is None:
-            return _validate_or_warn(_exported_dataset_adapter, data)
-
-        Dataset, _ = _import_pydantic_evals()
-        typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)
+        return self._get_dataset(
+            response,
+            input_type=input_type,
+            output_type=output_type,
+            metadata_type=metadata_type,
+            include_cases=include_cases,
+            custom_evaluator_types=custom_evaluator_types,
+            custom_report_evaluator_types=custom_report_evaluator_types,
+        )
 
 
 class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
@@ -1382,16 +1399,16 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
 
         See `LogfireAPIClient.get_dataset` for full documentation.
         """
-        if not include_cases:
+        if include_cases:
+            response = await self.client.get(f'/v1/datasets/{id_or_name}/export/')
+        else:
             response = await self.client.get(f'/v1/datasets/{id_or_name}/')
-            return _validate_or_warn(_dataset_detail_adapter, self._handle_response(response))
-
-        response = await self.client.get(f'/v1/datasets/{id_or_name}/export/')
-        data = self._handle_response(response)
-
-        if input_type is None:
-            return _validate_or_warn(_exported_dataset_adapter, data)
-
-        Dataset, _ = _import_pydantic_evals()
-        typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # pyright: ignore[reportIndexIssue, reportUnknownVariableType]
-        return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)
+        return self._get_dataset(
+            response,
+            input_type=input_type,
+            output_type=output_type,
+            metadata_type=metadata_type,
+            include_cases=include_cases,
+            custom_evaluator_types=custom_evaluator_types,
+            custom_report_evaluator_types=custom_report_evaluator_types,
+        )

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -519,7 +519,9 @@ class _BaseLogfireAPIClient(Generic[T]):
         try:
             from pydantic_evals import Dataset
         except ImportError:
-            raise ImportError('pydantic-evals is required for this operation. Install with: pip install pydantic-evals')
+            raise ImportError(
+                'pydantic-evals is required for this operation. Install with: pip install pydantic-evals'
+            ) from None
 
         typed_dataset_cls = cast(
             type[Dataset[InputsT, OutputT, MetadataT]],

--- a/logfire/experimental/api_client.py
+++ b/logfire/experimental/api_client.py
@@ -54,11 +54,11 @@ from collections.abc import Sequence
 from datetime import datetime
 from functools import cache
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, Generic, Literal, cast, overload
 from uuid import UUID
 
 from pydantic import TypeAdapter, ValidationError
-from typing_extensions import NotRequired, Self, TypedDict
+from typing_extensions import NotRequired, Self, TypedDict, TypeForm, TypeVar
 
 from logfire._internal.config import get_base_url_from_token
 from logfire._internal.stack_info import warn_at_user_stacklevel
@@ -503,9 +503,9 @@ class _BaseLogfireAPIClient(Generic[T]):
         self,
         response: Response,
         *,
-        input_type: type[InputsT] | None,
-        output_type: type[OutputT] | None,
-        metadata_type: type[MetadataT] | None,
+        input_type: TypeForm[InputsT] | None,
+        output_type: TypeForm[OutputT],
+        metadata_type: TypeForm[MetadataT],
         include_cases: bool,
         custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]],
         custom_report_evaluator_types: Sequence[type[Any]],
@@ -521,9 +521,10 @@ class _BaseLogfireAPIClient(Generic[T]):
         except ImportError:
             raise ImportError('pydantic-evals is required for this operation. Install with: pip install pydantic-evals')
 
-        output_type = output_type or Any  # type: ignore
-        metadata_type = metadata_type or Any  # type: ignore
-        typed_dataset_cls: type[Dataset[InputsT, OutputT, MetadataT]] = Dataset[input_type, output_type, metadata_type]  # type: ignore
+        typed_dataset_cls = cast(
+            type[Dataset[InputsT, OutputT, MetadataT]],
+            Dataset[input_type, output_type, metadata_type],
+        )
         return _from_dict_compat(typed_dataset_cls, data, custom_evaluator_types, custom_report_evaluator_types)
 
 
@@ -1026,9 +1027,9 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
     def get_dataset(
         self,
         id_or_name: str,
-        input_type: type[InputsT],
-        output_type: type[OutputT] | None = None,
-        metadata_type: type[MetadataT] | None = None,
+        input_type: TypeForm[InputsT],
+        output_type: TypeForm[OutputT] = Any,
+        metadata_type: TypeForm[MetadataT] = Any,
         *,
         custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (),
         custom_report_evaluator_types: Sequence[type[Any]] = (),
@@ -1037,9 +1038,9 @@ class LogfireAPIClient(_BaseLogfireAPIClient[Client]):
     def get_dataset(
         self,
         id_or_name: str,
-        input_type: type[InputsT] | None = None,
-        output_type: type[OutputT] | None = None,
-        metadata_type: type[MetadataT] | None = None,
+        input_type: TypeForm[InputsT] | None = None,
+        output_type: TypeForm[OutputT] = Any,
+        metadata_type: TypeForm[MetadataT] = Any,
         *,
         include_cases: bool = True,
         custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]] = (),
@@ -1376,9 +1377,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     async def get_dataset(
         self,
         id_or_name: str,
-        input_type: type[InputsT],
-        output_type: type[OutputT] | None = None,
-        metadata_type: type[MetadataT] | None = None,
+        input_type: TypeForm[InputsT],
+        output_type: TypeForm[OutputT] = Any,
+        metadata_type: TypeForm[MetadataT] = Any,
         *,
         custom_evaluator_types: Sequence[type[Evaluator[InputsT, OutputT, MetadataT]]] = (),
         custom_report_evaluator_types: Sequence[type[Any]] = (),
@@ -1387,9 +1388,9 @@ class AsyncLogfireAPIClient(_BaseLogfireAPIClient[AsyncClient]):
     async def get_dataset(
         self,
         id_or_name: str,
-        input_type: type[InputsT] | None = None,
-        output_type: type[OutputT] | None = None,
-        metadata_type: type[MetadataT] | None = None,
+        input_type: TypeForm[InputsT] | None = None,
+        output_type: TypeForm[OutputT] = Any,
+        metadata_type: TypeForm[MetadataT] = Any,
         *,
         include_cases: bool = True,
         custom_evaluator_types: Sequence[type[Evaluator[Any, Any, Any]]] = (),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "opentelemetry-instrumentation >= 0.41b0",
     "rich >= 13.4.2",
     "protobuf >= 4.23.4",
-    "typing-extensions >= 4.1.0",
+    "typing-extensions >= 4.13.0",
     "tomli >= 2.0.1; python_version < '3.11'",
     "executing >= 2.0.1",
 ]

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import warnings
 from dataclasses import dataclass
 from datetime import datetime
@@ -1012,6 +1013,13 @@ class TestLogfireAPIClient:
         from pydantic_evals import Dataset
 
         assert isinstance(result, Dataset)
+
+    def test_get_dataset_typed_without_pydantic_evals(self, monkeypatch: pytest.MonkeyPatch):
+        client = make_client()
+        monkeypatch.setitem(sys.modules, 'pydantic_evals', None)
+
+        with pytest.raises(ImportError, match='pydantic-evals is required for this operation'):
+            client.get_dataset('test-dataset', input_type=MyInput)
 
     def test_add_cases_with_dicts(self):
         client = make_client()

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -1014,6 +1014,19 @@ class TestLogfireAPIClient:
 
         assert isinstance(result, Dataset)
 
+    def test_get_dataset_typed_type_form_with_defaults(self):
+        export = {
+            'name': 'test-dataset',
+            'cases': [{'name': 'test-case', 'inputs': [1, 2]}],
+        }
+        responses = {('GET', '/v1/datasets/test-dataset/export/'): httpx.Response(200, json=export)}
+        client = make_client(responses)
+
+        result = client.get_dataset('test-dataset', input_type=list[int])
+
+        assert _get_dataset_type_args(result) == (list[int], Any, Any)
+        assert result.cases[0].inputs == [1, 2]
+
     def test_get_dataset_typed_without_pydantic_evals(self, monkeypatch: pytest.MonkeyPatch):
         client = make_client()
         monkeypatch.setitem(sys.modules, 'pydantic_evals', None)
@@ -1436,6 +1449,20 @@ class TestAsyncLogfireAPIClient:
         from pydantic_evals import Dataset
 
         assert isinstance(result, Dataset)
+
+    @pytest.mark.anyio
+    async def test_get_dataset_typed_type_form_with_defaults(self):
+        export = {
+            'name': 'test-dataset',
+            'cases': [{'name': 'test-case', 'inputs': [1, 2]}],
+        }
+        responses = {('GET', '/v1/datasets/test-dataset/export/'): httpx.Response(200, json=export)}
+        client = make_async_client(responses)
+
+        result = await client.get_dataset('test-dataset', input_type=list[int])
+
+        assert _get_dataset_type_args(result) == (list[int], Any, Any)
+        assert result.cases[0].inputs == [1, 2]
 
     @pytest.mark.anyio
     async def test_add_cases_with_dicts(self):

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 import sys
 import warnings
@@ -1032,6 +1033,26 @@ class TestLogfireAPIClient:
         monkeypatch.setitem(sys.modules, 'pydantic_evals', None)
 
         with pytest.raises(ImportError, match='pydantic-evals is required for this operation'):
+            client.get_dataset('test-dataset', input_type=MyInput)
+
+    def test_get_dataset_typed_with_broken_pydantic_evals_dependency(self, monkeypatch: pytest.MonkeyPatch):
+        client = make_client()
+        import_ = builtins.__import__
+
+        def mock_import(
+            name: str,
+            globals: dict[str, Any] | None = None,
+            locals: dict[str, Any] | None = None,
+            fromlist: tuple[str, ...] = (),
+            level: int = 0,
+        ) -> Any:
+            if name == 'pydantic_evals':
+                raise ModuleNotFoundError("No module named 'broken_dependency'", name='broken_dependency')
+            return import_(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, '__import__', mock_import)
+
+        with pytest.raises(ModuleNotFoundError, match='broken_dependency'):
             client.get_dataset('test-dataset', input_type=MyInput)
 
     def test_add_cases_with_dicts(self):

--- a/tests/test_datasets_client.py
+++ b/tests/test_datasets_client.py
@@ -9,7 +9,6 @@ import warnings
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, cast
-from unittest.mock import patch
 from uuid import UUID
 
 import httpx
@@ -31,7 +30,6 @@ from logfire.experimental.api_client import (
     _from_dict_compat,
     _from_dict_supports_report_evaluators,
     _get_dataset_type_args,
-    _import_pydantic_evals,
     _serialize_case,
     _serialize_evaluators,
     _serialize_value,
@@ -305,20 +303,6 @@ class TestSerializeCase:
         )
         result = _serialize_case(case)
         assert result == {'inputs': {'q': 'hi'}, 'metadata': {'source': 'test'}, 'evaluators': []}
-
-
-class TestImportPydanticEvals:
-    def test_success(self):
-        Dataset, Case_ = _import_pydantic_evals()
-        from pydantic_evals import Case as RealCase, Dataset as RealDataset
-
-        assert Dataset is RealDataset
-        assert Case_ is RealCase
-
-    def test_import_error(self):
-        with patch.dict('sys.modules', {'pydantic_evals': None}):
-            with pytest.raises(ImportError, match='pydantic-evals is required'):
-                _import_pydantic_evals()
 
 
 class TestFromDictCompat:

--- a/tests/type_checking.py
+++ b/tests/type_checking.py
@@ -1,9 +1,12 @@
-from typing import assert_type
+from typing import TYPE_CHECKING, Any, assert_type, reveal_type
 
 from pydantic import BaseModel
 
 import logfire
 from logfire.variables import TemplateVariable, Variable
+
+if TYPE_CHECKING:
+    from logfire.experimental.api_client import LogfireAPIClient
 
 # Documenting the current behavior: including a default of an incompatible type extends the union rather than producing
 # a type error. This is arguably a feature, not a bug — the `type` is only used for validating provider values, not the
@@ -27,3 +30,14 @@ my_template_variable = logfire.template_var(
 )
 assert_type(my_template_variable, TemplateVariable[str, PromptInputs])
 assert_type(my_template_variable.get(PromptInputs(name='Alice')).value, str)
+
+if TYPE_CHECKING:
+    dataset_client = LogfireAPIClient()
+    reveal_type(
+        dataset_client.get_dataset('dataset', input_type=PromptInputs),
+        expected_text='Dataset[PromptInputs, Any, Any]',
+    )
+    reveal_type(
+        dataset_client.get_dataset('dataset', input_type=PromptInputs, output_type=Any, metadata_type=Any),
+        expected_text='Dataset[PromptInputs, Any, Any]',
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -3008,7 +3008,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.4.2" },
     { name = "starlette", marker = "extra == 'gateway'", specifier = ">=0.37.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
-    { name = "typing-extensions", specifier = ">=4.1.0" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
     { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.30.0" },
 ]
 provides-extras = ["gateway", "system-metrics", "asgi", "wsgi", "aiohttp", "aiohttp-client", "aiohttp-server", "celery", "django", "fastapi", "flask", "httpx", "starlette", "sqlalchemy", "asyncpg", "psycopg", "psycopg2", "pymongo", "redis", "requests", "mysql", "sqlite3", "aws-lambda", "google-genai", "litellm", "dspy", "datasets", "variables"]


### PR DESCRIPTION
## Summary

- share typed dataset response handling between the synchronous and asynchronous clients
- accept runtime type expressions through `TypeForm` and infer omitted output and metadata types as `Any`
- localize the cast required for dynamic `Dataset[...]` specialization
- add static inference regression coverage

## Testing

- `uv run pyright logfire/experimental/api_client.py tests/type_checking.py`
- `uv run pytest tests/test_datasets_client.py`
