### PR TITLE
Skip the Logfire token check inside AWS Lambda

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -126,6 +126,7 @@ from .utils import (
     SeededRandomIdGenerator,
     ensure_data_dir_exists,
     handle_internal_errors,
+    platform_is_aws_lambda,
     platform_is_emscripten,
     suppress_instrumentation,
 )
@@ -1370,6 +1371,14 @@ class LogfireConfig(_LogfireConfigData):
                                         validated_credentials.print_token_summary()
 
                     if emscripten:  # pragma: no cover
+                        check_tokens()
+                    elif platform_is_aws_lambda():
+                        # Run the check synchronously: `configure()` is typically called at import
+                        # time, i.e. in the Lambda init phase, and Lambda may freeze the environment
+                        # right after init (proactive initialization) until the first invocation
+                        # arrives, sometimes minutes later. A thread frozen mid-TLS-handshake reads an
+                        # EOF once thawed and warns "Logfire API is unreachable" although nothing is
+                        # wrong. The synchronous check costs one HTTP round trip during init.
                         check_tokens()
                     else:
                         thread = Thread(target=check_tokens, name='check_logfire_token')

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1373,13 +1373,14 @@ class LogfireConfig(_LogfireConfigData):
                     if emscripten:  # pragma: no cover
                         check_tokens()
                     elif platform_is_aws_lambda():
-                        # Run the check synchronously: `configure()` is typically called at import
-                        # time, i.e. in the Lambda init phase, and Lambda may freeze the environment
-                        # right after init (proactive initialization) until the first invocation
-                        # arrives, sometimes minutes later. A thread frozen mid-TLS-handshake reads an
-                        # EOF once thawed and warns "Logfire API is unreachable" although nothing is
-                        # wrong. The synchronous check costs one HTTP round trip during init.
-                        check_tokens()
+                        # Skip the check inside AWS Lambda. `configure()` usually runs in the init
+                        # phase, and Lambda may freeze the environment right after init until the
+                        # first invocation arrives (proactive initialization), sometimes minutes
+                        # later. A thread frozen mid-request warns "Logfire API is unreachable" once
+                        # thawed although nothing is wrong, and running the check synchronously would
+                        # slow down every cold start. The check is not essential: the exporters
+                        # report a rejected token on the first export anyway.
+                        pass
                     else:
                         thread = Thread(target=check_tokens, name='check_logfire_token')
                         thread.start()

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -467,6 +467,17 @@ def platform_is_emscripten() -> bool:
     return platform.system().lower() == 'emscripten'
 
 
+def platform_is_aws_lambda() -> bool:
+    """Return True when running inside an AWS Lambda function.
+
+    Lambda freezes the execution environment between the end of the init phase and the first
+    invocation (and between invocations). A background thread that is mid-way through a network
+    call when the freeze happens finds the connection closed by the remote side once it thaws.
+    `AWS_LAMBDA_FUNCTION_NAME` is set by the runtime in every Lambda execution environment.
+    """
+    return bool(os.environ.get('AWS_LAMBDA_FUNCTION_NAME'))
+
+
 def canonicalize_exception_traceback(exc: BaseException, seen: set[int] | None = None) -> str:
     """Return a canonical string representation of an exception traceback.
 

--- a/logfire/_internal/utils.py
+++ b/logfire/_internal/utils.py
@@ -471,9 +471,9 @@ def platform_is_aws_lambda() -> bool:
     """Return True when running inside an AWS Lambda function.
 
     Lambda freezes the execution environment between the end of the init phase and the first
