### PR TITLE
Make managed variable pushes strict by default

### DIFF
--- a/docs/reference/advanced/managed-variables/remote.md
+++ b/docs/reference/advanced/managed-variables/remote.md
@@ -138,7 +138,7 @@ logfire.variables_push(yes=True)
 ```
 
 !!! note "Schema Updates"
-    When you push a variable that already exists in Logfire, `logfire.variables_push()` will update the JSON schema if it has changed but will preserve existing versions, labels, and rollout configurations. If existing label values are incompatible with the new schema, you'll see a warning (or an error if using `strict=True`).
+    When you push a variable that already exists in Logfire, `logfire.variables_push()` will update the JSON schema if it has changed but will preserve existing versions, labels, and rollout configurations. By default, the push is rejected if existing label values are incompatible with the new schema. Pass `strict=False` to publish anyway and show a warning.
 
 !!! note "Write scope required"
     `logfire.variables_push()` and `logfire.variables_push_types()` require an API key with the `project:write_variables` scope.

--- a/docs/reference/advanced/managed-variables/remote.md
+++ b/docs/reference/advanced/managed-variables/remote.md
@@ -119,7 +119,7 @@ Successfully applied changes.
 | `variables` | List of specific variables to push. If not provided, all registered variables are pushed. |
 | `dry_run` | If `True`, shows what would change without actually applying changes. |
 | `yes` | If `True`, skips the confirmation prompt. |
-| `strict` | If `True`, fails if any existing label values in Logfire are incompatible with your new schema. |
+| `strict` | Rejects incompatible label values, missing references, and template-field issues by default. Set to `False` to publish with warnings; reference cycles are always rejected. |
 
 **Pushing specific variables:**
 
@@ -200,7 +200,7 @@ logfire.variables_push_types([
 | `types` | List of types to push. Items can be a type (uses `__name__`) or a tuple of `(type, name)` for explicit naming. |
 | `dry_run` | If `True`, shows what would change without actually applying changes. |
 | `yes` | If `True`, skips the confirmation prompt. |
-| `strict` | If `True`, fails if any existing variable label values are incompatible with the new type schema. |
+| `strict` | Rejects existing variable label values that are incompatible with the new type schema by default. Set to `False` to publish with warnings. |
 
 **Example output:**
 

--- a/docs/reference/advanced/managed-variables/templates-and-composition.md
+++ b/docs/reference/advanced/managed-variables/templates-and-composition.md
@@ -345,7 +345,7 @@ with warnings.catch_warnings(record=True) as caught:
     #> True
 ```
 
-**Push / sync time is the real safety net.** `logfire.variables_validate()` reports missing references and cycles, and `logfire.variables_push(strict=True)` refuses to apply an invalid configuration. The walk covers the *full* reachable graph (local code defaults and server-stored label values), so a missing reference (or a cycle whose midpoint is a server-only variable) is caught before it ever ships.
+**Push / sync time is the real safety net.** `logfire.variables_validate()` reports missing references and cycles, and `logfire.variables_push()` refuses to apply an invalid configuration by default. The walk covers the *full* reachable graph (local code defaults and server-stored label values), so a missing reference (or a cycle whose midpoint is a server-only variable) is caught before it ever ships. Pass `strict=False` only when a missing reference is expected to resolve in another codebase or environment.
 
 A cycle (or depth overflow) is always a structural failure. When it occurs while composing a stored value, resolution falls back to the code default; the example below puts the cycle in the code defaults themselves, so resolution can only return the raw, uncomposed default:
 

