### PR TITLE
Remove deprecated Flask exclude_urls argument

### DIFF
--- a/logfire/_internal/integrations/flask.py
+++ b/logfire/_internal/integrations/flask.py
@@ -4,8 +4,6 @@ from typing import Any
 
 from flask.app import Flask
 
-from logfire._internal.stack_info import warn_at_user_stacklevel
-
 try:
     from opentelemetry.instrumentation.flask import FlaskInstrumentor
 except ImportError:
@@ -35,11 +33,6 @@ def instrument_flask(
     See the `Logfire.instrument_flask` method for details.
     """
     maybe_capture_server_headers(capture_headers)
-
-    # Previously the parameter was accidentally called exclude_urls, so we support both.
-    if 'exclude_urls' in kwargs:  # pragma: no cover
-        warn_at_user_stacklevel('exclude_urls is deprecated; use excluded_urls instead', DeprecationWarning)
-    excluded_urls = excluded_urls or kwargs.pop('exclude_urls', None)
 
     FlaskInstrumentor().instrument_app(  # pyright: ignore[reportUnknownMemberType]
         app,

--- a/tests/otel_integrations/test_flask.py
+++ b/tests/otel_integrations/test_flask.py
@@ -183,6 +183,23 @@ def test_flask_instrumentation(exporter: TestExporter, time_generator: TimeGener
     )
 
 
+def test_excluded_urls_is_forwarded() -> None:
+    app = Flask(__name__)
+
+    with mock.patch.object(opentelemetry.instrumentation.flask.FlaskInstrumentor, 'instrument_app') as instrument_app:
+        logfire.instrument_flask(app, excluded_urls='/health')
+
+    assert instrument_app.call_args.kwargs['excluded_urls'] == '/health'
+    assert 'exclude_urls' not in instrument_app.call_args.kwargs
+
+
+def test_exclude_urls_is_no_longer_supported() -> None:
+    app = Flask(__name__)
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'exclude_urls'"):
+        logfire.instrument_flask(app, exclude_urls='/health')
+
+
 def test_missing_opentelemetry_dependency() -> None:
     with mock.patch.dict('sys.modules', {'opentelemetry.instrumentation.flask': None}):
         with pytest.raises(RuntimeError) as exc_info:


### PR DESCRIPTION
## Summary

- remove Logfire's deprecated `exclude_urls` compatibility translation
- preserve the supported `excluded_urls` forwarding behavior
- verify the removed spelling now fails as an unexpected OpenTelemetry keyword

## Tests

- `uv run pytest tests/otel_integrations/test_flask.py -q`
- `uv run ruff check logfire/_internal/integrations/flask.py tests/otel_integrations/test_flask.py`
- `uv run pyright logfire/_internal/integrations/flask.py tests/otel_integrations/test_flask.py`
