### PR TITLE
Add frontend observability guides

### DIFF
--- a/docs/get-started/for-product-and-growth.md
+++ b/docs/get-started/for-product-and-growth.md
@@ -17,8 +17,8 @@ Each link says why it's here.
 
 3. **Tie changes back to usage**: every managed-variable resolution is recorded in your traces. That means you can correlate a flag or prompt change directly with what happened next (the basis for A/B tests and online experiments) using the same data your app already sends. See [Explore](../guides/web-ui/explore.md) to query that data in SQL and [Dashboards](../guides/web-ui/dashboards.md) to watch it over time.
 
-!!! note "Product analytics, session replay, and real-user monitoring"
-    Deeper product analytics, real-user monitoring (RUM, seeing performance and behavior from the actual browser) and session replay are on the roadmap and currently available to design partners. If that's what you need, [get in touch](../help.md).
+!!! note "Frontend observability and session replay"
+    [Frontend monitoring](../guides/web-ui/frontend.md) and [session replay](../guides/web-ui/session-replays.md) are available as experimental features. Enable **Frontend observability** from **Settings → Early access** to try them.
 
 ## No code required
 

--- a/docs/guides/web-ui/frontend.md
+++ b/docs/guides/web-ui/frontend.md
@@ -1,0 +1,49 @@
+---
+title: "Frontend"
+description: "Find slow pages, browser errors, heavy resources, and user sessions from frontend telemetry in Logfire."
+---
+# Frontend
+
+Use the <OpenInLogfire path="frontend" variant="inline" label="Frontend" /> page to find slow pages, browser errors, and the resources or API calls affecting real users.
+
+The page groups browser telemetry by frontend application. A frontend application gives browser data a stable service name and a restricted token that is safe to publish in a browser bundle. The token can send data only for that application. It cannot read project data or report as another service.
+
+!!! note "Experimental"
+
+    Open **Settings → Early access**, choose **Show experimental features**, and enable **Frontend observability**. This browser-level setting applies across every organization you use in that browser.
+
+## Send browser data
+
+1. Open **Project settings → Frontend applications**.
+2. Select **New application** and give the application a stable name, such as `customer-portal`.
+3. Copy the generated setup into your browser application.
+4. Enable the browser signals you want to investigate. See the [browser SDK guide](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/) for automatic request tracing, Core Web Vitals, browser metrics, and framework-specific options.
+
+Browser telemetry is sent to and stored in your Logfire project. Review the attributes your application adds before sending sensitive values.
+
+## Find what affects users
+
+Select a time range and, when a project has several frontend applications, choose one application or keep **All applications** selected. You can filter the results by page, domain, country, browser, operating system, or device.
+
+The page combines several views of the same browser activity:
+
+- **Page loads** and load-time summaries show traffic and the latency users experienced.
+- **Core Web Vitals** show loading, responsiveness, and visual-stability measurements from real page loads. The default p75 view reports the 75th percentile, so 75% of observations are at or below the displayed value.
+- **What's slow** identifies page elements and interactions associated with poor results.
+- **Top pages**, **Largest resources**, and **Slowest API calls** help connect a slow experience to a route, asset, or request.
+- **Top errors** links browser failures to the matching records in Live view.
+
+When you filter to an investigation target, Logfire also shows related recorded sessions when a [session replay](session-replays.md) is available.
+
+## Verify browser data
+
+Load an instrumented page, interact with it, and return to **Frontend**. Expand the time range if needed. You should see a page load and the application's name. Core Web Vitals appear only after you enable `rum.webVitals` and supported browsers report measurements.
+
+## Fix missing frontend data
+
+| Symptom | What to check |
+|---------|---------------|
+| **No frontend data in this range** | Confirm the generated browser setup is running, the token belongs to the selected application, and the time range includes a recent page load. |
+| The application is missing | Select **All applications**, then confirm the application still exists under **Project settings → Frontend applications**. |
+| Page loads appear without Core Web Vitals | Enable `rum.webVitals` in the browser SDK configuration, reload the page, and wait for supported measurements to complete. |
+| Requests fail from the browser | Check the browser network panel for authentication, content-security-policy, or ad-blocker failures. |

