### PR TITLE
Document agent framework coverage across Logfire views

### DIFF
--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -26,7 +26,7 @@ Logfire detects agent runs from several telemetry conventions:
 - **OpenLLMetry** (`traceloop.span.kind = 'agent'`): agents wrapped with Traceloop's `@agent` decorator.
 - **Framework-specific attributes**: Logfire recognizes the root spans emitted by Genkit and VoltAgent.
 
-Detection only determines whether a run appears on the Agents page. Model, token, cost, tool, and message fields depend on the attributes and trace relationships emitted by the framework. See the [agent framework support matrix](../../integrations/agent-frameworks/support-matrix.md) for the current behavior of each integration.
+Detection only determines whether a run appears in this curated Agents view. It does not determine whether Logfire supports or can ingest the framework's OpenTelemetry: that data remains available in Live and Explore. Model, token, cost, tool, and message fields depend on the attributes and trace relationships emitted by the framework. See [agent framework coverage in Logfire](../../integrations/agent-frameworks/support-matrix.md) for the current experience with each integration.
 
 !!! note "Cost for OpenInference-detected agents"
     The current reader does not populate aggregate agent cost from OpenInference model spans, so these agents show no cost in the Agents list and the **Metrics** tab. An individual run's **Summary** can still estimate cost from a recognized model and token counts.

