### PR TITLE
docs: remove leftover authoring TODO comments from the dashboards guide

### DIFF
--- a/docs/guides/web-ui/dashboards.md
+++ b/docs/guides/web-ui/dashboards.md
@@ -160,7 +160,6 @@ To add variables to a custom dashboard:
 3. Click **+ Add variable**.
 4. Define and configure your variables.
 
-<!-- TODO screenshot: dashboard toolbar with variable selectors, ideally one multiple-value dropdown with All selected -->
 
 Each variable has a **Name** (how you reference it in queries), plus an optional **Display Label** and **Description** shown on its selector. There are two variable types:
 
@@ -175,7 +174,6 @@ The **Source** setting controls where a list variable's options come from:
 * **Logfire Query List Variable**: options are loaded from a SQL query against your data. The query must return exactly one column, and each distinct non-null value becomes an option.
 * **Time Bucket Variable**: time intervals derived from the dashboard's time range. This source powers the built-in [`$resolution`](#resolution-variable) variable, and you'll rarely need to create one yourself.
 
-<!-- TODO screenshot: variable editor form with the Source dropdown open, showing all three sources -->
 
 A query source keeps the dropdown in sync with your data automatically. For example, if your metrics record a `tenant_id` attribute, this query fills the dropdown with every tenant ID captured on the `api.requests` metric:
 


### PR DESCRIPTION
`docs/guides/web-ui/dashboards.md` shipped two authoring debris comments (`<!-- TODO screenshot: dashboard toolbar with variable selectors … -->` and `<!-- TODO screenshot: variable editor form … -->`). Removed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

