### PR TITLE
Remove deprecated configure arguments

### DIFF
--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -19,7 +19,7 @@ from datetime import timedelta
 from importlib.metadata import entry_points
 from pathlib import Path
 from threading import RLock, Thread
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from urllib.parse import urljoin
 from uuid import uuid4
 
@@ -65,7 +65,7 @@ from opentelemetry.sdk.trace.id_generator import IdGenerator
 from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio, Sampler
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
-from typing_extensions import Self, Unpack, assert_type
+from typing_extensions import Self, assert_type
 
 from logfire._internal.auth import LOGFIRE_TOKEN_REGION_PATTERN, REGIONS
 from logfire._internal.baggage import DirectBaggageAttributesSpanProcessor
@@ -495,11 +495,6 @@ class LocalVariablesOptions:
     """
 
 
-class DeprecatedKwargs(TypedDict):
-    # Empty so that passing any additional kwargs makes static type checkers complain.
-    pass
-
-
 def configure(
     *,
     local: bool = False,
@@ -524,7 +519,6 @@ def configure(
     variables: VariablesOptions | LocalVariablesOptions | None = None,
     distributed_tracing: bool | None = None,
     advanced: AdvancedOptions | None = None,
-    **deprecated_kwargs: Unpack[DeprecatedKwargs],
 ) -> Logfire:
     """Configure the logfire SDK.
 