--- a/docs/reference/advanced/managed-variables/templates-and-composition.md
+++ b/docs/reference/advanced/managed-variables/templates-and-composition.md
@@ -345,7 +345,7 @@ with warnings.catch_warnings(record=True) as caught:
     #> True
 ```
 
-**Push / sync time is the real safety net.** `logfire.variables_validate()` reports missing references and cycles, and `logfire.variables_push()` refuses to apply an invalid configuration by default. The walk covers the *full* reachable graph (local code defaults and server-stored label values), so a missing reference (or a cycle whose midpoint is a server-only variable) is caught before it ever ships. Pass `strict=False` only when a missing reference is expected to resolve in another codebase or environment.
+**Push / sync time is the real safety net.** `logfire.variables_validate()` reports missing references and cycles, and `logfire.variables_push()` refuses to apply an invalid configuration by default. The walk covers the *full* reachable graph (local code defaults and server-stored label values), so a missing reference (or a cycle whose midpoint is a server-only variable) is caught before it ever ships. Pass `strict=False` when a missing reference, incompatible existing label value, or template-field issue is expected or intentional. Cycles are still rejected.
 
 A cycle (or depth overflow) is always a structural failure. When it occurs while composing a stored value, resolution falls back to the code default; the example below puts the cycle in the code defaults themselves, so resolution can only return the raw, uncomposed default:
 

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -1231,7 +1231,7 @@ class Logfire:
         """
     def variables_get(self) -> list[Variable[Any] | TemplateVariable[Any, Any]]:
         """Get all variables registered with this Logfire instance's config."""
-    def variables_push(self, variables: list[Variable[Any] | TemplateVariable[Any, Any]] | None = None, *, dry_run: bool = False, yes: bool = False, strict: bool = False) -> bool:
+    def variables_push(self, variables: list[Variable[Any] | TemplateVariable[Any, Any]] | None = None, *, dry_run: bool = False, yes: bool = False, strict: bool = True) -> bool:
         """Push variable definitions (metadata only) to the configured variable provider.
 
         This method syncs local variable definitions with the provider:
@@ -1249,7 +1249,7 @@ class Logfire:
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found.
+                or any reference errors are found. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -1269,7 +1269,7 @@ class Logfire:
                 logfire.variables_push([feature_enabled])
             ```
         """
-    def variables_push_types(self, types: Sequence[type[Any] | tuple[type[Any], str]], *, dry_run: bool = False, yes: bool = False, strict: bool = False) -> bool:
+    def variables_push_types(self, types: Sequence[type[Any] | tuple[type[Any], str]], *, dry_run: bool = False, yes: bool = False, strict: bool = True) -> bool:
         """Push variable type definitions to the configured variable provider.
 
         Variable types are reusable schema definitions that can be referenced by variables.
@@ -1291,7 +1291,7 @@ class Logfire:
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, abort when existing label values are incompatible with
-                the new type schema.
+                the new type schema. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/logfire-api/logfire_api/_internal/main.pyi
+++ b/logfire-api/logfire_api/_internal/main.pyi
@@ -1248,8 +1248,8 @@ class Logfire:
                 variables registered on `with_settings()` siblings.
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
-            strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found. Set to False to publish despite these issues.
+            strict: If True, fail on incompatible label values, missing references, or template-field issues.
+                Set to False to publish despite those issues. Reference cycles always block the push.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/logfire-api/logfire_api/variables/abstract.pyi
+++ b/logfire-api/logfire_api/variables/abstract.pyi
@@ -342,8 +342,8 @@ class VariableProvider(ABC):
             variables: Variable instances to push.
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
-            strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found. Set to False to publish despite these issues.
+            strict: If True, fail on incompatible label values, missing references, or template-field issues.
+                Set to False to publish despite those issues. Reference cycles always block the push.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/logfire-api/logfire_api/variables/abstract.pyi
+++ b/logfire-api/logfire_api/variables/abstract.pyi
@@ -330,7 +330,7 @@ class VariableProvider(ABC):
         Returns:
             The current VariablesConfig from the provider.
         """
-    def push_variables(self, variables: Sequence[Variable[object]], *, dry_run: bool = False, yes: bool = False, strict: bool = False) -> bool:
+    def push_variables(self, variables: Sequence[Variable[object]], *, dry_run: bool = False, yes: bool = False, strict: bool = True) -> bool:
         """Push variable definitions to this provider.
 
         This method syncs local variable definitions (metadata only) with the provider:
@@ -343,7 +343,7 @@ class VariableProvider(ABC):
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found.
+                or any reference errors are found. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -397,7 +397,7 @@ class VariableProvider(ABC):
         Returns:
             The created or updated VariableTypeConfig.
         """
-    def push_variable_types(self, types: Sequence[type[Any] | tuple[type[Any], str]], *, dry_run: bool = False, yes: bool = False, strict: bool = False) -> bool:
+    def push_variable_types(self, types: Sequence[type[Any] | tuple[type[Any], str]], *, dry_run: bool = False, yes: bool = False, strict: bool = True) -> bool:
         '''Push variable type definitions to this provider.
 
         This method syncs local type definitions with the provider:
@@ -413,7 +413,7 @@ class VariableProvider(ABC):
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, abort when existing label values are incompatible with
-                the new type schema.
+                the new type schema. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -459,7 +459,7 @@ class NoOpVariableProvider(VariableProvider):
         Returns:
             Always None since no provider is configured.
         """
-    def push_variables(self, variables: Sequence[Variable[Any]], *, dry_run: bool = False, yes: bool = False, strict: bool = False) -> bool:
+    def push_variables(self, variables: Sequence[Variable[Any]], *, dry_run: bool = False, yes: bool = False, strict: bool = True) -> bool:
         """No-op implementation that prints a message about missing provider configuration.
 
         Returns:

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2792,8 +2792,8 @@ class Logfire:
                 variables registered on `with_settings()` siblings.
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
-            strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found. Set to False to publish despite these issues.
+            strict: If True, fail on incompatible label values, missing references, or template-field issues.
+                Set to False to publish despite those issues. Reference cycles always block the push.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/logfire/_internal/main.py
+++ b/logfire/_internal/main.py
@@ -2774,7 +2774,7 @@ class Logfire:
         *,
         dry_run: bool = False,
         yes: bool = False,
-        strict: bool = False,
+        strict: bool = True,
     ) -> bool:
         """Push variable definitions (metadata only) to the configured variable provider.
 
