### PR TITLE
Prioritize first data in Logfire setup skill

### DIFF
--- a/logfire/.agents/skills/logfire-instrumentation/SKILL.md
+++ b/logfire/.agents/skills/logfire-instrumentation/SKILL.md
@@ -25,11 +25,13 @@ Identify the project language and instrumentable libraries:
 - **JavaScript/TypeScript**: Read `package.json`. Common frameworks: Express, Next.js, Fastify. Also check for Cloudflare Workers or Deno.
 - **Rust**: Read `Cargo.toml`.
 
+For a broad setup request or a repository with multiple runnable services, choose one representative service with the shortest path to a real request, job, or agent run. Complete Steps 3-5 for only that service and confirm fresh data reaches Logfire before touching another service or language. If the user named a specific target, start there. After the first service is verified, expand one service at a time.
+
 Then continue to Step 3: Install and Instrument.
 
 ## Step 3: Install and Instrument
 
-Follow every applicable subsection for the language(s) detected in Step 2 — a polyglot repo (e.g. a Python backend with a JS/TS frontend) needs more than one.
+Follow only the subsection(s) needed by the representative service selected in Step 2. Do not instrument every detected language or package during the first pass.
 
 ### Python
 
@@ -142,6 +144,8 @@ These apply to every language and are what make the **Services**, **Hosts**,
 **Metrics**, and **Dashboards** views useful — don't skip them when the goal is
 broad coverage.
 
+For the first-data pass, set a meaningful `service.name`, but do not let optional metrics or exhaustive metadata delay the first verified record. Return for those after Step 5 succeeds.
+
 ### Service metadata
 
 Every span and metric carries resource attributes the product uses to group and
@@ -197,6 +201,8 @@ Instrumentation isn't done when the code compiles or an SDK reports "connected."
 4. **Fix every gap you find, then re-run and re-check.** Repeat until it's clean. Absence of startup/exporter errors is not success on its own.
 
 If nothing arrives at all, trace the path in order: authentication and exact project/region (Step 1), `configure()` called before `instrument_*()` (Python) or before the app's own imports run (JS/TS preload order), the correct packages/extras installed, then the exercised code path and exporter/flush behavior. Make the smallest safe correction and verify again — report one specific blocker, not a generic checklist.
+
+After the representative service is verified, offer to instrument the next service or language and add broader metadata, metrics, or infrastructure coverage. Continue only with the work the user wants, one verified source at a time.
 
 Close with a final report built from real values you just confirmed, not a template — org, project, and region from `whoami`; the service name(s) actually seen; what Step 4 covered (AI/LLM content level, agent framework if any); and, if you ran Step 3's optional `logfire run --summary`, what it detected. **Include the project's URL** (from `whoami` or `projects status`) as a direct link to the Live view, so the user can see their own traces arrive without having to ask where to look. A report with a placeholder in it means a step above was skipped, not finished.
 

--- a/logfire/.agents/skills/logfire-instrumentation/SKILL.md
+++ b/logfire/.agents/skills/logfire-instrumentation/SKILL.md
@@ -210,8 +210,9 @@ Close with a final report built from real values you just confirmed, not a templ
 
 Logfire's value scales with how much useful telemetry you send. When the user
 asks to "get me set up properly" or "send as much data as would be useful,"
-don't stop at app traces — work down this map. Each row is a distinct data
-source and the product surface it lights up.
+first get the representative service to verified first data. Then work down
+this map one source at a time, verifying each source before adding the next.
+Each row is a distinct data source and the product surface it lights up.
 
 | To get this in the UI | Send this | How |
 |-----------------------|-----------|-----|

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -42,7 +42,7 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |
 | AI Gateway | Spend caps, failover, and routing for model calls (`logfire gateway`) | no dedicated skill yet — see the product's own docs |
 