@@ -610,111 +604,6 @@ def configure(
         advanced: Advanced options primarily used for testing by Logfire developers.
     """
     from .. import DEFAULT_LOGFIRE_INSTANCE, Logfire
-
-    processors = deprecated_kwargs.pop('processors', None)
-    if processors is not None:  # pragma: no cover
-        raise ValueError(
-            'The `processors` argument has been replaced by `additional_span_processors`. '
-            'Set `send_to_logfire=False` to disable the default processor.'
-        )
-
-    metric_readers = deprecated_kwargs.pop('metric_readers', None)
-    if metric_readers is not None:  # pragma: no cover
-        raise ValueError(
-            'The `metric_readers` argument has been replaced by '
-            '`metrics=logfire.MetricsOptions(additional_readers=[...])`. '
-            'Set `send_to_logfire=False` to disable the default metric reader.'
-        )
-
-    collect_system_metrics = deprecated_kwargs.pop('collect_system_metrics', None)
-    if collect_system_metrics is False:
-        raise ValueError(
-            'The `collect_system_metrics` argument has been removed. System metrics are no longer collected by default.'
-        )
-
-    if collect_system_metrics is not None:
-        raise ValueError(
-            'The `collect_system_metrics` argument has been removed. Use `logfire.instrument_system_metrics()` instead.'
-        )
-
-    scrubbing_callback = deprecated_kwargs.pop('scrubbing_callback', None)
-    scrubbing_patterns = deprecated_kwargs.pop('scrubbing_patterns', None)
-    if scrubbing_callback or scrubbing_patterns:
-        if scrubbing is not None:
-            raise ValueError(
-                'Cannot specify `scrubbing` and `scrubbing_callback` or `scrubbing_patterns` at the same time. '
-                'Use only `scrubbing`.'
-            )
-        warnings.warn(
-            'The `scrubbing_callback` and `scrubbing_patterns` arguments are deprecated. '
-            'Use `scrubbing=logfire.ScrubbingOptions(callback=..., extra_patterns=[...])` instead.',
-        )
-        scrubbing = ScrubbingOptions(callback=scrubbing_callback, extra_patterns=scrubbing_patterns)  # pyright: ignore[reportArgumentType]
-
-    project_name = deprecated_kwargs.pop('project_name', None)
-    if project_name is not None:
-        warnings.warn(
-            'The `project_name` argument is deprecated and not needed.',
-        )
-
-    trace_sample_rate: float | None = deprecated_kwargs.pop('trace_sample_rate', None)  # pyright: ignore[reportAssignmentType]
-    if trace_sample_rate is not None:
-        if sampling:
-            raise ValueError(
-                'Cannot specify both `trace_sample_rate` and `sampling`. '
-                'Use `sampling.head` instead of `trace_sample_rate`.'
-            )
-        else:
-            sampling = SamplingOptions(head=trace_sample_rate)
-            warnings.warn(
-                'The `trace_sample_rate` argument is deprecated. '
-                'Use `sampling=logfire.SamplingOptions(head=...)` instead.',
-            )
-
-    show_summary = deprecated_kwargs.pop('show_summary', None)
-    if show_summary is not None:  # pragma: no cover
-        warnings.warn(
-            'The `show_summary` argument is deprecated. '
-            'Use `console=False` or `console=logfire.ConsoleOptions(show_project_link=False)` instead.',
-        )
-
-    for key in ('base_url', 'id_generator', 'ns_timestamp_generator'):
-        value: Any = deprecated_kwargs.pop(key, None)
-        if value is None:
-            continue
-        if advanced is not None:
-            raise ValueError(f'Cannot specify `{key}` and `advanced`. Use only `advanced`.')
-        # (this means that specifying two deprecated advanced kwargs at the same time will raise an error)
-        advanced = AdvancedOptions(**{key: value})
-        warnings.warn(
-            f'The `{key}` argument is deprecated. Use `advanced=logfire.AdvancedOptions({key}=...)` instead.',
-            stacklevel=2,
-        )
-
-    additional_metric_readers: Any = deprecated_kwargs.pop('additional_metric_readers', None)
-    if additional_metric_readers:
-        if metrics is not None:
-            raise ValueError(
-                'Cannot specify both `additional_metric_readers` and `metrics`. '
-                'Use `metrics=logfire.MetricsOptions(additional_readers=[...])` instead.'
-            )
-        warnings.warn(
-            'The `additional_metric_readers` argument is deprecated. '
-            'Use `metrics=logfire.MetricsOptions(additional_readers=[...])` instead.',
-        )
-        metrics = MetricsOptions(additional_readers=additional_metric_readers)
-
-    pydantic_plugin: Any = deprecated_kwargs.pop('pydantic_plugin', None)
-    if pydantic_plugin is not None:
-        warnings.warn(
-            'The `pydantic_plugin` argument is deprecated. Use `logfire.instrument_pydantic()` instead.',
-        )
-        from logfire.integrations.pydantic import set_pydantic_plugin_config
-
-        set_pydantic_plugin_config(pydantic_plugin)
-
-    if deprecated_kwargs:
-        raise TypeError(f'configure() got unexpected keyword arguments: {", ".join(deprecated_kwargs)}')
 
     if local:
         config = LogfireConfig()

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -474,20 +474,6 @@ def test_pydantic_plugin_include_exclude_strings():
     assert fresh_pydantic_plugin().exclude == {'exc'}
 
 
-def test_deprecated_configure_pydantic_plugin(config_kwargs: dict[str, Any]):
-    assert fresh_pydantic_plugin().record == 'off'
-
-    with pytest.warns(UserWarning) as warnings:
-        logfire.configure(**config_kwargs, pydantic_plugin=logfire.PydanticPlugin(record='all'))  # type: ignore
-
-    assert fresh_pydantic_plugin().record == 'all'
-
-    assert len(warnings) == 1
-    assert str(warnings[0].message) == snapshot(
-        'The `pydantic_plugin` argument is deprecated. Use `logfire.instrument_pydantic()` instead.'
-    )
-
-
 def test_read_config_from_environment_variables() -> None:
     assert fresh_pydantic_plugin().record == 'off'
 
@@ -2884,76 +2870,9 @@ def test_dynamic_module_ignored_in_ensure_flush_after_aws_lambda(
     assert capsys.readouterr().err == ''
 
 
-def test_collect_system_metrics_false():
-    with inline_snapshot.extra.raises(
-        snapshot(
-            'ValueError: The `collect_system_metrics` argument has been removed. '
-            'System metrics are no longer collected by default.'
-        )
-    ):
-        logfire.configure(collect_system_metrics=False)  # type: ignore
-
-
-def test_collect_system_metrics_true():
-    with inline_snapshot.extra.raises(
-        snapshot(
-            'ValueError: The `collect_system_metrics` argument has been removed. '
-            'Use `logfire.instrument_system_metrics()` instead.'
-        )
-    ):
-        logfire.configure(collect_system_metrics=True)  # type: ignore
-
-
 def test_unknown_kwargs():
-    with inline_snapshot.extra.raises(snapshot('TypeError: configure() got unexpected keyword arguments: foo, bar')):
-        logfire.configure(foo=1, bar=2)  # type: ignore
-
-
-def test_project_name_deprecated():
-    with inline_snapshot.extra.raises(
-        snapshot('UserWarning: The `project_name` argument is deprecated and not needed.')
-    ):
-        logfire.configure(project_name='foo')  # type: ignore
-
-
-def test_base_url_deprecated():
-    with pytest.warns(UserWarning) as warnings:
-        logfire.configure(base_url='foo')  # type: ignore
-    assert len(warnings) == 1
-    assert str(warnings[0].message) == snapshot(
-        'The `base_url` argument is deprecated. Use `advanced=logfire.AdvancedOptions(base_url=...)` instead.'
-    )
-    assert GLOBAL_CONFIG.advanced.base_url == 'foo'
-
-
-def test_combine_deprecated_and_new_advanced():
-    with inline_snapshot.extra.raises(
-        snapshot('ValueError: Cannot specify `base_url` and `advanced`. Use only `advanced`.')
-    ):
-        logfire.configure(base_url='foo', advanced=logfire.AdvancedOptions(base_url='bar'))  # type: ignore
-
-
-def test_additional_metric_readers_deprecated():
-    readers = [InMemoryMetricReader()]
-    with pytest.warns(UserWarning) as warnings:
-        logfire.configure(additional_metric_readers=readers)  # type: ignore
-    assert len(warnings) == 1
-    assert str(warnings[0].message) == snapshot(
-        'The `additional_metric_readers` argument is deprecated. '
-        'Use `metrics=logfire.MetricsOptions(additional_readers=[...])` instead.'
-    )
-    assert GLOBAL_CONFIG.metrics.additional_readers is readers  # type: ignore
-
-
-def test_additional_metric_readers_combined_with_metrics():
-    readers = [InMemoryMetricReader()]
-    with inline_snapshot.extra.raises(
-        snapshot(
-            'ValueError: Cannot specify both `additional_metric_readers` and `metrics`. '
-            'Use `metrics=logfire.MetricsOptions(additional_readers=[...])` instead.'
-        )
-    ):
-        logfire.configure(additional_metric_readers=readers, metrics=False)  # type: ignore
+    with inline_snapshot.extra.raises(snapshot("TypeError: configure() got an unexpected keyword argument 'foo'")):
+        logfire.configure(foo=1)  # type: ignore
 
 
 def test_environment(config_kwargs: dict[str, Any], exporter: TestExporter):

--- a/tests/test_secret_scrubbing.py
+++ b/tests/test_secret_scrubbing.py
@@ -514,27 +514,6 @@ def test_disable_scrubbing(exporter: TestExporter, logs_exporter: TestLogExporte
     )
 
 
-def test_scrubbing_deprecated_args(config_kwargs: dict[str, Any]):
-    def callback(match: logfire.ScrubMatch):  # pragma: no cover
-        return str(match)
-
-    with pytest.warns(UserWarning, match='The `scrubbing_callback` and `scrubbing_patterns` arguments are deprecated.'):
-        logfire.configure(**config_kwargs, scrubbing_patterns=['my_pattern'], scrubbing_callback=callback)  # type: ignore
-
-    config = logfire.DEFAULT_LOGFIRE_INSTANCE.config
-    assert config.scrubbing
-    assert config.scrubbing.extra_patterns == ['my_pattern']
-    assert config.scrubbing.callback is callback
-
-
-def test_scrubbing_deprecated_args_combined_with_new_options():
-    with pytest.raises(
-        ValueError,
-        match='Cannot specify `scrubbing` and `scrubbing_callback` or `scrubbing_patterns` at the same time.',
-    ):
-        logfire.configure(scrubbing_patterns=['my_pattern'], scrubbing=logfire.ScrubbingOptions())  # type: ignore
-
-
 def test_do_not_scrub(exporter: TestExporter):
     # do_not_scrub is a safe key to provide a crude workaround, but it only works if the matched value is *inside*
     logfire.info(

--- a/tests/test_tail_sampling.py
+++ b/tests/test_tail_sampling.py
@@ -502,26 +502,6 @@ def test_invalid_rates():
         logfire.SamplingOptions.level_or_duration(head=2)
 
 
-def test_trace_sample_rate(config_kwargs: dict[str, Any]):
-    with pytest.warns(UserWarning) as warnings:
-        logfire.configure(trace_sample_rate=0.123, **config_kwargs)  # type: ignore
-    assert logfire.DEFAULT_LOGFIRE_INSTANCE.config.sampling.head == 0.123
-    assert len(warnings) == 1
-    assert str(warnings[0].message) == snapshot(
-        'The `trace_sample_rate` argument is deprecated. Use `sampling=logfire.SamplingOptions(head=...)` instead.'
-    )
-
-
-def test_both_trace_and_head():
-    with inline_snapshot.extra.raises(
-        snapshot(
-            'ValueError: Cannot specify both `trace_sample_rate` and `sampling`. '
-            'Use `sampling.head` instead of `trace_sample_rate`.'
-        )
-    ):
-        logfire.configure(trace_sample_rate=0.5, sampling=logfire.SamplingOptions())  # type: ignore
-
-
 def test_tail_sampling_no_warning_on_ended_span(
     exporter: TestExporter,
     id_generator: Any,


### PR DESCRIPTION
## Summary

- remove the deprecated keyword catch-all from `logfire.configure()`
- let Python reject retired and unknown keyword arguments with its standard `TypeError`
- delete tests for the removed compatibility translations and warnings
- retain `PydanticPlugin` for environment-based Pydantic instrumentation configuration

## Tests

- `uv run pytest tests/test_configure.py tests/test_secret_scrubbing.py tests/test_tail_sampling.py`
- `uv run ruff check logfire/_internal/config.py tests/test_configure.py tests/test_secret_scrubbing.py tests/test_tail_sampling.py`
- `uv run pyright logfire/_internal/config.py tests/test_configure.py tests/test_secret_scrubbing.py tests/test_tail_sampling.py`