@@ -2793,7 +2793,7 @@ class Logfire:
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found.
+                or any reference errors are found. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -2825,7 +2825,7 @@ class Logfire:
         *,
         dry_run: bool = False,
         yes: bool = False,
-        strict: bool = False,
+        strict: bool = True,
     ) -> bool:
         """Push variable type definitions to the configured variable provider.
 
@@ -2848,7 +2848,7 @@ class Logfire:
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, abort when existing label values are incompatible with
-                the new type schema.
+                the new type schema. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -1480,15 +1480,13 @@ class VariableProvider(ABC):
         self.refresh(force=True)
         return self.get_all_variables_config()
 
-    # TODO(next major): consider making strict=True the default and requiring an explicit
-    #  opt-out for pushes that publish missing refs or undeclared template fields.
     def push_variables(
         self,
         variables: Sequence[Variable[object]],
         *,
         dry_run: bool = False,
         yes: bool = False,
-        strict: bool = False,
+        strict: bool = True,
     ) -> bool:
         """Push variable definitions to this provider.
 
@@ -1502,7 +1500,7 @@ class VariableProvider(ABC):
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found.
+                or any reference errors are found. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -1778,7 +1776,7 @@ class VariableProvider(ABC):
         *,
         dry_run: bool = False,
         yes: bool = False,
-        strict: bool = False,
+        strict: bool = True,
     ) -> bool:
         """Push variable type definitions to this provider.
 
@@ -1795,7 +1793,7 @@ class VariableProvider(ABC):
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
             strict: If True, abort when existing label values are incompatible with
-                the new type schema.
+                the new type schema. Set to False to publish despite these issues.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.
@@ -2002,7 +2000,7 @@ class NoOpVariableProvider(VariableProvider):
         *,
         dry_run: bool = False,
         yes: bool = False,
-        strict: bool = False,
+        strict: bool = True,
     ) -> bool:
         """No-op implementation that prints a message about missing provider configuration.
 

--- a/logfire/variables/abstract.py
+++ b/logfire/variables/abstract.py
@@ -1499,8 +1499,8 @@ class VariableProvider(ABC):
             variables: Variable instances to push.
             dry_run: If True, only show what would change without applying.
             yes: If True, skip confirmation prompt.
-            strict: If True, fail if any existing label values are incompatible with new schemas
-                or any reference errors are found. Set to False to publish despite these issues.
+            strict: If True, fail on incompatible label values, missing references, or template-field issues.
+                Set to False to publish despite those issues. Reference cycles always block the push.
 
         Returns:
             True if changes were applied (or would be applied in dry_run mode), False otherwise.

--- a/tests/test_push_variables.py
+++ b/tests/test_push_variables.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from typing import Any
+from unittest import mock
 
 import pytest
 from inline_snapshot import snapshot
@@ -1249,6 +1250,41 @@ def test_push_variables_no_variables() -> None:
     # Use an explicit empty list to avoid picking up variables from the global DEFAULT_LOGFIRE_INSTANCE
     result = logfire.variables_push([])
     assert result is False
+
+
+def test_variables_push_is_strict_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The public API rejects incompatible label values unless strict mode is explicitly disabled."""
+    provider = LocalVariableProvider(
+        VariablesConfig(
+            variables={
+                'strict_default': VariableConfig(
+                    name='strict_default',
+                    labels={'production': LabeledValue(version=1, serialized_value='"not_an_int"')},
+                    rollout=Rollout(labels={'production': 1.0}),
+                    overrides=[],
+                    json_schema={'type': 'string'},
+                )
+            }
+        )
+    )
+    monkeypatch.setattr(logfire.DEFAULT_LOGFIRE_INSTANCE.config, '_variable_provider', provider)
+    variable = logfire.var(name='strict_default', default=0, type=int)
+
+    assert logfire.variables_push([variable], yes=True) is False
+    assert provider.get_all_variables_config().variables['strict_default'].json_schema == {'type': 'string'}
+
+
+def test_variables_push_types_is_strict_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The public type-push API passes the new strict default to its provider."""
+    provider = mock.Mock()
+    provider.push_variable_types.return_value = False
+    monkeypatch.setattr(logfire.DEFAULT_LOGFIRE_INSTANCE.config, '_variable_provider', provider)
+
+    class FeatureConfig(BaseModel):
+        enabled: bool
+
+    assert logfire.variables_push_types([FeatureConfig]) is False
+    provider.push_variable_types.assert_called_once_with([FeatureConfig], dry_run=False, yes=False, strict=True)
 
 
 def test_var_registers_variable() -> None:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -3898,7 +3898,7 @@ class TestPushVariables:
         lf = logfire.configure(**config_kwargs)
         # Now we want it to be a string
         var = lf.var(name='my_var', default='default', type=str)
