### PR TITLE
Default OpenAI and Anthropic instrumentation to new `version=2`

### DIFF
--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -99,7 +99,7 @@ Not seeing your model calls in Logfire? Check these first:
 
 ### Keep legacy attributes during migration
 
-Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
+Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
 ```python skip-run="true" skip-reason="migration configuration example"

--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -102,7 +102,7 @@ Not seeing your model calls in Logfire? Check these first:
 Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
-```python skip-run="true" skip-reason="migration configuration example"
+```python
 import logfire
 
 logfire.configure()

--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -97,6 +97,17 @@ Not seeing your model calls in Logfire? Check these first:
 
 ## Advanced
 
+### Keep legacy attributes during migration
+
+Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
+on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
+
+```python skip-run="true" skip-reason="migration configuration example"
+import logfire
+
+logfire.instrument_anthropic(version=[1, 2])
+```
+
 ### Methods covered
 
 !!! note

--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -105,6 +105,7 @@ on the legacy `request_data` and `response_data` attributes, emit both formats w
 ```python skip-run="true" skip-reason="migration configuration example"
 import logfire
 
+logfire.configure()
 logfire.instrument_anthropic(version=[1, 2])
 ```
 

--- a/docs/integrations/llms/anthropic.md
+++ b/docs/integrations/llms/anthropic.md
@@ -99,7 +99,7 @@ Not seeing your model calls in Logfire? Check these first:
 
 ### Keep legacy attributes during migration
 
-Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
+Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
 ```python

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -95,7 +95,7 @@ Not seeing your model calls in Logfire? Check these first:
 
 ### Keep legacy attributes during migration
 
-Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
+Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
 ```python

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -101,6 +101,7 @@ on the legacy `request_data` and `response_data` attributes, emit both formats w
 ```python skip-run="true" skip-reason="migration configuration example"
 import logfire
 
+logfire.configure()
 logfire.instrument_openai(version=[1, 2])
 ```
 

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -93,6 +93,17 @@ Not seeing your model calls in Logfire? Check these first:
 
 ## Advanced
 
+### Keep legacy attributes during migration
+
+Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
+on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
+
+```python skip-run="true" skip-reason="migration configuration example"
+import logfire
+
+logfire.instrument_openai(version=[1, 2])
+```
+
 ### Methods covered
 
 The following OpenAI methods are covered:

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -98,7 +98,7 @@ Not seeing your model calls in Logfire? Check these first:
 Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
-```python skip-run="true" skip-reason="migration configuration example"
+```python
 import logfire
 
 logfire.configure()

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -95,7 +95,7 @@ Not seeing your model calls in Logfire? Check these first:
 
 ### Keep legacy attributes during migration
 
-Logfire uses semantic convention version 2 by default. If your queries or dashboards still depend
+Logfire uses instrumentation version 2 by default. If your queries or dashboards still depend
 on the legacy `request_data` and `response_data` attributes, emit both formats while you migrate:
 
 ```python skip-run="true" skip-reason="migration configuration example"

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -528,7 +528,7 @@ class Logfire:
                 without waiting for the context manager to be opened,
                 i.e. it's not necessary to use this as a context manager.
         """
-    def instrument_openai(self, openai_client: openai.OpenAI | openai.AsyncOpenAI | type[openai.OpenAI] | type[openai.AsyncOpenAI] | None = None, *, suppress_other_instrumentation: bool = True, version: SemconvVersion | Sequence[SemconvVersion] = 1) -> AbstractContextManager[None]:
+    def instrument_openai(self, openai_client: openai.OpenAI | openai.AsyncOpenAI | type[openai.OpenAI] | type[openai.AsyncOpenAI] | None = None, *, suppress_other_instrumentation: bool = True, version: SemconvVersion | Sequence[SemconvVersion] = 2) -> AbstractContextManager[None]:
         '''Instrument an OpenAI client so that spans are automatically created for each request.
 
         This instruments the [standard OpenAI SDK](https://pypi.org/project/openai/) package, for instrumentation
@@ -579,14 +579,15 @@ class Logfire:
 
             version: The version(s) of the span attribute format to use:
 
-                - `1` (the default): Uses `request_data` and `response_data` attributes.
-                - `\'latest\'`: Uses OpenTelemetry Gen AI semantic convention attributes
+                - `1`: Uses the legacy `request_data` and `response_data` attributes.
+                - `2` (the default): Uses OpenTelemetry Gen AI semantic convention attributes
                   (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.) and omits the full
                   `response_data` attribute. A minimal `request_data` (e.g. `{"model": ...}`) is
-                  still recorded for message template compatibility. This format may change between
-                  releases.
-                - `[1, \'latest\']`: Emits both the full legacy attributes and the semantic convention
-                  attributes simultaneously, useful for migration and testing.
+                  still recorded for message template compatibility.
+                - `\'latest\'`: Uses the latest format, which is currently identical to version 2.
+                  Unlike a numbered version, this format may change between releases.
+                - `[1, 2]` or `[1, \'latest\']`: Emits both the full legacy attributes and the semantic
+                  convention attributes simultaneously, useful for migration and testing.
 
         Returns:
             A context manager that will revert the instrumentation when exited.
@@ -598,7 +599,7 @@ class Logfire:
         For instrumentation of the standard OpenAI SDK package,
         see [`instrument_openai()`][logfire.Logfire.instrument_openai].
         """