-- No specific scope given (e.g. "set up Logfire in this repo end to end")? Default to `logfire-instrumentation` for ordinary application code. Concrete repo evidence of another surface — a `docker-compose.yml`, Kubernetes manifests, an agent worth evaluating rather than just observing — fetch the matching additional skill(s) too.
+- No specific scope given (e.g. "set up Logfire in this repo end to end")? Default to `logfire-instrumentation` for ordinary application code. Incidental Docker, Kubernetes, infrastructure, or eval files do not expand the initial setup: get one representative application service to verified first data, then offer the matching additional skill(s). If the repository is clearly infrastructure-only, route directly to `logfire-infrastructure` instead.
 - A request already scoped to one surface ("monitor my Postgres server", "set up evals for this agent") → fetch that skill directly, skipping the rest of this table.
 - Genuinely ambiguous between two adjacent surfaces (e.g. "watch my Postgres" could mean Collector-level infrastructure metrics or app-level query instrumentation)? Ask one clarifying question rather than guessing — loading the wrong skill wastes the user's time reading instructions for a job they didn't ask for.
 
@@ -80,11 +80,13 @@ Identify the project language and instrumentable libraries:
 - **JavaScript/TypeScript**: Read `package.json`. Common frameworks: Express, Next.js, Fastify. Also check for Cloudflare Workers or Deno.
 - **Rust**: Read `Cargo.toml`.
 
+For a broad setup request or a repository with multiple runnable services, choose one representative service with the shortest path to a real request, job, or agent run. Complete Steps 3-5 for only that service and confirm fresh data reaches Logfire before touching another service or language. If the user named a specific target, start there. After the first service is verified, expand one service at a time.
+
 Then continue to Step 3: Install and Instrument.
 
 ## Step 3: Install and Instrument
 
-Follow every applicable subsection for the language(s) detected in Step 2 — a polyglot repo (e.g. a Python backend with a JS/TS frontend) needs more than one.
+Follow only the subsection(s) needed by the representative service selected in Step 2. Do not instrument every detected language or package during the first pass.
 
 ### Python
 
@@ -197,6 +199,8 @@ These apply to every language and are what make the **Services**, **Hosts**,
 **Metrics**, and **Dashboards** views useful — don't skip them when the goal is
 broad coverage.
 
+For the first-data pass, set a meaningful `service.name`, but do not let optional metrics or exhaustive metadata delay the first verified record. Return for those after Step 5 succeeds.
+
 ### Service metadata
 
 Every span and metric carries resource attributes the product uses to group and
@@ -253,14 +257,17 @@ Instrumentation isn't done when the code compiles or an SDK reports "connected."
 
 If nothing arrives at all, trace the path in order: authentication and exact project/region (Step 1), `configure()` called before `instrument_*()` (Python) or before the app's own imports run (JS/TS preload order), the correct packages/extras installed, then the exercised code path and exporter/flush behavior. Make the smallest safe correction and verify again — report one specific blocker, not a generic checklist.
 
+After the representative service is verified, offer to instrument the next service or language and add broader metadata, metrics, or infrastructure coverage. Continue only with the work the user wants, one verified source at a time.
+
 Close with a final report built from real values you just confirmed, not a template — org, project, and region from `whoami`; the service name(s) actually seen; what Step 4 covered (AI/LLM content level, agent framework if any); and, if you ran Step 3's optional `logfire run --summary`, what it detected. **Include the project's URL** (from `whoami` or `projects status`) as a direct link to the Live view, so the user can see their own traces arrive without having to ask where to look. A report with a placeholder in it means a step above was skipped, not finished.
 
 ## Going Further: Full Coverage Map
 
 Logfire's value scales with how much useful telemetry you send. When the user
 asks to "get me set up properly" or "send as much data as would be useful,"
-don't stop at app traces — work down this map. Each row is a distinct data
-source and the product surface it lights up.
+first get the representative service to verified first data. Then work down
+this map one source at a time, verifying each source before adding the next.
+Each row is a distinct data source and the product surface it lights up.
 
 | To get this in the UI | Send this | How |
 |-----------------------|-----------|-----|

