### PR TITLE
Move scoped sampling into with_settings

### DIFF
--- a/docs/reference/api/logfire.md
+++ b/docs/reference/api/logfire.md
@@ -17,7 +17,6 @@ description: "Introduction to basic Logfire configuration, trace configuration a
             - "!instrument_redis"
             - "!instrument_pymongo"
             - "!instrument_psycopg"
-            - "!^with_trace_sample_rate$"
             - "!^_[^_]"
 
 

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -341,21 +341,13 @@ class Logfire:
         Returns:
             A new Logfire instance with the `tags` added to any existing tags.
         """
-    def with_trace_sample_rate(self, sample_rate: float) -> Logfire:
-        """A new Logfire instance with the given sampling ratio applied.
-
-        Args:
-            sample_rate: The sampling ratio to use.
-
-        Returns:
-            A new Logfire instance with the sampling ratio applied.
-        """
-    def with_settings(self, *, tags: Sequence[str] = (), console_log: bool | None = None, custom_scope_suffix: str | None = None) -> Logfire:
+    def with_settings(self, *, tags: Sequence[str] = (), console_log: bool | None = None, sample_rate: float | None = None, custom_scope_suffix: str | None = None) -> Logfire:
         """A new Logfire instance which uses the given settings.
 
         Args:
             tags: Sequence of tags to include in the log.
             console_log: Whether to log to the console, defaults to `True`.
+            sample_rate: The sampling ratio to use, between 0 and 1. By default, the current ratio is preserved.
             custom_scope_suffix: A custom suffix to append to `logfire.` e.g. `logfire.loguru`.
 
                 It should only be used when instrumenting another library with Logfire, such as structlog or loguru.

--- a/logfire-api/logfire_api/integrations/pydantic.pyi
+++ b/logfire-api/logfire_api/integrations/pydantic.pyi
@@ -31,7 +31,6 @@ class PluginSettings(TypedDict, total=False):
 
 class LogfireSettings(TypedDict, total=False):
     """Settings for the logfire integration."""
-    trace_sample_rate: float
     tags: list[str]
     record: Literal['all', 'failure', 'metrics']
 

--- a/logfire/__init__.py
+++ b/logfire/__init__.py
@@ -72,7 +72,6 @@ instrument_claude_agent_sdk = DEFAULT_LOGFIRE_INSTANCE.instrument_claude_agent_s
 suppress_scopes = DEFAULT_LOGFIRE_INSTANCE.suppress_scopes
 shutdown = DEFAULT_LOGFIRE_INSTANCE.shutdown
 with_tags = DEFAULT_LOGFIRE_INSTANCE.with_tags
-# with_trace_sample_rate = DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate
 with_settings = DEFAULT_LOGFIRE_INSTANCE.with_settings
 url_from_eval = DEFAULT_LOGFIRE_INSTANCE.url_from_eval
 forward_export_request = DEFAULT_LOGFIRE_INSTANCE.forward_export_request
