### PR TITLE
Handle backend 413 responses for span exports

### DIFF
--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -365,7 +365,7 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             start_time=span.end_time,
             end_time=span.end_time,
         )
-        with contextlib.suppress(BodyTooLargeError):
+        with contextlib.suppress(Exception):
             super().export([error_span])
 
 

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -75,6 +75,8 @@ class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
 
         response = super()._export(serialized_data, *args, **kwargs)
         if response.status_code == 413:
+            # The backend checks the decompressed payload, so keep this in the same
+            # pre-compression units as the local size limit above.
             raise BodyTooLargeError(len(serialized_data), None)
         return response
 

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import atexit
-import contextlib
 import random
 import shutil
 import time
@@ -25,17 +24,15 @@ from opentelemetry.sdk.trace.export import SpanExportResult
 from requests import Session
 
 import logfire
+from logfire._internal.utils import handle_internal_errors
 
 from ..constants import (
-    ATTRIBUTES_JSON_SCHEMA_KEY,
     ATTRIBUTES_MESSAGE_KEY,
-    ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
     ATTRIBUTES_SPAN_TYPE_KEY,
     HTTP_CONNECT_TIMEOUT,
     OTLP_MAX_INT_SIZE,
     log_level_attributes,
 )
-from ..json_schema import attributes_json_schema, attributes_json_schema_properties
 from ..stack_info import STACK_INFO_KEYS
 from ..utils import logger, platform_is_emscripten, truncate_string
 from .wrapper import WrapperLogExporter, WrapperSpanExporter
@@ -307,7 +304,10 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             return super().export(spans)
         except BodyTooLargeError as e:
             if len(spans) == 1:
-                self._log_too_large_span(e, spans[0])
+                error_span = self._make_log_too_large_span(e, spans[0])
+                with handle_internal_errors:
+                    super().export([error_span])
+
                 return SpanExportResult.FAILURE
 
             half = len(spans) // 2
@@ -317,14 +317,16 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
                 return SpanExportResult.FAILURE
             return SpanExportResult.SUCCESS
 
-    def _log_too_large_span(self, e: BodyTooLargeError, span: ReadableSpan) -> None:
+    @staticmethod
+    @handle_internal_errors
+    def _make_log_too_large_span(e: BodyTooLargeError, span: ReadableSpan) -> ReadableSpan:
         original_attributes = span.attributes or {}
         new_attributes: dict[str, Any] = {'size': e.size}
         if e.max_size is not None:
             new_attributes['max_size'] = e.max_size
 
-        with contextlib.suppress(Exception):
-            for key in STACK_INFO_KEYS:
+        for key in STACK_INFO_KEYS:
+            with handle_internal_errors:
                 if key in original_attributes:  # pragma: no branch
                     value = original_attributes[key]
                     if isinstance(value, str):
@@ -332,8 +334,8 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
                     elif key == 'code.lineno' and type(value) is int and 0 <= value <= OTLP_MAX_INT_SIZE:
                         new_attributes[key] = value
 
-        span_name = truncate_string(span.name, max_length=1000)
-        with contextlib.suppress(Exception):
+        with handle_internal_errors:
+            span_name = truncate_string(span.name, max_length=1000)
             new_attributes.update(
                 span_name=span_name,
                 num_attributes=len(original_attributes),
@@ -343,20 +345,16 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
                 num_link_attributes=sum(len(link.attributes or {}) for link in span.links),
             )
 
-        message_template = 'Failed to export a span of size {size:,} bytes: {span_name}'
         message = f'Failed to export a span of size {e.size:,} bytes: {span_name}'
         attributes = {
             ATTRIBUTES_SPAN_TYPE_KEY: 'log',
             **log_level_attributes('error'),
-            ATTRIBUTES_MESSAGE_TEMPLATE_KEY: message_template,
             ATTRIBUTES_MESSAGE_KEY: message,
             **new_attributes,
         }
