### PR TITLE
Remove deprecated HTTPX capture arguments

### DIFF
--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -129,14 +129,14 @@ def instrument_httpx(
 
     See the `Logfire.instrument_httpx` method for details.
     """
+    for removed_parameter in ('capture_request_headers', 'capture_response_headers'):
+        if removed_parameter in kwargs:
+            raise TypeError(f"instrument_httpx() got an unexpected keyword argument '{removed_parameter}'")
+
     if capture_all and (capture_headers or capture_request_body or capture_response_body):
         warn_at_user_stacklevel(
             'You should use either `capture_all` or the specific capture parameters, not both.', UserWarning
         )
-
-    for removed_parameter in ('capture_request_headers', 'capture_response_headers'):
-        if removed_parameter in kwargs:
-            raise TypeError(f"instrument_httpx() got an unexpected keyword argument '{removed_parameter}'")
 
     capture_all = cast(bool, GLOBAL_CONFIG.param_manager.load_param('httpx_capture_all', capture_all))
 

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -134,22 +134,14 @@ def instrument_httpx(
             'You should use either `capture_all` or the specific capture parameters, not both.', UserWarning
         )
 
-    capture_request_headers = kwargs.get('capture_request_headers')
-    capture_response_headers = kwargs.get('capture_response_headers')
-
-    if capture_request_headers is not None:
-        warn_at_user_stacklevel(
-            'The `capture_request_headers` parameter is deprecated. Use `capture_headers` instead.', DeprecationWarning
-        )
-    if capture_response_headers is not None:
-        warn_at_user_stacklevel(
-            'The `capture_response_headers` parameter is deprecated. Use `capture_headers` instead.', DeprecationWarning
-        )
+    for removed_parameter in ('capture_request_headers', 'capture_response_headers'):
+        if removed_parameter in kwargs:
+            raise TypeError(f"instrument_httpx() got an unexpected keyword argument '{removed_parameter}'")
 
     capture_all = cast(bool, GLOBAL_CONFIG.param_manager.load_param('httpx_capture_all', capture_all))
 
-    should_capture_request_headers = capture_request_headers or capture_headers or capture_all
-    should_capture_response_headers = capture_response_headers or capture_headers or capture_all
+    should_capture_request_headers = capture_headers or capture_all
+    should_capture_response_headers = capture_headers or capture_all
     should_capture_request_body = capture_request_body or capture_all
     should_capture_response_body = capture_response_body or capture_all
 
@@ -158,8 +150,6 @@ def instrument_httpx(
         capture_headers,
         capture_request_body,
         capture_response_body,
-        capture_request_headers,
-        capture_response_headers,
     )
 
     final_kwargs: dict[str, Any] = {

--- a/logfire/_internal/integrations/httpx.py
+++ b/logfire/_internal/integrations/httpx.py
@@ -131,7 +131,7 @@ def instrument_httpx(
     """
     for removed_parameter in ('capture_request_headers', 'capture_response_headers'):
         if removed_parameter in kwargs:
-            raise TypeError(f"instrument_httpx() got an unexpected keyword argument '{removed_parameter}'")
+            raise TypeError(f'The `{removed_parameter}` parameter has been removed. Use `capture_headers` instead.')
 
     if capture_all and (capture_headers or capture_request_body or capture_response_body):
         warn_at_user_stacklevel(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -334,8 +334,6 @@ filterwarnings = [
     'ignore:(?s).*aiosqlite/core\.py.*get_loop\(future\).call_soon_threadsafe.*RuntimeError. Event loop is closed:pytest.PytestUnhandledThreadExceptionWarning',
     # This problem is fixed in https://github.com/open-telemetry/opentelemetry-python-contrib/pull/2013, but not the warning.
     "ignore:The '__version__' attribute is deprecated and will be removed in Flask 3.1:DeprecationWarning",
-    "ignore:The `capture_request_headers` parameter is deprecated. Use `capture_headers` instead.:DeprecationWarning",
-    "ignore:The `capture_response_headers` parameter is deprecated. Use `capture_headers` instead.:DeprecationWarning",
     # kombu using deprecated redis API
     "ignore:Call to 'get_connection' function with deprecated usage of input argument/s.*:DeprecationWarning",
     # celery's redis backend uses redis's deprecated `setex` (deprecated in redis-py 8.0)

--- a/tests/otel_integrations/test_httpx.py
+++ b/tests/otel_integrations/test_httpx.py
@@ -430,13 +430,17 @@ RESPONSE_ATTRIBUTES = {
 @pytest.mark.parametrize(
     ('instrument_kwargs', 'expected_attributes'),
     [
-        ({'capture_request_headers': True}, REQUEST_ATTRIBUTES),
-        ({'capture_request_headers': True, 'request_hook': request_hook}, {*REQUEST_ATTRIBUTES, 'request_hook'}),
-        ({'capture_request_headers': False, 'request_hook': request_hook}, {'request_hook'}),
-        ({'capture_response_headers': True}, RESPONSE_ATTRIBUTES),
-        ({'capture_response_headers': True, 'response_hook': response_hook}, {*RESPONSE_ATTRIBUTES, 'response_hook'}),
-        ({'capture_response_headers': False, 'response_hook': response_hook}, {'response_hook'}),
         ({'capture_headers': True}, {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES}),
+        (
+            {'capture_headers': True, 'request_hook': request_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'request_hook'},
+        ),
+        ({'capture_headers': False, 'request_hook': request_hook}, {'request_hook'}),
+        (
+            {'capture_headers': True, 'response_hook': response_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'response_hook'},
+        ),
+        ({'capture_headers': False, 'response_hook': response_hook}, {'response_hook'}),
     ],
 )
 def test_httpx_client_instrumentation_with_capture_headers(
@@ -458,19 +462,24 @@ def test_httpx_client_instrumentation_with_capture_headers(
 @pytest.mark.parametrize(
     ('instrument_kwargs', 'expected_attributes'),
     [
-        ({'capture_request_headers': True}, REQUEST_ATTRIBUTES),
-        ({'capture_request_headers': True, 'request_hook': request_hook}, {*REQUEST_ATTRIBUTES, 'request_hook'}),
-        ({'capture_request_headers': False, 'request_hook': request_hook}, {'request_hook'}),
-        ({'capture_response_headers': True}, RESPONSE_ATTRIBUTES),
-        ({'capture_response_headers': True, 'response_hook': response_hook}, {*RESPONSE_ATTRIBUTES, 'response_hook'}),
-        ({'capture_response_headers': False, 'response_hook': response_hook}, {'response_hook'}),
+        ({'capture_headers': True}, {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES}),
         (
-            {'capture_request_headers': True, 'request_hook': async_request_hook},
-            {*REQUEST_ATTRIBUTES, 'async_request_hook'},
+            {'capture_headers': True, 'request_hook': request_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'request_hook'},
+        ),
+        ({'capture_headers': False, 'request_hook': request_hook}, {'request_hook'}),
+        (
+            {'capture_headers': True, 'response_hook': response_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'response_hook'},
+        ),
+        ({'capture_headers': False, 'response_hook': response_hook}, {'response_hook'}),
+        (
+            {'capture_headers': True, 'request_hook': async_request_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'async_request_hook'},
         ),
         (
-            {'capture_response_headers': True, 'response_hook': async_response_hook},
-            {*RESPONSE_ATTRIBUTES, 'async_response_hook'},
+            {'capture_headers': True, 'response_hook': async_response_hook},
+            {*REQUEST_ATTRIBUTES, *RESPONSE_ATTRIBUTES, 'async_response_hook'},
         ),
     ],
 )
@@ -488,6 +497,18 @@ async def test_async_httpx_client_instrumentation_with_capture_headers(
 
     span = exporter.exported_spans_as_dict(parse_json_attributes=True)[0]
     assert all(key in span['attributes'] for key in expected_attributes)
+
+
+@pytest.mark.parametrize('removed_parameter', ['capture_request_headers', 'capture_response_headers'])
+def test_removed_capture_header_parameters(removed_parameter: str, httpx_family: HTTPXFamilyType):
+    expected_message = f"unexpected keyword argument '{removed_parameter}'"
+
+    with pytest.raises(TypeError, match=expected_message):
+        cast(Any, logfire.instrument_httpx)(**{removed_parameter: True})
+
+    with httpx_family.client() as client:
+        with pytest.raises(TypeError, match=expected_message):
+            cast(Any, logfire.instrument_httpx)(client, **{removed_parameter: True})
 
 
 CAPTURE_JSON_BODY_PARAMETERS: tuple[tuple[str, ...], list[Any]] = (
@@ -574,7 +595,7 @@ def test_httpx_client_capture_stream_body(exporter: TestExporter, httpx_family: 
 def test_httpx_client_capture_full_request(exporter: TestExporter, httpx_family: HTTPXFamilyType):
     with check_traceparent_header() as checker:
         with httpx_family.client() as client:
-            logfire.instrument_httpx(client, capture_request_headers=True, capture_request_body=True)
+            logfire.instrument_httpx(client, capture_headers=True, capture_request_body=True)
             response = client.post('https://example.org:8080/foo', json={'hello': 'world'})
             checker(response)
 
@@ -585,7 +606,7 @@ def test_httpx_client_capture_full_request(exporter: TestExporter, httpx_family:
 async def test_async_httpx_client_capture_full_request(exporter: TestExporter, httpx_family: HTTPXFamilyType):
     with check_traceparent_header() as checker:
         async with httpx_family.async_client() as client:
-            logfire.instrument_httpx(client, capture_request_headers=True, capture_request_body=True)
+            logfire.instrument_httpx(client, capture_headers=True, capture_request_body=True)
             response = await client.post('https://example.org:8080/foo', json={'hello': 'world'})
             checker(response)
 

--- a/tests/otel_integrations/test_httpx.py
+++ b/tests/otel_integrations/test_httpx.py
@@ -502,16 +502,18 @@ async def test_async_httpx_client_instrumentation_with_capture_headers(
 
 @pytest.mark.parametrize('removed_parameter', ['capture_request_headers', 'capture_response_headers'])
 def test_removed_capture_header_parameters(removed_parameter: str, httpx_family: HTTPXFamilyType):
-    expected_message = f"unexpected keyword argument '{removed_parameter}'"
+    expected_message = f'The `{removed_parameter}` parameter has been removed. Use `capture_headers` instead.'
 
     with warnings.catch_warnings():
         warnings.simplefilter('error')
-        with pytest.raises(TypeError, match=expected_message):
+        with pytest.raises(TypeError) as exc_info:
             cast(Any, logfire.instrument_httpx)(capture_all=True, capture_headers=True, **{removed_parameter: True})
+        assert str(exc_info.value) == expected_message
 
     with httpx_family.client() as client:
-        with pytest.raises(TypeError, match=expected_message):
+        with pytest.raises(TypeError) as exc_info:
             cast(Any, logfire.instrument_httpx)(client, **{removed_parameter: True})
+        assert str(exc_info.value) == expected_message
 
 
 CAPTURE_JSON_BODY_PARAMETERS: tuple[tuple[str, ...], list[Any]] = (

--- a/tests/otel_integrations/test_httpx.py
+++ b/tests/otel_integrations/test_httpx.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import Any, Generic, TypeAlias, TypeVar, cast
@@ -503,8 +504,10 @@ async def test_async_httpx_client_instrumentation_with_capture_headers(
 def test_removed_capture_header_parameters(removed_parameter: str, httpx_family: HTTPXFamilyType):
     expected_message = f"unexpected keyword argument '{removed_parameter}'"
 
-    with pytest.raises(TypeError, match=expected_message):
-        cast(Any, logfire.instrument_httpx)(**{removed_parameter: True})
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        with pytest.raises(TypeError, match=expected_message):
+            cast(Any, logfire.instrument_httpx)(capture_all=True, capture_headers=True, **{removed_parameter: True})
 
     with httpx_family.client() as client:
         with pytest.raises(TypeError, match=expected_message):


### PR DESCRIPTION
## Summary

- remove Logfire's deprecated `capture_request_headers` and `capture_response_headers` compatibility behavior
- reject the removed names explicitly instead of letting the OpenTelemetry passthrough silently ignore them
- retain `capture_headers` as the supported request-and-response header option
- remove the obsolete deprecation-warning filters and update focused coverage for sync, async, global, and client instrumentation

## Tests

- `uv run pytest tests/otel_integrations/test_httpx.py`
- `make typecheck`
- `uv run ruff check logfire/_internal/integrations/httpx.py tests/otel_integrations/test_httpx.py`
- `uv run ruff format --check logfire/_internal/integrations/httpx.py tests/otel_integrations/test_httpx.py`