-    def instrument_anthropic(self, anthropic_client: anthropic.Anthropic | anthropic.AsyncAnthropic | _AnthropicBedrock | _AsyncAnthropicBedrock | type[anthropic.Anthropic] | type[anthropic.AsyncAnthropic] | type[_AnthropicBedrock] | type[_AsyncAnthropicBedrock] | None = None, *, suppress_other_instrumentation: bool = True, version: SemconvVersion | Sequence[SemconvVersion] = 1) -> AbstractContextManager[None]:
+    def instrument_anthropic(self, anthropic_client: anthropic.Anthropic | anthropic.AsyncAnthropic | _AnthropicBedrock | _AsyncAnthropicBedrock | type[anthropic.Anthropic] | type[anthropic.AsyncAnthropic] | type[_AnthropicBedrock] | type[_AsyncAnthropicBedrock] | None = None, *, suppress_other_instrumentation: bool = True, version: SemconvVersion | Sequence[SemconvVersion] = 2) -> AbstractContextManager[None]:
         '''Instrument an Anthropic client so that spans are automatically created for each request.
 
         The following methods are instrumented for both the sync and async clients:
@@ -644,14 +645,15 @@ class Logfire:
 
             version: The version(s) of the span attribute format to use:
 
-                - `1` (the default): Uses `request_data` and `response_data` attributes.
-                - `\'latest\'`: Uses OpenTelemetry Gen AI semantic convention attributes
+                - `1`: Uses the legacy `request_data` and `response_data` attributes.
+                - `2` (the default): Uses OpenTelemetry Gen AI semantic convention attributes
                   (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.) and omits the full
                   `response_data` attribute. A minimal `request_data` (e.g. `{"model": ...}`) is
-                  still recorded for message template compatibility. This format may change between
-                  releases.
-                - `[1, \'latest\']`: Emits both the full legacy attributes and the semantic convention
-                  attributes simultaneously, useful for migration and testing.
+                  still recorded for message template compatibility.
+                - `\'latest\'`: Uses the latest format, which is currently identical to version 2.
+                  Unlike a numbered version, this format may change between releases.
+                - `[1, 2]` or `[1, \'latest\']`: Emits both the full legacy attributes and the semantic
+                  convention attributes simultaneously, useful for migration and testing.
 
         Returns:
             A context manager that will revert the instrumentation when exited.

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -30,8 +30,8 @@ from .semconv import (
     ChatMessage,
     InputMessages,
     MessagePart,
+    NormalizedSemconvVersion,
     OutputMessage,
-    SemconvVersion,
     SystemInstructions,
     TextPart,
     ToolCallPart,
@@ -76,7 +76,9 @@ def _extract_request_parameters(json_data: dict[str, Any], span_data: dict[str, 
         span_data[TOOL_DEFINITIONS] = json.dumps(tools)
 
 
-def _versioned_stream_cls(base_cls: type[StreamState], versions: frozenset[SemconvVersion]) -> type[StreamState]:
+def _versioned_stream_cls(
+    base_cls: type[StreamState], versions: frozenset[NormalizedSemconvVersion]
+) -> type[StreamState]:
     """Create a version-aware stream state subclass."""
 
     class VersionedStreamState(base_cls):
@@ -86,10 +88,12 @@ def _versioned_stream_cls(base_cls: type[StreamState], versions: frozenset[Semco
 
 
 def get_endpoint_config(
-    options: FinalRequestOptions, *, version: SemconvVersion | frozenset[SemconvVersion] = 1
+    options: FinalRequestOptions,
+    *,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
 ) -> EndpointConfig:
     """Returns the endpoint config for Anthropic or Bedrock depending on the url."""
-    versions: frozenset[SemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
+    versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
     url = options.url
     raw_json_data = options.json_data
     if not isinstance(raw_json_data, dict):  # pragma: no cover
@@ -107,7 +111,7 @@ def get_endpoint_config(
         span_data: dict[str, Any] = {**common_attrs, OPERATION_NAME: 'chat'}
         _extract_request_parameters(json_data, span_data)
 
-        if 'latest' in versions:
+        if 2 in versions:
             # Convert messages to semantic convention format
             messages: list[dict[str, Any]] = json_data.get('messages', [])
             system: str | list[dict[str, Any]] | None = json_data.get('system')
@@ -262,7 +266,7 @@ def convert_response_to_semconv(message: Message | BetaMessage) -> OutputMessage
 
 
 class AnthropicMessageStreamState(StreamState):
-    _versions: frozenset[SemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
 
     def __init__(self):
         self._message: Any = None
@@ -296,7 +300,7 @@ class AnthropicMessageStreamState(StreamState):
         result = dict(**span_data)
         if 1 in versions:
             result['response_data'] = self.get_response_data()
-        if 'latest' in versions and self._message and self._message.content:
+        if 2 in versions and self._message and self._message.content:
             result[OUTPUT_MESSAGES] = [convert_response_to_semconv(self._message)]
         if self._message is not None:
             result.update(get_anthropic_usage_attributes(self._message, self.base_url))
@@ -341,11 +345,11 @@ def on_response(
     response: ResponseT,
     span: LogfireSpan,
     *,
-    version: SemconvVersion | frozenset[SemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
     base_url: str | None = None,
 ) -> ResponseT:
     """Updates the span based on the type of response."""
-    versions: frozenset[SemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
+    versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
 
     if isinstance(response, (Message, BetaMessage)):
         if 1 in versions:
@@ -365,7 +369,7 @@ def on_response(
                     )
             span.set_attribute('response_data', {'message': message, 'usage': response.usage})
 
-        if 'latest' in versions:
+        if 2 in versions:
             output_message = convert_response_to_semconv(response)
             span.set_attribute(OUTPUT_MESSAGES, [output_message])
 

--- a/logfire/_internal/integrations/llm_providers/anthropic.py
+++ b/logfire/_internal/integrations/llm_providers/anthropic.py
@@ -90,7 +90,7 @@ def _versioned_stream_cls(
 def get_endpoint_config(
     options: FinalRequestOptions,
     *,
-    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 2,
 ) -> EndpointConfig:
     """Returns the endpoint config for Anthropic or Bedrock depending on the url."""
     versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
@@ -266,7 +266,7 @@ def convert_response_to_semconv(message: Message | BetaMessage) -> OutputMessage
 
 
 class AnthropicMessageStreamState(StreamState):
-    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({2})
 
     def __init__(self):
         self._message: Any = None
@@ -345,7 +345,7 @@ def on_response(
     response: ResponseT,
     span: LogfireSpan,
     *,
-    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 2,
     base_url: str | None = None,
 ) -> ResponseT:
     """Updates the span based on the type of response."""

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -42,10 +42,10 @@ from .semconv import (
     FilePart,
     InputMessages,
     MessagePart,
+    NormalizedSemconvVersion,
     OutputMessage,
     OutputMessages,
     Role,
-    SemconvVersion,
     SystemInstructions,
     TextPart,
     ToolCallPart,
@@ -101,7 +101,9 @@ def _extract_request_parameters(json_data: dict[str, Any], span_data: dict[str, 
         span_data[TOOL_DEFINITIONS] = json.dumps(tools)
 
 
-def _versioned_stream_cls(base_cls: type[StreamState], versions: frozenset[SemconvVersion]) -> type[StreamState]:
+def _versioned_stream_cls(
+    base_cls: type[StreamState], versions: frozenset[NormalizedSemconvVersion]
+) -> type[StreamState]:
     """Create a version-aware stream state subclass."""
 
     class VersionedStreamState(base_cls):
@@ -111,10 +113,12 @@ def _versioned_stream_cls(base_cls: type[StreamState], versions: frozenset[Semco
 
 
 def get_endpoint_config(
-    options: FinalRequestOptions, *, version: SemconvVersion | frozenset[SemconvVersion] = 1
+    options: FinalRequestOptions,
+    *,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
 ) -> EndpointConfig:
     """Returns the endpoint config for OpenAI depending on the url."""
-    versions: frozenset[SemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
+    versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
     url = options.url
 
     raw_json_data = options.json_data
@@ -143,7 +147,7 @@ def get_endpoint_config(
 
         span_data = common_attrs('chat')
 
-        if 'latest' in versions:
+        if 2 in versions:
             # Convert messages to semantic convention format
             messages: list[dict[str, Any]] = json_data.get('messages', [])
             if messages:
@@ -164,7 +168,7 @@ def get_endpoint_config(
         if 1 in versions:
             span_data['events'] = inputs_to_events(json_data.get('input'), json_data.get('instructions'))
 
-        if 'latest' in versions:
+        if 2 in versions:
             # Convert inputs to semantic convention format
             input_messages_resp, system_instructions = convert_responses_inputs_to_semconv(
                 json_data.get('input'), json_data.get('instructions')
@@ -468,7 +472,7 @@ def content_from_completions(chunk: Completion | None) -> str | None:
 
 
 class OpenaiCompletionStreamState(StreamState):
-    _versions: frozenset[SemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
 
     def __init__(self):
         self._content: list[str] = []
@@ -486,7 +490,7 @@ class OpenaiCompletionStreamState(StreamState):
         result = dict(**span_data)
         if 1 in versions:
             result['response_data'] = self.get_response_data()
-        if 'latest' in versions:
+        if 2 in versions:
             combined_content = ''.join(self._content)
             if combined_content:
                 result[OUTPUT_MESSAGES] = [
@@ -499,7 +503,7 @@ class OpenaiCompletionStreamState(StreamState):
 
 
 class OpenaiResponsesStreamState(StreamState):
-    _versions: frozenset[SemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
 
     def __init__(self):
         self._state = ResponseStreamState(input_tools=openai.omit, text_format=openai.omit)
@@ -516,7 +520,7 @@ class OpenaiResponsesStreamState(StreamState):
         versions = self._versions
         response = self.get_response_data()
         if response:
-            if 'latest' in versions:
+            if 2 in versions:
                 output_messages = convert_responses_outputs_to_semconv(response)
                 span_data[OUTPUT_MESSAGES] = output_messages
             if 1 in versions:
@@ -530,7 +534,7 @@ try:
     from openai.lib.streaming.chat._completions import ChatCompletionStreamState
 
     class OpenaiChatCompletionStreamState(StreamState):
-        _versions: frozenset[SemconvVersion] = frozenset({1})
+        _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
 
         def __init__(self):
             self._stream_state = ChatCompletionStreamState()
@@ -560,7 +564,7 @@ try:
             result = dict(**span_data)
             if 1 in versions:
                 result['response_data'] = self.get_response_data()
-            if 'latest' in versions:
+            if 2 in versions:
                 try:
                     final_completion = self._stream_state.current_completion_snapshot
                 except AssertionError:
@@ -611,11 +615,11 @@ def on_response(
     response: ResponseT,
     span: LogfireSpan,
     *,
-    version: SemconvVersion | frozenset[SemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
     base_url: str | None = None,
 ) -> ResponseT:
     """Updates the span based on the type of response."""
-    versions: frozenset[SemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
+    versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
 
     if isinstance(response, LegacyAPIResponse):  # pragma: no cover
         on_response(response.parse(), span, version=versions, base_url=base_url)  # pyright: ignore[reportUnknownArgumentType]
@@ -637,7 +641,7 @@ def on_response(
                 'response_data',
                 {'message': response.choices[0].message, 'usage': usage},
             )
-        if 'latest' in versions:
+        if 2 in versions:
             output_messages: OutputMessages = []
             for choice in response.choices:
                 output_messages.append(convert_openai_response_to_semconv(choice.message, choice.finish_reason))
@@ -655,7 +659,7 @@ def on_response(
                 'response_data',
                 {'finish_reason': first_choice.finish_reason, 'text': first_choice.text, 'usage': usage},
             )
-        if 'latest' in versions:
+        if 2 in versions:
             output_messages_completion: list[dict[str, Any]] = []
             for choice in response.choices:
                 output_messages_completion.append(
@@ -679,7 +683,7 @@ def on_response(
         if 1 in versions:
             span.set_attribute('response_data', {'images': response.data})
     elif isinstance(response, Response):  # pragma: no branch
-        if 'latest' in versions:
+        if 2 in versions:
             response_output_messages: OutputMessages = convert_responses_outputs_to_semconv(response)
             span.set_attribute(OUTPUT_MESSAGES, response_output_messages)
         if 1 in versions:

--- a/logfire/_internal/integrations/llm_providers/openai.py
+++ b/logfire/_internal/integrations/llm_providers/openai.py
@@ -115,7 +115,7 @@ def _versioned_stream_cls(
 def get_endpoint_config(
     options: FinalRequestOptions,
     *,
-    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 2,
 ) -> EndpointConfig:
     """Returns the endpoint config for OpenAI depending on the url."""
     versions: frozenset[NormalizedSemconvVersion] = version if isinstance(version, frozenset) else frozenset({version})
@@ -472,7 +472,7 @@ def content_from_completions(chunk: Completion | None) -> str | None:
 
 
 class OpenaiCompletionStreamState(StreamState):
-    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({2})
 
     def __init__(self):
         self._content: list[str] = []
@@ -503,7 +503,7 @@ class OpenaiCompletionStreamState(StreamState):
 
 
 class OpenaiResponsesStreamState(StreamState):
-    _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
+    _versions: frozenset[NormalizedSemconvVersion] = frozenset({2})
 
     def __init__(self):
         self._state = ResponseStreamState(input_tools=openai.omit, text_format=openai.omit)
@@ -534,7 +534,7 @@ try:
     from openai.lib.streaming.chat._completions import ChatCompletionStreamState
 
     class OpenaiChatCompletionStreamState(StreamState):
-        _versions: frozenset[NormalizedSemconvVersion] = frozenset({1})
+        _versions: frozenset[NormalizedSemconvVersion] = frozenset({2})
 
         def __init__(self):
             self._stream_state = ChatCompletionStreamState()
@@ -615,7 +615,7 @@ def on_response(
     response: ResponseT,
     span: LogfireSpan,
     *,
-    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 1,
+    version: NormalizedSemconvVersion | frozenset[NormalizedSemconvVersion] = 2,
     base_url: str | None = None,
 ) -> ResponseT:
     """Updates the span based on the type of response."""

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -11,14 +11,17 @@ from typing import Any, Literal, TypeAlias
 
 from typing_extensions import NotRequired, TypedDict
 
-# Version type for controlling span attribute format
-SemconvVersion = Literal[1, 'latest']
+# Version types for controlling span attribute format
+SemconvVersion = Literal[1, 2, 'latest']
+NormalizedSemconvVersion = Literal[1, 2]
 
 
-ALLOWED_VERSIONS: frozenset[SemconvVersion] = frozenset((1, 'latest'))
+ALLOWED_VERSIONS: frozenset[SemconvVersion] = frozenset((1, 2, 'latest'))
 
 
-def normalize_versions(version: SemconvVersion | Sequence[SemconvVersion]) -> frozenset[SemconvVersion]:
+def normalize_versions(
+    version: SemconvVersion | Sequence[SemconvVersion],
+) -> frozenset[NormalizedSemconvVersion]:
     """Normalize a version parameter to a validated frozenset of version values."""
     if isinstance(version, (int, str)):
         versions: frozenset[Any] = frozenset({version})
@@ -28,13 +31,13 @@ def normalize_versions(version: SemconvVersion | Sequence[SemconvVersion]) -> fr
     invalid = versions - ALLOWED_VERSIONS
     if invalid:
         raise ValueError(
-            f"Invalid semconv version(s): {sorted(invalid, key=repr)!r}. Supported versions are: 1, 'latest'."
+            f"Invalid semconv version(s): {sorted(invalid, key=repr)!r}. Supported versions are: 1, 2, 'latest'."
         )
 
     if not versions:
-        raise ValueError("At least one semconv version must be specified. Supported versions are: 1, 'latest'.")
+        raise ValueError("At least one semconv version must be specified. Supported versions are: 1, 2, 'latest'.")
 
-    return versions
+    return frozenset(2 if item == 'latest' else item for item in versions)
 
 
 # Provider, system, and operation

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -1258,7 +1258,7 @@ class Logfire:
         | None = None,
         *,
         suppress_other_instrumentation: bool = True,
-        version: SemconvVersion | Sequence[SemconvVersion] = 1,
+        version: SemconvVersion | Sequence[SemconvVersion] = 2,
     ) -> AbstractContextManager[None]:
         """Instrument an OpenAI client so that spans are automatically created for each request.
 
@@ -1310,14 +1310,15 @@ class Logfire:
 
             version: The version(s) of the span attribute format to use:
 
-                - `1` (the default): Uses `request_data` and `response_data` attributes.
-                - `'latest'`: Uses OpenTelemetry Gen AI semantic convention attributes
+                - `1`: Uses the legacy `request_data` and `response_data` attributes.
+                - `2` (the default): Uses OpenTelemetry Gen AI semantic convention attributes
                   (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.) and omits the full
                   `response_data` attribute. A minimal `request_data` (e.g. `{"model": ...}`) is
-                  still recorded for message template compatibility. This format may change between
-                  releases.
-                - `[1, 'latest']`: Emits both the full legacy attributes and the semantic convention
-                  attributes simultaneously, useful for migration and testing.
+                  still recorded for message template compatibility.
+                - `'latest'`: Uses the latest format, which is currently identical to version 2.
+                  Unlike a numbered version, this format may change between releases.
+                - `[1, 2]` or `[1, 'latest']`: Emits both the full legacy attributes and the semantic
+                  convention attributes simultaneously, useful for migration and testing.
 
         Returns:
             A context manager that will revert the instrumentation when exited.
@@ -1368,7 +1369,7 @@ class Logfire:
         ) = None,
         *,
         suppress_other_instrumentation: bool = True,
-        version: SemconvVersion | Sequence[SemconvVersion] = 1,
+        version: SemconvVersion | Sequence[SemconvVersion] = 2,
     ) -> AbstractContextManager[None]:
         """Instrument an Anthropic client so that spans are automatically created for each request.
 
@@ -1415,14 +1416,15 @@ class Logfire:
 
             version: The version(s) of the span attribute format to use:
 
-                - `1` (the default): Uses `request_data` and `response_data` attributes.
-                - `'latest'`: Uses OpenTelemetry Gen AI semantic convention attributes
+                - `1`: Uses the legacy `request_data` and `response_data` attributes.
+                - `2` (the default): Uses OpenTelemetry Gen AI semantic convention attributes
                   (`gen_ai.input.messages`, `gen_ai.output.messages`, etc.) and omits the full
                   `response_data` attribute. A minimal `request_data` (e.g. `{"model": ...}`) is
-                  still recorded for message template compatibility. This format may change between
-                  releases.
-                - `[1, 'latest']`: Emits both the full legacy attributes and the semantic convention
-                  attributes simultaneously, useful for migration and testing.
+                  still recorded for message template compatibility.
+                - `'latest'`: Uses the latest format, which is currently identical to version 2.
+                  Unlike a numbered version, this format may change between releases.
+                - `[1, 2]` or `[1, 'latest']`: Emits both the full legacy attributes and the semantic
+                  convention attributes simultaneously, useful for migration and testing.
 
         Returns:
             A context manager that will revert the instrumentation when exited.

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -4,6 +4,7 @@ import gc
 import json
 import logging
 from collections.abc import AsyncIterator, Iterator
+from inspect import signature
 from typing import Any, cast
 
 import anthropic
@@ -36,6 +37,22 @@ pytestmark = [
 
 
 ANY_ADAPTER = pydantic.TypeAdapter(Any)  # type: ignore
+
+
+def test_semconv_version_defaults() -> None:
+    from logfire._internal.integrations.llm_providers.anthropic import get_endpoint_config
+
+    assert signature(logfire.instrument_anthropic).parameters['version'].default == 2
+
+    class MockOptions:
+        url = '/v1/messages'
+        json_data = {'model': 'claude-haiku-4-5', 'messages': [{'role': 'user', 'content': 'Hello'}]}
+
+    config = get_endpoint_config(MockOptions())  # type: ignore
+    assert config.span_data['request_data'] == {'model': 'claude-haiku-4-5'}
+    assert config.span_data['gen_ai.input.messages'] == [
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}
+    ]
 
 
 def request_handler(request: httpx.Request) -> httpx.Response:

--- a/tests/otel_integrations/test_anthropic.py
+++ b/tests/otel_integrations/test_anthropic.py
@@ -1324,30 +1324,30 @@ def test_on_response_unknown_block_type() -> None:
     )
 
 
-def test_get_endpoint_config_latest_no_messages_no_system() -> None:
-    """Test get_endpoint_config with 'latest' version and empty messages + no system."""
+def test_get_endpoint_config_v2_no_messages_no_system() -> None:
+    """Test get_endpoint_config with version 2 and empty messages plus no system."""
     from logfire._internal.integrations.llm_providers.anthropic import get_endpoint_config
 
     class MockOptions:
         url = '/v1/messages'
         json_data: dict[str, Any] = {'model': 'claude-3-haiku', 'messages': [], 'max_tokens': 100}
 
-    config = get_endpoint_config(MockOptions(), version='latest')  # type: ignore
+    config = get_endpoint_config(MockOptions(), version=2)  # type: ignore
 
     assert config.message_template == 'Message with {request_data[model]!r}'
     assert 'gen_ai.input.messages' not in config.span_data
     assert 'gen_ai.system_instructions' not in config.span_data
 
 
-def test_get_endpoint_config_latest_messages_no_system() -> None:
-    """Test get_endpoint_config with messages but no system."""
+def test_get_endpoint_config_v2_messages_no_system() -> None:
+    """Test get_endpoint_config with version 2 messages but no system."""
     from logfire._internal.integrations.llm_providers.anthropic import get_endpoint_config
 
     class MockOptions:
         url = '/v1/messages'
         json_data = {'model': 'claude-3-haiku', 'messages': [{'role': 'user', 'content': 'Hi'}], 'max_tokens': 100}
 
-    config = get_endpoint_config(MockOptions(), version='latest')  # type: ignore
+    config = get_endpoint_config(MockOptions(), version=2)  # type: ignore
 
     assert 'gen_ai.input.messages' in config.span_data
     assert 'gen_ai.system_instructions' not in config.span_data

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -2,6 +2,7 @@ from __future__ import annotations as _annotations
 
 import json
 from collections.abc import AsyncIterator, Iterator
+from inspect import signature
 from io import BytesIO
 from typing import Any
 
@@ -779,6 +780,22 @@ def test_normalize_versions_validation() -> None:
         normalize_versions('v2')  # type: ignore
     with pytest.raises(ValueError, match='At least one semconv version'):
         normalize_versions([])
+
+
+def test_semconv_version_defaults() -> None:
+    from logfire._internal.integrations.llm_providers.openai import get_endpoint_config
+
+    assert signature(logfire.instrument_openai).parameters['version'].default == 2
+
+    class MockOptions:
+        url = '/chat/completions'
+        json_data = {'model': 'gpt-4', 'messages': [{'role': 'user', 'content': 'Hello'}]}
+
+    config = get_endpoint_config(MockOptions())  # type: ignore
+    assert config.span_data['request_data'] == {'model': 'gpt-4'}
+    assert config.span_data['gen_ai.input.messages'] == [
+        {'role': 'user', 'parts': [{'type': 'text', 'content': 'Hello'}]}
+    ]
 
 
 async def test_async_chat_completions(instrumented_async_client: openai.AsyncClient, exporter: TestExporter) -> None:

--- a/tests/otel_integrations/test_openai.py
+++ b/tests/otel_integrations/test_openai.py
@@ -768,11 +768,13 @@ def test_normalize_versions_validation() -> None:
     from logfire._internal.integrations.llm_providers.semconv import normalize_versions
 
     assert normalize_versions(1) == frozenset({1})
-    assert normalize_versions('latest') == frozenset({'latest'})
-    assert normalize_versions([1, 'latest']) == frozenset({1, 'latest'})
+    assert normalize_versions(2) == frozenset({2})
+    assert normalize_versions('latest') == frozenset({2})
+    assert normalize_versions([1, 'latest']) == frozenset({1, 2})
+    assert normalize_versions([2, 'latest']) == frozenset({2})
 
     with pytest.raises(ValueError, match='Invalid semconv version'):
-        normalize_versions(2)  # type: ignore
+        normalize_versions(3)  # type: ignore
     with pytest.raises(ValueError, match='Invalid semconv version'):
         normalize_versions('v2')  # type: ignore
     with pytest.raises(ValueError, match='At least one semconv version'):
@@ -4303,15 +4305,15 @@ def test_inputs_to_events_no_inputs() -> None:
     )
 
 
-def test_get_endpoint_config_chat_completions_latest_empty_messages() -> None:
-    """Test get_endpoint_config for /chat/completions with latest version and empty messages."""
+def test_get_endpoint_config_chat_completions_v2_empty_messages() -> None:
+    """Test get_endpoint_config for /chat/completions with version 2 and empty messages."""
     from logfire._internal.integrations.llm_providers.openai import get_endpoint_config
 
     class MockOptions:
         url = '/chat/completions'
         json_data: dict[str, Any] = {'model': 'gpt-4', 'messages': []}
 
-    config = get_endpoint_config(MockOptions(), version='latest')  # type: ignore
+    config = get_endpoint_config(MockOptions(), version=2)  # type: ignore
     assert config.message_template == 'Chat Completion with {request_data[model]!r}'
     assert 'gen_ai.input.messages' not in config.span_data
 
@@ -4330,29 +4332,29 @@ def test_get_endpoint_config_responses_v1_only() -> None:
     assert 'gen_ai.input.messages' not in config.span_data
 
 
-def test_get_endpoint_config_responses_latest_only() -> None:
-    """Test get_endpoint_config for /responses with version='latest' only."""
+def test_get_endpoint_config_responses_v2_only() -> None:
+    """Test get_endpoint_config for /responses with version 2 only."""
     from logfire._internal.integrations.llm_providers.openai import get_endpoint_config
 
     class MockOptions:
         url = '/responses'
         json_data = {'model': 'gpt-4.1', 'input': 'Hello'}
 
-    config = get_endpoint_config(MockOptions(), version='latest')  # type: ignore
+    config = get_endpoint_config(MockOptions(), version=2)  # type: ignore
     assert config.message_template == 'Responses API with {gen_ai.request.model!r}'
     assert 'events' not in config.span_data
     assert 'gen_ai.input.messages' in config.span_data
 
 
-def test_get_endpoint_config_responses_latest_no_inputs() -> None:
-    """Test get_endpoint_config for /responses with latest but no inputs."""
+def test_get_endpoint_config_responses_v2_no_inputs() -> None:
+    """Test get_endpoint_config for /responses with version 2 but no inputs."""
     from logfire._internal.integrations.llm_providers.openai import get_endpoint_config
 
     class MockOptions:
         url = '/responses'
         json_data = {'model': 'gpt-4.1'}
 
-    config = get_endpoint_config(MockOptions(), version='latest')  # type: ignore
+    config = get_endpoint_config(MockOptions(), version=2)  # type: ignore
     assert 'gen_ai.input.messages' not in config.span_data
     assert 'gen_ai.system_instructions' not in config.span_data
 
@@ -4513,14 +4515,14 @@ def test_convert_responses_outputs_non_text_content() -> None:
     )
 
 
-def test_completion_stream_state_version_latest_only() -> None:
-    """Test OpenaiCompletionStreamState.get_attributes with version='latest'."""
+def test_completion_stream_state_version_v2_only() -> None:
+    """Test OpenaiCompletionStreamState.get_attributes with version 2."""
     from logfire._internal.integrations.llm_providers.openai import (
         OpenaiCompletionStreamState,
         _versioned_stream_cls,  # pyright: ignore[reportPrivateUsage]
     )
 
-    stream_cls = _versioned_stream_cls(OpenaiCompletionStreamState, frozenset({'latest'}))
+    stream_cls = _versioned_stream_cls(OpenaiCompletionStreamState, frozenset({2}))
     state = stream_cls()
     state._content = ['Hello', ' world']  # type: ignore[attr-defined]
 
@@ -4531,14 +4533,14 @@ def test_completion_stream_state_version_latest_only() -> None:
     )
 
 
-def test_completion_stream_state_version_latest_empty_content() -> None:
-    """Test OpenaiCompletionStreamState with latest version but no content."""
+def test_completion_stream_state_version_v2_empty_content() -> None:
+    """Test OpenaiCompletionStreamState with version 2 but no content."""
     from logfire._internal.integrations.llm_providers.openai import (
         OpenaiCompletionStreamState,
         _versioned_stream_cls,  # pyright: ignore[reportPrivateUsage]
     )
 
-    stream_cls = _versioned_stream_cls(OpenaiCompletionStreamState, frozenset({'latest'}))
+    stream_cls = _versioned_stream_cls(OpenaiCompletionStreamState, frozenset({2}))
     state = stream_cls()
 
     result = state.get_attributes({})
@@ -4571,8 +4573,8 @@ def test_responses_stream_state_version_specific() -> None:
         _versioned_stream_cls,  # pyright: ignore[reportPrivateUsage]
     )
 
-    # Test with 'latest' only and a truthy response
-    stream_cls = _versioned_stream_cls(OpenaiResponsesStreamState, frozenset({'latest'}))
+    # Test with version 2 only and a truthy response
+    stream_cls = _versioned_stream_cls(OpenaiResponsesStreamState, frozenset({2}))
     state = stream_cls()
     mock_response_latest = MagicMock()
     mock_response_latest.output = []
@@ -4988,7 +4990,7 @@ def test_get_endpoint_config_chat_completions_agent_span() -> None:
         json_data = {'model': 'gpt-4', 'messages': [{'role': 'user', 'content': 'Hi'}]}
 
     with patch('logfire._internal.integrations.llm_providers.openai.is_current_agent_span', return_value=True):
-        config = get_endpoint_config(MockOptions(), version=frozenset({1, 'latest'}))  # type: ignore
+        config = get_endpoint_config(MockOptions(), version=frozenset({1, 2}))  # type: ignore
 
     assert config.message_template == ''
     assert config.span_data == {}
@@ -5005,7 +5007,7 @@ def test_get_endpoint_config_responses_agent_span() -> None:
         json_data = {'model': 'gpt-4.1', 'input': 'Hello'}
 
     with patch('logfire._internal.integrations.llm_providers.openai.is_current_agent_span', return_value=True):
-        config = get_endpoint_config(MockOptions(), version=frozenset({1, 'latest'}))  # type: ignore
+        config = get_endpoint_config(MockOptions(), version=frozenset({1, 2}))  # type: ignore
 
     assert config.message_template == ''
     assert config.span_data == {}


### PR DESCRIPTION
## Summary

- add numeric semantic-convention version 2 for OpenAI and Anthropic instrumentation
- freeze the current `latest` telemetry behavior as version 2 and normalize `latest` to it internally
- make version 2 the public and provider-internal default while retaining version 1 and dual emission
- document the migration path and update the `logfire-api` generated signature surface

## Tests

- `uv run pytest tests/otel_integrations/test_openai.py tests/otel_integrations/test_anthropic.py`
- `uv run pytest tests/test_docs.py::test_formatting`
- repository-wide Ruff, Ruff format, and Pyright checks via pre-commit
