### PR TITLE
fix: require path boundaries for non-user code

### DIFF
--- a/logfire/_internal/stack_info.py
+++ b/logfire/_internal/stack_info.py
@@ -118,7 +118,8 @@ def is_non_user_path(path: str | Path) -> bool:
     Specifically the standard library, site-packages (wherever opentelemetry is installed),
     the logfire package, and anything registered with `add_non_user_code_prefix`.
     """
-    return str(Path(path).absolute()).startswith(NON_USER_CODE_PREFIXES)
+    path = Path(path).absolute()
+    return any(path.is_relative_to(prefix) for prefix in NON_USER_CODE_PREFIXES)
 
 
 @lru_cache(maxsize=8192)

--- a/tests/test_stack_info.py
+++ b/tests/test_stack_info.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+import pytest
+
+from logfire._internal import stack_info
+
+
+def test_non_user_path_requires_directory_boundary(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    library = tmp_path / 'library'
+    monkeypatch.setattr(stack_info, 'NON_USER_CODE_PREFIXES', (str(library),))
+
+    assert stack_info.is_non_user_path(library / 'module.py')
+    assert not stack_info.is_non_user_path(tmp_path / 'library-extra' / 'app.py')


### PR DESCRIPTION
## Description

`is_non_user_path` currently uses string prefix matching. Registering `/path/library` therefore also classifies `/path/library-extra/app.py` as non-user code.

Use `Path.is_relative_to` for component-aware containment checks.

## Testing

- Added coverage for a file inside a registered prefix and a sibling directory with the same textual prefix.
- `pytest -c /dev/null -p no:cacheprovider --noconftest tests/test_stack_info.py -q`
- Ruff check, formatting check, and `compileall` on both changed files.