-        result = provider.push_variables([var], yes=True)
+        result = provider.push_variables([var], yes=True, strict=False)
         assert result is True
         captured = capsys.readouterr()
         assert 'Variables to UPDATE' in captured.out
@@ -3922,15 +3922,15 @@ class TestPushVariables:
         lf = logfire.configure(**config_kwargs)
         # Changing from string to int - existing label is incompatible
         var = lf.var(name='my_var', default=0, type=int)
-        result = provider.push_variables([var], yes=True)
+        result = provider.push_variables([var], yes=True, strict=False)
         assert result is True
         captured = capsys.readouterr()
         assert 'Warning' in captured.out or 'Incompatible' in captured.out
 
-    def test_push_variables_strict_mode_fails_with_incompatible(
+    def test_push_variables_fails_with_incompatible_by_default(
         self, capsys: pytest.CaptureFixture[str], config_kwargs: dict[str, Any]
     ):
-        """Test push_variables in strict mode fails with incompatible labels."""
+        """Test push_variables fails with incompatible labels by default."""
         server_config = VariablesConfig(
             variables={
                 'my_var': VariableConfig(
@@ -3945,7 +3945,7 @@ class TestPushVariables:
         provider = LocalVariableProvider(server_config)
         lf = logfire.configure(**config_kwargs)
         var = lf.var(name='my_var', default=0, type=int)
-        result = provider.push_variables([var], strict=True)
+        result = provider.push_variables([var])
         assert result is False
         captured = capsys.readouterr()
         # Error message may go to stdout or stderr depending on implementation
@@ -3980,7 +3980,7 @@ class TestPushVariables:
         var1 = lf.var(name='schema_change_var', default=0, type=int)
         # unchanged_var: same schema (int) but label value is incompatible
         var2 = lf.var(name='unchanged_var', default=0, type=int)
-        result = provider.push_variables([var1, var2], yes=True)
+        result = provider.push_variables([var1, var2], yes=True, strict=False)
         assert result is True
         captured = capsys.readouterr()
         assert 'incompatible with the variable types' in captured.out
@@ -4006,7 +4006,7 @@ class TestPushVariables:
         # Create a new var to ensure there are changes (so push proceeds)
         var_new = lf.var(name='new_var', default='hello', type=str)
         var_unchanged = lf.var(name='unchanged_var', default=0, type=int)
-        result = provider.push_variables([var_new, var_unchanged], yes=True)
+        result = provider.push_variables([var_new, var_unchanged], yes=True, strict=False)
         assert result is True
         captured = capsys.readouterr()
         assert 'incompatible with the variable types (schema unchanged)' in captured.out
@@ -5323,15 +5323,15 @@ class TestPushVariableTypesWithIncompatibleLabels:
                 ),
             },
         )
-        result = provider.push_variable_types([FeatureConfig], yes=True)
+        result = provider.push_variable_types([FeatureConfig], yes=True, strict=False)
         assert result is True
         captured = capsys.readouterr()
         assert 'Label compatibility warnings' in captured.out
         assert 'my_feature' in captured.out
         assert 'incompatible with the new type schema' in captured.out
 
-    def test_push_types_with_incompatible_labels_strict(self, capsys: pytest.CaptureFixture[str]):
-        """Test push_variable_types in strict mode fails with incompatible labels (line 1356-1357)."""
+    def test_push_types_with_incompatible_labels_fails_by_default(self, capsys: pytest.CaptureFixture[str]):
+        """Test push_variable_types fails with incompatible labels by default."""
         from pydantic import BaseModel
 
         class FeatureConfig(BaseModel):
@@ -5349,7 +5349,7 @@ class TestPushVariableTypesWithIncompatibleLabels:
                 ),
             },
         )
-        result = provider.push_variable_types([FeatureConfig], strict=True)
+        result = provider.push_variable_types([FeatureConfig])
         assert result is False
         captured = capsys.readouterr()
         assert 'Error' in captured.out


### PR DESCRIPTION
## Summary

- make managed variable and variable-type pushes strict by default
- retain `strict=False` as the explicit escape hatch for publishing incompatible definitions
- update public stubs, API docs, and tests for the new default

## Tests

- `uv run pytest tests/test_push_variables.py tests/test_variables.py -q`
- pre-commit Ruff, formatting, and pyright checks
