### PR TITLE
Direct frontend early access requests to Pydantic

### DIFF
--- a/docs/get-started/for-product-and-growth.md
+++ b/docs/get-started/for-product-and-growth.md
@@ -18,7 +18,7 @@ Each link says why it's here.
 3. **Tie changes back to usage**: every managed-variable resolution is recorded in your traces. That means you can correlate a flag or prompt change directly with what happened next (the basis for A/B tests and online experiments) using the same data your app already sends. See [Explore](../guides/web-ui/explore.md) to query that data in SQL and [Dashboards](../guides/web-ui/dashboards.md) to watch it over time.
 
 !!! note "Frontend observability and session replay"
-    [Frontend monitoring](../guides/web-ui/frontend.md) and [session replay](../guides/web-ui/session-replays.md) are available as experimental features. Enable **Frontend observability** from **Settings → Early access** to try them.
+    [Frontend monitoring](../guides/web-ui/frontend.md) and [session replay](../guides/web-ui/session-replays.md) are available in early access. [Contact Pydantic](https://pydantic.dev/contact) if you are interested.
 
 ## No code required
 

--- a/docs/guides/web-ui/frontend.md
+++ b/docs/guides/web-ui/frontend.md
@@ -8,9 +8,9 @@ Use the <OpenInLogfire path="frontend" variant="inline" label="Frontend" /> page
 
 The page groups browser telemetry by frontend application. A frontend application gives browser data a stable service name and a restricted token that is safe to publish in a browser bundle. The token can send data only for that application. It cannot read project data or report as another service.
 
-!!! note "Experimental"
+!!! note "Early access"
 
-    Open **Settings → Early access**, choose **Show experimental features**, and enable **Frontend observability**. This browser-level setting applies across every organization you use in that browser.
+    Frontend observability is available in early access. [Contact Pydantic](https://pydantic.dev/contact) if you are interested.
 
 ## Send browser data
 

--- a/docs/guides/web-ui/session-replays.md
+++ b/docs/guides/web-ui/session-replays.md
@@ -8,9 +8,9 @@ Use <OpenInLogfire path="frontend/session-replays" variant="inline" label="Sessi
 
 A session replay records changes to the page's document structure and user interactions. Logfire reconstructs those events in a player. It does not store a video stream.
 
-!!! note "Experimental"
+!!! note "Early access"
 
-    Open **Settings → Early access**, choose **Show experimental features**, and enable **Frontend observability**. The same setting enables the Frontend and Session Replays pages.
+    Session Replay is available in early access. [Contact Pydantic](https://pydantic.dev/contact) if you are interested.
 
 ## Record sessions
 


### PR DESCRIPTION
## Summary

- remove instructions for enabling Frontend observability through browser experimental settings
- direct interested users to contact Pydantic for early access
- apply the guidance consistently across the Frontend, Session Replays, and product-and-growth pages

## Test plan

- `uv run pre-commit run --files docs/get-started/for-product-and-growth.md docs/guides/web-ui/frontend.md docs/guides/web-ui/session-replays.md`
- verified `https://pydantic.dev/contact` returns HTTP 200

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