@@ -183,7 +182,6 @@ __all__ = (
     'AutoTraceModule',
     'with_tags',
     'with_settings',
-    # 'with_trace_sample_rate',
     'suppress_scopes',
     'shutdown',
     'no_auto_trace',

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -861,28 +861,12 @@ class Logfire:
         """
         return self.with_settings(tags=tags)
 
-    def with_trace_sample_rate(self, sample_rate: float) -> Logfire:  # pragma: no cover
-        """A new Logfire instance with the given sampling ratio applied.
-
-        Args:
-            sample_rate: The sampling ratio to use.
-
-        Returns:
-            A new Logfire instance with the sampling ratio applied.
-        """
-        if sample_rate > 1 or sample_rate < 0:
-            raise ValueError('sample_rate must be between 0 and 1')
-        return Logfire(
-            config=self._config,
-            tags=self._tags,
-            sample_rate=sample_rate,
-        )
-
     def with_settings(
         self,
         *,
         tags: Sequence[str] = (),
         console_log: bool | None = None,
+        sample_rate: float | None = None,
         custom_scope_suffix: str | None = None,
     ) -> Logfire:
         """A new Logfire instance which uses the given settings.
@@ -890,6 +874,7 @@ class Logfire:
         Args:
             tags: Sequence of tags to include in the log.
             console_log: Whether to log to the console, defaults to `True`.
+            sample_rate: The sampling ratio to use, between 0 and 1. By default, the current ratio is preserved.
             custom_scope_suffix: A custom suffix to append to `logfire.` e.g. `logfire.loguru`.
 
                 It should only be used when instrumenting another library with Logfire, such as structlog or loguru.
@@ -900,11 +885,12 @@ class Logfire:
         Returns:
             A new Logfire instance with the given settings applied.
         """
-        # TODO add sample_rate once it's more stable
+        if sample_rate is not None and (sample_rate > 1 or sample_rate < 0):
+            raise ValueError('sample_rate must be between 0 and 1')
         return Logfire(
             config=self._config,
             tags=self._tags + tuple(tags),
-            sample_rate=self._sample_rate,
+            sample_rate=self._sample_rate if sample_rate is None else sample_rate,
             console_log=self._console_log if console_log is None else console_log,
             otel_scope=self._otel_scope if custom_scope_suffix is None else f'logfire.{custom_scope_suffix}',
         )

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -885,7 +885,7 @@ class Logfire:
         Returns:
             A new Logfire instance with the given settings applied.
         """
-        if sample_rate is not None and (sample_rate > 1 or sample_rate < 0):
+        if sample_rate is not None and not 0 <= sample_rate <= 1:
             raise ValueError('sample_rate must be between 0 and 1')
         return Logfire(
             config=self._config,

--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -56,8 +56,6 @@ class PluginSettings(TypedDict, total=False):
 class LogfireSettings(TypedDict, total=False):
     """Settings for the logfire integration."""
 
-    trace_sample_rate: float
-    """The sample rate to use for tracing."""
     tags: list[str]
     """Tags to add to the spans."""
     record: Literal['all', 'failure', 'metrics']

--- a/logfire/integrations/pydantic.py
+++ b/logfire/integrations/pydantic.py
@@ -98,9 +98,6 @@ class _ValidateWrapper:
         self._record = record
 
         self._logfire = logfire.DEFAULT_LOGFIRE_INSTANCE
-        # trace_sample_rate = _plugin_settings.get('logfire', {}).get('trace_sample_rate')
-        # if trace_sample_rate:
-        #     self._logfire = self._logfire.with_trace_sample_rate(float(trace_sample_rate))
 
         tags = _plugin_settings.get('logfire', {}).get('tags')
         if tags:

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -12,7 +12,6 @@ import sqlmodel
 from dirty_equals import IsInt
 from inline_snapshot import snapshot
 from opentelemetry.sdk.metrics.export import AggregationTemporality, InMemoryMetricReader
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from pydantic import (
     AfterValidator,
     BaseModel,
@@ -701,27 +700,6 @@ def test_pydantic_plugin_sample_rate_config(exporter: TestExporter, config_kwarg
     assert len(exporter.exported_spans_as_dict()) == 1
 
 
-@pytest.mark.xfail(reason='We need to fix the nesting `trace_sample_rate` logic.')
-def test_pydantic_plugin_plugin_settings_sample_rate(exporter: TestExporter) -> None:
-    logfire.configure(
-        send_to_logfire=False,
-        additional_span_processors=[SimpleSpanProcessor(exporter)],
-        advanced=logfire.AdvancedOptions(
-            id_generator=SeededRandomIdGenerator(),
-        ),
-        metrics=logfire.MetricsOptions(additional_readers=[InMemoryMetricReader()]),
-    )
-
-    class MyModel(BaseModel, plugin_settings={'logfire': {'record': 'all', 'trace_sample_rate': 0.4}}):
-        x: int
-
-    for _ in range(10):
-        with pytest.raises(ValidationError):
-            MyModel.model_validate({'x': 'a'})
-
-    assert len(exporter.exported_spans_as_dict()) == 6
-
-
 @pytest.mark.parametrize('tags', [['tag1', 'tag2'], ('tag1', 'tag2')])
 def test_pydantic_plugin_plugin_settings_tags(exporter: TestExporter, tags: Any) -> None:
     class MyModel(BaseModel, plugin_settings={'logfire': {'record': 'failure', 'tags': tags}}):
@@ -732,33 +710,6 @@ def test_pydantic_plugin_plugin_settings_tags(exporter: TestExporter, tags: Any)
 
     span = exporter.exported_spans_as_dict()[0]
     assert span['attributes']['logfire.tags'] == ('tag1', 'tag2')
-
-
-@pytest.mark.xfail(reason='We need to fix the nesting `trace_sample_rate` logic.')
-def test_pydantic_plugin_plugin_settings_sample_rate_with_tag(exporter: TestExporter) -> None:
-    logfire.configure(
-        send_to_logfire=False,
-        additional_span_processors=[SimpleSpanProcessor(exporter)],
-        advanced=logfire.AdvancedOptions(
-            id_generator=SeededRandomIdGenerator(),
-        ),
-        metrics=logfire.MetricsOptions(additional_readers=[InMemoryMetricReader()]),
-    )
-
-    class MyModel(
-        BaseModel, plugin_settings={'logfire': {'record': 'all', 'trace_sample_rate': 0.4, 'tags': 'test_tag'}}
-    ):
-        x: int
-
-    for _ in range(10):
-        with pytest.raises(ValidationError):
-            MyModel.model_validate({'x': 'a'})
-
-    assert len(exporter.exported_spans_as_dict()) == 6
-
-    # TODO(Marcelo): Why are those lines not being reached?
-    span = exporter.exported_spans_as_dict()[0]  # pragma: no cover
-    assert span['attributes']['logfire.tags'] == ('test_tag',)  # pragma: no cover
 
 
 def test_pydantic_plugin_nested_model(exporter: TestExporter):

--- a/tests/test_pydantic_plugin.py
+++ b/tests/test_pydantic_plugin.py
@@ -700,8 +700,11 @@ def test_pydantic_plugin_sample_rate_config(exporter: TestExporter, config_kwarg
     assert len(exporter.exported_spans_as_dict()) == 1
 
 
-@pytest.mark.parametrize('tags', [['tag1', 'tag2'], ('tag1', 'tag2')])
-def test_pydantic_plugin_plugin_settings_tags(exporter: TestExporter, tags: Any) -> None:
+@pytest.mark.parametrize(
+    ('tags', 'expected'),
+    [(['tag1', 'tag2'], ('tag1', 'tag2')), (('tag1', 'tag2'), ('tag1', 'tag2')), ('tag1', ('tag1',))],
+)
+def test_pydantic_plugin_plugin_settings_tags(exporter: TestExporter, tags: Any, expected: tuple[str, ...]) -> None:
     class MyModel(BaseModel, plugin_settings={'logfire': {'record': 'failure', 'tags': tags}}):
         x: int
 
@@ -709,7 +712,7 @@ def test_pydantic_plugin_plugin_settings_tags(exporter: TestExporter, tags: Any)
         MyModel.model_validate({'x': 'test'})
 
     span = exporter.exported_spans_as_dict()[0]
-    assert span['attributes']['logfire.tags'] == ('tag1', 'tag2')
+    assert span['attributes']['logfire.tags'] == expected
 
 
 def test_pydantic_plugin_nested_model(exporter: TestExporter):

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -45,7 +45,7 @@ def build_tree(exported_spans: list[dict[str, Any]]) -> list[SpanNode]:
     return roots
 
 
-@pytest.mark.parametrize('sample_rate', [-1, 1.5])
+@pytest.mark.parametrize('sample_rate', [-1, 1.5, float('nan')])
 def test_invalid_sample_rate(sample_rate: float) -> None:
     with pytest.raises(ValueError, match='sample_rate must be between 0 and 1'):
         logfire.with_settings(sample_rate=sample_rate)
@@ -85,7 +85,7 @@ def test_sample_rate_runtime() -> None:
 
     # 100 iterations of 2 spans -> 200 spans
     # 50% sampling -> 100 spans (approximately)
-    assert 80 <= len(exporter.exported_spans_as_dict()) <= 120
+    assert len(exporter.exported_spans_as_dict()) == 114
 
 
 def test_outer_sampled_inner_not() -> None:
@@ -105,10 +105,7 @@ def test_outer_sampled_inner_not() -> None:
                     pass
 
     trees = build_tree(exporter.exported_spans_as_dict())
-    assert 1 <= len(trees) <= 20
-    assert all(
-        tree == SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3')])]) for tree in trees
-    )
+    assert trees == [SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3')])])] * 8
 
 
 def test_outer_and_inner_sampled() -> None:
@@ -128,9 +125,15 @@ def test_outer_and_inner_sampled() -> None:
                     pass
 
     trees = build_tree(exporter.exported_spans_as_dict())
-    assert trees
-    assert any(tree.children and tree.children[0].children for tree in trees)
-    assert any(not tree.children or not tree.children[0].children for tree in trees)
+    assert trees == [
+        SpanNode(name='1', children=[SpanNode(name='2')]),
+        SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3')])]),
+        SpanNode(name='1'),
+        SpanNode(name='1'),
+        SpanNode(name='1'),
+        SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3')])]),
+        SpanNode(name='1'),
+    ]
 
 
 def test_sampling_rate_does_not_get_overwritten() -> None:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pytest
-from inline_snapshot import snapshot
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
@@ -19,8 +18,7 @@ class SpanNode:
     children: list[SpanNode] = field(default_factory=list['SpanNode'])
 
 
-# TODO(Marcelo): Remove pragma when this file is covered by tests.
-def build_tree(exported_spans: list[dict[str, Any]]) -> list[SpanNode]:  # pragma: no cover
+def build_tree(exported_spans: list[dict[str, Any]]) -> list[SpanNode]:
     traces: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for span in exported_spans:
         trace_id: int = span['context']['trace_id']
@@ -47,13 +45,10 @@ def build_tree(exported_spans: list[dict[str, Any]]) -> list[SpanNode]:  # pragm
     return roots
 
 
-@pytest.mark.skipif(
-    not hasattr(logfire, 'with_trace_sample_rate'), reason='with_trace_sample_rate is hidden from public API'
-)
 @pytest.mark.parametrize('sample_rate', [-1, 1.5])
-def test_invalid_sample_rate(sample_rate: float) -> None:  # pragma: no cover
+def test_invalid_sample_rate(sample_rate: float) -> None:
     with pytest.raises(ValueError, match='sample_rate must be between 0 and 1'):
-        logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(sample_rate)
+        logfire.with_settings(sample_rate=sample_rate)
 
 
 def test_sample_rate_config(exporter: TestExporter, config_kwargs: dict[str, Any]) -> None:
@@ -73,10 +68,7 @@ def test_sample_rate_config(exporter: TestExporter, config_kwargs: dict[str, Any
     assert len(exporter.exported_spans_as_dict()) == 588, len(exporter.exported_spans_as_dict())
 
 
-@pytest.mark.skipif(
-    not hasattr(logfire, 'with_trace_sample_rate'), reason='with_trace_sample_rate is hidden from public API'
-)
-def test_sample_rate_runtime() -> None:  # pragma: no cover
+def test_sample_rate_runtime() -> None:
     exporter = TestExporter()
 
     logfire.configure(
@@ -87,19 +79,16 @@ def test_sample_rate_runtime() -> None:  # pragma: no cover
     )
 
     for _ in range(100):
-        with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0.5).span('outer'):
+        with logfire.with_settings(sample_rate=0.5).span('outer'):
             with logfire.span('inner'):
                 pass
 
     # 100 iterations of 2 spans -> 200 spans
     # 50% sampling -> 100 spans (approximately)
-    assert len(exporter.exported_spans_as_dict()) == 102
+    assert 80 <= len(exporter.exported_spans_as_dict()) <= 120
 
 
-@pytest.mark.skipif(
-    not hasattr(logfire, 'with_trace_sample_rate'), reason='with_trace_sample_rate is hidden from public API'
-)
-def test_outer_sampled_inner_not() -> None:  # pragma: no cover
+def test_outer_sampled_inner_not() -> None:
     exporter = TestExporter()
 
     logfire.configure(
@@ -109,24 +98,20 @@ def test_outer_sampled_inner_not() -> None:  # pragma: no cover
         metrics=logfire.MetricsOptions(additional_readers=[InMemoryMetricReader()]),
     )
 
-    for _ in range(10):
-        with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0.1).span('1'):
+    for _ in range(100):
+        with logfire.with_settings(sample_rate=0.1).span('1'):
             with logfire.span('2'):
                 with logfire.span('3'):
                     pass
 
-    assert build_tree(exporter.exported_spans_as_dict()) == snapshot(
-        [
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-        ]
+    trees = build_tree(exporter.exported_spans_as_dict())
+    assert 1 <= len(trees) <= 20
+    assert all(
+        tree == SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3')])]) for tree in trees
     )
 
 
-@pytest.mark.skipif(
-    not hasattr(logfire, 'with_trace_sample_rate'), reason='with_trace_sample_rate is hidden from public API'
-)
-def test_outer_and_inner_sampled() -> None:  # pragma: no cover
+def test_outer_and_inner_sampled() -> None:
     exporter = TestExporter()
 
     logfire.configure(
@@ -137,29 +122,18 @@ def test_outer_and_inner_sampled() -> None:  # pragma: no cover
     )
 
     for _ in range(10):
-        with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0.75).span('1'):
-            with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0.75).span('2'):
-                with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0.75).span('3'):
+        with logfire.with_settings(sample_rate=0.75).span('1'):
+            with logfire.with_settings(sample_rate=0.75).span('2'):
+                with logfire.with_settings(sample_rate=0.75).span('3'):
                     pass
 
-    assert build_tree(exporter.exported_spans_as_dict()) == snapshot(
-        [
-            SpanNode(name='1', children=[SpanNode(name='2', children=[])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-            SpanNode(name='1', children=[SpanNode(name='2', children=[SpanNode(name='3', children=[])])]),
-        ]
-    )
+    trees = build_tree(exporter.exported_spans_as_dict())
+    assert trees
+    assert any(tree.children and tree.children[0].children for tree in trees)
+    assert any(not tree.children or not tree.children[0].children for tree in trees)
 
 
-@pytest.mark.skipif(
-    not hasattr(logfire, 'with_trace_sample_rate'), reason='with_trace_sample_rate is hidden from public API'
-)
-def test_sampling_rate_does_not_get_overwritten() -> None:  # pragma: no cover
+def test_sampling_rate_does_not_get_overwritten() -> None:
     exporter = TestExporter()
 
     logfire.configure(
@@ -170,9 +144,9 @@ def test_sampling_rate_does_not_get_overwritten() -> None:  # pragma: no cover
     )
 
     for _ in range(10):
-        with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(0).span('1'):
+        with logfire.with_settings(sample_rate=0).span('1'):
             for _ in range(100):
-                with logfire.DEFAULT_LOGFIRE_INSTANCE.with_trace_sample_rate(1).span('2'):
+                with logfire.with_settings(sample_rate=1).span('2'):
                     pass
 
-    assert build_tree(exporter.exported_spans_as_dict()) == snapshot([])
+    assert build_tree(exporter.exported_spans_as_dict()) == []


### PR DESCRIPTION
## Summary

- add `sample_rate` to the public `with_settings()` API
- remove the hidden `Logfire.with_trace_sample_rate()` compatibility method
- activate and stabilize the scoped-sampling behavior tests

## Tests

- `uv run pytest tests/test_sampling.py tests/test_logfire_api.py -q`
- pre-commit Ruff, formatting, and pyright checks
