### PR TITLE
Don't warn when inspect_arguments has no caller source

### DIFF
--- a/logfire/_internal/ast_utils.py
+++ b/logfire/_internal/ast_utils.py
@@ -169,14 +169,10 @@ class CallNodeFinder(ABC):
         # This shouldn't happen in most cases, but it's best not to rely on it always working.
 
         if not self.source.text:
-            # This is a very likely cause.
-            # There's nothing we could possibly do to make magic work here,
-            # and it's a clear case where the user should turn the magic off.
-            self.warn_inspect_arguments(
-                'No source code available. '
-                'This happens when running in an interactive shell, '
-                'using exec(), or running .pyc files without the source .py files.',
-            )
+            # Nothing we can inspect: exec(), a REPL, or a .pyc without sources.
+            # The formatter already falls back to the provided template and kwargs,
+            # which is correct for a literal message. Warning on every span made
+            # that expected fallback look like a defect (#2223).
             return None
 
         msg = '`executing` failed to find a node.'

--- a/tests/test_source_code_extraction.py
+++ b/tests/test_source_code_extraction.py
@@ -9,7 +9,7 @@ from inline_snapshot import snapshot
 
 import logfire
 from logfire._internal import ast_utils
-from logfire._internal.ast_utils import InspectArgumentsFailedWarning
+from logfire._internal.ast_utils import InspectArgumentsFailedWarning  # noqa: F401
 from logfire.testing import TestExporter
 
 
@@ -101,49 +101,25 @@ def test_source_code_extraction_method(exporter: TestExporter) -> None:
 
 
 def test_source_code_extraction_module(exporter: TestExporter) -> None:
-    with pytest.warns(InspectArgumentsFailedWarning, match='No source code available'):
-        exec(
-            """import logfire
+    # exec() has no source for `executing` to read. A literal template with
+    # explicit kwargs does not need inspection, so this must not warn (#2223).
+    exec(
+        """import logfire
 with logfire.span('from module'):
     pass
     """
-        )
+    )
 
     assert normalize_filepaths(
         exporter.exported_spans_as_dict(strip_filepaths=False, _strip_function_qualname=False)
     ) == snapshot(
         [
             {
-                'name': """\
-Failed to introspect calling code. Please report this issue to Logfire. Falling back to normal message formatting which may result in loss of information if using an f-string. Set inspect_arguments=False in logfire.configure() to suppress this warning. The problem was:
-No source code available. This happens when running in an interactive shell, using exec(), or running .pyc files without the source .py files.\
-""",
+                'name': 'from module',
                 'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
                 'parent': None,
                 'start_time': 1000000000,
-                'end_time': 1000000000,
-                'attributes': {
-                    'logfire.span_type': 'log',
-                    'logfire.level_num': 13,
-                    'logfire.msg_template': """\
-Failed to introspect calling code. Please report this issue to Logfire. Falling back to normal message formatting which may result in loss of information if using an f-string. Set inspect_arguments=False in logfire.configure() to suppress this warning. The problem was:
-No source code available. This happens when running in an interactive shell, using exec(), or running .pyc files without the source .py files.\
-""",
-                    'logfire.msg': """\
-Failed to introspect calling code. Please report this issue to Logfire. Falling back to normal message formatting which may result in loss of information if using an f-string. Set inspect_arguments=False in logfire.configure() to suppress this warning. The problem was:
-No source code available. This happens when running in an interactive shell, using exec(), or running .pyc files without the source .py files.\
-""",
-                    'code.filepath': 'tests/test_source_code_extraction.py',
-                    'code.function': 'test_source_code_extraction_module',
-                    'code.lineno': 123,
-                },
-            },
-            {
-                'name': 'from module',
-                'context': {'trace_id': 2, 'span_id': 2, 'is_remote': False},
-                'parent': None,
-                'start_time': 2000000000,
-                'end_time': 3000000000,
+                'end_time': 2000000000,
                 'attributes': {
                     'code.filepath': 'tests/test_source_code_extraction.py',
                     'code.function': 'test_source_code_extraction_module',

--- a/tests/test_source_code_extraction.py
+++ b/tests/test_source_code_extraction.py
@@ -9,7 +9,7 @@ from inline_snapshot import snapshot
 
 import logfire
 from logfire._internal import ast_utils
-from logfire._internal.ast_utils import InspectArgumentsFailedWarning  # noqa: F401
+from logfire._internal.ast_utils import InspectArgumentsFailedWarning
 from logfire.testing import TestExporter
 
 
@@ -100,22 +100,23 @@ def test_source_code_extraction_method(exporter: TestExporter) -> None:
     )
 
 
-def test_source_code_extraction_module(exporter: TestExporter) -> None:
+def test_source_code_extraction_module(exporter: TestExporter, recwarn: pytest.WarningsRecorder) -> None:
     # exec() has no source for `executing` to read. A literal template with
     # explicit kwargs does not need inspection, so this must not warn (#2223).
     exec(
         """import logfire
-with logfire.span('from module'):
+with logfire.span('from {name}', name='module'):
     pass
     """
     )
+    assert [w for w in recwarn if w.category is InspectArgumentsFailedWarning] == []
 
     assert normalize_filepaths(
         exporter.exported_spans_as_dict(strip_filepaths=False, _strip_function_qualname=False)
     ) == snapshot(
         [
             {
-                'name': 'from module',
+                'name': 'from {name}',
                 'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
                 'parent': None,
                 'start_time': 1000000000,
@@ -124,8 +125,10 @@ with logfire.span('from module'):
                     'code.filepath': 'tests/test_source_code_extraction.py',
                     'code.function': 'test_source_code_extraction_module',
                     'code.lineno': 123,
-                    'logfire.msg_template': 'from module',
+                    'name': 'module',
+                    'logfire.msg_template': 'from {name}',
                     'logfire.msg': 'from module',
+                    'logfire.json_schema': '{"type":"object","properties":{"name":{}}}',
                     'logfire.span_type': 'span',
                 },
             },


### PR DESCRIPTION
## Summary
`inspect_arguments` warned on every span when `executing` could not read source (exec, REPL, or .pyc without the .py). A literal template with explicit kwargs already falls back correctly, so the warning just repeated in pytest output, including bind-mounted checkouts where the code object's path is unreadable.

Skip the warning when there is no source. Real f-string inspection failures still warn.

## Test plan
- [x] `tests/test_source_code_extraction.py` (6 passed)

Fixes #2223

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->