### PR TITLE
docs(live): retitle the ask-in-language heading so its anchor resolves

### DIFF
--- a/docs/guides/web-ui/live.md
+++ b/docs/guides/web-ui/live.md
@@ -37,7 +37,7 @@ If you're not sure where to start, scroll down to the `Start here` for beginner-
 
 ![Search box start here](../../images/guide/live-view-start-here.png)
 
-### Ask in Language -> Get SQL
+### Ask in Language, Get SQL
 
 Write your question in your native language, and the model will convert that question to a SQL query.
 


### PR DESCRIPTION
`docs/guides/web-ui/live.md` links `#ask-in-language-get-sql`, but the target heading is `### Ask in Language -> Get SQL` — the slugger keeps the arrow's hyphen, producing `ask-in-language---get-sql`, so the link matches nothing.

Retitled the heading to `### Ask in Language, Get SQL`, whose slug is exactly what the existing link expects — the anchor now resolves without touching the link.