--- a/logfire/.agents/skills/logfire-setup/SKILL.md
+++ b/logfire/.agents/skills/logfire-setup/SKILL.md
@@ -29,7 +29,7 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |
 | AI Gateway | Spend caps, failover, and routing for model calls (`logfire gateway`) | no dedicated skill yet — see the product's own docs |
 
-- No specific scope given (e.g. "set up Logfire in this repo end to end")? Default to `logfire-instrumentation` for ordinary application code. Concrete repo evidence of another surface — a `docker-compose.yml`, Kubernetes manifests, an agent worth evaluating rather than just observing — fetch the matching additional skill(s) too.
+- No specific scope given (e.g. "set up Logfire in this repo end to end")? Default to `logfire-instrumentation` for ordinary application code. Incidental Docker, Kubernetes, infrastructure, or eval files do not expand the initial setup: get one representative application service to verified first data, then offer the matching additional skill(s). If the repository is clearly infrastructure-only, route directly to `logfire-infrastructure` instead.
 - A request already scoped to one surface ("monitor my Postgres server", "set up evals for this agent") → fetch that skill directly, skipping the rest of this table.
 - Genuinely ambiguous between two adjacent surfaces (e.g. "watch my Postgres" could mean Collector-level infrastructure metrics or app-level query instrumentation)? Ask one clarifying question rather than guessing — loading the wrong skill wastes the user's time reading instructions for a job they didn't ask for.
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -53,6 +53,18 @@ def test_agent_setup_prompt_states_the_load_bearing_content() -> None:
     assert 'Authenticate first, confirmed via `whoami`, before opening or running any application file' in prompt
 
 
+def test_setup_skills_prioritize_one_service_reaching_first_data() -> None:
+    hub = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-setup' / 'SKILL.md').read_text()
+    instrumentation = (
+        REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-instrumentation' / 'SKILL.md'
+    ).read_text()
+
+    assert 'get one representative application service to verified first data' in hub
+    assert 'choose one representative service with the shortest path' in instrumentation
+    assert 'Do not instrument every detected language or package during the first pass' in instrumentation
+    assert 'Follow every applicable subsection' not in instrumentation
+
+
 def _wrap(component: str, prompt_lines: list[str]) -> str:
     return f'<{component}>\n\n````text\n' + '\n'.join(prompt_lines) + f'\n````\n\n</{component}>\n'
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -62,6 +62,8 @@ def test_setup_skills_prioritize_one_service_reaching_first_data() -> None:
     assert 'get one representative application service to verified first data' in hub
     assert 'choose one representative service with the shortest path' in instrumentation
     assert 'Do not instrument every detected language or package during the first pass' in instrumentation
+    assert 'first get the representative service to verified first data' in instrumentation
+    assert 'verifying each source before adding the next' in instrumentation
     assert 'Follow every applicable subsection' not in instrumentation
 
 


### PR DESCRIPTION
## Summary

- restore the one-representative-service-first sequencing that Platform guided setup previously carried in its generated prompt
- keep incidental Docker, Kubernetes, infrastructure, and eval files from expanding the initial setup scope
- defer additional services, languages, optional metrics, and infrastructure until the first service has sent verified data
- protect the sequencing with a focused prompt-contract test

## Context

Platform PR pydantic/platform#34031 added this first-data gate to the generated guided-setup prompt. Platform PR pydantic/platform#35077 later moved guided setup to the pinned external skill, but the canonical skill had never inherited that instruction.

## Validation

- `uv run --no-sync pytest tests/test_agent_setup_prompt.py -q` (5 passed)
- `make lint`
- `quick_validate.py logfire/.agents/skills/logfire-setup`
- instrumentation skill body and frontmatter parse in repository tests; standalone `quick_validate.py` still reports the pre-existing 1,112-character description as exceeding its 1,024-character limit

## Follow-up

After merge, Platform should bump `LOGFIRE_SETUP_SKILL_COMMIT` to this PRs merged commit so guided onboarding consumes the change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