--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -22,7 +22,7 @@ If you don't see an agent you expect, widen the time range: the list only reflec
 Logfire detects agent runs from several telemetry conventions:
 
 - **OpenTelemetry GenAI** (`gen_ai.operation.name = 'invoke_agent'`): [Pydantic AI](https://ai.pydantic.dev) emits these natively, as does any SDK that follows the [GenAI agent conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md).
-- **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, and the OpenAI Agents SDK.
+- **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, and the OpenAI Agents SDK for Python.
 - **OpenLLMetry** (`traceloop.span.kind = 'agent'`): agents wrapped with Traceloop's `@agent` decorator.
 - **Framework-specific attributes**: Logfire recognizes the root spans emitted by Genkit and VoltAgent.
 

--- a/docs/guides/web-ui/agents.md
+++ b/docs/guides/web-ui/agents.md
@@ -19,13 +19,20 @@ If you don't see an agent you expect, widen the time range: the list only reflec
 
 ## Supported frameworks
 
-Logfire detects an agent from either of two span conventions, so most agent frameworks appear on this page with no extra work:
+Logfire detects agent runs from several telemetry conventions:
 
 - **OpenTelemetry GenAI** (`gen_ai.operation.name = 'invoke_agent'`): [Pydantic AI](https://ai.pydantic.dev) emits these natively, as does any SDK that follows the [GenAI agent conventions](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md).
-- **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, AutoGen, and the OpenAI Agents SDK.
+- **OpenInference** (`openinference.span.kind = 'AGENT'`): frameworks instrumented with [OpenInference](https://github.com/Arize-ai/openinference), including LangGraph, CrewAI, smolagents, Agno, and the OpenAI Agents SDK.
+- **OpenLLMetry** (`traceloop.span.kind = 'agent'`): agents wrapped with Traceloop's `@agent` decorator.
+- **Framework-specific attributes**: Logfire recognizes the root spans emitted by Genkit and VoltAgent.
+
+Detection only determines whether a run appears on the Agents page. Model, token, cost, tool, and message fields depend on the attributes and trace relationships emitted by the framework. See the [agent framework support matrix](../../integrations/agent-frameworks/support-matrix.md) for the current behavior of each integration.
 
 !!! note "Cost for OpenInference-detected agents"
-    OpenInference spans don't report a per-call cost, so these agents show no cost in the Agents list and the **Metrics** tab. An individual run's **Summary** still shows an estimated cost, derived from its model and token counts.
+    The current reader does not populate aggregate agent cost from OpenInference model spans, so these agents show no cost in the Agents list and the **Metrics** tab. An individual run's **Summary** can still estimate cost from a recognized model and token counts.
+
+!!! note "OpenInference prompts and tools"
+    The **Info** tab can show a system prompt reconstructed from OpenInference input messages. The **Tools** tab can show definitions when the instrumentor records `llm.tools.*.tool.json_schema`. The full **Messages** tab does not yet read OpenInference message attributes.
 
 See the integration guide for your framework to set up the instrumentation that produces these spans.
 

--- a/docs/integrations/agent-frameworks/agent-framework-dotnet.md
+++ b/docs/integrations/agent-frameworks/agent-framework-dotnet.md
@@ -92,7 +92,7 @@ This uses Microsoft Agent Framework's real `ChatClientAgent` and `AIFunction`; n
 You'll see `invoke_agent`, `chat`, and `execute_tool` spans in **Logfire**. To also
 collect `gen_ai.client.*` metrics, configure a `MeterProvider` with `AddMeter(SourceName)` and an OpenTelemetry
 Protocol metrics exporter. Microsoft Agent Framework runs also appear in the specialized **Agents** view; the
-[support matrix](support-matrix.md) shows which columns each view populates.
+[framework coverage guide](support-matrix.md) shows which details each view adds.
 
 !!! warning "Common pitfalls"
     - **Default OTLP protocol is gRPC.** Logfire accepts both, but the endpoint has to match: gRPC takes the

--- a/docs/integrations/agent-frameworks/eve.md
+++ b/docs/integrations/agent-frameworks/eve.md
@@ -101,8 +101,8 @@ The large language model (LLM) call also appears on the **LLMs** page. Logfire c
 and their conversations, but aggregate Agent metrics can miss turns or count repeated token attributes more
 than once. Use the **LLMs** page for exact model-call usage while
 [full Eve Agent analytics support](https://github.com/pydantic/platform/issues/28737) is in progress. Eve runs
-also appear in the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns each
-view populates.
+also appear in the specialized **Agents** view; the [framework coverage guide](support-matrix.md) shows which
+details each view adds.
 
 ## Troubleshoot missing traces
 

--- a/docs/integrations/agent-frameworks/genkit-go.md
+++ b/docs/integrations/agent-frameworks/genkit-go.md
@@ -109,8 +109,8 @@ func main() {
 
 Set `GEMINI_API_KEY` (or your provider's key) and run `go run .`. The example verifies that Genkit executes its
 native `lookup_incident` tool. You'll see the generation, model, and tool spans in **Logfire**. Genkit runs are
-detected in the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns each
-view populates. Use `https://logfire-eu.pydantic.dev/v1/traces` for the EU region.
+detected in the specialized **Agents** view; the [framework coverage guide](support-matrix.md) shows which details
+each view adds. Use `https://logfire-eu.pydantic.dev/v1/traces` for the EU region.
 
 !!! warning "Common pitfalls"
     - **Set the global provider before `genkit.Init`**, or early spans are dropped.

--- a/docs/integrations/agent-frameworks/index.md
+++ b/docs/integrations/agent-frameworks/index.md
@@ -45,8 +45,9 @@ The examples do not add manual wrapper spans to simulate agent support. If a fra
 official, or maintained third-party OpenTelemetry path, its guide says that it is not fully supported.
 
 !!! tip "At a glance"
-    The [**support matrix**](support-matrix.md) summarizes which Logfire views — Live, Explore, LLMs, and Agents —
-    work with each framework, and where a framework has a known limitation.
+    The [**framework coverage guide**](support-matrix.md) shows how each integration's telemetry appears across
+    Live, Explore, LLMs, and Agents. Every OpenTelemetry trace stays queryable even when a purpose-built view
+    does not yet populate every field.
 
 ## Python
 

--- a/docs/integrations/agent-frameworks/mastra.md
+++ b/docs/integrations/agent-frameworks/mastra.md
@@ -86,8 +86,8 @@ main();
 
 Set `OPENAI_API_KEY` and `LOGFIRE_WRITE_TOKEN`, then run. The example fails unless Mastra executes the native
 `get-weather` tool. The agent run, model call, and tool call appear as a nested trace in **Logfire**. Mastra
-runs also appear in the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns
-each view populates.
+runs also appear in the specialized **Agents** view; the [framework coverage guide](support-matrix.md) shows which
+details each view adds.
 
 !!! warning "Common pitfalls"
     - **Use the current `observability` config.** The older top-level `telemetry: {}` (`OtelConfig`) on

--- a/docs/integrations/agent-frameworks/rig.md
+++ b/docs/integrations/agent-frameworks/rig.md
@@ -117,11 +117,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 Run `LOGFIRE_TOKEN=<write-token> OPENAI_API_KEY=<key> cargo run` in your terminal. The program fails unless the
-native Rig agent executes `lookup_incident`. In Logfire, the trace contains Rig's agent, completion, and tool
-spans. Because `record_content_telemetry(true)` is enabled, the completion spans also contain
+native Rig agent executes `lookup_incident`. Logfire receives Rig's agent, completion, and tool spans. Because
+`record_content_telemetry(true)` is enabled, the completion spans also contain
 `gen_ai.input.messages` and `gen_ai.output.messages`, and tool spans contain the arguments and results. The
 Logfire SDK does not add a synthetic agent wrapper. Rig runs also appear in the specialized **Agents** view; the
 [support matrix](support-matrix.md) shows which columns each view populates.
+
+Rig currently records the agent run and its completion on separate trace IDs. The **LLMs** page shows the model
+call and its token counts, and the **Agents** page shows the agent run, but Logfire cannot safely associate those
+records. Agent-level model, token, cost, tool, and message fields therefore remain empty. Use Live or Explore to
+inspect both traces.
 
 For an EU-region project, use its EU write token. The Logfire Rust SDK infers the data region from the token.
 

--- a/docs/integrations/agent-frameworks/rig.md
+++ b/docs/integrations/agent-frameworks/rig.md
@@ -121,7 +121,7 @@ native Rig agent executes `lookup_incident`. Logfire receives Rig's agent, compl
 `record_content_telemetry(true)` is enabled, the completion spans also contain
 `gen_ai.input.messages` and `gen_ai.output.messages`, and tool spans contain the arguments and results. The
 Logfire SDK does not add a synthetic agent wrapper. Rig runs also appear in the specialized **Agents** view; the
-[support matrix](support-matrix.md) shows which columns each view populates.
+[framework coverage guide](support-matrix.md) shows which details each view adds.
 
 Rig currently records the agent run and its completion on separate trace IDs. The **LLMs** page shows the model
 call and its token counts, and the **Agents** page shows the agent run, but Logfire cannot safely associate those

--- a/docs/integrations/agent-frameworks/semantic-kernel-dotnet.md
+++ b/docs/integrations/agent-frameworks/semantic-kernel-dotnet.md
@@ -114,7 +114,7 @@ The example fails unless `ChatCompletionAgent` invokes its native `lookup_incide
 the model and function spans with model and token data and, because the sensitive switch is on, the prompt and
 completion in **Logfire**. Semantic Kernel does not currently emit every attribute required for all specialized
 Agents-view features, so use Live or Explore to inspect the complete trace. Semantic Kernel runs also appear in
-the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns each view populates.
+the specialized **Agents** view; the [framework coverage guide](support-matrix.md) shows which details each view adds.
 
 !!! warning "Common pitfalls"
     - **Default OTLP protocol is gRPC.** **Logfire** accepts both, but the endpoint has to match: gRPC takes

--- a/docs/integrations/agent-frameworks/support-matrix.md
+++ b/docs/integrations/agent-frameworks/support-matrix.md
@@ -70,10 +70,15 @@ These integrations send useful traces, but their current agent root is not recog
 | [LlamaIndex (TS)](llamaindex-ts.md) | ● | ● | ○ | Emits an LLM chat span, but no agent span. |
 | [LangChain (JS)](langchain-js.md) | ● | ○ | ○ | Uses LangSmith's trace convention, which the specialized views do not currently interpret. |
 | [Instructor](../llms/instructor.md) | ● | ● | ○ | Emits an LLM span and is not an agent framework. |
-| [Eino (Go)](eino.md) | ○ | ○ | ○ | Has no maintained instrumentation for its agent and tool lifecycle. Surrounding application or model-client spans can still reach Logfire. |
 | [Letta](../llms/letta.md) | ● | ○ | ○ | Sends server traces over OTLP, but no recognized agent span. |
 | [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ◐ | ○ | Has no complete OpenTelemetry exporter; an instrumented model client can provide LLM spans only. |
 | [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ● | ○ | Emits native `gen_ai` conversation, model, and tool spans, but no `gen_ai.agent.name`. |
+
+## No maintained agent telemetry
+
+| Framework | Live & Explore | LLMs | Agents | Notes |
+| --- | :---: | :---: | :---: | --- |
+| [Eino (Go)](eino.md) | ○ | ○ | ○ | Has no maintained instrumentation for its agent and tool lifecycle. Surrounding application or model-client spans can still reach Logfire. |
 
 [^nested-native]: The agent run and model call are visible, but an intermediate framework span currently prevents Logfire from assigning the model call to aggregate agent metrics.
 

--- a/docs/integrations/agent-frameworks/support-matrix.md
+++ b/docs/integrations/agent-frameworks/support-matrix.md
@@ -1,39 +1,43 @@
 ---
-title: Agent framework support matrix
-description: "Which Logfire views work with each agent framework, and which agent-level fields each integration currently provides."
+title: Agent framework coverage in Logfire
+description: "How telemetry from each agent framework appears in Logfire's general observability and curated AI views."
 ---
 
-# Agent framework support matrix
+# Agent framework coverage in Logfire
 
-Every framework that sends OpenTelemetry (OTel), the open industry standard for collecting traces, metrics, and logs, to Logfire appears in **Live** and **Explore**. The specialized **LLMs** and **Agents** views also require attributes and parent-child relationships that Logfire recognizes.
+Logfire can ingest, query, and correlate telemetry from any framework that emits OpenTelemetry (OTel), the open industry standard for collecting traces, metrics, and logs. Those traces appear in **Live** and **Explore** alongside the rest of your application and infrastructure. Logfire also turns recognized AI attributes and trace relationships into purpose-built **LLMs** and **Agents** views.
 
-The columns below describe current specialized-view behavior:
+This matrix describes how richly each integration populates those product surfaces. It is not a yes-or-no list of frameworks that Logfire supports:
 
-- **LLMs** means model calls appear on the LLMs page.
-- **Agents** means agent runs appear on the Agents page.
+- **Live & Explore** means the integration's OpenTelemetry is available in Logfire's general-purpose observability views and SQL query layer.
+- **Curated LLMs view** means Logfire recognizes model calls and adds them to the model inventory.
+- **Curated Agents view** means Logfire recognizes agent roots and adds them to the agent-run inventory.
 - **Agent model & tokens** and **Agent cost** mean the aggregate values shown in the Agents list and Metrics tab. Seeing these fields on a raw span does not guarantee that Logfire can associate the model call with its agent run.
 - **Agent Tools** and **Agent Messages** mean the corresponding tabs in an agent run's detail panel. Raw tool or message attributes can still appear in Live and Explore when these columns are empty.
 
 An individual run can estimate cost from its model and token counts even when aggregate agent cost is unavailable. Aggregate cost requires the instrumentation to record `operation.cost` on a model call that Logfire can associate with the agent.
 
-Legend: **●** full &nbsp;·&nbsp; **◐** partial or configuration-dependent &nbsp;·&nbsp; **○** unavailable in the named view.
+!!! tip "A dash does not mean the framework is unsupported"
+    A dash in a curated-view column means that Logfire does not yet normalize that field into that particular view. When **Live & Explore** is available, the underlying telemetry is still searchable, queryable, and correlated with the rest of your system.
+
+Legend: **● Available** &nbsp;·&nbsp; **◐ Partial or setup-dependent** &nbsp;·&nbsp; **— Not populated in this view**.
 
 ## Native OTel GenAI
 
 These frameworks emit native `gen_ai.*` spans. Differences in operation names, trace relationships, and optional content recording still affect the specialized views.
 
-| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| Framework | Live & Explore | Curated LLMs view | Curated Agents view | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | [Pydantic AI](../llms/pydanticai.md) | ● | ● | ● | ● | ● | ● | ● |
 | [Google ADK](../llms/google-adk.md) | ● | ● | ● | ● | ◐ | ◐ | ◐ |
-| [Strands Agents](../llms/strands.md) [^nested-native] | ● | ● | ● | ○ | ○ | ○ | ◐ |
-| [Semantic Kernel](../llms/semantic-kernel.md) [^semantic-kernel-python] | ● | ○ | ● | ○ | ○ | ○ | ○ |
-| [AutoGen](../llms/autogen.md) | ● | ● | ● | ● | ○ | ◐ | ◐ |
-| [Mastra](mastra.md) | ● | ● | ● | ● | ◐ | ○ | ● |
-| [Vercel AI SDK](vercel-ai-sdk.md) [^nested-native] | ● | ● | ● | ○ | ○ | ◐ | ● |
-| [Rig](rig.md) [^rig] | ● | ● | ● | ○ | ○ | ○ | ○ |
+| [Strands Agents](../llms/strands.md) [^nested-native] | ● | ● | ● | — | — | — | ◐ |
+| [Semantic Kernel](../llms/semantic-kernel.md) [^semantic-kernel-python] | ● | — | ● | — | — | — | — |
+| [AutoGen](../llms/autogen.md) | ● | ● | ● | ● | — | ◐ | ◐ |
+| [Mastra](mastra.md) | ● | ● | ● | ● | ◐ | — | ● |
+| [Vercel AI SDK](vercel-ai-sdk.md) [^nested-native] | ● | ● | ● | — | — | ◐ | ● |
+| [Rig](rig.md) [^rig] | ● | ● | ● | — | — | — | — |
 | [Microsoft Agent Framework (.NET)](agent-framework-dotnet.md) | ● | ● | ● | ● | ◐ | ◐ | ◐ |
-| [Semantic Kernel (.NET)](semantic-kernel-dotnet.md) | ● | ● | ◐ | ● | ◐ | ○ | ◐ |
+| [Semantic Kernel (.NET)](semantic-kernel-dotnet.md) | ● | ● | ◐ | ● | ◐ | — | ◐ |
 
 ## OpenInference and other bridges
 
@@ -41,44 +45,46 @@ Logfire reads OpenInference LLM and agent spans. It can aggregate model and toke
 
 The Agents Info tab can show a system prompt reconstructed from OpenInference input messages. The Tools tab can show definitions when the instrumentor emits `llm.tools.*.tool.json_schema`. The full Agents Messages tab does not yet read OpenInference messages.
 
-| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| Framework | Live & Explore | Curated LLMs view | Curated Agents view | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [Agno](../llms/agno.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
-| [smolagents](../llms/smolagents.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
-| [LangGraph](../llms/langgraph.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
-| [OpenAI Agents SDK (Python)](../llms/openai.md#openai-agents) | ● | ● | ● | ● | ○ | ◐ | ○ |
-| [CrewAI](../llms/crewai.md) [^crewai] | ● | ○ | ● | ○ | ○ | ○ | ○ |
-| [Eve](eve.md) [^eve] | ● | ● | ◐ | ◐ | ○ | ○ | ○ |
+| [Agno](../llms/agno.md) | ● | ● | ● | ● | — | ◐ | — |
+| [smolagents](../llms/smolagents.md) | ● | ● | ● | ● | — | ◐ | — |
+| [LangGraph](../llms/langgraph.md) | ● | ● | ● | ● | — | ◐ | — |
+| [OpenAI Agents SDK (Python)](../llms/openai.md#openai-agents) | ● | ● | ● | ● | — | ◐ | — |
+| [CrewAI](../llms/crewai.md) [^crewai] | ● | — | ● | — | — | — | — |
+| [Eve](eve.md) [^eve] | ● | ● | ◐ | ◐ | — | — | — |
 
 ## Framework-specific conventions
 
 Logfire recognizes the agent root through a framework-specific attribute. Model-call support depends on the telemetry emitted below that root.
 
-| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| Framework | Live & Explore | Curated LLMs view | Curated Agents view | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
 | --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [Traceloop / OpenLLMetry](../../guides/web-ui/agents.md#supported-frameworks) [^traceloop] | ● | ● | ● | ● | ○ | ○ | ◐ |
-| [Genkit (Go)](genkit-go.md) | ● | ○ | ● | ○ | ○ | ○ | ○ |
-| [VoltAgent](voltagent.md) | ● | ○ | ● | ○ | ○ | ○ | ○ |
+| [Traceloop / OpenLLMetry](../../guides/web-ui/agents.md#supported-frameworks) [^traceloop] | ● | ● | ● | ● | — | — | ◐ |
+| [Genkit (Go)](genkit-go.md) | ● | — | ● | — | — | — | — |
+| [VoltAgent](voltagent.md) | ● | — | ● | — | — | — | — |
 
-## Tracing without Agents support
+## Tracing beyond the curated Agents view
 
-These integrations send useful traces, but their current agent root is not recognized by the Agents page.
+These integrations send useful telemetry to Live and Explore. Their current agent root is not yet normalized into the curated Agents view, so you inspect the complete trace directly instead.
 
-| Framework | Live & Explore | LLMs | Agents | Notes |
+| Framework | Live & Explore | Curated LLMs view | Curated Agents view | Notes |
 | --- | :---: | :---: | :---: | --- |
-| [Haystack](../llms/haystack.md) | ● | ● | ○ | Emits OpenInference chain and LLM spans, but no agent span. |
-| [LlamaIndex (TS)](llamaindex-ts.md) | ● | ● | ○ | Emits an LLM chat span, but no agent span. |
-| [LangChain (JS)](langchain-js.md) | ● | ○ | ○ | Uses LangSmith's trace convention, which the specialized views do not currently interpret. |
-| [Instructor](../llms/instructor.md) | ● | ● | ○ | Emits an LLM span and is not an agent framework. |
-| [Letta](../llms/letta.md) | ● | ○ | ○ | Sends server traces over OTLP, but no recognized agent span. |
-| [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ◐ | ○ | Has no complete OpenTelemetry exporter; an instrumented model client can provide LLM spans only. |
-| [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ● | ○ | Emits native `gen_ai` conversation, model, and tool spans, but no `gen_ai.agent.name`. |
+| [Haystack](../llms/haystack.md) | ● | ● | — | OpenInference chain and LLM spans provide a detailed trace; the instrumentor does not emit a distinct agent root. |
+| [LlamaIndex (TS)](llamaindex-ts.md) | ● | ● | — | Its LLM chat span appears in the LLMs view and the complete workflow remains available in Live and Explore. |
+| [LangChain (JS)](langchain-js.md) | ● | — | — | Its LangSmith trace convention remains fully inspectable in Live and Explore. |
+| [Instructor](../llms/instructor.md) | ● | ● | — | Its model calls appear in the LLMs view; Instructor itself is not an agent framework. |
+| [Letta](../llms/letta.md) | ● | — | — | Server traces arrive over OTLP and remain fully inspectable in Live and Explore. |
+| [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ◐ | — | Instrumenting the model client provides LLM spans while the SDK's OpenTelemetry exporter matures. |
+| [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ● | — | Native `gen_ai` conversation, model, and tool spans provide a detailed trace; the SDK does not yet emit `gen_ai.agent.name`. |
 
-## No maintained agent telemetry
+## Bring your own OpenTelemetry
 
-| Framework | Live & Explore | LLMs | Agents | Notes |
+This framework does not currently publish maintained instrumentation for its agent and tool lifecycle. You can still instrument the surrounding application and model client, preserving end-to-end observability in Logfire.
+
+| Framework | Live & Explore | Curated LLMs view | Curated Agents view | Notes |
 | --- | :---: | :---: | :---: | --- |
-| [Eino (Go)](eino.md) | ○ | ○ | ○ | Has no maintained instrumentation for its agent and tool lifecycle. Surrounding application or model-client spans can still reach Logfire. |
+| [Eino (Go)](eino.md) | — | — | — | Add OpenTelemetry around the application or model client to send the surrounding workflow to Logfire. |
 
 [^nested-native]: The agent run and model call are visible, but an intermediate framework span currently prevents Logfire from assigning the model call to aggregate agent metrics.
 

--- a/docs/integrations/agent-frameworks/support-matrix.md
+++ b/docs/integrations/agent-frameworks/support-matrix.md
@@ -1,91 +1,91 @@
 ---
 title: Agent framework support matrix
-description: "At-a-glance view of which Logfire views work with each agent framework — tracing, the LLMs view, and the Agents view — and where a framework has a known limitation."
+description: "Which Logfire views work with each agent framework, and which agent-level fields each integration currently provides."
 ---
 
 # Agent framework support matrix
 
-Every framework that sends OpenTelemetry (OTel) spans to Logfire gets the **Live** and **Explore** views, the
-trace waterfall, annotations, dashboards, and alerts. The specialized **LLMs** and **Agents** views need specific
-span attributes and parent-child relationships, so their support varies by framework.
+Every framework that sends OpenTelemetry (OTel), the open industry standard for collecting traces, metrics, and logs, to Logfire appears in **Live** and **Explore**. The specialized **LLMs** and **Agents** views also require attributes and parent-child relationships that Logfire recognizes.
 
-This page summarizes what each framework's guide describes about Logfire's views. The determining factor is
-**how the framework emits its spans**:
+The columns below describe current specialized-view behavior:
 
-- **Native OTel-GenAI semconv** (`gen_ai.*`): the LLMs and Agents views understand these directly, so model, token,
-  **cost**, and — where the framework emits them — tool and message data all populate.
-- **Instrumentor or bridge** (e.g. [OpenInference](https://github.com/Arize-ai/openinference) /
-  [OpenLLMetry](https://github.com/traceloop/openllmetry), a framework's own OTel bridge, or a Logfire-native
-  instrumentor): agent runs and token counts populate, but cost, the tools tab, and message/prompt content are not
-  yet read from these conventions.
+- **LLMs** means model calls appear on the LLMs page.
+- **Agents** means agent runs appear on the Agents page.
+- **Agent model & tokens** and **Agent cost** mean the aggregate values shown in the Agents list and Metrics tab. Seeing these fields on a raw span does not guarantee that Logfire can associate the model call with its agent run.
+- **Agent Tools** and **Agent Messages** mean the corresponding tabs in an agent run's detail panel. Raw tool or message attributes can still appear in Live and Explore when these columns are empty.
 
-Legend: **●** full &nbsp;·&nbsp; **◐** partial or framework-dependent &nbsp;·&nbsp; **○** not yet.
+An individual run can estimate cost from its model and token counts even when aggregate agent cost is unavailable. Aggregate cost requires the instrumentation to record `operation.cost` on a model call that Logfire can associate with the agent.
 
-## Full agent support — native OTel-GenAI
+Legend: **●** full &nbsp;·&nbsp; **◐** partial or configuration-dependent &nbsp;·&nbsp; **○** unavailable in the named view.
 
-These frameworks emit `gen_ai.*` spans, so the Agents view shows runs, tokens, model, and cost; where a framework
-populates only a subset, the marks below show it. Tools and message content appear when the framework emits them
-(see each guide).
+## Native OTel GenAI
 
-| Framework | Live & Explore | Agents view | Tokens & model | Cost | Tools | Messages |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| [Pydantic AI](../llms/pydanticai.md) | ● | ● | ● | ● | ● | ● |
-| [Google ADK](../llms/google-adk.md) | ● | ● | ● | ● | ◐ | ◐ |
-| [Strands Agents](../llms/strands.md) | ● | ● | ● | ● | ○ | ◐ |
-| [Semantic Kernel](../llms/semantic-kernel.md) | ● | ● | ● | ● | ○ | ○ |
-| [AutoGen](../llms/autogen.md) | ● | ● | ● | ● | ◐ | ◐ |
-| [Mastra](mastra.md) | ● | ● | ● | ● | ○ | ● |
-| [Vercel AI SDK](vercel-ai-sdk.md) | ● | ● | ● | ● | ◐ | ● |
-| [Rig](rig.md) | ● | ● | ● | ● | ◐ | ◐ |
-| [Microsoft Agent Framework (.NET)](agent-framework-dotnet.md) | ● | ● | ● | ● | ◐ | ◐ |
-| [Semantic Kernel (.NET)](semantic-kernel-dotnet.md) | ● | ◐ | ● | ● | ○ | ◐ |
+These frameworks emit native `gen_ai.*` spans. Differences in operation names, trace relationships, and optional content recording still affect the specialized views.
 
-## Agent runs and tokens — instrumentor or bridge
+| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [Pydantic AI](../llms/pydanticai.md) | ● | ● | ● | ● | ● | ● | ● |
+| [Google ADK](../llms/google-adk.md) | ● | ● | ● | ● | ◐ | ◐ | ◐ |
+| [Strands Agents](../llms/strands.md) [^nested-native] | ● | ● | ● | ○ | ○ | ○ | ◐ |
+| [Semantic Kernel](../llms/semantic-kernel.md) [^semantic-kernel-python] | ● | ○ | ● | ○ | ○ | ○ | ○ |
+| [AutoGen](../llms/autogen.md) | ● | ● | ● | ● | ○ | ◐ | ◐ |
+| [Mastra](mastra.md) | ● | ● | ● | ● | ◐ | ○ | ● |
+| [Vercel AI SDK](vercel-ai-sdk.md) [^nested-native] | ● | ● | ● | ○ | ○ | ◐ | ● |
+| [Rig](rig.md) [^rig] | ● | ● | ● | ○ | ○ | ○ | ○ |
+| [Microsoft Agent Framework (.NET)](agent-framework-dotnet.md) | ● | ● | ● | ● | ◐ | ◐ | ◐ |
+| [Semantic Kernel (.NET)](semantic-kernel-dotnet.md) | ● | ● | ◐ | ● | ◐ | ○ | ◐ |
 
-Detected as agents with per-run token counts. Cost, the tools tab, and message/prompt content are not yet read
-from these conventions.
+## OpenInference and other bridges
 
-| Framework | Live & Explore | Agents view | Tokens & model | Cost | Tools | Messages |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| [Agno](../llms/agno.md) | ● | ● | ● | ○ | ○ | ○ |
-| [smolagents](../llms/smolagents.md) | ● | ● | ● | ○ | ○ | ○ |
-| [LangGraph](../llms/langgraph.md) | ● | ● | ● | ○ | ○ | ○ |
-| [OpenAI Agents SDK (Python)](../llms/openai.md#openai-agents) | ● | ● | ● | ○ | ○ | ○ |
-| [CrewAI](../llms/crewai.md) [^crewai] | ● | ● | ○ | ○ | ○ | ○ |
-| [Eve](eve.md) [^eve] | ● | ◐ | ● | ○ | ○ | ○ |
+Logfire reads OpenInference LLM and agent spans. It can aggregate model and token data when an LLM span has a recognized agent ancestor. OpenInference does not populate aggregate agent cost in the current reader.
 
-## Detected agents — custom conventions
+The Agents Info tab can show a system prompt reconstructed from OpenInference input messages. The Tools tab can show definitions when the instrumentor emits `llm.tools.*.tool.json_schema`. The full Agents Messages tab does not yet read OpenInference messages.
 
-Detected as agent runs from a framework-specific key. Model-call metrics depend on how the framework emits its
-LLM calls; in the configurations we tested they are not captured as model calls.
+| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [Agno](../llms/agno.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
+| [smolagents](../llms/smolagents.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
+| [LangGraph](../llms/langgraph.md) | ● | ● | ● | ● | ○ | ◐ | ○ |
+| [OpenAI Agents SDK (Python)](../llms/openai.md#openai-agents) | ● | ● | ● | ● | ○ | ◐ | ○ |
+| [CrewAI](../llms/crewai.md) [^crewai] | ● | ○ | ● | ○ | ○ | ○ | ○ |
+| [Eve](eve.md) [^eve] | ● | ● | ◐ | ◐ | ○ | ○ | ○ |
 
-| Framework | Live & Explore | Agents view | Tokens & model | Cost | Tools | Messages |
-| --- | :---: | :---: | :---: | :---: | :---: | :---: |
-| [Genkit (Go)](genkit-go.md) | ● | ● | ○ | ○ | ○ | ○ |
-| [VoltAgent](voltagent.md) | ● | ● | ○ | ○ | ○ | ○ |
+## Framework-specific conventions
 
-## Tracing only
+Logfire recognizes the agent root through a framework-specific attribute. Model-call support depends on the telemetry emitted below that root.
 
-These emit valid OTel spans — so Live, Explore, dashboards, and alerts all work — but do not currently produce an
-agent-run span the Agents view recognizes (they emit an LLM or chain span, or a non-agent convention).
+| Framework | Live & Explore | LLMs | Agents | Agent model & tokens | Agent cost | Agent Tools | Agent Messages |
+| --- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [Traceloop / OpenLLMetry](../../guides/web-ui/agents.md#supported-frameworks) [^traceloop] | ● | ● | ● | ● | ○ | ○ | ◐ |
+| [Genkit (Go)](genkit-go.md) | ● | ○ | ● | ○ | ○ | ○ | ○ |
+| [VoltAgent](voltagent.md) | ● | ○ | ● | ○ | ○ | ○ | ○ |
 
-| Framework | Live & Explore | Agents view | Notes |
-| --- | :---: | :---: | --- |
-| [Haystack](../llms/haystack.md) | ● | ○ | Emits a chain/LLM span, not an agent-run span. |
-| [LlamaIndex (TS)](llamaindex-ts.md) | ● | ○ | Emits an LLM chat span only. |
-| [LangChain (JS)](langchain-js.md) | ● | ○ | Traced via LangSmith's own convention. |
-| [Instructor](../llms/instructor.md) | ● | ○ | LLM-only; not an agent framework. |
-| [Eino (Go)](eino.md) | ● | ○ | No agent-run convention we detect today. |
-| [Letta](../llms/letta.md) | ● | ○ | Server traces export directly over OTLP/gRPC, with a collector optional; no agent-run span is detected. |
-| [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ○ | No OpenTelemetry exporter yet; instrument the underlying model client for LLM spans only. |
-| [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ○ | Emits native gen_ai `invoke_agent`/`chat`/`execute_tool` spans (LLMs view, tokens, and cost populate), but sets no `gen_ai.agent.name`, so the Agents view does not detect the run. |
+## Tracing without Agents support
 
-[^crewai]: CrewAI is detected and named on the Agents view, but the CrewAI instrumentation in our tests emits no
-    LLM spans, so token, model, and cost columns are empty.
+These integrations send useful traces, but their current agent root is not recognized by the Agents page.
 
-[^eve]: Eve agent runs and conversations are detected, but aggregate Agent metrics can miss turns or double-count
-    repeated token attributes (tracking issue #28737).
+| Framework | Live & Explore | LLMs | Agents | Notes |
+| --- | :---: | :---: | :---: | --- |
+| [Haystack](../llms/haystack.md) | ● | ● | ○ | Emits OpenInference chain and LLM spans, but no agent span. |
+| [LlamaIndex (TS)](llamaindex-ts.md) | ● | ● | ○ | Emits an LLM chat span, but no agent span. |
+| [LangChain (JS)](langchain-js.md) | ● | ○ | ○ | Uses LangSmith's trace convention, which the specialized views do not currently interpret. |
+| [Instructor](../llms/instructor.md) | ● | ● | ○ | Emits an LLM span and is not an agent framework. |
+| [Eino (Go)](eino.md) | ○ | ○ | ○ | Has no maintained instrumentation for its agent and tool lifecycle. Surrounding application or model-client spans can still reach Logfire. |
+| [Letta](../llms/letta.md) | ● | ○ | ○ | Sends server traces over OTLP, but no recognized agent span. |
+| [OpenAI Agents SDK (TS)](openai-agents-js.md) | ◐ | ◐ | ○ | Has no complete OpenTelemetry exporter; an instrumented model client can provide LLM spans only. |
+| [Claude Agent SDK](../llms/claude-agent-sdk.md) | ● | ● | ○ | Emits native `gen_ai` conversation, model, and tool spans, but no `gen_ai.agent.name`. |
 
-!!! note "This reflects tested configurations"
-    Marks are derived from real captured telemetry for each framework. A different SDK version or instrumentation
-    setup can change what appears — each framework's guide documents the exact setup we tested.
+[^nested-native]: The agent run and model call are visible, but an intermediate framework span currently prevents Logfire from assigning the model call to aggregate agent metrics.
+
+[^semantic-kernel-python]: Semantic Kernel emits `chat.completions` model operations. Live and Explore show those spans, but the current LLMs and Agents readers do not recognize that operation for model metrics.
+
+[^rig]: Rig emits the agent run and model call on separate trace IDs. Both traces reach Logfire, but Logfire cannot safely assign the model, tokens, cost, tools, or messages to the agent run.
+
+[^crewai]: CrewAI is detected and named on the Agents page, but its current OpenInference instrumentation does not emit separate LLM spans.
+
+[^eve]: Eve agent runs and conversations are detected, but aggregate Agent metrics can miss turns or count repeated token attributes more than once. Use the LLMs page for exact model-call usage.
+
+[^traceloop]: Logfire recognizes spans created by OpenLLMetry's `@agent` decorator. Model and token aggregation works when the model call is a child of that span. Other detail fields depend on the model-client instrumentation used inside the agent.
+
+!!! note "Framework versions can change telemetry"
+    This matrix describes the setup in each linked guide and Logfire's current readers. A framework or instrumentor update can change its span names, attributes, or trace relationships. If your result differs, inspect the trace in Live and compare your package versions with the guide.

--- a/docs/integrations/agent-frameworks/vercel-ai-sdk.md
+++ b/docs/integrations/agent-frameworks/vercel-ai-sdk.md
@@ -71,6 +71,10 @@ native `ToolLoopAgent` executes `weather`. You'll see spans for the agent, promp
 tool call in **Logfire**. Vercel AI SDK runs also appear in the specialized **Agents** view; the
 [support matrix](support-matrix.md) shows which columns each view populates.
 
+The current Agents reader detects the run but does not associate model calls through the SDK's intermediate
+`agent_step` span. Use the **LLMs** page for model and token totals. Aggregate model, token, and cost fields on the
+Agents list and Metrics tab remain empty.
+
 !!! warning "Common pitfalls"
     - **Register both pieces before running the agent.** Configure Logfire's global tracer provider and attach
       `new OpenTelemetry()` in the agent's `telemetry.integrations`.

--- a/docs/integrations/agent-frameworks/vercel-ai-sdk.md
+++ b/docs/integrations/agent-frameworks/vercel-ai-sdk.md
@@ -69,7 +69,7 @@ main();
 Set your `OPENAI_API_KEY` and `LOGFIRE_TOKEN`, then run with `npx tsx agent.ts`. The example fails unless the
 native `ToolLoopAgent` executes `weather`. You'll see spans for the agent, prompt, response, token counts, and
 tool call in **Logfire**. Vercel AI SDK runs also appear in the specialized **Agents** view; the
-[support matrix](support-matrix.md) shows which columns each view populates.
+[framework coverage guide](support-matrix.md) shows which details each view adds.
 
 The current Agents reader detects the run but does not associate model calls through the SDK's intermediate
 `agent_step` span. Use the **LLMs** page for model and token totals. Aggregate model, token, and cost fields on the

--- a/docs/integrations/agent-frameworks/voltagent.md
+++ b/docs/integrations/agent-frameworks/voltagent.md
@@ -75,8 +75,8 @@ main();
 
 Set `OPENAI_API_KEY` and `LOGFIRE_WRITE_TOKEN`, then run. The example fails unless VoltAgent executes the
 native `lookup_incident` tool. The agent run, model call, and tool call appear in **Logfire**. VoltAgent runs
-also appear in the specialized **Agents** view; the [support matrix](support-matrix.md) shows which columns each
-view populates.
+also appear in the specialized **Agents** view; the [framework coverage guide](support-matrix.md) shows which
+details each view adds.
 
 !!! warning "Common pitfalls"
     - **Full `/v1/traces` URL.** When you pass `url` explicitly to `OTLPTraceExporter`, it does not append the

--- a/docs/integrations/llms/agno.md
+++ b/docs/integrations/llms/agno.md
@@ -47,7 +47,7 @@ agent.print_response('What is Pydantic Logfire, in one sentence?')
 
 You'll see a trace in **Logfire** with the agent run at the top and the underlying tool calls and model
 requests nested beneath it. Agno agents also appear in the specialized **Agents** view with per-run token
-counts; the [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+counts; the [framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! note
     Agno's own docs show configuring a raw OTLP exporter. With **Logfire** you don't need to — just call

--- a/docs/integrations/llms/autogen.md
+++ b/docs/integrations/llms/autogen.md
@@ -72,12 +72,12 @@ asyncio.run(main())
 
 You'll see the native AutoGen agent run in **Live** and **Agents**, with the `lookup_incident` tool call and
 instrumented OpenAI model requests nested beneath it. AutoGen runs also appear in the specialized **Agents**
-view; the [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+view; the [framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! warning
     Don't also enable `openinference-instrumentation-autogen-agentchat`. It wraps the same agent and tool methods
     that current AutoGen versions trace natively, which can produce duplicate spans. For the AG2 fork, use AG2's
-    own OpenTelemetry support (`pip install "ag2[openai,tracing]"`) instead. The support matrix describes the
+    own OpenTelemetry support (`pip install "ag2[openai,tracing]"`) instead. The framework coverage guide describes the
     native AutoGen setup on this page, not the third-party OpenInference instrumentor.
 
 ## Managed prompts

--- a/docs/integrations/llms/autogen.md
+++ b/docs/integrations/llms/autogen.md
@@ -77,7 +77,8 @@ view; the [support matrix](../agent-frameworks/support-matrix.md) shows which co
 !!! warning
     Don't also enable `openinference-instrumentation-autogen-agentchat`. It wraps the same agent and tool methods
     that current AutoGen versions trace natively, which can produce duplicate spans. For the AG2 fork, use AG2's
-    own OpenTelemetry support (`pip install "ag2[openai,tracing]"`) instead.
+    own OpenTelemetry support (`pip install "ag2[openai,tracing]"`) instead. The support matrix describes the
+    native AutoGen setup on this page, not the third-party OpenInference instrumentor.
 
 ## Managed prompts
 

--- a/docs/integrations/llms/crewai.md
+++ b/docs/integrations/llms/crewai.md
@@ -73,7 +73,7 @@ after the agent's role.
 
 The CrewAI OpenInference instrumentation emits agent and chain spans, but not separate model-call spans, so the
 **LLMs** view and the Agents view's token, model, and cost columns stay empty for CrewAI runs. The
-[support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+[framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! warning "Prompt and tool content"
     OpenInference can include task descriptions, outputs, tool arguments, and tool results in spans sent to

--- a/docs/integrations/llms/google-adk.md
+++ b/docs/integrations/llms/google-adk.md
@@ -69,7 +69,7 @@ if __name__ == '__main__':
 
 You'll see a trace in **Logfire** with the agent run, the underlying LLM (Gemini) call, and the `get_weather`
 tool call nested as a timeline. Google ADK runs also appear in the specialized **Agents** view; the
-[support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+[framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! note "Capturing message content"
     `SPAN_ONLY` records prompts, responses, tool calls, and tool results in the standard

--- a/docs/integrations/llms/langgraph.md
+++ b/docs/integrations/llms/langgraph.md
@@ -99,7 +99,7 @@ print(result['messages'][-1].content)
 The example fails unless the graph executes its native `ToolNode`. You'll see a trace in **Logfire** with a span
 for the graph run, a span per node, and the underlying LLM and `lookup_incident` tool calls nested beneath them.
 LangGraph agents also appear in the specialized **Agents** view with per-run token counts; the
-[support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+[framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! tip
     `LANGSMITH_OTEL_ONLY=true` stops LangSmith from also sending traces to its own backend, so you get

--- a/docs/integrations/llms/openai.md
+++ b/docs/integrations/llms/openai.md
@@ -213,7 +213,7 @@ Shows up like this in Logfire:
 Logfire also instruments the [OpenAI "agents"](https://github.com/openai/openai-agents-python)
 framework, so you can see each step an agent takes and every tool it calls as nested spans in one
 trace. OpenAI Agents runs also appear in the specialized **Agents** view; the
-[support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+[framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 ```python hl_lines="5-6" skip-run="true" skip-reason="external-connection"
 from agents import Agent, Runner

--- a/docs/integrations/llms/pydanticai.md
+++ b/docs/integrations/llms/pydanticai.md
@@ -72,7 +72,7 @@ You can use Pydantic AI with a [large variety of models][pydantic_ai.models.Know
 
 ## Verify it worked
 
-Run your program, then open the [Live view](../../guides/web-ui/live.md). Within a few seconds you'll see a trace for the agent run. Click it to read the conversation, expand the `roulette_wheel` tool call, and see the token count and duration. Pydantic AI runs also appear in the specialized **Agents** view; the [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+Run your program, then open the [Live view](../../guides/web-ui/live.md). Within a few seconds you'll see a trace for the agent run. Click it to read the conversation, expand the `roulette_wheel` tool call, and see the token count and duration. Pydantic AI runs also appear in the specialized **Agents** view; the [framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 The example above displays like this in Logfire:
 

--- a/docs/integrations/llms/semantic-kernel.md
+++ b/docs/integrations/llms/semantic-kernel.md
@@ -72,7 +72,7 @@ You'll see an `invoke_agent` span in **Live** and **Agents**, with child `chat.c
 spans. With the `SENSITIVE` flag enabled, the model span records the conversation for inspection in Live and
 Explore. The current specialized readers do not recognize Semantic Kernel's `chat.completions` operation for the
 LLMs page or aggregate agent model, token, and cost fields. Semantic Kernel runs still appear in the **Agents** view; the
-[support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+[framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 !!! warning "Common pitfalls"
     - **No diagnostics, no `gen_ai` spans.** Without the `SEMANTICKERNEL_EXPERIMENTAL_GENAI_*` env var, you get

--- a/docs/integrations/llms/semantic-kernel.md
+++ b/docs/integrations/llms/semantic-kernel.md
@@ -69,8 +69,9 @@ if __name__ == '__main__':
 ```
 
 You'll see an `invoke_agent` span in **Live** and **Agents**, with child `chat.completions` and function-invocation
-spans. With the `SENSITIVE` flag enabled, the conversation is also available in the agent-run detail. Semantic
-Kernel runs also appear in the specialized **Agents** view; the
+spans. With the `SENSITIVE` flag enabled, the model span records the conversation for inspection in Live and
+Explore. The current specialized readers do not recognize Semantic Kernel's `chat.completions` operation for the
+LLMs page or aggregate agent model, token, and cost fields. Semantic Kernel runs still appear in the **Agents** view; the
 [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
 
 !!! warning "Common pitfalls"

--- a/docs/integrations/llms/smolagents.md
+++ b/docs/integrations/llms/smolagents.md
@@ -45,8 +45,8 @@ agent.run('What is the current population of Tokyo? Search the web.')
 
 You'll see a trace in **Logfire** with the agent run at the top and a span for each step, including the code it
 generated, the tools it called, and the underlying LLM requests. smolagents runs also appear in the specialized
-**Agents** view with per-run token counts; the [support matrix](../agent-frameworks/support-matrix.md) shows which
-columns each view populates.
+**Agents** view with per-run token counts; the [framework coverage guide](../agent-frameworks/support-matrix.md)
+shows which details each view adds.
 
 !!! warning
     Don't pass a `tracer_provider` argument to `instrument()` — omit it so the instrumentor uses the global

--- a/docs/integrations/llms/strands.md
+++ b/docs/integrations/llms/strands.md
@@ -57,6 +57,10 @@ as a nested timeline. The model and agent spans contain standard `gen_ai.input.m
 `gen_ai.output.messages` attributes for the conversation. Strands runs also appear in the specialized **Agents**
 view; the [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
 
+The current Agents reader detects the run but does not associate the nested model call through Strands'
+intermediate event-loop span. Use the **LLMs** page for model and token totals. Aggregate model, token, and cost
+fields on the Agents list and Metrics tab remain empty.
+
 !!! warning "Message content is sensitive"
     By default, Strands records message and system-prompt content, which can include personally identifiable
     information (PII) and is sent to **Logfire**. Use [scrubbing](../../how-to-guides/scrubbing.md) to redact

--- a/docs/integrations/llms/strands.md
+++ b/docs/integrations/llms/strands.md
@@ -55,7 +55,7 @@ print(result)
 You'll see a trace in **Logfire** with the agent invocation, the model (LLM) call, and the `weather` tool call
 as a nested timeline. The model and agent spans contain standard `gen_ai.input.messages` and
 `gen_ai.output.messages` attributes for the conversation. Strands runs also appear in the specialized **Agents**
-view; the [support matrix](../agent-frameworks/support-matrix.md) shows which columns each view populates.
+view; the [framework coverage guide](../agent-frameworks/support-matrix.md) shows which details each view adds.
 
 The current Agents reader detects the run but does not associate the nested model call through Strands'
 intermediate event-loop span. Use the **LLMs** page for model and token totals. Aggregate model, token, and cost


### PR DESCRIPTION
## Summary

- lead with the universal OpenTelemetry path: emitted spans remain queryable and correlated in Live and Explore
- explain that LLMs and Agents are curated product views, not yes-or-no framework support gates
- document model, token, cost, tool, and message enrichment by framework
- replace the ambiguous hollow circle with a dash defined as not populated in this view

## Validation

- `pre-commit run --files <changed docs>`
- `uv run --no-sync pytest tests/test_docs.py -q` (129 passed)

## Non-goal

This describes the readers on `main`; it does not pre-document behavior from the still-stacked Platform materialized-view rollout.