-    invocation (and between invocations). A background thread that is mid-way through a network
-    call when the freeze happens finds the connection closed by the remote side once it thaws.
-    `AWS_LAMBDA_FUNCTION_NAME` is set by the runtime in every Lambda execution environment.
+    invocation (and between invocations), so background work started during init may be
+    interrupted for minutes. `AWS_LAMBDA_FUNCTION_NAME` is set by the runtime in every Lambda
+    execution environment.
     """
     return bool(os.environ.get('AWS_LAMBDA_FUNCTION_NAME'))
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2358,14 +2358,31 @@ def wait_for_check_token_thread():
 def test_token_check_is_synchronous_on_aws_lambda(monkeypatch: pytest.MonkeyPatch) -> None:
     # Lambda freezes the environment after the init phase; a background token check frozen
     # mid-request would fail once thawed. Inside Lambda the check must complete in configure().
+    # The mocked /v1/info response is held back until `release` is set, so configure() can only
+    # return early if it (wrongly) delegates the check to a background thread.
     monkeypatch.setenv('AWS_LAMBDA_FUNCTION_NAME', 'my-function')
-    with requests_mock.Mocker() as request_mocker:
-        request_mocker.get(
-            'https://logfire-us.pydantic.dev/v1/info',
-            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
-        )
+    release = threading.Event()
+    configured = threading.Event()
+
+    def held_back_info(_request: Any, _context: Any) -> dict[str, str]:
+        release.wait(timeout=5)
+        return {'project_name': 'myproject', 'project_url': 'fake_project_url'}
+
+    def run_configure() -> None:
         configure(token='foobar', send_to_logfire='if-token-present', console=False)
-        # No wait_for_check_token_thread(): the request must already be recorded.
+        configured.set()
+
+    with requests_mock.Mocker() as request_mocker:
+        request_mocker.get('https://logfire-us.pydantic.dev/v1/info', json=held_back_info)
+        helper = threading.Thread(target=run_configure)
+        helper.start()
+        try:
+            # While the response is held back, configure() must still be waiting for it.
+            assert not configured.wait(timeout=0.5)
+        finally:
+            release.set()
+            helper.join(timeout=5)
+        assert configured.is_set()
         assert len(request_mocker.request_history) == 1
         assert not any(thread.name == 'check_logfire_token' for thread in threading.enumerate())
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2355,6 +2355,21 @@ def wait_for_check_token_thread():
             thread.join()
 
 
+def test_token_check_is_synchronous_on_aws_lambda(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Lambda freezes the environment after the init phase; a background token check frozen
+    # mid-request would fail once thawed. Inside Lambda the check must complete in configure().
+    monkeypatch.setenv('AWS_LAMBDA_FUNCTION_NAME', 'my-function')
+    with requests_mock.Mocker() as request_mocker:
+        request_mocker.get(
+            'https://logfire-us.pydantic.dev/v1/info',
+            json={'project_name': 'myproject', 'project_url': 'fake_project_url'},
+        )
+        configure(token='foobar', send_to_logfire='if-token-present', console=False)
+        # No wait_for_check_token_thread(): the request must already be recorded.
+        assert len(request_mocker.request_history) == 1
+        assert not any(thread.name == 'check_logfire_token' for thread in threading.enumerate())
+
+
 def test_send_to_logfire_if_token_present_not_empty(capsys: pytest.CaptureFixture[str]) -> None:
     os.environ['LOGFIRE_TOKEN'] = 'foobar'
     try:

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -2355,36 +2355,27 @@ def wait_for_check_token_thread():
             thread.join()
 
 
-def test_token_check_is_synchronous_on_aws_lambda(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_token_check_is_skipped_on_aws_lambda(monkeypatch: pytest.MonkeyPatch) -> None:
     # Lambda freezes the environment after the init phase; a background token check frozen
-    # mid-request would fail once thawed. Inside Lambda the check must complete in configure().
-    # The mocked /v1/info response is held back until `release` is set, so configure() can only
-    # return early if it (wrongly) delegates the check to a background thread.
+    # mid-request would warn once thawed, and a synchronous check would slow every cold start.
+    # Inside Lambda the check is skipped. The mocked /v1/info response is held back until
+    # `release` is set, so a (wrongly) started background thread would still be alive and
+    # visible when the assertions run.
     monkeypatch.setenv('AWS_LAMBDA_FUNCTION_NAME', 'my-function')
     release = threading.Event()
-    configured = threading.Event()
 
     def held_back_info(_request: Any, _context: Any) -> dict[str, str]:
         release.wait(timeout=5)
         return {'project_name': 'myproject', 'project_url': 'fake_project_url'}
 
-    def run_configure() -> None:
-        configure(token='foobar', send_to_logfire='if-token-present', console=False)
-        configured.set()
-
     with requests_mock.Mocker() as request_mocker:
         request_mocker.get('https://logfire-us.pydantic.dev/v1/info', json=held_back_info)
-        helper = threading.Thread(target=run_configure)
-        helper.start()
         try:
-            # While the response is held back, configure() must still be waiting for it.
-            assert not configured.wait(timeout=0.5)
+            configure(token='foobar', send_to_logfire='if-token-present', console=False)
+            assert not any(thread.name == 'check_logfire_token' for thread in threading.enumerate())
+            assert request_mocker.request_history == []
         finally:
             release.set()
-            helper.join(timeout=5)
-        assert configured.is_set()
-        assert len(request_mocker.request_history) == 1
-        assert not any(thread.name == 'check_logfire_token' for thread in threading.enumerate())
 
 
 def test_send_to_logfire_if_token_present_not_empty(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Problem

`logfire.configure()` validates the token in a background thread (`check_logfire_token`, added in #274 so that `configure()` does not block).

In AWS Lambda, `configure()` is usually called at import time, i.e. during the **init phase**. Lambda may pre-initialize an execution environment and then **freeze** it until the first invocation arrives ("proactive initialization" — see [Understanding the Lambda execution environment lifecycle](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtime-environment.html) and [AJ Stuyvenberg's write-up](https://aaronstuyvenberg.com/posts/understanding-proactive-initialization)). That can be minutes later. A thread frozen in the middle of the TLS handshake finds the connection closed by the server once thawed and warns:

```
UserWarning: Logfire API is unreachable, you may have trouble sending data. Error: HTTPSConnectionPool(host='logfire-eu.pydantic.dev', port=443): Max retries exceeded with url: /v1/info (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032)')))
```

Nothing is actually wrong: the exporters work and no data is lost. But the warning lands in CloudWatch Logs on every affected cold start (≈23 % of cold starts on a production function with ~14k invocations/day) and any log-based alarm that matches "Error" fires on it.

Evidence from that function (Logs Insights, 88 cold starts over 3 days, logfire 4.32.1):

| cold starts | gap between end of init and first `START` | count |
| --- | --- | --- |
| with the warning | 23 s min, 144 s median, 316 s max — every one > 1 s | 14 / 14 |
| without the warning | 0.00 s median; 2 of 74 above 1 s | 74 |

The warning is printed 0.07–0.21 s after the first `START` in every failing case — exactly the thaw.

## Fix

When `AWS_LAMBDA_FUNCTION_NAME` is set (the runtime sets it in every Lambda execution environment), skip the token check. As suggested in review, running it synchronously would slow down every cold start, and the check is not essential: it only prints the project link and warns early about a rejected token, which the exporters report on the first export anyway. `platform_is_aws_lambda()` lives next to `platform_is_emscripten()` in `_internal/utils.py`.

Users on older versions can work around it by joining the thread after `configure()`:

```python
for t in threading.enumerate():
    if t.name == 'check_logfire_token':
        t.join(3.0)
```

## Checks

- New test `test_token_check_is_skipped_on_aws_lambda`: the mocked `/v1/info` response is held back on an event, so a background thread started by mistake would still be alive and visible; asserts no `check_logfire_token` thread and no request. Fails on the previous threaded code, passes with this change.
- `pytest tests/test_configure.py -k "aws_lambda or send_to_logfire_if_token_present"`: 9 passed.
- `ruff check`, `ruff format --check`, `pyright` on the touched files: clean.
