### PR TITLE
fix(pydantic): make plugin entry point lazy

### DIFF
--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import functools
-import inspect
 import os
 import re
 import sys
@@ -17,6 +16,7 @@ from typing_extensions import ParamSpec
 
 import logfire
 from logfire import LogfireSpan
+from logfire_pydantic_plugin import patch_pluggable_schema_validator
 
 from .._internal.config import GLOBAL_CONFIG, PydanticPlugin
 from .._internal.stack_info import is_non_user_path
@@ -339,7 +339,7 @@ class LogfirePydanticPlugin:
                     three `None` if recording is `off`.
             """
             # Patch a bug that occurs even if the plugin is disabled.
-            _patch_PluggableSchemaValidator()
+            patch_pluggable_schema_validator()
 
             logfire_settings = plugin_settings.get('logfire')
             if logfire_settings and 'record' in logfire_settings:
@@ -395,11 +395,6 @@ def set_pydantic_plugin_config(plugin_config: PydanticPlugin | None) -> None:
     """Set the pydantic plugin config."""
     global _pydantic_plugin_config_value
     _pydantic_plugin_config_value = plugin_config
-    # Keep the lazy entry-point shim in sync so it can enable recording without
-    # consulting GLOBAL_CONFIG before the heavy module is imported.
-    from logfire_pydantic_plugin import set_plugin_config_override
-
-    set_plugin_config_override(plugin_config)
 
 
 def _include_model(schema_type_path: SchemaTypePath) -> bool:
@@ -438,36 +433,6 @@ def _patch_build_wrapper():
     from pydantic.plugin import _schema_validator
 
     _schema_validator.build_wrapper = _build_wrapper
-
-
-@lru_cache  # only patch once
-def _patch_PluggableSchemaValidator():
-    """Patch a 'bug' in PluggableSchemaValidator.
-
-    Getting an attribute before proper initializing (e.g. when using cloudpickle)
-    leads to infinite recursion trying to get _schema_validator.
-    """
-    from pydantic.plugin._schema_validator import PluggableSchemaValidator
-
-    if (  # pragma: no branch
-        inspect.getsource(PluggableSchemaValidator.__getattr__).strip()
-        # Check that we're replacing the code that's known to be buggy.
-        == """
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._schema_validator, name)
-    """.strip()
-    ):
-
-        def __getattr__(self: Any, name: str) -> Any:
-            # Add these two lines to the above.
-            # The exact error or return value is not important, as long as the end result
-            # is an AttributeError rather than infinite recursion.
-            if name == '_schema_validator':
-                raise AttributeError(name)
-
-            return getattr(self._schema_validator, name)
-
-        PluggableSchemaValidator.__getattr__ = __getattr__
 
 
 P = ParamSpec('P')

--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -395,6 +395,11 @@ def set_pydantic_plugin_config(plugin_config: PydanticPlugin | None) -> None:
     """Set the pydantic plugin config."""
     global _pydantic_plugin_config_value
     _pydantic_plugin_config_value = plugin_config
+    # Keep the lazy entry-point shim in sync so it can enable recording without
+    # consulting GLOBAL_CONFIG before the heavy module is imported.
+    from logfire_pydantic_plugin import set_plugin_config_override
+
+    set_plugin_config_override(plugin_config)
 
 
 def _include_model(schema_type_path: SchemaTypePath) -> bool:

--- a/logfire_pydantic_plugin/__init__.py
+++ b/logfire_pydantic_plugin/__init__.py
@@ -1,0 +1,81 @@
+"""Top-level Pydantic entry-point shim for Logfire.
+
+Must live outside the ``logfire`` package: importing any ``logfire.*`` module
+executes ``logfire/__init__.py``, which eagerly pulls OpenTelemetry. Pydantic
+loads every ``pydantic`` entry point on first ``SchemaValidator`` construction,
+so the entry point target has to stay cheap when instrumentation is off.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+# Set by ``logfire.integrations.pydantic.set_pydantic_plugin_config`` /
+# ``instrument_pydantic`` without requiring this module to import Logfire.
+_plugin_config_override: Any = None
+
+
+def get_plugin_config_override() -> Any:
+    return _plugin_config_override
+
+
+def set_plugin_config_override(config: Any) -> None:
+    global _plugin_config_override
+    _plugin_config_override = config
+
+
+def _record_from_plugin_settings(plugin_settings: dict[str, Any] | None) -> str | None:
+    if not plugin_settings:
+        return None
+    logfire_settings = plugin_settings.get('logfire')
+    if isinstance(logfire_settings, dict) and 'record' in logfire_settings:
+        return logfire_settings['record']
+    return None
+
+
+def _should_load_full_plugin(plugin_settings: dict[str, Any] | None) -> bool:
+    settings_record = _record_from_plugin_settings(plugin_settings)
+    if settings_record is not None:
+        return settings_record != 'off'
+
+    if os.environ.get('LOGFIRE_PYDANTIC_RECORD') == 'off':
+        return False
+
+    if _plugin_config_override is not None:
+        return getattr(_plugin_config_override, 'record', 'off') != 'off'
+
+    env_record = os.environ.get('LOGFIRE_PYDANTIC_RECORD')
+    if env_record not in (None, '') and env_record != 'off':
+        return True
+
+    # Default is off. Only consult GLOBAL_CONFIG if Logfire was already imported
+    # (e.g. ``logfire.configure()`` loaded pydantic_plugin_record from settings).
+    if 'logfire._internal.config' not in sys.modules:
+        return False
+
+    from logfire._internal.config import GLOBAL_CONFIG
+
+    return GLOBAL_CONFIG.param_manager.pydantic_plugin.record != 'off'
+
+
+class _LazyLogfirePydanticPlugin:
+    """Entry-point object: cheap to import, delegates when recording is enabled."""
+
+    def new_schema_validator(self, *args: Any, **kwargs: Any) -> tuple[Any, ...]:
+        plugin_settings: dict[str, Any] | None
+        if len(args) >= 6:
+            plugin_settings = args[5]
+        else:
+            plugin_settings = kwargs.get('plugin_settings')
+
+        if not _should_load_full_plugin(plugin_settings if isinstance(plugin_settings, dict) else None):
+            return None, None, None
+
+        from logfire.integrations.pydantic import plugin as real_plugin
+
+        return real_plugin.new_schema_validator(*args, **kwargs)
+
+
+plugin = _LazyLogfirePydanticPlugin()

