### PR TITLE
docs: point the Slack alerts guide at the images that actually ship

### DIFF
--- a/docs/how-to-guides/setup-slack-alerts.md
+++ b/docs/how-to-guides/setup-slack-alerts.md
@@ -60,14 +60,14 @@ We'll create an alert that will let us know if any HTTP request takes longer tha
   ```
 * Click **Preview query results** and make sure you get some results back.  If your service is lightning fast, firstly congratulations! Secondly try adjust the duration cutoff to something smaller, like `duration > 0.1` (i.e, any requests taking longer than 100ms).
 
-    ![](../images/guide/browser-alerts-create-alert.png)
+    ![](../images/guide/browser-alerts-create.png)
 
 * You can adjust when alerts are sent under the **When this alert fires** section.  With this style of alert, we just want to know if anything within the last 5 minutes has been slow.  So we can use the following options:
     * **Fire when**: the query has any results
     * **Look at rows from**: the last 5 minutes
     * **Check every**: 5 minutes
 
-    ![](../images/guide/browser-alerts-parameters.png)
+    ![](../images/guide/browser-alerts-create.png)
 
 ### Send Alert to a Slack Channel
 
@@ -86,7 +86,7 @@ In the **Send notifications to** section of the alert form:
 * Click **Create channel** to create the channel and close the dialog
 * Click the checkbox next to your new channel to select it
 
-    ![](../images/guide/browser-alerts-create-channel.png)
+    ![](../images/guide/browser-alerts-create.png)
 
 Once your Slack channel is connected, click **Create alert** to save all your changes. Your alert is now live!
 


### PR DESCRIPTION
`docs/how-to-guides/setup-slack-alerts.md` embeds three images that don't exist (`browser-alerts-create-alert.png`, `browser-alerts-parameters.png`, `browser-alerts-create-channel.png` — absent from `docs/images/guide/` and from every commit, per git log). The page and the differently-named screenshots landed together in ccdd7f4, so the filenames never matched.

All three now use `browser-alerts-create.png`, which shows the full create-alert form (preview button, when-fired section, notification channels) that the surrounding steps describe — the same image the `web-ui/alerts.md` guide uses for these steps.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