-        json_schema_properties = attributes_json_schema_properties(new_attributes)
-        attributes[ATTRIBUTES_JSON_SCHEMA_KEY] = attributes_json_schema(json_schema_properties)
 
-        error_span = ReadableSpan(
-            name=message_template,
+        return ReadableSpan(
+            name='Failed to export span that was too large',
             # The original span was rejected, so this small record replaces it in the same trace.
             context=span.context,
             parent=span.parent,
@@ -365,8 +363,6 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             start_time=span.end_time,
             end_time=span.end_time,
         )
-        with contextlib.suppress(Exception):
-            super().export([error_span])
 
 
 class BodyTooLargeError(Exception):

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import atexit
+import contextlib
 import random
 import shutil
 import time
@@ -18,14 +19,25 @@ import requests.exceptions
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk._logs._internal.export import LogRecordExportResult
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
 from requests import Session
 
 import logfire
 
-from ..constants import HTTP_CONNECT_TIMEOUT
-from ..utils import logger, platform_is_emscripten
+from ..constants import (
+    ATTRIBUTES_JSON_SCHEMA_KEY,
+    ATTRIBUTES_MESSAGE_KEY,
+    ATTRIBUTES_MESSAGE_TEMPLATE_KEY,
+    ATTRIBUTES_SPAN_TYPE_KEY,
+    HTTP_CONNECT_TIMEOUT,
+    OTLP_MAX_INT_SIZE,
+    log_level_attributes,
+)
+from ..json_schema import attributes_json_schema, attributes_json_schema_properties
+from ..stack_info import STACK_INFO_KEYS
+from ..utils import logger, platform_is_emscripten, truncate_string
 from .wrapper import WrapperLogExporter, WrapperSpanExporter
 
 _DISK_RETRYERS: list[weakref.ref[DiskRetryer]] = []
@@ -61,7 +73,10 @@ class BodySizeCheckingOTLPSpanExporter(OTLPSpanExporter):
             # Tell outer RetryFewerSpansSpanExporter to split in half
             raise BodyTooLargeError(len(serialized_data), self.max_body_size)
 
-        return super()._export(serialized_data, *args, **kwargs)
+        response = super()._export(serialized_data, *args, **kwargs)
+        if response.status_code == 413:
+            raise BodyTooLargeError(len(serialized_data), None)
+        return response
 
 
 class OTLPExporterHttpSession(Session):
@@ -288,21 +303,77 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         try:
             return super().export(spans)
-        except BodyTooLargeError:
+        except BodyTooLargeError as e:
+            if len(spans) == 1:
+                self._log_too_large_span(e, spans[0])
+                return SpanExportResult.FAILURE
+
             half = len(spans) // 2
-            # BodySizeCheckingOTLPSpanExporter should only raise BodyTooLargeError for >1 span,
-            # otherwise it should just try exporting it.
-            assert half > 0
             res1 = self.export(spans[:half])
             res2 = self.export(spans[half:])
             if res1 is not SpanExportResult.SUCCESS or res2 is not SpanExportResult.SUCCESS:
                 return SpanExportResult.FAILURE
             return SpanExportResult.SUCCESS
 
+    def _log_too_large_span(self, e: BodyTooLargeError, span: ReadableSpan) -> None:
+        original_attributes = span.attributes or {}
+        new_attributes: dict[str, Any] = {'size': e.size}
+        if e.max_size is not None:
+            new_attributes['max_size'] = e.max_size
+
+        with contextlib.suppress(Exception):
+            for key in STACK_INFO_KEYS:
+                if key in original_attributes:  # pragma: no branch
+                    value = original_attributes[key]
+                    if isinstance(value, str):
+                        new_attributes[key] = truncate_string(value, max_length=300)
+                    elif key == 'code.lineno' and type(value) is int and 0 <= value <= OTLP_MAX_INT_SIZE:
+                        new_attributes[key] = value
+
+        span_name = truncate_string(span.name, max_length=1000)
+        with contextlib.suppress(Exception):
+            new_attributes.update(
+                span_name=span_name,
+                num_attributes=len(original_attributes),
+                num_events=len(span.events),
+                num_links=len(span.links),
+                num_event_attributes=sum(len(event.attributes or {}) for event in span.events),
+                num_link_attributes=sum(len(link.attributes or {}) for link in span.links),
+            )
+
+        message_template = 'Failed to export a span of size {size:,} bytes: {span_name}'
+        message = f'Failed to export a span of size {e.size:,} bytes: {span_name}'
+        attributes = {
+            ATTRIBUTES_SPAN_TYPE_KEY: 'log',
+            **log_level_attributes('error'),
+            ATTRIBUTES_MESSAGE_TEMPLATE_KEY: message_template,
+            ATTRIBUTES_MESSAGE_KEY: message,
+            **new_attributes,
+        }
+        json_schema_properties = attributes_json_schema_properties(new_attributes)
+        attributes[ATTRIBUTES_JSON_SCHEMA_KEY] = attributes_json_schema(json_schema_properties)
+
+        error_span = ReadableSpan(
+            name=message_template,
+            # The original span was rejected, so this small record replaces it in the same trace.
+            context=span.context,
+            parent=span.parent,
+            resource=Resource.get_empty(),
+            attributes=attributes,
+            start_time=span.end_time,
+            end_time=span.end_time,
+        )
+        with contextlib.suppress(BodyTooLargeError):
+            super().export([error_span])
+
 
 class BodyTooLargeError(Exception):
-    def __init__(self, size: int, max_size: int) -> None:
-        super().__init__(f'Request body is too large ({size} bytes), must be less than {max_size} bytes.')
+    def __init__(self, size: int, max_size: int | None) -> None:
+        if max_size is None:
+            message = f'Request body is too large ({size} bytes).'
+        else:
+            message = f'Request body is too large ({size} bytes), must be less than {max_size} bytes.'
+        super().__init__(message)
         self.size = size
         self.max_size = max_size
 

--- a/logfire/_internal/exporters/otlp.py
+++ b/logfire/_internal/exporters/otlp.py
@@ -304,8 +304,8 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             return super().export(spans)
         except BodyTooLargeError as e:
             if len(spans) == 1:
-                error_span = self._make_log_too_large_span(e, spans[0])
                 with handle_internal_errors:
+                    error_span = self._make_log_too_large_span(e, spans[0])
                     super().export([error_span])
 
                 return SpanExportResult.FAILURE
@@ -318,7 +318,6 @@ class RetryFewerSpansSpanExporter(WrapperSpanExporter):
             return SpanExportResult.SUCCESS
 
     @staticmethod
-    @handle_internal_errors
     def _make_log_too_large_span(e: BodyTooLargeError, span: ReadableSpan) -> ReadableSpan:
         original_attributes = span.attributes or {}
         new_attributes: dict[str, Any] = {'size': e.size}

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 import requests.exceptions
 from dirty_equals import IsStr
+from inline_snapshot import snapshot
 from opentelemetry.exporter.otlp.proto.http import Compression
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from opentelemetry.sdk.resources import Resource
@@ -162,10 +163,10 @@ def test_backend_payload_too_large_reports_decompressed_size() -> None:
     assert exc_info.value.size > adapter.body_sizes[0]
 
 
-def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:
+def _make_large_span():
     large_value = 'x' * (2 * 1024 * 1024)
     original = TEST_SPANS[0]
-    span = ReadableSpan(
+    return ReadableSpan(
         name=original.name,
         context=original.context,
         parent=original.parent,
@@ -179,17 +180,43 @@ def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:
         end_time=original.end_time,
         instrumentation_scope=InstrumentationScope('test', attributes={'large': large_value}),
     )
+
+
+def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:
     session = OTLPExporterHttpSession()
-    adapter = StatusCodeHTTPAdapter(413, 413)
+    adapter = StatusCodeHTTPAdapter(413, 200)
     session.mount('http://', adapter)
     exporter = RetryFewerSpansSpanExporter(
         BodySizeCheckingOTLPSpanExporter(session=session, compression=Compression.NoCompression)
     )
 
-    assert exporter.export([span]) is SpanExportResult.FAILURE
+    assert exporter.export([_make_large_span()]) is SpanExportResult.FAILURE
     assert len(adapter.timeouts) == 2
     assert adapter.body_sizes[0] > 5 * 1024 * 1024
     assert adapter.body_sizes[1] < 10_000
+
+
+def test_make_log_too_large_span() -> None:
+    span = _make_large_span()
+    error = BodyTooLargeError(1234, None)
+    new_span = RetryFewerSpansSpanExporter._make_log_too_large_span(error, span)  # type: ignore
+    assert new_span.name == snapshot('Failed to export span that was too large')
+    assert dict(new_span.attributes or {}) == snapshot(
+        {
+            'logfire.span_type': 'log',
+            'logfire.level_num': 17,
+            'logfire.msg': 'Failed to export a span of size 1,234 bytes: test span name 1',
+            'size': 1234,
+            'span_name': 'test span name 1',
+            'num_attributes': 3,
+            'num_events': 0,
+            'num_links': 0,
+            'num_event_attributes': 0,
+            'num_link_attributes': 0,
+        }
+    )
+    assert dict(new_span.resource.attributes or {}) == snapshot({})
+    assert new_span.start_time == new_span.end_time == span.end_time
 
 
 def test_other_client_errors_are_not_split() -> None:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -14,6 +14,7 @@ import requests
 import requests.exceptions
 from dirty_equals import IsStr
 from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
@@ -44,12 +45,15 @@ class SinkHTTPAdapter(HTTPAdapter):
     def __init__(self) -> None:
         super().__init__()
         self.timeouts: list[float | tuple[float, float] | None] = []
+        self.bodies: list[bytes] = []
         self.body_sizes: list[int] = []
 
     def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
         self.timeouts.append(kwargs.get('timeout'))
         assert request.body is None or isinstance(request.body, bytes)
-        self.body_sizes.append(len(request.body or b''))
+        body = request.body or b''
+        self.bodies.append(body)
+        self.body_sizes.append(len(body))
         resp = Response()
         resp.status_code = 200
         return resp
@@ -124,6 +128,17 @@ def test_backend_payload_too_large_splits_spans() -> None:
 
     assert exporter.export(TEST_SPANS[:2]) is SpanExportResult.SUCCESS
     assert len(adapter.timeouts) == 3
+    span_counts: list[int] = []
+    for body in adapter.bodies:
+        request = ExportTraceServiceRequest.FromString(body)
+        span_counts.append(
+            sum(
+                len(scope_spans.spans)
+                for resource_spans in request.resource_spans
+                for scope_spans in resource_spans.scope_spans
+            )
+        )
+    assert span_counts == [2, 1, 1]
 
 
 def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -13,7 +13,11 @@ import pytest
 import requests
 import requests.exceptions
 from dirty_equals import IsStr
+from opentelemetry.exporter.otlp.proto.http import Compression
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
 from requests.models import PreparedRequest, Response as Response
 from requests.sessions import HTTPAdapter
 
@@ -25,6 +29,7 @@ from logfire._internal.exporters.otlp import (
     BodyTooLargeError,
     DiskRetryer,
     OTLPExporterHttpSession,
+    RetryFewerSpansSpanExporter,
     cleanup_disk_retryers,
 )
 from logfire._internal.exporters.remove_pending import RemovePendingSpansExporter
@@ -39,12 +44,26 @@ class SinkHTTPAdapter(HTTPAdapter):
     def __init__(self) -> None:
         super().__init__()
         self.timeouts: list[float | tuple[float, float] | None] = []
+        self.body_sizes: list[int] = []
 
     def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
         self.timeouts.append(kwargs.get('timeout'))
+        assert request.body is None or isinstance(request.body, bytes)
+        self.body_sizes.append(len(request.body or b''))
         resp = Response()
         resp.status_code = 200
         return resp
+
+
+class StatusCodeHTTPAdapter(SinkHTTPAdapter):
+    def __init__(self, *status_codes: int) -> None:
+        super().__init__()
+        self.status_codes = list(status_codes)
+
+    def send(self, request: PreparedRequest, *args: Any, **kwargs: Any) -> Response:
+        response = super().send(request, *args, **kwargs)
+        response.status_code = self.status_codes.pop(0)
+        return response
 
 
 @pytest.mark.parametrize(
@@ -93,6 +112,58 @@ def test_max_body_size_bytes() -> None:
     # The exact serialized size depends on the OpenTelemetry version, so match the message shape
     # rather than a hardcoded byte count.
     assert str(e.value) == IsStr(regex=r'Request body is too large \(\d+ bytes\), must be less than 10 bytes\.')
+
+
+def test_backend_payload_too_large_splits_spans() -> None:
+    session = OTLPExporterHttpSession()
+    adapter = StatusCodeHTTPAdapter(413, 200, 200)
+    session.mount('http://', adapter)
+    exporter = RetryFewerSpansSpanExporter(
+        BodySizeCheckingOTLPSpanExporter(session=session, compression=Compression.NoCompression)
+    )
+
+    assert exporter.export(TEST_SPANS[:2]) is SpanExportResult.SUCCESS
+    assert len(adapter.timeouts) == 3
+
+
+def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:
+    large_value = 'x' * (2 * 1024 * 1024)
+    original = TEST_SPANS[0]
+    span = ReadableSpan(
+        name=original.name,
+        context=original.context,
+        parent=original.parent,
+        resource=Resource({'large': large_value}),
+        attributes={
+            'code.filepath': [large_value],
+            'code.function': [large_value],
+            'code.lineno': [1],
+        },
+        start_time=original.start_time,
+        end_time=original.end_time,
+        instrumentation_scope=InstrumentationScope('test', attributes={'large': large_value}),
+    )
+    session = OTLPExporterHttpSession()
+    adapter = StatusCodeHTTPAdapter(413, 413)
+    session.mount('http://', adapter)
+    exporter = RetryFewerSpansSpanExporter(
+        BodySizeCheckingOTLPSpanExporter(session=session, compression=Compression.NoCompression)
+    )
+
+    assert exporter.export([span]) is SpanExportResult.FAILURE
+    assert len(adapter.timeouts) == 2
+    assert adapter.body_sizes[0] > 5 * 1024 * 1024
+    assert adapter.body_sizes[1] < 10_000
+
+
+def test_other_client_errors_are_not_split() -> None:
+    session = OTLPExporterHttpSession()
+    adapter = StatusCodeHTTPAdapter(400)
+    session.mount('http://', adapter)
+    exporter = RetryFewerSpansSpanExporter(BodySizeCheckingOTLPSpanExporter(session=session))
+
+    assert exporter.export(TEST_SPANS[:2]) is SpanExportResult.FAILURE
+    assert len(adapter.timeouts) == 1
 
 
 def test_connection_error_retries(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/exporters/test_otlp_session.py
+++ b/tests/exporters/test_otlp_session.py
@@ -141,6 +141,27 @@ def test_backend_payload_too_large_splits_spans() -> None:
     assert span_counts == [2, 1, 1]
 
 
+def test_backend_payload_too_large_reports_decompressed_size() -> None:
+    original = TEST_SPANS[0]
+    span = ReadableSpan(
+        name=original.name,
+        context=original.context,
+        attributes={'large': 'x' * 200_000},
+        start_time=original.start_time,
+        end_time=original.end_time,
+    )
+    session = OTLPExporterHttpSession()
+    adapter = StatusCodeHTTPAdapter(413)
+    session.mount('http://', adapter)
+    exporter = BodySizeCheckingOTLPSpanExporter(session=session, compression=Compression.Gzip)
+
+    with pytest.raises(BodyTooLargeError) as exc_info:
+        exporter.export([span])
+
+    assert exc_info.value.max_size is None
+    assert exc_info.value.size > adapter.body_sizes[0]
+
+
 def test_single_backend_payload_too_large_exports_bounded_diagnostic() -> None:
     large_value = 'x' * (2 * 1024 * 1024)
     original = TEST_SPANS[0]

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import json
 from collections.abc import Sequence
 from typing import cast
 
 import pytest
+from inline_snapshot import snapshot
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import Event, ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
@@ -122,18 +122,16 @@ def test_single_span_too_large_exports_diagnostic(max_size: int | None) -> None:
 
     assert exporter.export(TEST_SPANS[:1]) is SpanExportResult.FAILURE
     [diagnostic] = test_exporter.exported_spans
-    assert diagnostic.name == 'Failed to export a span of size {size:,} bytes: {span_name}'
+    assert diagnostic.name == snapshot('Failed to export span that was too large')
     assert diagnostic.context == TEST_SPANS[0].context
     assert diagnostic.resource == Resource.get_empty()
     assert diagnostic.instrumentation_scope is None
     assert diagnostic.start_time == diagnostic.end_time == TEST_SPANS[0].end_time
     attributes = dict(diagnostic.attributes or {})
     filepath = cast(str, attributes.pop('code.filepath'))
-    json_schema = json.loads(cast(str, attributes.pop('logfire.json_schema')))
     expected_attributes = {
         'logfire.span_type': 'log',
         'logfire.level_num': 17,
-        'logfire.msg_template': 'Failed to export a span of size {size:,} bytes: {span_name}',
         'logfire.msg': 'Failed to export a span of size 20,000,000 bytes: test span name 1',
         'size': 20_000_000,
         'code.function': 'test_function',
@@ -151,31 +149,3 @@ def test_single_span_too_large_exports_diagnostic(max_size: int | None) -> None:
     assert len(filepath) <= 300
     assert len(filepath) < len('super/' * 100 + 'long/path.py')
     assert filepath.startswith('super/') and filepath.endswith('long/path.py')
-    assert set(json_schema['properties']) == {
-        'size',
-        'span_name',
-        'num_attributes',
-        'num_events',
-        'num_links',
-        'num_event_attributes',
-        'num_link_attributes',
-    } | ({'max_size'} if max_size is not None else set())
-
-
-def test_single_span_too_large_suppresses_diagnostic_export_error() -> None:
-    class DiagnosticErrorExporter(TestExporter):
-        def __init__(self) -> None:
-            super().__init__()
-            self.calls = 0
-
-        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-            self.calls += 1
-            if self.calls == 1:
-                raise BodyTooLargeError(20_000_000, 5_000_000)
-            raise RuntimeError('diagnostic export failed')
-
-    test_exporter = DiagnosticErrorExporter()
-    exporter = RetryFewerSpansSpanExporter(test_exporter)
-
-    assert exporter.export(TEST_SPANS[:1]) is SpanExportResult.FAILURE
-    assert test_exporter.calls == 2

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
+from typing import cast
 
 import pytest
 from opentelemetry.sdk.resources import Resource
@@ -100,3 +102,61 @@ def test_retry_fewer_spans_when_too_many():
     res = exporter.export(TEST_SPANS)
     assert res is SpanExportResult.SUCCESS
     assert test_exporter.exported_spans == TEST_SPANS
+
+
+class SingleSpanTooLargeExporter(TestExporter):
+    def __init__(self, max_size: int | None) -> None:
+        super().__init__()
+        self.max_size = max_size
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        if spans[0].name.startswith('test span name'):
+            raise BodyTooLargeError(20_000_000, self.max_size)
+        return super().export(spans)
+
+
+@pytest.mark.parametrize('max_size', [None, 5_000_000])
+def test_single_span_too_large_exports_diagnostic(max_size: int | None) -> None:
+    test_exporter = SingleSpanTooLargeExporter(max_size)
+    exporter = RetryFewerSpansSpanExporter(test_exporter)
+
+    assert exporter.export(TEST_SPANS[:1]) is SpanExportResult.FAILURE
+    [diagnostic] = test_exporter.exported_spans
+    assert diagnostic.name == 'Failed to export a span of size {size:,} bytes: {span_name}'
+    assert diagnostic.context == TEST_SPANS[0].context
+    assert diagnostic.resource == Resource.get_empty()
+    assert diagnostic.instrumentation_scope is None
+    assert diagnostic.start_time == diagnostic.end_time == TEST_SPANS[0].end_time
+    attributes = dict(diagnostic.attributes or {})
+    filepath = cast(str, attributes.pop('code.filepath'))
+    json_schema = json.loads(cast(str, attributes.pop('logfire.json_schema')))
+    expected_attributes = {
+        'logfire.span_type': 'log',
+        'logfire.level_num': 17,
+        'logfire.msg_template': 'Failed to export a span of size {size:,} bytes: {span_name}',
+        'logfire.msg': 'Failed to export a span of size 20,000,000 bytes: test span name 1',
+        'size': 20_000_000,
+        'code.function': 'test_function',
+        'code.lineno': 321,
+        'span_name': 'test span name 1',
+        'num_attributes': 4,
+        'num_events': 2,
+        'num_links': 0,
+        'num_event_attributes': 3,
+        'num_link_attributes': 0,
+    }
+    if max_size is not None:
+        expected_attributes['max_size'] = max_size
+    assert attributes == expected_attributes
+    assert len(filepath) <= 300
+    assert len(filepath) < len('super/' * 100 + 'long/path.py')
+    assert filepath.startswith('super/') and filepath.endswith('long/path.py')
+    assert set(json_schema['properties']) == {
+        'size',
+        'span_name',
+        'num_attributes',
+        'num_events',
+        'num_links',
+        'num_event_attributes',
+        'num_link_attributes',
+    } | ({'max_size'} if max_size is not None else set())

--- a/tests/exporters/test_retry_fewer_spans.py
+++ b/tests/exporters/test_retry_fewer_spans.py
@@ -160,3 +160,22 @@ def test_single_span_too_large_exports_diagnostic(max_size: int | None) -> None:
         'num_event_attributes',
         'num_link_attributes',
     } | ({'max_size'} if max_size is not None else set())
+
+
+def test_single_span_too_large_suppresses_diagnostic_export_error() -> None:
+    class DiagnosticErrorExporter(TestExporter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.calls = 0
+
+        def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+            self.calls += 1
+            if self.calls == 1:
+                raise BodyTooLargeError(20_000_000, 5_000_000)
+            raise RuntimeError('diagnostic export failed')
+
+    test_exporter = DiagnosticErrorExporter()
+    exporter = RetryFewerSpansSpanExporter(test_exporter)
+
+    assert exporter.export(TEST_SPANS[:1]) is SpanExportResult.FAILURE
+    assert test_exporter.calls == 2


### PR DESCRIPTION
## Summary

- convert backend HTTP 413 responses into the existing `BodyTooLargeError` signal so multi-span payloads are retried in smaller batches
- replace a rejected single span with a bounded diagnostic `ReadableSpan` instead of asserting or relying on suppressed instrumentation
- keep the diagnostic payload small by dropping the rejected span's resource/scope and only copying bounded scalar stack metadata

Fixes #1035.

## Tests

- `uv run --no-sync pytest -q tests/exporters` — 21 passed
- `make lint` — passed
- `make typecheck` — passed
- full local suite: 2434 passed; the remaining Docker/service-backed and aiohttp environment failures were reproduced unchanged on the base commit

AI assistance was used to develop and review this change; the diff and reported commands were manually inspected and executed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