--- a/logfire_pydantic_plugin/__init__.py
+++ b/logfire_pydantic_plugin/__init__.py
@@ -8,69 +8,99 @@ so the entry point target has to stay cheap when instrumentation is off.
 
 from __future__ import annotations
 
+import inspect
 import os
 import sys
+from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
-# Set by ``logfire.integrations.pydantic.set_pydantic_plugin_config`` /
-# ``instrument_pydantic`` without requiring this module to import Logfire.
-_plugin_config_override: Any = None
 
-
-def get_plugin_config_override() -> Any:
-    return _plugin_config_override
-
-
-def set_plugin_config_override(config: Any) -> None:
-    global _plugin_config_override
-    _plugin_config_override = config
-
-
-def _record_from_plugin_settings(plugin_settings: dict[str, Any] | None) -> str | None:
-    if not plugin_settings:
-        return None
+def _should_load_full_plugin(plugin_settings: dict[str, Any]) -> bool:
     logfire_settings = plugin_settings.get('logfire')
-    if isinstance(logfire_settings, dict) and 'record' in logfire_settings:
-        return logfire_settings['record']
-    return None
+    if logfire_settings and 'record' in logfire_settings:
+        return logfire_settings['record'] != 'off'
+
+    if 'logfire.integrations.pydantic' in sys.modules:
+        from logfire.integrations.pydantic import get_pydantic_plugin_config
+
+        return get_pydantic_plugin_config().record != 'off'
+
+    config_module = sys.modules.get('logfire._internal.config')
+    if config_module is not None:
+        config = getattr(config_module, 'GLOBAL_CONFIG', None)
+        # Config can be partially initialized while its own models are built.
+        return config is not None and config.param_manager.pydantic_plugin.record != 'off'
+
+    env_record = os.environ.get('LOGFIRE_PYDANTIC_PLUGIN_RECORD')
+    if env_record:
+        return env_record != 'off'
+    return _file_enables_recording()
 
 
-def _should_load_full_plugin(plugin_settings: dict[str, Any] | None) -> bool:
-    settings_record = _record_from_plugin_settings(plugin_settings)
-    if settings_record is not None:
-        return settings_record != 'off'
-
-    if os.environ.get('LOGFIRE_PYDANTIC_RECORD') == 'off':
+@lru_cache
+def _file_enables_recording() -> bool:
+    """Check the initial file setting without importing the SDK's config module."""
+    config_file = Path(os.environ.get('LOGFIRE_CONFIG_DIR') or '.') / 'pyproject.toml'
+    if not config_file.exists():
         return False
