### PR TITLE
Identify the client and its source in the device auth flow

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,6 +43,11 @@ Then, if you go back to the terminal, you'll see that you are authenticated! :ta
 
 ![Terminal screenshot with successful authentication](../images/cli/terminal-screenshot-auth-2.png)
 
+Set the optional `LOGFIRE_AUTH_SOURCE` environment variable to tell Logfire where a signup came from,
+such as a setup skill, installer script, or docs page, instead of attributing it only to the CLI. The
+value can contain letters, digits, dots, underscores, and hyphens (`[A-Za-z0-9._-]+`); the SDK trims
+it and caps it at 100 characters. This value never affects authentication or CLI behavior.
+
 ### Log out (`auth logout`)
 
 To log out and remove the locally stored credentials, run:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -31,6 +31,19 @@ via the cli instead of interactively, use `logfire --region eu auth` or `logfire
     If you're using a [self-hosted Logfire instance](./self-hosted/overview.md), you can authenticate by specifying your instance's URL using the `--base-url` flag:
     `logfire --base-url="https://<your_logfire_hostname>" auth`
 
+!!! note
+    To add optional signup attribution, set `LOGFIRE_AUTH_SOURCE` before running `logfire auth`. It
+    tells Logfire where a signup came from, such as a setup skill, installer script, or docs page.
+
+    ```bash
+    export LOGFIRE_AUTH_SOURCE=pydantic-ai-skill
+    logfire auth
+    ```
+
+    The value can contain letters, digits, dots, underscores, and hyphens. The SDK trims the value,
+    caps it at 100 characters, and ignores it if it does not fit that shape. It never affects
+    authentication or what the CLI does.
+
 Then you will be given the option to open logfire in your browser:
 ![Terminal screenshot with Logfire auth command](../images/cli/terminal-screenshot-auth-1.png)
 
@@ -42,11 +55,6 @@ After pressing `"Enter"`, you will be redirected to the browser to log in to you
 Then, if you go back to the terminal, you'll see that you are authenticated! :tada:
 
 ![Terminal screenshot with successful authentication](../images/cli/terminal-screenshot-auth-2.png)
-
-Set the optional `LOGFIRE_AUTH_SOURCE` environment variable to tell Logfire where a signup came from,
-such as a setup skill, installer script, or docs page, instead of attributing it only to the CLI. The
-value can contain letters, digits, dots, underscores, and hyphens (`[A-Za-z0-9._-]+`); the SDK trims
-it and caps it at 100 characters. This value never affects authentication or CLI behavior.
 
 ### Log out (`auth logout`)
 

--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -36,6 +36,7 @@ Both halves of the flow use it so they can't drift apart.
 _CLIENT_NAME: str = 'logfire-python'
 _AUTH_SOURCE_ENV_VAR: str = 'LOGFIRE_AUTH_SOURCE'
 _MAX_AUTH_SOURCE_LENGTH: int = 100
+_AUTH_SOURCE_PATTERN = re.compile(r'[A-Za-z0-9._-]+')
 
 
 LOGFIRE_TOKEN_REGION_PATTERN = re.compile(r'^pylf_v[0-9]+_(?P<region>[a-z]+)_')
@@ -267,8 +268,9 @@ def request_device_code(session: requests.Session, base_api_url: str) -> tuple[s
         'client': _CLIENT_NAME,
         'client_version': VERSION,
     }
+    # The source is trimmed, capped, and dropped if it does not match the shape accepted by the platform.
     source = os.environ.get(_AUTH_SOURCE_ENV_VAR, '').strip()[:_MAX_AUTH_SOURCE_LENGTH]
-    if source:
+    if _AUTH_SOURCE_PATTERN.fullmatch(source):
         params['source'] = source
 
     # The platform uses these details to attribute CLI signups to the SDK and the upstream tool.

--- a/logfire/_internal/auth.py
+++ b/logfire/_internal/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import platform
 import re
 import sys
@@ -16,6 +17,7 @@ from rich.prompt import IntPrompt
 from typing_extensions import Self
 
 from logfire.exceptions import LogfireConfigError
+from logfire.version import VERSION
 
 from .utils import UnexpectedResponse, read_toml_file
 
@@ -31,6 +33,9 @@ The `wait` endpoint blocks server-side for ~10 seconds while it waits for the us
 authenticate, so this is a snug bound around that rather than a general-purpose HTTP timeout.
 Both halves of the flow use it so they can't drift apart.
 """
+_CLIENT_NAME: str = 'logfire-python'
+_AUTH_SOURCE_ENV_VAR: str = 'LOGFIRE_AUTH_SOURCE'
+_MAX_AUTH_SOURCE_LENGTH: int = 100
 
 
 LOGFIRE_TOKEN_REGION_PATTERN = re.compile(r'^pylf_v[0-9]+_(?P<region>[a-z]+)_')
@@ -257,8 +262,19 @@ def request_device_code(session: requests.Session, base_api_url: str) -> tuple[s
     """
     machine_name = platform.uname()[1]
     device_auth_endpoint = urljoin(base_api_url, '/v1/device-auth/new/')
+    params: dict[str, str] = {
+        'machine_name': machine_name,
+        'client': _CLIENT_NAME,
+        'client_version': VERSION,
+    }
+    source = os.environ.get(_AUTH_SOURCE_ENV_VAR, '').strip()[:_MAX_AUTH_SOURCE_LENGTH]
+    if source:
+        params['source'] = source
+
+    # The platform uses these details to attribute CLI signups to the SDK and the upstream tool.
+    # Older platforms ignore unknown query parameters, which preserves compatibility in both directions.
     try:
-        res = session.post(device_auth_endpoint, params={'machine_name': machine_name}, timeout=_DEVICE_FLOW_TIMEOUT)
+        res = session.post(device_auth_endpoint, params=params, timeout=_DEVICE_FLOW_TIMEOUT)
         UnexpectedResponse.raise_for_status(res)
     except requests.RequestException as e:  # pragma: no cover
         raise LogfireConfigError('Failed to request a device code.') from e

--- a/logfire/_internal/cli/__init__.py
+++ b/logfire/_internal/cli/__init__.py
@@ -1034,6 +1034,8 @@ def _main(args: list[str] | None = None) -> None:
             context = get_context()
             session.hooks = {'response': [functools.partial(log_trace_id, context=context)]}
             session.headers.update(context)
+            # Ensure CLI requests, including device auth, identify the SDK and its version.
+            session.headers.update({'User-Agent': UA_HEADER})
             install_logfire_response_hook(session)
             namespace._session = session
             namespace.func(namespace)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -216,7 +216,7 @@ def test_request_device_code_sends_client_details_without_source(monkeypatch: py
         request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
 
         assert m.last_request is not None
-        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        query = parse_qs(urlparse(str(m.last_request.url)).query, keep_blank_values=True)
         assert query == {
             'machine_name': [platform.uname()[1]],
             'client': ['logfire-python'],
@@ -238,8 +238,13 @@ def test_request_device_code_strips_auth_source(monkeypatch: pytest.MonkeyPatch)
         request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
 
         assert m.last_request is not None
-        query = parse_qs(urlparse(str(m.last_request.url)).query)
-        assert query['source'] == ['pydantic-ai-skill']
+        query = parse_qs(urlparse(str(m.last_request.url)).query, keep_blank_values=True)
+        assert query == {
+            'machine_name': [platform.uname()[1]],
+            'client': ['logfire-python'],
+            'client_version': [VERSION],
+            'source': ['pydantic-ai-skill'],
+        }
 
 
 def test_request_device_code_truncates_auth_source(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -256,7 +261,7 @@ def test_request_device_code_truncates_auth_source(monkeypatch: pytest.MonkeyPat
         request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
 
         assert m.last_request is not None
-        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        query = parse_qs(urlparse(str(m.last_request.url)).query, keep_blank_values=True)
         assert query['source'] == ['x' * 100]
 
 
@@ -275,5 +280,28 @@ def test_request_device_code_omits_blank_auth_source(monkeypatch: pytest.MonkeyP
         request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
 
         assert m.last_request is not None
-        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        query = parse_qs(urlparse(str(m.last_request.url)).query, keep_blank_values=True)
         assert 'source' not in query
+
+
+@pytest.mark.parametrize('source', ['setup skill', 'setup/skill', 'setup@skill'])
+def test_request_device_code_omits_invalid_auth_source(monkeypatch: pytest.MonkeyPatch, source: str) -> None:
+    """The device code request omits an attribution source with an invalid shape."""
+    monkeypatch.setenv('LOGFIRE_AUTH_SOURCE', source)
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert m.last_request is not None
+        query = parse_qs(urlparse(str(m.last_request.url)).query, keep_blank_values=True)
+        assert query == {
+            'machine_name': [platform.uname()[1]],
+            'client': ['logfire-python'],
+            'client_version': [VERSION],
+        }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import platform
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import parse_qs, urlparse
 
 import inline_snapshot.extra
 import pytest
@@ -11,6 +13,7 @@ from inline_snapshot import snapshot
 
 from logfire._internal.auth import UserToken, UserTokenCollection, request_device_code
 from logfire.exceptions import LogfireConfigError
+from logfire.version import VERSION
 
 
 @pytest.mark.parametrize(
@@ -197,3 +200,80 @@ def test_request_device_code_sends_a_timeout() -> None:
         assert m.last_request is not None
         # Both halves of the device flow share this timeout.
         assert m.last_request.timeout == 15
+
+
+def test_request_device_code_sends_client_details_without_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The device code request always identifies the SDK but omits an unset attribution source."""
+    monkeypatch.delenv('LOGFIRE_AUTH_SOURCE', raising=False)
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert m.last_request is not None
+        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        assert query == {
+            'machine_name': [platform.uname()[1]],
+            'client': ['logfire-python'],
+            'client_version': [VERSION],
+        }
+
+
+def test_request_device_code_strips_auth_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The device code request strips surrounding whitespace from the attribution source."""
+    monkeypatch.setenv('LOGFIRE_AUTH_SOURCE', '  pydantic-ai-skill  ')
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert m.last_request is not None
+        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        assert query['source'] == ['pydantic-ai-skill']
+
+
+def test_request_device_code_truncates_auth_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The device code request caps the attribution source at 100 characters."""
+    monkeypatch.setenv('LOGFIRE_AUTH_SOURCE', 'x' * 150)
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert m.last_request is not None
+        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        assert query['source'] == ['x' * 100]
+
+
+@pytest.mark.parametrize('source', ['', '   '])
+def test_request_device_code_omits_blank_auth_source(monkeypatch: pytest.MonkeyPatch, source: str) -> None:
+    """The device code request omits an empty or whitespace-only attribution source."""
+    monkeypatch.setenv('LOGFIRE_AUTH_SOURCE', source)
+    with requests_mock.Mocker() as m:
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            json={
+                'device_code': 'device-code',
+                'frontend_auth_url': 'https://logfire-us.pydantic.dev/auth/device-code',
+            },
+        )
+        request_device_code(requests.Session(), 'https://logfire-us.pydantic.dev')
+
+        assert m.last_request is not None
+        query = parse_qs(urlparse(str(m.last_request.url)).query)
+        assert 'source' not in query

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -663,6 +663,31 @@ expiration = "fake_exp"
         webbrowser_open.assert_called_once_with('http://example.com/auth', new=2)
 
 
+def test_auth_device_request_user_agent(tmp_path: Path) -> None:
+    """The device auth request identifies the Logfire SDK and its version."""
+    auth_file = tmp_path / 'default.toml'
+    with ExitStack() as stack:
+        stack.enter_context(patch('logfire._internal.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.DEFAULT_FILE', auth_file))
+        stack.enter_context(patch('logfire._internal.cli.auth.input', side_effect=EOFError))
+
+        m = requests_mock.Mocker()
+        stack.enter_context(m)
+        m.post(
+            'https://logfire-us.pydantic.dev/v1/device-auth/new/',
+            text='{"device_code": "DC", "frontend_auth_url": "http://example.com/auth"}',
+        )
+        m.get(
+            'https://logfire-us.pydantic.dev/v1/device-auth/wait/DC',
+            text='{"token": "fake_token", "expiration": "fake_exp"}',
+        )
+
+        main(['--region', 'us', 'auth'])
+
+        device_auth_request = next(request for request in m.request_history if request.path == '/v1/device-auth/new/')
+        assert device_auth_request.headers['User-Agent'] == f'logfire/{VERSION}'
+
+
 def test_auth_non_interactive_completes_without_a_keypress(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """`logfire --region us auth` works with no terminal attached.
 


### PR DESCRIPTION
## What

`request_device_code()` now sends three extra query params on the existing `POST /v1/device-auth/new/` call: `client` (the constant `logfire-python`), `client_version` (the SDK version, read from the existing `logfire.version.VERSION`, no second source of truth), and, when the `LOGFIRE_AUTH_SOURCE` environment variable is set and non-empty, `source`. Nothing else changes on the wire, and there is no new CLI flag: the environment variable is the whole interface, so a caller can set it without caring which SDK version is installed.

The `requests.Session` the CLI builds for the auth flow also gets the SDK's standard user agent. It was sending the default `python-requests/x.y.z`, so neither the device code POST nor the token poll identified the SDK. It now carries the same `logfire/{VERSION}` value (`UA_HEADER`) that the other Logfire HTTP clients use, which covers every request the CLI makes, not just the two in this flow.

## Why

The CLI device flow is currently invisible in signup attribution. About half of Logfire signups arrive with no referrer, and the device flow is one of the reasons: the platform sees a device-code row with a machine name and nothing else, so it cannot tell a CLI signup from a web one, let alone which tool sent the user. The Pydantic AI first-run banner and its instrumentation skill will both route new users through `logfire auth`, so that share is about to grow. `client` and `client_version` make CLI signups countable, and `source` lets whatever sent the user there (a setup skill, an installer script, a docs page) name itself.

The `requests.Session` used by the CLI was not identifying the SDK either: `logfire/_internal/cli/__init__.py` gave the session only the trace context headers and a response hook, so the device-auth request went out with the default `python-requests/x.y.z` while other Logfire HTTP clients already set `logfire/{VERSION}` (see `UA_HEADER` in `logfire/_internal/client.py`). That gap is closed here as well. The query params are still sent explicitly, because they are what the platform stores on the device-flow row, and a user agent is a header that nothing persists.

## The contract

| Param | Value |
|---|---|
| `client` | the constant `logfire-python` |
| `client_version` | `logfire.version.VERSION` |
| `source` | `LOGFIRE_AUTH_SOURCE`, trimmed, capped at 100 characters, omitted when unset, blank, or outside `[A-Za-z0-9._-]+` |

`LOGFIRE_AUTH_SOURCE` is optional and never affects authentication or what the CLI does. The platform validates it as `[A-Za-z0-9._-]+`, and the SDK checks the same shape after trimming and truncating, dropping the param silently when it does not match (following review) so that a stray space cannot turn into a rejected device auth request. Nothing is raised or warned about.

Backward compatible in both directions: an older platform ignores unknown query params, so this SDK keeps working against a server that has not shipped the platform side, and an older SDK that sends only `machine_name` keeps working against the new platform.

The platform side is a separate PR in `pydantic/platform`, which stores these values on the device flow and carries them onto the resulting user and organization.

## Verification

Run locally against this branch:

- `uv run --no-sync pytest tests/test_auth.py tests/test_cli.py -q`: 323 passed
- `uv run ruff check`: all checks passed
- `uv run ruff format --check`: 261 files already formatted
- `uv run pyright`: 0 errors, 0 warnings

Four new tests in `tests/test_auth.py` pin the behaviour: `client` and `client_version` always present with `source` absent when the variable is unset, whitespace trimmed, values over 100 characters truncated, and blank, whitespace-only or wrongly shaped values omitted. They follow the `requests_mock` style of the existing `test_request_device_code_sends_a_timeout`. `tests/test_cli.py` gains `test_auth_device_request_user_agent`, which drives the real `logfire auth` path and asserts the user agent on the device-auth request.

CHANGELOG.md is left alone: this repo writes it at release time from the release notes, not per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFw6SWGpVkBz6SfLR6wH8B
