### PR TITLE
Document early access infrastructure integrations

### DIFF
--- a/docs/guides/web-ui/integrations.md
+++ b/docs/guides/web-ui/integrations.md
@@ -9,7 +9,7 @@ An **integration** is a ready-made observability bundle for a piece of infrastru
 
 !!! note "Integrations are in Beta"
 
-    Integrations are available in every project, but their dashboards, alerts, and setup instructions may change while the feature is in Beta.
+    The integrations catalog is in Beta. Its standard integrations are available in every project, but their dashboards, alerts, and setup instructions may change.
 
 They are built on the metrics the [OpenTelemetry Collector](../../how-to-guides/otel-collector/otel-collector-overview.md) already scrapes from those services. The Collector is a separate program that gathers telemetry and forwards it to Logfire. Point it at Redis, open the catalog, and install: you get the dashboard and alerts without working out which attributes the receiver emits, writing the SQL behind each panel, or repeating that work for the next service.
 
@@ -75,7 +75,7 @@ The catalog is also reachable through the [Logfire MCP server](../../how-to-guid
 
 ## Available integrations
 
-Integrations marked **Beta** are available as part of the integrations beta. Integrations marked **Early access** are newer and still being validated against the technology they monitor. Their dashboards and alerts work, but their metric names and thresholds may change. [Contact Pydantic](https://pydantic.dev/contact) if you want to try them.
+Integrations marked **Beta** are the standard set available in every project. Integrations marked **Early access** are newer and still being validated against the technology they monitor. Their dashboards and alerts work, but their metric names and thresholds may change. [Contact Pydantic](https://pydantic.dev/contact) if you want to try them.
 
 | Integration | Tags | Availability |
 |---|---|---|

--- a/docs/guides/web-ui/integrations.md
+++ b/docs/guides/web-ui/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: "Install dashboards and alerts for your infrastructure"
-description: "Use the Logfire integrations catalog to install ready-made dashboards and alerts for databases, messaging systems, web infrastructure, and GPU hardware."
+description: "Use the Logfire integrations catalog to install ready-made dashboards and alerts for databases, messaging and compute systems, web infrastructure, metric collectors, and GPU hardware."
 ---
 
 # Integrations
@@ -59,11 +59,11 @@ Logfire maintains installed integrations for you. We may revise dashboards and a
 
 The catalog groups the integrations visible to your project by service type. Each row shows the service, its tags, its contents as a count of dashboards and alerts, and its **status** for your project:
 
-- **Available**: no telemetry from this service has been seen.
+- **Available**: Logfire has not detected telemetry from this service.
 - **Detected**: the service's metrics are arriving and it is ready to install.
 - **Installed**: its dashboards are enabled and its alerts exist.
 
-Narrow the list with the search box, the status dropdown (**All statuses**, **Available**, **Installed**), and tag chips such as `Database`, `Cache`, `Queue`, `Streaming`, `Web Server`, `Compute`, `Metrics`, and `GPU`. The **Available** filter includes detected integrations that you have not installed. Selecting several tags matches any of them.
+Narrow the list with the search box, the status dropdown (**All statuses**, **Available**, **Installed**), and tag chips such as `Database`, `Cache`, `Queue`, `Streaming`, `Web Server`, `Compute`, `Metrics`, and `GPU`. In the dropdown, **Available** means not installed, so it shows rows with either an **Available** or **Detected** status. Selecting several tags matches any of them.
 
 !!! note "Detection runs on demand"
 
@@ -75,7 +75,7 @@ The catalog is also reachable through the [Logfire MCP server](../../how-to-guid
 
 ## Available integrations
 
-Integrations marked **Early access** are still being validated against the technology they monitor. Their dashboards and alerts work, but their metric names and thresholds may change. [Contact Pydantic](https://pydantic.dev/contact) if you want to try them.
+Integrations marked **Beta** are available as part of the integrations beta. Integrations marked **Early access** are newer and still being validated against the technology they monitor. Their dashboards and alerts work, but their metric names and thresholds may change. [Contact Pydantic](https://pydantic.dev/contact) if you want to try them.
 
 | Integration | Tags | Availability |
 |---|---|---|

--- a/docs/guides/web-ui/integrations.md
+++ b/docs/guides/web-ui/integrations.md
@@ -1,11 +1,11 @@
 ---
 title: "Install dashboards and alerts for your infrastructure"
-description: "Use the Logfire integrations catalog to install ready-made dashboards and alerts for Redis, PostgreSQL, Kafka, NGINX, and other services you already run."
+description: "Use the Logfire integrations catalog to install ready-made dashboards and alerts for databases, messaging systems, web infrastructure, and GPU hardware."
 ---
 
 # Integrations
 
-An **integration** is a ready-made observability bundle for a piece of infrastructure you run: a standard dashboard, a set of health alerts, and the configuration needed to collect the data. The catalog covers common databases, caches, queues, streaming systems, web servers, and proxies.
+An **integration** is a ready-made observability bundle for a piece of infrastructure you run: a standard dashboard, a set of health alerts, and the configuration needed to collect the data. The catalog covers common databases, caches, queues, streaming and compute systems, web infrastructure, tools that collect metrics, and GPU hardware.
 
 !!! note "Integrations are in Beta"
 
@@ -63,7 +63,7 @@ The catalog groups the integrations visible to your project by service type. Eac
 - **Detected**: the service's metrics are arriving and it is ready to install.
 - **Installed**: its dashboards are enabled and its alerts exist.
 
-Narrow the list with the search box, the status dropdown (**All statuses**, **Available**, **Installed**), and the tag chips: `Database`, `Cache`, `SQL`, `NoSQL`, `Search`, `Queue`, `Streaming`, `Web Server`, and `Proxy`. The **Available** filter includes detected integrations that you have not installed. Selecting several tags matches any of them.
+Narrow the list with the search box, the status dropdown (**All statuses**, **Available**, **Installed**), and tag chips such as `Database`, `Cache`, `Queue`, `Streaming`, `Web Server`, `Compute`, `Metrics`, and `GPU`. The **Available** filter includes detected integrations that you have not installed. Selecting several tags matches any of them.
 
 !!! note "Detection runs on demand"
 
@@ -75,17 +75,29 @@ The catalog is also reachable through the [Logfire MCP server](../../how-to-guid
 
 ## Available integrations
 
-| Integration | Tags |
-|---|---|
-| Redis | Database, Cache |
-| Memcached | Cache |
-| PostgreSQL | Database, SQL |
-| MySQL | Database, SQL |
-| MongoDB | Database, NoSQL |
-| Elasticsearch | Database, Search |
-| RabbitMQ | Queue |
-| Apache Kafka | Queue, Streaming |
-| NGINX | Proxy, Web Server |
-| Apache HTTP Server | Web Server |
+Integrations marked **Early access** are still being validated against the technology they monitor. Their dashboards and alerts work, but their metric names and thresholds may change. [Contact Pydantic](https://pydantic.dev/contact) if you want to try them.
+
+| Integration | Tags | Availability |
+|---|---|---|
+| Redis | Database, Cache | Beta |
+| Memcached | Cache | Beta |
+| PostgreSQL | Database, SQL | Beta |
+| MySQL | Database, SQL | Beta |
+| MongoDB | Database, NoSQL | Beta |
+| Elasticsearch | Database, Search | Beta |
+| RabbitMQ | Queue | Beta |
+| Apache Kafka | Queue, Streaming | Beta |
+| NGINX | Proxy, Web Server | Beta |
+| Apache HTTP Server | Web Server | Beta |
+| ActiveMQ | Queue, Messaging, Java | Early access |
+| Apache Cassandra | Database, NoSQL | Early access |
+| Apache Flink | Compute, Streaming, Big Data | Early access |
+| HAProxy | Proxy, Load Balancer | Early access |
+| NVIDIA GPUs | GPU, CUDA, Kubernetes, Hardware | Early access |
+| Prometheus | Metrics, Collector, Monitoring | Early access |
+| Apache Spark | Compute, Big Data | Early access |
+| Telegraf | Metrics, Collector, Agent | Early access |
+| Apache Tomcat | Web Server, Java | Early access |
+| ZooKeeper | Coordination, Distributed Systems | Early access |
 
 Integrations are added over time. Each is a data-only definition, so the catalog grows without new per-service code.


### PR DESCRIPTION
## Summary

- add the 10 Early access infrastructure integrations to the catalog documentation
- show availability and the exact product tags for all 20 integrations
- update the overview and filtering examples to include compute, metric collection, and GPU hardware

## Validation

- `uv run pre-commit run --files docs/guides/web-ui/integrations.md`
- compared every documented name, tag, and availability value with the current product catalog definitions
- confirmed every Early access integration defines detection, a dashboard, alerts, and setup instructions


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