-
-    if _plugin_config_override is not None:
-        return getattr(_plugin_config_override, 'record', 'off') != 'off'
-
-    env_record = os.environ.get('LOGFIRE_PYDANTIC_RECORD')
-    if env_record not in (None, '') and env_record != 'off':
+    if sys.version_info >= (3, 11):
+        from tomllib import load
+    else:
+        from tomli import load
+    try:
+        with config_file.open('rb') as f:
+            record = load(f).get('tool', {}).get('logfire', {}).get('pydantic_plugin_record')
+    except Exception:
+        # Delegate malformed/unreadable config to the existing SDK error handling.
         return True
+    return record not in (None, 'off')
 
-    # Default is off. Only consult GLOBAL_CONFIG if Logfire was already imported
-    # (e.g. ``logfire.configure()`` loaded pydantic_plugin_record from settings).
-    if 'logfire._internal.config' not in sys.modules:
-        return False
 
-    from logfire._internal.config import GLOBAL_CONFIG
+@lru_cache
+def patch_pluggable_schema_validator():
+    """Preserve Pydantic's cloudpickle workaround even while recording is off.
 
-    return GLOBAL_CONFIG.param_manager.pydantic_plugin.record != 'off'
+    Getting an attribute before initialization leads to infinite recursion
+    trying to get _schema_validator.
+    """
+    from pydantic.plugin._schema_validator import PluggableSchemaValidator
+
+    if (  # pragma: no branch
+        inspect.getsource(PluggableSchemaValidator.__getattr__).strip()
+        # Check that we're replacing the code that's known to be buggy.
+        == """
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._schema_validator, name)
+    """.strip()
+    ):
+
+        def __getattr__(self: Any, name: str) -> Any:
+            # Missing attributes must raise AttributeError rather than recurse.
+            if name == '_schema_validator':
+                raise AttributeError(name)
+            return getattr(self._schema_validator, name)
+
+        PluggableSchemaValidator.__getattr__ = __getattr__
 
 
 class _LazyLogfirePydanticPlugin:
     """Entry-point object: cheap to import, delegates when recording is enabled."""
 
     def new_schema_validator(self, *args: Any, **kwargs: Any) -> tuple[Any, ...]:
+        from pydantic.version import VERSION
+
+        if tuple(map(int, VERSION.split('.')[:2])) < (2, 5) or os.environ.get('LOGFIRE_PYDANTIC_RECORD') == 'off':
+            return None, None, None
+
+        patch_pluggable_schema_validator()
         plugin_settings: dict[str, Any] | None
         if len(args) >= 6:
             plugin_settings = args[5]
         else:
             plugin_settings = kwargs.get('plugin_settings')
 
-        if not _should_load_full_plugin(plugin_settings if isinstance(plugin_settings, dict) else None):
+        if not _should_load_full_plugin(plugin_settings or {}):
             return None, None, None
 
         from logfire.integrations.pydantic import plugin as real_plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -251,7 +251,7 @@ allow-direct-references = true
 packages = ["logfire", "logfire_pydantic_plugin"]
 
 [tool.hatch.build.targets.sdist]
-include = ["/README.md", "CHANGELOG.md", "/Makefile", "/logfire", "/tests"]
+include = ["/README.md", "CHANGELOG.md", "/Makefile", "/logfire", "/logfire_pydantic_plugin", "/tests"]
 
 # https://beta.ruff.rs/docs/configuration/
 [tool.ruff]
@@ -307,7 +307,7 @@ exclude = ["*.md"]
 typeCheckingMode = "strict"
 reportUnnecessaryTypeIgnoreComment = true
 reportMissingTypeStubs = false
-include = ["logfire", "tests"]
+include = ["logfire", "logfire_pydantic_plugin", "tests"]
 venvPath = "."
 venv = ".venv"
 
@@ -367,7 +367,7 @@ DJANGO_SETTINGS_MODULE = "tests.otel_integrations.django_test_project.django_tes
 # https://coverage.readthedocs.io/en/latest/config.html#run
 [tool.coverage.run]
 branch = true