--- a/docs/guides/web-ui/session-replays.md
+++ b/docs/guides/web-ui/session-replays.md
@@ -1,0 +1,50 @@
+---
+title: "Session Replays"
+description: "Replay a user's browser session alongside navigation, network, console, and Logfire trace data."
+---
+# Session Replays
+
+Use <OpenInLogfire path="frontend/session-replays" variant="inline" label="Session Replays" /> to reproduce what a user saw, then connect the recording to browser errors, failed requests, and the matching Logfire spans.
+
+A session replay records changes to the page's document structure and user interactions. Logfire reconstructs those events in a player. It does not store a video stream.
+
+!!! note "Experimental"
+
+    Open **Settings → Early access**, choose **Show experimental features**, and enable **Frontend observability**. The same setting enables the Frontend and Session Replays pages.
+
+## Record sessions
+
+1. Create a frontend application under **Project settings → Frontend applications** and add its generated browser setup to your application.
+2. Install the optional `@pydantic/logfire-session-replay` package.
+3. Follow the [Session Replay setup](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/#session-replay) to load the recorder and configure the replay endpoint.
+4. Deploy the change, open the application, and interact with more than one page or control.
+
+Replay data is sent to and stored in your Logfire project. The recorder masks rendered text and input values by default, leaves console capture off, and removes query strings and fragments from captured URLs. Those defaults do not redact document attributes, CSS-generated content, resource URLs, or custom-event payloads. Review the [privacy controls](https://pydantic.dev/docs/logfire/instrument/typescript/packages/browser/#session-replay) before recording pages that contain sensitive data.
+
+## Find a useful recording
+
+The list shows the entry page, user identity when available, last page, activity counts, duration, and start time. Use the time range, duration, error-only, and text filters to narrow the list. The search matches users, pages, and session identifiers.
+
+Open a recording to inspect:
+
+- **Playback**, including idle-period skipping and activity markers.
+- **Activity**, such as navigation, clicks, and input activity.
+- **Network**, including failed and incomplete requests.
+- **Console**, when the application explicitly enables console capture.
+- **Session and browser context**, including URLs, environment, application version, country, language, and platform when those values were retained.
+- **Browser telemetry**, with a link to every span from the same browser session in Live view.
+
+The event rows are synchronized with playback. Select an activity, network request, or console entry to seek to that point in the recording.
+
+## Verify a recording
+
+After using the instrumented application, open **Frontend → Session Replays** and include the session's start time in the selected range. You should see the entry page and activity counts. Open the row and confirm that playback and the activity list advance together.
+
+## Fix missing or incomplete recordings
+
+| Symptom | What to check |
+|---------|---------------|
+| **No replays yet** | Confirm the optional replay package loads, the replay endpoint accepts the frontend application token, and the browser did not block the request. |
+| A recording stops early | Some replay chunks failed to upload or download. Check browser network failures and retry from the replay page. |
+| The recording is playable but browser telemetry is empty | Confirm browser spans and replay chunks share the same application setup and browser session. Also check the project's retention and sampling configuration. |
+| Text is missing from playback | Text and input masking is on by default. Change masking only after reviewing what the page may expose. |

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -906,9 +906,15 @@ navigation:
         aliases:
           - "reference/query-api"
           - "how-to-guides/query-api"
-  - section: "Product & Experimentation"
+  - section: "User Experience"
     slug: ""
     contents:
+      - page: "Frontend"
+        path: "guides/web-ui/frontend.md"
+        slug: "observe/frontend"
+      - page: "Session Replays"
+        path: "guides/web-ui/session-replays.md"
+        slug: "observe/session-replays"
       - section: "Feature Flags"
         contents:
           - page: "Overview"


### PR DESCRIPTION
## Summary

- rename the docs section from Product & Experimentation to User Experience
- add guides for Frontend and Session Replays
- replace the stale design-partner note with the current experimental setup path

## Test plan

- `uv run pre-commit run --files docs/navigation.yml docs/get-started/for-product-and-growth.md docs/guides/web-ui/frontend.md docs/guides/web-ui/session-replays.md`
- rendered both new routes in unified-docs and checked navigation, links, tables, and normal viewport layout

Documentation drafting: drafted with Codex, then checked against the current Platform and logfire-js implementations and rendered in unified-docs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

