### PR TITLE
docs: fix 'a a' duplication and the stale 'logfire login' reference

### DIFF
--- a/docs/guides/web-ui/organizations-and-projects.md
+++ b/docs/guides/web-ui/organizations-and-projects.md
@@ -17,7 +17,7 @@ Depending on the user's organization role, they may have implicit access to the 
 ## Which organization type should I use?
 
 While you _can_ use your personal org for production use-cases (e.g. if you
-are working alone or in a small team), we strongly encourage using a a normal organization if you are working
+are working alone or in a small team), we strongly encourage using a normal organization if you are working
 at a larger company and want to create a more "official" Logfire org for that company. This also means you don't have
 to share your personal org's projects (which you may wish to keep private) with any colleagues.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "Logfire SDK CLI: SDK Command Line Interface Guide"
-description: "Use the Logfire CLI to simplify project management. Use commands to authenticate (`logfire auth`), create new projects, and manage read/write tokens."
+description: "Use the Logfire CLI to simplify project management. Use commands to authenticate, create new projects, and manage read/write tokens."
 ---
 # SDK Command Line Interface
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 ---
 title: "Logfire SDK CLI: SDK Command Line Interface Guide"
-description: "Use the Logfire CLI to simplify project management. Use commands to authenticate, logfire login, create new projects, and manage read/write tokens."
+description: "Use the Logfire CLI to simplify project management. Use commands to authenticate (`logfire auth`), create new projects, and manage read/write tokens."
 ---
 # SDK Command Line Interface
 


### PR DESCRIPTION
- `docs/guides/web-ui/organizations-and-projects.md`: "encourage using **a a** normal organization".
- `docs/reference/cli.md`: the page's meta description advertised a `logfire login` command — no such subcommand exists (authentication is `logfire auth`; the doc line was the only occurrence of "logfire login" in the repo). Now references `logfire auth`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