-source = ["logfire", "logfire-api"]
+source = ["logfire", "logfire_pydantic_plugin", "logfire-api"]
 omit = [
     "*/tmp/*",
     "*/temp/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ Changelog = "https://github.com/pydantic/logfire/blob/main/CHANGELOG.md"
 logfire = "logfire.cli:main"
 
 [project.entry-points."pydantic"]
-logfire-plugin = "logfire.integrations.pydantic:plugin"
+logfire-plugin = "logfire_pydantic_plugin:plugin"
 
 [project.entry-points."pytest11"]
 logfire = "logfire.testing"
@@ -248,7 +248,7 @@ members = ["logfire-api"]
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
-packages = ["logfire"]
+packages = ["logfire", "logfire_pydantic_plugin"]
 
 [tool.hatch.build.targets.sdist]
 include = ["/README.md", "CHANGELOG.md", "/Makefile", "/logfire", "/tests"]

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -65,7 +65,9 @@ def test_check_plugin_installed():
     """Check Pydantic has found the logfire pydantic plugin."""
     from pydantic.plugin import _loader
 
-    assert repr(next(iter(_loader.get_plugins()))) == 'LogfirePydanticPlugin()'
+    from logfire_pydantic_plugin import plugin
+
+    assert plugin in _loader.get_plugins()
 
 
 def test_disable_logfire_pydantic_plugin() -> None:

--- a/tests/test_pydantic_plugin_lazy.py
+++ b/tests/test_pydantic_plugin_lazy.py
@@ -1,0 +1,40 @@
+"""Ensure the Pydantic entry point stays cheap when instrumentation is off."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+
+def test_entry_point_module_does_not_import_logfire_sdk():
+    # Simulate a fresh process where only the entry-point shim is loaded.
+    doomed = [
+        name
+        for name in list(sys.modules)
+        if name == 'logfire'
+        or name.startswith('logfire.')
+        or name == 'logfire_pydantic_plugin'
+        or name.startswith('logfire_pydantic_plugin.')
+        or name.startswith('opentelemetry')
+    ]
+    for name in doomed:
+        del sys.modules[name]
+
+    mod = importlib.import_module('logfire_pydantic_plugin')
+    assert 'logfire' not in sys.modules
+    assert 'logfire.integrations.pydantic' not in sys.modules
+    assert not any(name.startswith('opentelemetry') for name in sys.modules)
+
+    # Default path: recording is off → no heavy import.
+    assert mod.plugin.new_schema_validator(None, None, None, None, None, {}) == (None, None, None)
+    assert 'logfire' not in sys.modules
+
+
+def test_entry_point_loads_full_plugin_when_env_enables_recording(monkeypatch):
+    monkeypatch.setenv('LOGFIRE_PYDANTIC_RECORD', 'all')
+    for name in list(sys.modules):
+        if name == 'logfire_pydantic_plugin' or name.startswith('logfire_pydantic_plugin.'):
+            del sys.modules[name]
+
+    mod = importlib.import_module('logfire_pydantic_plugin')
+    assert mod._should_load_full_plugin({}) is True

--- a/tests/test_pydantic_plugin_lazy.py
+++ b/tests/test_pydantic_plugin_lazy.py
@@ -1,40 +1,155 @@
-"""Ensure the Pydantic entry point stays cheap when instrumentation is off."""
+"""Exercise the installed Pydantic entry point in genuinely fresh processes."""
 
 from __future__ import annotations
 
-import importlib
+import os
+import subprocess
 import sys
+from pathlib import Path
+
+import pytest
 
 
-def test_entry_point_module_does_not_import_logfire_sdk():
-    # Simulate a fresh process where only the entry-point shim is loaded.
-    doomed = [
-        name
-        for name in list(sys.modules)
-        if name == 'logfire'
-        or name.startswith('logfire.')
-        or name == 'logfire_pydantic_plugin'
-        or name.startswith('logfire_pydantic_plugin.')
-        or name.startswith('opentelemetry')
-    ]
-    for name in doomed:
-        del sys.modules[name]
-
-    mod = importlib.import_module('logfire_pydantic_plugin')
-    assert 'logfire' not in sys.modules
-    assert 'logfire.integrations.pydantic' not in sys.modules
-    assert not any(name.startswith('opentelemetry') for name in sys.modules)
-
-    # Default path: recording is off → no heavy import.
-    assert mod.plugin.new_schema_validator(None, None, None, None, None, {}) == (None, None, None)
-    assert 'logfire' not in sys.modules
+def run_script(script: str, cwd: Path, **settings: str) -> None:
+    env = {key: value for key, value in os.environ.items() if not key.startswith('LOGFIRE_')}
+    env.pop('PYDANTIC_DISABLE_PLUGINS', None)
+    env.update(LOGFIRE_SEND_TO_LOGFIRE='false', **settings)
+    result = subprocess.run(
+        [sys.executable, '-c', script], cwd=cwd, env=env, capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_entry_point_loads_full_plugin_when_env_enables_recording(monkeypatch):
-    monkeypatch.setenv('LOGFIRE_PYDANTIC_RECORD', 'all')
-    for name in list(sys.modules):
-        if name == 'logfire_pydantic_plugin' or name.startswith('logfire_pydantic_plugin.'):
-            del sys.modules[name]
+@pytest.mark.parametrize('record', [None, '', 'off'])
+def test_entry_point_module_does_not_import_logfire_sdk(tmp_path: Path, record: str | None) -> None:
+    settings = {} if record is None else {'LOGFIRE_PYDANTIC_RECORD': record}
+    run_script(
+        """
+import sys
+from importlib.metadata import entry_points
+from pydantic import BaseModel
 
-    mod = importlib.import_module('logfire_pydantic_plugin')
-    assert mod._should_load_full_plugin({}) is True
+entry = next(e for e in entry_points(group='pydantic') if e.name == 'logfire-plugin')
+entry.load()
+class Model(BaseModel):
+    value: int
+assert Model(value='1').value == 1
+assert 'logfire' not in sys.modules
+assert not any(name.startswith('opentelemetry') for name in sys.modules)
+""",
+        tmp_path,
+        **settings,
+    )
+
+
+def test_disabled_plugin_preserves_cloudpickle_compatibility(tmp_path: Path) -> None:
+    run_script(
+        """
+import sys
+import cloudpickle
+from pydantic import BaseModel
+class Model(BaseModel):
+    value: int
+model = Model(value=1)
+assert cloudpickle.loads(cloudpickle.dumps(model)).model_dump() == {'value': 1}
+assert 'logfire' not in sys.modules
+""",
+        tmp_path,
+    )
+
+
+@pytest.mark.parametrize('source', ['environment', 'model', 'file', 'configured_file', 'instrument'])
+def test_entry_point_records_when_enabled(tmp_path: Path, source: str) -> None:
+    setup = ''
+    model_settings = ''
+    settings: dict[str, str] = {}
+    if source == 'environment':
+        settings['LOGFIRE_PYDANTIC_PLUGIN_RECORD'] = 'all'
+    elif source == 'model':
+        model_settings = ", plugin_settings={'logfire': {'record': 'all'}}"
+    elif source in ('file', 'configured_file'):
+        config_dir = tmp_path / 'config'
+        config_dir.mkdir()
+        (config_dir / 'pyproject.toml').write_text('[tool.logfire]\npydantic_plugin_record = "all"\n')
+        if source == 'file':
+            settings['LOGFIRE_CONFIG_DIR'] = str(config_dir)
+        else:
+            setup = f'import logfire\nlogfire.configure(send_to_logfire=False, config_dir={str(config_dir)!r})\n'
+    else:
+        setup = 'import logfire\nlogfire.instrument_pydantic()\n'
+    run_script(
+        f"""
+import sys
+from pydantic import BaseModel
+from pydantic.version import VERSION
+{setup}
+class Model(BaseModel{model_settings}):
+    value: int
+assert Model(value='1').value == 1
+if tuple(map(int, VERSION.split('.')[:2])) >= (2, 5):
+    assert 'logfire.integrations.pydantic' in sys.modules
+    import logfire
+    from logfire.testing import TestExporter
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    exporter = TestExporter()
+    logfire.configure(send_to_logfire=False, console=False, additional_span_processors=[SimpleSpanProcessor(exporter)])
+    Model(value=2)
+    spans = exporter.exported_spans_as_dict()
+    assert len(spans) == 1
+    assert spans[0]['name'] == 'pydantic.validate_python'
+    assert spans[0]['attributes']['success'] is True
+""",
+        tmp_path,
+        **settings,
+    )
+
+
+def test_global_disable_overrides_model_settings(tmp_path: Path) -> None:
+    run_script(
+        """
+import sys
+from pydantic import BaseModel
+class Model(BaseModel, plugin_settings={'logfire': {'record': 'all'}}):
+    value: int
+assert Model(value='1').value == 1
+assert 'logfire' not in sys.modules
+""",
+        tmp_path,
+        LOGFIRE_PYDANTIC_RECORD='off',
+    )
+
+
+def test_invalid_config_preserves_configuration_error(tmp_path: Path) -> None:
+    (tmp_path / 'pyproject.toml').write_text('[invalid toml')
+    run_script(
+        """
+from pydantic import BaseModel
+from pydantic.version import VERSION
+if tuple(map(int, VERSION.split('.')[:2])) >= (2, 5):
+    try:
+        class Model(BaseModel):
+            value: int
+    except Exception as exc:
+        assert type(exc).__name__ == 'LogfireConfigError', repr(exc)
+        assert 'Invalid config file:' in str(exc)
+    else:
+        raise AssertionError('Invalid config should retain the SDK error')
+""",
+        tmp_path,
+    )
+
+
+def test_keyword_plugin_protocol_call_stays_lazy(tmp_path: Path) -> None:
+    run_script(
+        """
+import sys
+from pydantic_core import core_schema
+from logfire_pydantic_plugin import plugin
+assert plugin.new_schema_validator(
+    schema=core_schema.int_schema(), schema_type=int, schema_type_path=None,
+    schema_kind='TypeAdapter', config=None, plugin_settings={},
+) == (None, None, None)
+assert 'logfire' not in sys.modules
+""",
+        tmp_path,
+    )

--- a/tests/test_pydantic_plugin_lazy.py
+++ b/tests/test_pydantic_plugin_lazy.py
@@ -8,6 +8,14 @@ import sys
 from pathlib import Path
 
 import pytest
+from pydantic.version import VERSION
+
+from logfire._internal.utils import get_version
+
+requires_supported_plugin = pytest.mark.skipif(
+    get_version(VERSION) < get_version('2.5.0'),
+    reason='Pydantic instrumentation and its cloudpickle workaround require Pydantic >= 2.5.',
+)
 
 
 def run_script(script: str, cwd: Path, **settings: str) -> None:
@@ -42,6 +50,7 @@ assert not any(name.startswith('opentelemetry') for name in sys.modules)
     )
 
 
+@requires_supported_plugin
 def test_disabled_plugin_preserves_cloudpickle_compatibility(tmp_path: Path) -> None:
     run_script(
         """
@@ -58,7 +67,10 @@ assert 'logfire' not in sys.modules
     )
 
 
