### PR TITLE
Report failures from every force_flush pipeline

### DIFF
--- a/logfire-api/logfire_api/__init__.py
+++ b/logfire-api/logfire_api/__init__.py
@@ -124,7 +124,8 @@ except ImportError:
             def with_settings(self, *args, **kwargs) -> Logfire:
                 return self
 
-            def force_flush(self, *args, **kwargs) -> None: ...
+            def force_flush(self, *args, **kwargs) -> bool:
+                return True
 
             def log_slow_async_callbacks(self, *args, **kwargs) -> None:  # pragma: no cover
                 return nullcontext()

--- a/logfire-api/logfire_api/_internal/config.pyi
+++ b/logfire-api/logfire_api/_internal/config.pyi
@@ -270,13 +270,13 @@ class LogfireConfig(_LogfireConfigData):
     def initialize(self) -> None:
         """Configure internals to start exporting traces and metrics."""
     def force_flush(self, timeout_millis: int = 30000) -> bool:
-        """Force flush all spans and metrics.
+        """Force flush all telemetry and forwarding pipelines.
 
         Args:
             timeout_millis: The timeout in milliseconds.
 
         Returns:
-            Whether the flush of spans was successful.
+            Whether every component that reports a status flushed successfully.
         """
     def shutdown(self, timeout_millis: int = 30000, flush: bool = True) -> bool:
         """Shut down variables, forwarding, traces, logs, and metrics."""

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -367,13 +367,13 @@ class Logfire:
             A new Logfire instance with the given settings applied.
         """
     def force_flush(self, timeout_millis: int = 3000) -> bool:
-        """Force flush all spans and metrics.
+        """Force flush all telemetry and forwarding pipelines.
 
         Args:
             timeout_millis: The timeout in milliseconds.
 
         Returns:
-            Whether the flush of spans was successful.
+            Whether every component that reports a status flushed successfully.
         """
     def url_from_eval(self, report: EvaluationReport[Any, Any, Any]) -> str | None:
         """Generate a Logfire URL to view an evaluation report.

--- a/logfire/_internal/config.py
+++ b/logfire/_internal/config.py
@@ -1505,19 +1505,21 @@ class LogfireConfig(_LogfireConfigData):
             self._ensure_flush_after_aws_lambda()
 
     def force_flush(self, timeout_millis: int = 30_000) -> bool:
-        """Force flush all spans and metrics.
+        """Force flush all telemetry and forwarding pipelines.
 
         Args:
             timeout_millis: The timeout in milliseconds.
 
         Returns:
-            Whether the flush of spans was successful.
+            Whether every component that reports a status flushed successfully.
         """
         self._meter_provider.force_flush(timeout_millis)
-        self._logger_provider.force_flush(timeout_millis)
-        # TODO: Combine non-tracer flush results into the returned status in a follow-up.
-        self._otlp_forwarding.force_flush(timeout_millis)
-        return self._tracer_provider.force_flush(timeout_millis)
+        results = (
+            self._logger_provider.force_flush(timeout_millis),
+            self._otlp_forwarding.force_flush(timeout_millis),
+            self._tracer_provider.force_flush(timeout_millis),
+        )
+        return all(result is not False for result in results)
 
     def shutdown(self, timeout_millis: int = 30_000, flush: bool = True) -> bool:
         """Shut down variables, forwarding, traces, logs, and metrics."""

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -910,13 +910,13 @@ class Logfire:
         )
 
     def force_flush(self, timeout_millis: int = 3_000) -> bool:  # pragma: no cover
-        """Force flush all spans and metrics.
+        """Force flush all telemetry and forwarding pipelines.
 
         Args:
             timeout_millis: The timeout in milliseconds.
 
         Returns:
-            Whether the flush of spans was successful.
+            Whether every component that reports a status flushed successfully.
         """
         return self._config.force_flush(timeout_millis)
 

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -676,6 +676,43 @@ def test_logfire_shutdown_closes_providers(monkeypatch: pytest.MonkeyPatch, flus
     meter_provider.shutdown.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ('logger_result', 'forwarding_result', 'tracer_result', 'expected'),
+    [
+        (True, True, True, True),
+        (None, True, True, True),
+        (False, True, True, False),
+        (True, False, True, False),
+        (True, True, False, False),
+    ],
+)
+def test_force_flush_combines_provider_results(
+    monkeypatch: pytest.MonkeyPatch,
+    logger_result: bool | None,
+    forwarding_result: bool,
+    tracer_result: bool,
+    expected: bool,
+) -> None:
+    config = logfire.DEFAULT_LOGFIRE_INSTANCE.config
+    meter_provider = mock.Mock()
+    logger_provider = mock.Mock()
+    logger_provider.force_flush.return_value = logger_result
+    otlp_forwarding = mock.Mock()
+    otlp_forwarding.force_flush.return_value = forwarding_result
+    tracer_provider = mock.Mock()
+    tracer_provider.force_flush.return_value = tracer_result
+    monkeypatch.setattr(config, '_meter_provider', meter_provider)
+    monkeypatch.setattr(config, '_logger_provider', logger_provider)
+    monkeypatch.setattr(config, '_otlp_forwarding', otlp_forwarding)
+    monkeypatch.setattr(config, '_tracer_provider', tracer_provider)
+
+    assert config.force_flush(123) is expected
+    meter_provider.force_flush.assert_called_once_with(123)
+    logger_provider.force_flush.assert_called_once_with(123)
+    otlp_forwarding.force_flush.assert_called_once_with(123)
+    tracer_provider.force_flush.assert_called_once_with(123)
+
+
 def get_batch_span_exporter(processor: SpanProcessor) -> SpanExporter:
     assert isinstance(processor, BatchSpanProcessor)
     try:

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -166,7 +166,7 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     logfire__all__.remove('with_tags')
 
     assert hasattr(logfire_api, 'force_flush')
-    logfire_api.force_flush()
+    assert logfire_api.force_flush() is True
     logfire__all__.remove('force_flush')
 
     assert hasattr(logfire_api, 'no_auto_trace')


### PR DESCRIPTION
## Summary

- combine log, forwarding, and trace flush statuses in `force_flush()`
- still invoke every telemetry component even when one reports failure
- make the no-op API shim report a successful flush and clarify the return-value docs

## Tests

- `uv run pytest tests/test_configure.py tests/test_logfire_api.py -q`
- pre-commit Ruff, formatting, and pyright checks
