### PR TITLE
Document API keys that can send telemetry

### DIFF
--- a/docs/how-to-guides/create-write-tokens.md
+++ b/docs/how-to-guides/create-write-tokens.md
@@ -2,7 +2,8 @@
 title: "Logfire Write Tokens: Setup Guide"
 description: "Step-by-step guide for creating a Logfire write token in the web UI by injecting LOGFIRE_TOKEN in apps & for optionally suppressing it in local development."
 ---
-To send data to **Logfire**, you need to create a <OpenInLogfire path="settings/write-tokens" variant="inline" label="write token" />.
+To send data to **Logfire**, use a project [API key with **Send telemetry**](../reference/advanced/use-api-keys.md) or a <OpenInLogfire path="settings/write-tokens" variant="inline" label="write token" />.
+This guide covers write tokens. Existing write tokens continue to work.
 A write token is a unique identifier that allows you to send data to a specific **Logfire** project.
 If you set up Logfire according to the [getting started guide](../index.md), you already have a write token locally tied to the project you created.
 But if you want to configure other computers to write to that project, for example in a deployed application, you need to create a new write token.

--- a/docs/how-to-guides/create-write-tokens.md
+++ b/docs/how-to-guides/create-write-tokens.md
@@ -28,7 +28,7 @@ Set the token as the value for the environment variable `LOGFIRE_TOKEN` and logf
 
 You may want to not send data to logfire during local development, but still have the option to send it in production without changing your code.
 To do this we provide the parameter `send_to_logfire='if-token-present'` in the `logfire.configure()` function.
-If you set it to `'if-token-present'`, logfire will only send data to logfire if a write token is present in the environment variable `LOGFIRE_TOKEN` or there is a token saved locally.
+If you set it to `'if-token-present'`, Logfire will only send data if `LOGFIRE_TOKEN` contains a project API key with **Send telemetry** (`project:write_otlp`) permission or a write token, or if a token is saved locally.
 If you run tests in CI no data will be sent.
 
 You can also set the environment variable `LOGFIRE_SEND_TO_LOGFIRE` to configure this option.

--- a/docs/reference/advanced/use-api-keys.md
+++ b/docs/reference/advanced/use-api-keys.md
@@ -3,11 +3,12 @@ title: "Using API Keys to Access Public APIs"
 description: "Guide on how to create API keys and use them to call Logfire public APIs for managing organizations, projects, and other resources."
 ---
 
-**Logfire** provides public APIs that allow you to programmatically manage your organizations, projects, and other resources. To access these APIs, you'll need to create an **API key**.
+Use a **Logfire API key** to access the public APIs or send data from your application. The permissions you select determine what the key can do.
 
-!!! info "Public APIs"
-    API keys are for accessing the Logfire platform APIs, _not_ for sending telemetry data (traces, logs, metrics).
-    To send data to Logfire, use [write tokens](../../how-to-guides/create-write-tokens.md).
+!!! info "Sending data"
+    A key scoped to a specific project can send logs, traces, and metrics when it has the **Send telemetry** capability (`project:write_otlp`).
+    An API key without that permission cannot send data. Organization-wide keys must be scoped to a project before this capability is available.
+    Existing [write tokens](../../how-to-guides/create-write-tokens.md) also work; you do not need to replace them.
 
 !!! tip "What you can do"
     **Available to all plans:**
@@ -50,6 +51,9 @@ Navigate to your project, then **Settings → API Keys → New API Key**.
 
 Project API keys are limited to the project where they were created.
 
+To send data from your app, select **Send telemetry** when creating the key. For the Python SDK, use the key as `LOGFIRE_TOKEN`, just as you would a write token.
+This permission allows sending data, not reading it or managing project settings. Add other permissions only when your application needs them.
+
 !!! warning
     Copy your API key when it's displayed. It won't be shown again.
 
@@ -75,6 +79,8 @@ Available scopes depend on whether you're creating an organization or project AP
 | Audit logs                           | ✓                    | -               |
 | SCIM provisioning                    | ✓                    | -               |
 | Billing usage                        | ✓                    | -               |
+| Send telemetry (`project:write_otlp`) | Specific project only | ✓              |
+| Query telemetry (`project:read_otlp`) | Specific project only | ✓              |
 | Project settings                     | ✓                    | ✓               |
 | Write tokens management              | ✓                    | ✓               |
 | Read tokens management               | ✓                    | ✓               |


### PR DESCRIPTION
## Summary

Correct the API-key guide, which currently says API keys cannot send telemetry. A project-scoped key with **Send telemetry** (`project:write_otlp`) can send logs, traces, and metrics. The Assistant was repeating the outdated distinction when answering setup questions.

- Explain the required permission and project scope, including using the key as `LOGFIRE_TOKEN` with the Python SDK.
- Add send/query telemetry permissions to the scope table.
- Keep write tokens documented as supported; no migration is required.

## Validation

- Checked scope and ingestion behavior against current Platform code and Python SDK token handling.
- Documentation pre-commit checks and `git diff --check` passed.
- Local unified-docs preview starts, but its rendered Markdown still comes from the sibling checkout despite the explicit worktree source; that preview is not proof of this patch. Hosted docs preview requested.

Documentation only; no runtime or API changes. This touches the same guide as #2353 but changes the telemetry introduction and scope rows, not SCIM setup.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