-@pytest.mark.parametrize('source', ['environment', 'model', 'file', 'configured_file', 'instrument'])
+@pytest.mark.parametrize(
+    'source',
+    ['environment', 'model', 'file', 'configured_file', pytest.param('instrument', marks=requires_supported_plugin)],
+)
 def test_entry_point_records_when_enabled(tmp_path: Path, source: str) -> None:
     setup = ''
     model_settings = ''


### PR DESCRIPTION
## Summary

Fixes #2343.

Pydantic loads installed plugins while constructing its first schema validator. Move Logfire's entry point outside the `logfire` package so default-off model validation does not import the SDK or OpenTelemetry.

- Preserve recording via `LOGFIRE_PYDANTIC_PLUGIN_RECORD`, per-model settings, `instrument_pydantic()`, and initial/configured TOML settings. Retain the `LOGFIRE_PYDANTIC_RECORD=off` hard-disable switch.
- Keep the existing Pydantic/cloudpickle compatibility patch active without importing the SDK.
- Include the new package in both sdist and wheel, type checking, and coverage.
- Replace process-wide module deletion with fresh-process public-model regressions; check an actual completed validation span when recording is enabled.

## Validation

- Focused plugin, lazy-entry-point, and server-response tests: 76 passed, 2 expected failures.
- All 12 lazy-entry-point regressions pass.
- All repository pre-commit hooks pass, including Ruff, formatting, Pyright, and zizmor.
- sdist and wheel build successfully and contain the new entry-point package.
- Full local suite: 2464 passed, 9 skipped, 2 expected failures; 3 aiohttp DNS-behavior failures and 8 Docker socket setup errors. The same DNS/socket failure classes reproduce on the initial PR head; they are not claimed as passing or suppressed.
- With the correct command-local Colima socket mapping, all affected Celery/MySQL/Redis tests pass: 10 passed. The DNS-dependent tests remain a local environment limitation.
- Source-install smoke checks pass with Pydantic 2.4/2.5/2.6/2.9/2.12 and Python 3.10/current. Actual lazy tests: 2.4 has 10 passed and 2 intentionally skipped (unsupported cloudpickle/instrumentation features); 2.5 has 12 passed. These version markers correct two failures found by the first hosted follow-up run.
- Hosted CI and combined coverage are pending for this follow-up.

AI assistance: the initial change was made with Cursor; this follow-up was independently reviewed, repaired, and tested using Codex.
