### PR TITLE
Add the Claude Agent SDK adapter for `logfire.agent_control`

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -114,4 +114,5 @@ Not seeing data? Check that `logfire.configure()` ran before `instrument_claude_
 ## Reference
 
 - API reference: [`logfire.instrument_claude_agent_sdk()`][logfire.Logfire.instrument_claude_agent_sdk]
+- [Agent Control for the Claude Agent SDK](../../reference/advanced/agent-control/claude-agent-sdk.md): edit this agent's prompt, model, thinking effort, and tool descriptions in Logfire instead of in your code.
 - [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview)

--- a/docs/navigation.yml
+++ b/docs/navigation.yml
@@ -702,9 +702,14 @@ navigation:
           - page: "Access and Prerequisites"
             path: "reference/advanced/prompt-management/plan-requirements.md"
             slug: "prompt-management/plan-requirements"
-      - page: "Agent Control"
-        path: "reference/advanced/agent-control.md"
-        slug: "agent-control"
+      - section: "Agent Control"
+        contents:
+          - page: "Overview"
+            path: "reference/advanced/agent-control.md"
+            slug: "agent-control"
+          - page: "Claude Agent SDK"
+            path: "reference/advanced/agent-control/claude-agent-sdk.md"
+            slug: "agent-control/claude-agent-sdk"
       - section: "AI Gateway"
         contents:
           - page: "Overview"

--- a/docs/reference/advanced/agent-control.md
+++ b/docs/reference/advanced/agent-control.md
@@ -17,7 +17,7 @@ Agent Control is built on [managed variables](managed-variables/index.md), and i
 
 `logfire.agent_control` is the **framework-neutral core**. It assumes nothing about how you built your agent: it owns the config contract, the Logfire variable each agent's config lives in, and the pure functions that say what a published value *does* to a request.
 
-Eventually most people will never call it directly: you will install the adapter for the agent framework you already use, and it will call this core for you. None of those [adapters](#framework-adapters) has shipped yet, so for now driving Agent Control means writing the per-request hook yourself, which [Writing an adapter](#writing-an-adapter) walks through. Read on for that, for exactly what a published value can and cannot do to your agent, or if your agent is hand-rolled.
+Eventually most people will never call it directly: you will install the adapter for the agent framework you already use, and it will call this core for you. Only the [Claude Agent SDK adapter](agent-control/claude-agent-sdk.md) has shipped so far, so for every other framework driving Agent Control means writing the per-request hook yourself, which [Writing an adapter](#writing-an-adapter) walks through. Read on for that, for exactly what a published value can and cannot do to your agent, or if your agent is hand-rolled.
 
 ## Quick start
 
@@ -305,15 +305,15 @@ Values are read **strictly** with respect to JSON types: `1` is a valid `tempera
 
 You normally use Agent Control through an adapter for the framework you already build with. Each is this core plus that framework's own per-request hook, typically under fifty lines.
 
-!!! note "The adapters are not released yet"
-    None of the adapters below ships today. Each lands as its own change on top of this core, and this section will link to each one as it becomes available. Until then, the way to drive Agent Control is to write the per-request hook yourself, as [Writing an adapter](#writing-an-adapter) describes.
+!!! note "Most of the adapters are not released yet"
+    Only the Claude Agent SDK adapter ships today. Each of the others lands as its own change on top of this core, and this section will link to it as it becomes available. Until then, the way to drive Agent Control for those frameworks is to write the per-request hook yourself, as [Writing an adapter](#writing-an-adapter) describes.
 
 | Framework | Language |
 |---|---|
+| [Claude Agent SDK](agent-control/claude-agent-sdk.md) | Python |
 | OpenAI Agents SDK | Python |
 | LangChain | Python |
 | Google ADK | Python |
-| Claude Agent SDK | Python |
 | LiveKit Agents | Python |
 | Vercel AI SDK | TypeScript |
 | Codex SDK | TypeScript |

--- a/docs/reference/advanced/agent-control/claude-agent-sdk.md
+++ b/docs/reference/advanced/agent-control/claude-agent-sdk.md
@@ -13,7 +13,7 @@ This page is the adapter for that SDK. Everything it applies comes from [Agent C
     pip install 'logfire[agent-control-claude-agent-sdk]'
     ```
 
-    It brings in Agent Control and `claude-agent-sdk>=0.2`.
+    It brings in Agent Control and the Claude Agent SDK.
 
 You also need a Logfire project with variables enabled, and `logfire.configure()` called before the first session starts. The Logfire token comes from your project settings, the same one the rest of the SDK uses.
 

--- a/docs/reference/advanced/agent-control/claude-agent-sdk.md
+++ b/docs/reference/advanced/agent-control/claude-agent-sdk.md
@@ -1,0 +1,199 @@
+---
+title: "Control a Claude Agent SDK agent from Logfire"
+description: "Edit a Claude Agent SDK agent's system prompt, subagent prompts, model, thinking effort, and tool descriptions in Logfire, with no redeploy."
+---
+# Claude Agent SDK
+
+Change what a [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) agent tells the model without touching your source code: its system prompt, its subagents' prompts, its model, how hard it thinks, and the descriptions its in-process tools show the model, all edited in the Logfire UI and rolled out on the agent's next session.
+
+This page is the adapter for that SDK. Everything it applies comes from [Agent Control](../agent-control.md), which owns the config shape, the Logfire variable it lives in, and the rules for what a published value may do. Read that page first if you have not: it explains versions, labels, rollouts, and what happens when Logfire is unreachable (your agent runs exactly as written).
+
+!!! note "Install the extra"
+    ```bash
+    pip install 'logfire[agent-control-claude-agent-sdk]'
+    ```
+
+    It brings in Agent Control and `claude-agent-sdk>=0.2`.
+
+You also need a Logfire project with variables enabled, and `logfire.configure()` called before the first session starts. The Logfire token comes from your project settings, the same one the rest of the SDK uses.
+
+## Quick start
+
+Wrap the `ClaudeAgentOptions` you already build, and pass what comes back to `query()` or `ClaudeSDKClient` instead:
+
+```python skip-run="true" skip-reason="starts the claude CLI"
+import asyncio
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions, query, tool
+
+import logfire
+from logfire.agent_control.claude_agent_sdk import agent_control, sdk_mcp_server
+
+logfire.configure()
+
+
+@tool('refund_order', 'Refund an order.', {'order_id': str})
+async def refund_order(args: dict[str, Any]) -> dict[str, Any]:
+    return {'content': [{'type': 'text', 'text': f'Refunded {args["order_id"]}.'}]}
+
+
+async def main() -> None:
+    options = agent_control(
+        ClaudeAgentOptions(
+            system_prompt='You are a concise checkout assistant.',
+            model='claude-sonnet-4-5',
+            # Use `sdk_mcp_server` in place of `create_sdk_mcp_server` to keep tool definitions editable.
+            mcp_servers={'shop': sdk_mcp_server('shop', tools=[refund_order])},
+            allowed_tools=['mcp__shop__refund_order'],
+        ),
+        name='checkout_assistant',
+    )
+    async for message in query(prompt='Refund my last order.', options=options):
+        print(message)
+
+
+asyncio.run(main())
+```
+
+Call `agent_control` **last**, once your options say everything your code wants them to say: a published value is applied over them, and anything you change afterwards wins over Logfire.
+
+**It returns a new `ClaudeAgentOptions` and never changes the one you passed**, neither the object, nor its `env` dictionary, nor its `mcp_servers` mapping. With nothing published for this agent it returns the very object you passed, unchanged.
+
+### Name the agent yourself
+
+The name is required and explicit. `ClaudeAgentOptions` has no name of its own, and the config is stored under the one you give (`agent__checkout_assistant`), so a name inferred from a Python variable would point the agent at a different config the day someone renames that variable. The name is kept as you wrote it for display and normalized for the variable key, so `checkout-assistant` and `Checkout Assistant` reach the same config.
+
+### `agent_control(options, *, name=...)`
+
+| Argument | |
+|---|---|
+| `options` | The `ClaudeAgentOptions` your code would start a session with. Optional: omitting it manages an agent that says nothing in code, so every section comes from Logfire. |
+| `name` | Required. The agent's name, which its config is stored under as `agent__<name>`. |
+| `label` | The label to resolve, such as `'production'`. `None` (the default) lets the variable's own targeting rules and rollout choose. |
+| `on_unmatched` | What to do about a published entry this agent cannot apply: `'warn'` (the default, once per process per message), `'error'`, or `'ignore'`. |
+| `publish_baseline` | Whether to publish the code baseline the Logfire editor diffs against. `True` by default. |
+| `logfire_instance` | The Logfire instance to resolve and publish through. Defaults to the one `logfire.configure()` sets up. |
+
+## What becomes editable in Logfire
+
+| Source or canonical field | Block ID or runtime mapping | Editable | Conditions and unmatched behavior |
+|---|---|---|---|
+| **Instructions** | | | |
+| `system_prompt='...'` (a string) | `system` | Yes | Removing the block sends `''`, which is what the SDK already sends for no custom prompt. |
+| `system_prompt={'type': 'preset', ..., 'append': '...'}` | `append` | Yes | The `append` half only. Removing it sends the preset alone. |
+| Claude Code's own preset prompt | `preset:claude_code` | No | The CLI renders it from your working directory, git status, and memory files, and never shows it to the SDK. Published as a dynamic block with no text; addressing it reports `dynamic-id`. |
+| `system_prompt={'type': 'file', ...}` | `system:file` | No | The CLI reads the file itself. Published as a dynamic block with no text; addressing it reports `dynamic-id`. Edit the file. |
+| `agents={'reviewer': AgentDefinition(prompt=...)}` | `agent:reviewer` | Text only | You can rewrite a subagent's prompt. You cannot remove the block: the CLI declares a subagent by its prompt and leaves one whose prompt is empty out of the session, so a removal would take the subagent, its description, and its tools away with it. The removal is reported and the code's prompt stays. An id no subagent carries reports `unknown-id`. |
+| Added instructions (an entry with no id) | appended to `system` or to `append` | Conditional | Goes into the agent's own system prompt, or a preset's `append`. With a `system_prompt` file there is nothing in the options to append to, and the addition is reported. |
+| `CLAUDE.md`, output styles, skills, plugins | | No | The CLI loads them, and they land in the conversation rather than the system prompt. Nothing addresses them, so nothing is reported. |
+| **Model** | | | |
+| `model` | `ClaudeAgentOptions.model` | Conditional | `anthropic:claude-sonnet-4-5`, an alias such as `anthropic:sonnet`, or a bare string with no `provider:` prefix. Any other provider is refused and reported: this SDK picks its provider from the CLI's environment, not from the model string. |
+| Subagent `model` | | No | `AgentDefinition.model` is not a section of the config, so a published `model` never reaches it. |
+| **Settings** | | | |
+| `thinking` | `thinking` and `effort` | Yes | `false` sends `{'type': 'disabled'}`, `true` sends `{'type': 'adaptive'}`, and a level also sets `effort`. A published value sets both fields together, so `true` clears an `effort` your code set. `'minimal'` becomes `'low'`, the lowest level this CLI has. |
+| `max_tokens` | `CLAUDE_CODE_MAX_OUTPUT_TOKENS` in `env` | Yes | The CLI stops the response there and reports the cap it read. |
+| `timeout` | `API_TIMEOUT_MS` in `env` | Yes | Seconds, converted to whole milliseconds by Agent Control's own rounding. A value outside the representable range is dropped by the core and reported. |
+| `temperature`, `top_p`, `top_k`, `seed`, `presence_penalty`, `frequency_penalty`, `parallel_tool_calls`, `stop_sequences` | | No | `ClaudeAgentOptions` has no such field, and the CLI chooses them itself. Each is reported as a setting this framework has no equivalent for. |
+| `max_turns`, `max_budget_usd`, `permission_mode`, `betas` | | No | Not part of the config, so nothing can be published for them. |
+| **Tools** | | | |
+| In-process tools built with `sdk_mcp_server(...)` | `mcp__<server>__<tool>`, grouped under `toolset: <server>` | Yes | Name, description, and top-level parameter descriptions. Parameter names, types, requiredness, and the implementation stay code-defined. |
+| In-process tools built with `create_sdk_mcp_server(...)` | | No | That helper keeps no reference to the definitions it was given, so there is nothing to rewrite. Such tools are not listed in the baseline, and an override naming one reports `unknown-tool`. Swap it for `sdk_mcp_server`, which takes the same arguments. |
+| Built-in tools (`Read`, `Bash`, `Edit`, `Task`, and the rest) | | No | Their descriptions live inside the CLI binary. An override naming one reports `unknown-tool`. Restrict them with `allowed_tools` and `disallowed_tools` in code. |
+| External MCP servers (stdio, SSE, HTTP) | | No | The CLI connects to them and lists their tools itself, so the SDK never sees a description. An override naming one reports `unknown-tool`. |
+| Which tools exist at all | | No | A published config re-describes tools. It does not add or remove them. |
+
+Every reported entry goes through `on_unmatched`: a `UserWarning` once per process by default, a `ValueError` under `'error'`, and nothing at all under `'ignore'`.
+
+## When a published config applies
+
+The Claude Agent SDK does not call the Messages API. It starts the `claude` CLI as a subprocess and talks JSON over its standard input and output, and the system prompt, the tool list, the model, and every sampling parameter are assembled *inside that process*. Nothing in the SDK, no hook, no callback, no transport, sees or can edit an outgoing model request.
+
+So a published config is applied at the only seam there is, the `ClaudeAgentOptions` a session starts from, and **the unit of resolution is one session**. Publishing in Logfire takes effect on the next session your code starts, not on the next request of a session already running. Two consequences worth knowing:
+
+- Call `agent_control` where you build the options for each `query()`, not once at import time, or a long-running process will never see anything you publish.
+- Claude Code snapshots the rendered system prompt on a conversation's first request and reuses it verbatim, so a changed prompt does not reach a resumed conversation either. Pass `extra_args={'system-prompt-snapshot': 'off'}` if you need it to.
+
+**Precedence** is code, then Logfire, then you: a published section is applied over what your options say, and anything you change on the returned object afterwards is the last word. A section nobody published is left exactly as your code wrote it.
+
+## Put the config version on a whole run
+
+`agent_control` resolves the config and returns, and you start the session afterwards, so the resolved label and version reach only the spans this adapter can still get inside: the hooks and the permission callback your options carry. To put them on a whole run, resolve and run inside one block with `ManagedAgent.session`:
+
+```python skip-run="true" skip-reason="starts the claude CLI"
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+from logfire.agent_control.claude_agent_sdk import ManagedAgent
+
+code_options = ClaudeAgentOptions(system_prompt='You are a concise checkout assistant.')
+managed = ManagedAgent('checkout_assistant', label='production')
+
+
+async def ask() -> None:
+    with managed.session(code_options) as options:  # spans inside carry the config version
+        async with ClaudeSDKClient(options=options) as client:
+            await managed.refresh_model(client, code_options)  # a model published since connecting
+            await client.query('Refund my last order.')
+            async for message in client.receive_response():
+                print(message)
+```
+
+`code_options` stays the options your *code* built, and it is what both calls are given. Applying a managed config to an already-managed object would add a second copy of any anonymous instruction block, and `refresh_model` reads the model to fall back to from what it is passed, so handing it managed options would make a withdrawn config roll back to the managed model instead of yours.
+
+## What the Logfire editor opens on
+
+The **baseline**, what your code says today, is published as the variable's `example` the first time an agent is configured in a process, so the editor opens on your prompt, block by block, rather than on a blank form. It is never resolved and never applied. Everything this SDK can be told is plain data on `ClaudeAgentOptions`, so the baseline describes the code rather than one observed request. A value Agent Control cannot describe, such as `effort='max'`, which is not `'xhigh'`, is left out of it and warned about rather than approximated.
+
+!!! warning "Publishing the baseline writes to the variable"
+    A value saved in the Logfire UI during that one round trip can be lost. Pass `publish_baseline=False` and create the variable in the UI if your deployment cannot tolerate that.
+
+## What a rename changes, and what it does not
+
+Your tool function is untouched and is never told a name: the SDK dispatches on the name the model called and hands your handler the same arguments. Parameter *names* are never renamed, only their descriptions, so arguments arrive exactly as your code declares them.
+
+The model-facing name of an in-process tool is `mcp__<server>__<name>`, and everything that refers to a tool is keyed on it. Those references are rewritten together with the definition:
+
+| Reference | What a rename does |
+|---|---|
+| `allowed_tools`, `disallowed_tools` | Rewritten, keeping any `(specifier)` as written. |
+| `AgentDefinition.tools`, `AgentDefinition.disallowedTools` | Rewritten, so a subagent keeps the tool it was allowed. |
+| `permission_prompt_tool_name` | Rewritten when it names a renamed tool. |
+| Hook matchers naming a tool exactly, `A\|B` alternations included | Rewritten. |
+| Hook matchers written as a pattern | Left as written. One that matched the old name and does not match the new one is reported through `on_unmatched`: rewriting a regular expression would mean editing one on a guess, and a `PreToolUse` hook that quietly stops running is a permission check that quietly stops happening. |
+| `can_use_tool(tool_name, ...)` | Called with the name **your code** gave the tool, and the CLI's suggested permission rules are translated the same way. Rules the callback asks to add come back out in the names the CLI knows. |
+| Hook callbacks | Called with `tool_name` set to the name **your code** gave the tool. Everything else in the payload is what the CLI sent. |
+| Two servers with the same tool name | A name is only taken inside its own server, since the model-facing name carries the server. Renaming the shop's `search` to `lookup` does not collide with the CRM's `lookup`. A rename onto a name already advertised *by the same server* is dropped, that override's other patches still apply, and the collision is reported. |
+
+Two things a rename does reach that this adapter cannot follow, both because they happen inside the CLI process:
+
+- **The conversation transcript.** The tool calls the CLI writes to its transcript, what `--resume` and `--continue` replay and what the model is shown on the next turn, carry the managed name. A session resumed after you change or withdraw a rename contains calls under a name the current tool list does not have.
+- **The message stream.** `ToolUseBlock.name` on the messages `query()` yields is the name the model called, so code that reads the stream sees the managed name. The name your handler, your hooks, and your permission callback see is the code-side one.
+
+## Known limits
+
+- **Only in-process servers built with `sdk_mcp_server` are editable.** The order of `mcp_servers` becomes the order the model is shown the tools in: a rebuilt server keeps its position, and unpatched tools keep their exact definitions.
+- **A tool edit invalidates the prompt cache.** The tool list sits ahead of the system prompt in the cached prefix, so renaming or re-describing any tool invalidates it for every session that starts afterwards. So does switching models with `refresh_model`.
+- **`refresh_model` sends only the model.** It does not re-apply instructions, settings, or tools, because the CLI has already been started with those.
+- **Hooks and the permission callback are wrapped.** The objects on the returned options are not the functions you passed. They call yours with the names above, and re-establish the resolved config's telemetry around it.
+- **The CLI's own telemetry does not carry the agent name.** The agent's identity in Logfire is the `name` you pass. Set `OTEL_RESOURCE_ATTRIBUTES` in `env` yourself if you want the CLI's spans to carry it too.
+- **Nothing published can crash a session.** An unreachable Logfire, a missing value, or one this release cannot parse all mean the same thing: the agent runs exactly as written. Beyond that, a value Agent Control cannot act on costs only the piece containing it, unless you asked for `on_unmatched='error'`, which raises instead.
+
+## Verify
+
+Start one session with `agent_control` in place. In Logfire you should now see a variable called `agent__<your agent name>` whose example is your agent's own prompt, model, and tool descriptions, block by block. Publish a change to the `system` block, run the agent again, and the next session sends the published text: the run's spans carry the label and version it came from, on the attributes `logfire.variables.agent__<name>` and `logfire.variables.agent__<name>.version`.
+
+## Troubleshooting
+
+**Nothing you publish reaches the agent.** The config is read when `agent_control` is called. A process that calls it once at import time keeps the first answer forever. Move the call to where you build the options for each session.
+
+**A published change reaches a new conversation but not a resumed one.** Claude Code reuses the system prompt it snapshotted on the conversation's first request. Pass `extra_args={'system-prompt-snapshot': 'off'}`.
+
+**A tool override warns `unknown-tool`.** The tool is not one this adapter can rewrite: a built-in, one from an external MCP server, or one from a server built with `create_sdk_mcp_server`. Only the last is fixable, by building the server with `sdk_mcp_server` instead.
+
+**A published `model` warns and does not apply.** The model string names a provider other than `anthropic`. This SDK takes an Anthropic model id and chooses its provider from the environment the CLI runs in, so publish `anthropic:<model>` or a bare model id.
+
+## Next steps
+
+- [Agent Control](../agent-control.md): the config shape every adapter reads, and what a published value may do to any agent.
+- [Instrument the Claude Agent SDK](../../../integrations/llms/claude-agent-sdk.md): the traces that show what the agent did with the config you published.
+- [Managed Variables](../managed-variables/index.md): the versions, labels, rollouts, and targeting Agent Control is built on.

--- a/docs/reference/advanced/agent-control/claude-agent-sdk.md
+++ b/docs/reference/advanced/agent-control/claude-agent-sdk.md
@@ -176,11 +176,13 @@ Two things a rename does reach that this adapter cannot follow, both because the
 - **`refresh_model` sends only the model.** It does not re-apply instructions, settings, or tools, because the CLI has already been started with those.
 - **Hooks and the permission callback are wrapped.** The objects on the returned options are not the functions you passed. They call yours with the names above, and re-establish the resolved config's telemetry around it.
 - **The CLI's own telemetry does not carry the agent name.** The agent's identity in Logfire is the `name` you pass. Set `OTEL_RESOURCE_ATTRIBUTES` in `env` yourself if you want the CLI's spans to carry it too.
-- **Nothing published can crash a session.** An unreachable Logfire, a missing value, or one this release cannot parse all mean the same thing: the agent runs exactly as written. Beyond that, a value Agent Control cannot act on costs only the piece containing it, unless you asked for `on_unmatched='error'`, which raises instead.
+- **Nothing about reading a config can crash a session.** An unreachable Logfire, a missing value, or one this release cannot parse all mean the same thing: the agent runs exactly as written. Beyond that, a value Agent Control cannot act on costs only the piece containing it, unless you asked for `on_unmatched='error'`, which raises instead. What a published value *says* is still yours to get right: a model id no provider knows fails the session the same way writing that id in your code would, so roll a model change out to a slice of traffic first.
 
 ## Verify
 
-Start one session with `agent_control` in place. In Logfire you should now see a variable called `agent__<your agent name>` whose example is your agent's own prompt, model, and tool descriptions, block by block. Publish a change to the `system` block, run the agent again, and the next session sends the published text: the run's spans carry the label and version it came from, on the attributes `logfire.variables.agent__<name>` and `logfire.variables.agent__<name>.version`.
+Start one session with `agent_control` in place. In Logfire you should now see a variable called `agent__<your agent name>` whose example is your agent's own prompt, model, and tool descriptions, block by block. Publish a change to the `system` block, run the agent again, and the next session sends the published text.
+
+To see which version produced a run, start the session inside `ManagedAgent.session(...)` as above: every span the block emits then carries `logfire.variables.agent__<name>` and `logfire.variables.agent__<name>.version`. With `agent_control` alone those attributes reach only the spans of the hooks and permission checks the options carry, since the session itself starts after the call returns.
 
 ## Troubleshooting
 

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/__init__.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/__init__.pyi
@@ -1,0 +1,4 @@
+from ._control import ManagedAgent as ManagedAgent, agent_control as agent_control
+from ._tools import sdk_mcp_server as sdk_mcp_server
+
+__all__ = ['ManagedAgent', 'agent_control', 'sdk_mcp_server']

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_control.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_control.pyi
@@ -1,0 +1,134 @@
+from ._instructions import apply_instruction_blocks as apply_instruction_blocks, instruction_blocks as instruction_blocks
+from ._settings import SUPPORTED_SETTINGS as SUPPORTED_SETTINGS, apply_managed_settings as apply_managed_settings, baseline_model as baseline_model, baseline_settings as baseline_settings, managed_model as managed_model
+from ._tools import managed_references as managed_references, rebuild_servers as rebuild_servers, tool_definitions as tool_definitions, tool_names as tool_names
+from _typeshed import Incomplete
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+from collections.abc import Generator
+from contextlib import contextmanager
+from logfire import Logfire as Logfire
+from logfire.agent_control import AgentConfig as AgentConfig, AgentControl as AgentControl, OnUnmatched as OnUnmatched, Resolution as Resolution, apply_instructions as apply_instructions, apply_settings as apply_settings, apply_tool_definitions as apply_tool_definitions, build_baseline as build_baseline, use_resolution as use_resolution
+
+def baseline(options: ClaudeAgentOptions) -> AgentConfig:
+    """Describe the agent `options` states, for the Logfire editor to diff published values against.
+
+    Everything this SDK can be told is plain data on `ClaudeAgentOptions` -- the only callables it
+    carries are hooks, permission handlers, and tool implementations -- so the whole baseline is
+    knowable before a session starts, and there is nothing to wait for a first request to learn.
+    """
+
+class ManagedAgent:
+    """One Claude Agent SDK agent, configurable from Logfire.
+
+    Everything this SDK lets an adapter rewrite is decided when a session starts: the system prompt,
+    the subagents, the model, the effort, and the in-process tool definitions all become CLI arguments
+    and one `initialize` message, and nothing after that reaches the model request the CLI builds. So
+    a managed config is applied by rewriting `ClaudeAgentOptions` -- once, before `query()` or
+    `ClaudeSDKClient.connect()` -- and takes effect on the *next* session rather than the next
+    request. [`refresh_model`][logfire.agent_control.claude_agent_sdk.ManagedAgent.refresh_model] is
+    the one exception the SDK offers mid-session.
+
+    Use [`agent_control`][logfire.agent_control.claude_agent_sdk.agent_control] for a one-shot
+    `query()`; keep a `ManagedAgent` when a long-lived `ClaudeSDKClient` should pick up a newly
+    published model, or when the run's spans should carry the config version that produced them.
+    """
+    control: Incomplete
+    def __init__(self, name: str, *, label: str | None = None, logfire_instance: Logfire | None = None, on_unmatched: OnUnmatched = 'warn', publish_baseline: bool = True) -> None:
+        """Declare the Logfire variable backing this agent's config.
+
+        Args:
+            name: The agent's name, which its config is stored under as `agent__<name>`. Required and
+                explicit: `ClaudeAgentOptions` has no name of its own, and one inferred from a Python
+                variable would point the agent at a different config the day someone renames it.
+            label: The label to resolve, such as `'production'`. `None` lets the variable's own
+                targeting rules and rollout choose.
+            logfire_instance: The Logfire instance to resolve and publish through; defaults to the
+                one `logfire.configure()` sets up.
+            on_unmatched: What to do about a published entry this agent cannot apply -- `'warn'`
+                (the default, once per process), `'error'`, or `'ignore'`.
+            publish_baseline: Whether to publish the code baseline the Logfire editor diffs against.
+        """
+    def options(self, options: ClaudeAgentOptions) -> ClaudeAgentOptions:
+        """`options` with the published config applied, ready to start a session with.
+
+        The argument is never mutated: what comes back is a new `ClaudeAgentOptions`, or the original
+        object itself when Logfire has nothing published for this agent.
+
+        The config is resolved here and the returned options carry it, but the session is started by
+        the caller, after this returns. So the resolved label and version reach the spans this
+        adapter can still get inside -- a hook, a permission check -- and not the spans of the query
+        itself. Use [`session`][logfire.agent_control.claude_agent_sdk.ManagedAgent.session] to put
+        them on the whole run.
+        """
+    @contextmanager
+    def session(self, options: ClaudeAgentOptions) -> Generator[ClaudeAgentOptions]:
+        """`options` with the published config applied, for the session run inside this block.
+
+        Resolving *and running* inside one context is what puts the resolved label and version on the
+        spans the block emits, so a run can be traced back to the config version that produced it.
+        Run the whole session inside it:
+
+        ```python
+        with managed.session(code_options) as options:
+            async for message in query(prompt='Refund my last order.', options=options):
+                ...
+        ```
+        """
+    async def refresh_model(self, client: ClaudeSDKClient, options: ClaudeAgentOptions) -> str | None:
+        """Re-resolve the managed model and set it on a connected client, for the turns still to come.
+
+        The model is the one thing this SDK can change without a new session, so it is the one thing a
+        long-lived client can pick up from Logfire while it runs. Everything else was sealed into the
+        CLI's arguments at connect time.
+
+        `options` is the same object the session was started from: it supplies the model to go back to
+        when the managed one is withdrawn, which is what keeps un-publishing a revert to code rather
+        than a switch to the CLI default.
+
+        Returns:
+            The model now in effect, or `None` when that is the CLI's own default.
+        """
+
+def agent_control(options: ClaudeAgentOptions | None = None, *, name: str, label: str | None = None, on_unmatched: OnUnmatched = 'warn', publish_baseline: bool = True, logfire_instance: Logfire | None = None) -> ClaudeAgentOptions:
+    """Make one agent's prompt, model, effort, and tool descriptions editable from Logfire.
+
+    Wrap the options you would pass to `query()` or `ClaudeSDKClient`, and pass what comes back
+    instead:
+
+    ```python
+    options = agent_control(ClaudeAgentOptions(system_prompt='...'), name='checkout_assistant')
+    async for message in query(prompt='Refund my last order.', options=options):
+        ...
+    ```
+
+    Call it last, once the options say everything your code wants them to say: what a published value
+    changes is applied over them, and anything you change afterwards wins over Logfire.
+
+    Nothing here can take the agent down. An unreachable Logfire, nothing published, or a value this
+    release cannot parse all return the options you passed in, unchanged.
+
+    Args:
+        options: The options your code would start a session with. Never mutated: what comes back is
+            a new `ClaudeAgentOptions`, or this same object when Logfire has nothing published.
+            Omitting it manages an agent that says nothing in code, so every section comes from
+            Logfire.
+        name: The agent's name, which its config is stored under as `agent__<name>`. Required and
+            explicit: `ClaudeAgentOptions` has no name of its own, and one inferred from a Python
+            variable would point the agent at a different config the day someone renames it.
+        label: The label to resolve, such as `'production'`. `None` lets the variable's own targeting
+            rules and rollout choose.
+        on_unmatched: What to do about a published entry this agent cannot apply -- `'warn'` (the
+            default, once per process), `'error'`, or `'ignore'`.
+        publish_baseline: Whether to publish the code baseline the Logfire editor diffs against.
+        logfire_instance: The Logfire instance to resolve and publish through; defaults to the one
+            `logfire.configure()` sets up.
+
+    Returns:
+        The `ClaudeAgentOptions` to start the session with.
+
+    The config is resolved when this is called, so call it where you build the options for each
+    session rather than once at import time. Because the session is started afterwards, the resolved
+    version reaches the spans of the hooks and permission checks the returned options carry, but not
+    the spans of the query itself; use
+    [`ManagedAgent.session`][logfire.agent_control.claude_agent_sdk.ManagedAgent.session] to put it on
+    the whole run, and to pick up a newly published model on a client that is already connected.
+    """

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_control.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_control.pyi
@@ -61,18 +61,18 @@ class ManagedAgent:
         """
     @contextmanager
     def session(self, options: ClaudeAgentOptions) -> Generator[ClaudeAgentOptions]:
-        """`options` with the published config applied, for the session run inside this block.
+        '''`options` with the published config applied, for the session run inside this block.
 
         Resolving *and running* inside one context is what puts the resolved label and version on the
         spans the block emits, so a run can be traced back to the config version that produced it.
         Run the whole session inside it:
 
-        ```python
+        ```python skip-run="true" skip-reason="illustrative-fragment"
         with managed.session(code_options) as options:
-            async for message in query(prompt='Refund my last order.', options=options):
+            async for message in query(prompt=\'Refund my last order.\', options=options):
                 ...
         ```
-        """
+        '''
     async def refresh_model(self, client: ClaudeSDKClient, options: ClaudeAgentOptions) -> str | None:
         """Re-resolve the managed model and set it on a connected client, for the turns still to come.
 
@@ -89,14 +89,14 @@ class ManagedAgent:
         """
 
 def agent_control(options: ClaudeAgentOptions | None = None, *, name: str, label: str | None = None, on_unmatched: OnUnmatched = 'warn', publish_baseline: bool = True, logfire_instance: Logfire | None = None) -> ClaudeAgentOptions:
-    """Make one agent's prompt, model, effort, and tool descriptions editable from Logfire.
+    '''Make one agent\'s prompt, model, effort, and tool descriptions editable from Logfire.
 
     Wrap the options you would pass to `query()` or `ClaudeSDKClient`, and pass what comes back
     instead:
 
-    ```python
-    options = agent_control(ClaudeAgentOptions(system_prompt='...'), name='checkout_assistant')
-    async for message in query(prompt='Refund my last order.', options=options):
+    ```python skip-run="true" skip-reason="illustrative-fragment"
+    options = agent_control(ClaudeAgentOptions(system_prompt=\'...\'), name=\'checkout_assistant\')
+    async for message in query(prompt=\'Refund my last order.\', options=options):
         ...
     ```
 
@@ -111,13 +111,13 @@ def agent_control(options: ClaudeAgentOptions | None = None, *, name: str, label
             a new `ClaudeAgentOptions`, or this same object when Logfire has nothing published.
             Omitting it manages an agent that says nothing in code, so every section comes from
             Logfire.
-        name: The agent's name, which its config is stored under as `agent__<name>`. Required and
+        name: The agent\'s name, which its config is stored under as `agent__<name>`. Required and
             explicit: `ClaudeAgentOptions` has no name of its own, and one inferred from a Python
             variable would point the agent at a different config the day someone renames it.
-        label: The label to resolve, such as `'production'`. `None` lets the variable's own targeting
+        label: The label to resolve, such as `\'production\'`. `None` lets the variable\'s own targeting
             rules and rollout choose.
-        on_unmatched: What to do about a published entry this agent cannot apply -- `'warn'` (the
-            default, once per process), `'error'`, or `'ignore'`.
+        on_unmatched: What to do about a published entry this agent cannot apply -- `\'warn\'` (the
+            default, once per process), `\'error\'`, or `\'ignore\'`.
         publish_baseline: Whether to publish the code baseline the Logfire editor diffs against.
         logfire_instance: The Logfire instance to resolve and publish through; defaults to the one
             `logfire.configure()` sets up.
@@ -131,4 +131,4 @@ def agent_control(options: ClaudeAgentOptions | None = None, *, name: str, label
     the spans of the query itself; use
     [`ManagedAgent.session`][logfire.agent_control.claude_agent_sdk.ManagedAgent.session] to put it on
     the whole run, and to pick up a newly published model on a client that is already connected.
-    """
+    '''

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_instructions.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_instructions.pyi
@@ -1,0 +1,43 @@
+from claude_agent_sdk import AgentDefinition as AgentDefinition, ClaudeAgentOptions
+from claude_agent_sdk.types import SystemPromptFile, SystemPromptPreset
+from collections.abc import Sequence
+from logfire.agent_control import Block as Block
+from typing import Any, TypeAlias
+
+SYSTEM_ID: str
+PRESET_ID: str
+APPEND_ID: str
+FILE_ID: str
+AGENT_PREFIX: str
+SystemPrompt: TypeAlias = str | SystemPromptPreset | SystemPromptFile | None
+
+def instruction_blocks(options: ClaudeAgentOptions) -> list[Block]:
+    '''Every prompt `options` states, in the order the agent sends them.
+
+    Two of them are dynamic, which in this SDK means "the text is never in this process": Claude
+    Code\'s preset prompt is assembled inside the CLI from the working directory, git status, and
+    memory files, and a `system_prompt` file is read by the CLI at session start. Both are published
+    as blocks that exist without text, so the Logfire editor shows the prompt is there and offers no
+    override for it -- and the core refuses one anyway.
+
+    `system_prompt=None` states no prompt at all (the CLI\'s minimal built-in one), so it contributes
+    no block; instructions published for it are added rather than replacing anything.
+    '''
+def apply_instruction_blocks(options: ClaudeAgentOptions, blocks: Sequence[Block]) -> tuple[dict[str, Any], list[str]]:
+    """Write applied blocks back into the fields they came from, as `ClaudeAgentOptions` changes.
+
+    `blocks` is what `apply_instructions` returned, so an id that is missing was dropped and a block
+    with no id was added. Added text is routed by its sink rather than by its position in the list:
+    every added block goes into the agent's own system prompt -- appended to a custom string, or into
+    a preset's `append` -- which is the only place this SDK has to put it.
+
+    A subagent's block cannot be dropped at all, and the attempt is reported. Removing an instruction
+    block removes *text*, and a subagent is not text: it has a description the model routes on, a
+    tool list, and a model of its own. The CLI declares a subagent by its prompt and leaves one whose
+    prompt is empty out of the session entirely -- so emptying it, the way `''` empties the agent's
+    own `system_prompt`, would take the whole subagent away, which is not something a section that
+    only describes instructions may do.
+
+    Returns the changes to apply and any messages the caller should report under `on_unmatched`, for
+    published text this agent's prompt shape has nowhere to put.
+    """

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_settings.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_settings.pyi
@@ -1,7 +1,7 @@
 from _typeshed import Incomplete
 from claude_agent_sdk import ClaudeAgentOptions
 from claude_agent_sdk.types import EffortLevel as EffortLevel
-from logfire.agent_control import to_milliseconds as to_milliseconds
+from logfire.agent_control import MAX_TIMEOUT_MILLISECONDS as MAX_TIMEOUT_MILLISECONDS, to_milliseconds as to_milliseconds
 from typing import Any
 
 SUPPORTED_SETTINGS: Incomplete

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_settings.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_settings.pyi
@@ -1,0 +1,38 @@
+from _typeshed import Incomplete
+from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk.types import EffortLevel as EffortLevel
+from logfire.agent_control import to_milliseconds as to_milliseconds
+from typing import Any
+
+SUPPORTED_SETTINGS: Incomplete
+MAX_OUTPUT_TOKENS_ENV: str
+TIMEOUT_ENV: str
+ANTHROPIC_PROVIDER: str
+
+def baseline_model(options: ClaudeAgentOptions) -> str | None:
+    """The code-defined model as a canonical `provider:model` string.
+
+    Every model this SDK can name is an Anthropic one -- a model id or an alias like `sonnet` -- since
+    Bedrock, Vertex, and the rest are selected by environment variables on the CLI subprocess rather
+    than by the model string. So the provider is always `anthropic`, and a `None` model (the CLI's own
+    default, chosen from settings or `ANTHROPIC_MODEL`) is not knowable from here at all.
+    """
+def managed_model(model: str) -> tuple[str | None, str | None]:
+    """Lower a published `provider:model` string to what `ClaudeAgentOptions.model` takes.
+
+    Returns the model to set and, when there is none, the reason to report. A string with no provider
+    is passed through untouched so a framework-native id keeps working, and any provider other than
+    `anthropic` is refused rather than silently truncated: this SDK's provider is a property of the
+    environment the CLI runs in, not of the model string, so applying the model half of
+    `bedrock:claude-fable-5-1` would send an Anthropic request under a name meant for Bedrock.
+    """
+def baseline_settings(options: ClaudeAgentOptions) -> dict[str, Any]:
+    """The canonical settings `options` states, for the baseline the Logfire editor diffs against."""
+def apply_managed_settings(options: ClaudeAgentOptions, patch: dict[str, Any]) -> dict[str, Any]:
+    """Lower a settings patch to `ClaudeAgentOptions` changes.
+
+    `patch` is what `apply_settings(config, supported=SUPPORTED_SETTINGS)` returned, so every key here
+    is one this framework has a knob for. A published `thinking` sets both `thinking` and `effort`
+    together, since the two are one statement in the contract and leaving the code's half in place is
+    how you get `effort='high'` on an agent whose thinking a published value just turned off.
+    """

--- a/logfire-api/logfire_api/agent_control/claude_agent_sdk/_tools.pyi
+++ b/logfire-api/logfire_api/agent_control/claude_agent_sdk/_tools.pyi
@@ -1,0 +1,87 @@
+from claude_agent_sdk import AgentDefinition as AgentDefinition, ClaudeAgentOptions, HookMatcher as HookMatcher, SdkMcpTool
+from claude_agent_sdk.types import McpSdkServerConfig, McpServerConfig as McpServerConfig
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from logfire.agent_control import Resolution as Resolution, ToolDef as ToolDef, ToolKey as ToolKey
+from typing import Any
+
+@dataclass(frozen=True)
+class _Registered:
+    """What it takes to rebuild an in-process server: the version and tools it was built from."""
+    version: str
+    tools: tuple[SdkMcpTool[Any], ...]
+
+def sdk_mcp_server(name: str, version: str = '1.0.0', tools: list[SdkMcpTool[Any]] | None = None) -> McpSdkServerConfig:
+    """Build an in-process MCP server whose tool definitions stay editable from Logfire.
+
+    A drop-in replacement for `claude_agent_sdk.create_sdk_mcp_server` with the same arguments and the
+    same return value. The difference is bookkeeping: `create_sdk_mcp_server` freezes each tool's
+    name, description, and schema into the server and keeps no reference to the definitions it was
+    given, so a managed description would have nothing to rewrite. This remembers them.
+
+    Tools in a server built with `create_sdk_mcp_server` still work exactly as written; they are
+    simply not listed in the baseline and not editable.
+    """
+def tool_definitions(options: ClaudeAgentOptions) -> list[ToolDef]:
+    """The tools of `options` whose definitions Agent Control can read and rewrite.
+
+    Each tool's `toolset` is its server name, which is both how the Logfire UI groups a long list and
+    how an override tells two servers' `search` tools apart. The name is the code-side one; the model
+    is shown `mcp__<server>__<name>`.
+    """
+def model_facing_name(server: str, tool: str) -> str:
+    """What the model calls an in-process tool: the name every permission rule is keyed on."""
+def rebuild_servers(options: ClaudeAgentOptions, code_tools: list[ToolDef], managed_tools: list[ToolDef]) -> dict[str, McpServerConfig] | None:
+    """Rebuild each in-process server whose tools were patched.
+
+    `managed_tools` is what `apply_tool_definitions` returned for `code_tools`, in the same order, so
+    the two zip. A server with no patched tool is left as the exact object the caller built, and a
+    patched server keeps every unpatched tool as its original definition -- rewriting only what a
+    published value actually changed, so nothing else about the wire format can drift.
+
+    Returns the new `mcp_servers` mapping, or `None` when nothing changed.
+    """
+
+@dataclass(frozen=True)
+class ToolNames:
+    """What a published rename did to the names the model calls, in both directions.
+
+    Everything that refers to an in-process tool from outside its own definition -- a permission
+    rule, a hook matcher, a subagent's tool list, the name a `can_use_tool` or hook callback is
+    handed -- is keyed on `mcp__<server>__<tool>`, the name the *model* calls. A rename that stopped
+    at the definition would leave every one of those pointing at a tool that no longer answers to
+    that name, so the two directions are what the rest of this module rewrites with:
+
+    - `managed` is the way *out*, for a name the code wrote: a permission rule, a matcher, a
+      subagent's `tools` entry, and a rule a permission callback asks to add.
+    - `code` is the way *in*, for a name the CLI hands back: the `tool_name` a callback is called
+      with, and the permission suggestions that come with it.
+    """
+    managed: Mapping[str, str]
+    code: Mapping[str, str]
+    def __bool__(self) -> bool:
+        """Whether anything was renamed at all."""
+
+def tool_names(forward: Mapping[ToolKey, str]) -> ToolNames:
+    """The model-facing renames behind `apply_tool_definitions`'s `(toolset, name) -> advertised` map.
+
+    Built from the core's own mapping rather than re-derived by comparing definitions, so what the
+    permissions, the matchers, and the callbacks are rewritten with is the same decision the tool
+    list was rewritten with -- collisions the core refused included.
+    """
+def rename_permissions(entries: Sequence[str], renames: Mapping[str, str]) -> list[str]:
+    """Rewrite `allowed_tools` / `disallowed_tools` entries that name a renamed tool.
+
+    Permissions are keyed on the name the *model* calls, so a rename that did not reach them would
+    silently un-allow a tool the user allowed. An entry may carry a specifier -- `Bash(rm *)` -- which
+    is kept as written around the rewritten name.
+    """
+def managed_references(options: ClaudeAgentOptions, names: ToolNames, resolution: Resolution) -> tuple[dict[str, Any], list[str]]:
+    """Everything on `options` that names a tool, rewritten around a rename.
+
+    Returns the `ClaudeAgentOptions` changes and the messages the caller reports under its
+    `on_unmatched` policy. The callbacks are wrapped whether or not anything was renamed: the
+    wrapper is also what puts the resolved config's label and version on the spans a hook or a
+    permission check emits, which is the only place this adapter gets to re-enter that scope once the
+    options it built have been handed to a session it does not run.
+    """

--- a/logfire/agent_control/claude_agent_sdk/__init__.py
+++ b/logfire/agent_control/claude_agent_sdk/__init__.py
@@ -1,0 +1,29 @@
+"""Logfire Agent Control for the Claude Agent SDK.
+
+Wrap the `ClaudeAgentOptions` you already build, and an agent's system prompt, its subagents' prompts,
+its model, how hard it thinks, and the descriptions its in-process tools show the model become
+editable from the Logfire UI -- versioned, labelled, rolled out, and rolled back as one unit, without
+a redeploy. Everything you do not change in Logfire keeps doing what your code says.
+
+```python skip-run="true" skip-reason="illustrative-fragment"
+from claude_agent_sdk import ClaudeAgentOptions, query
+from logfire.agent_control.claude_agent_sdk import agent_control
+
+options = agent_control(ClaudeAgentOptions(system_prompt='You are a checkout assistant.'), name='checkout_assistant')
+async for message in query(prompt='Refund my last order.', options=options):
+    ...
+```
+
+This SDK spawns the `claude` CLI and talks to it over stdio, so a config is applied where the SDK
+builds that process's arguments: at session start, not per model request. See the Agent Control
+documentation for what that means, and for the parts of a Claude Code agent no adapter can reach.
+"""
+
+from ._control import ManagedAgent, agent_control
+from ._tools import sdk_mcp_server
+
+__all__ = (
+    'ManagedAgent',
+    'agent_control',
+    'sdk_mcp_server',
+)

--- a/logfire/agent_control/claude_agent_sdk/_control.py
+++ b/logfire/agent_control/claude_agent_sdk/_control.py
@@ -1,0 +1,291 @@
+"""Wiring one Claude Agent SDK agent to its Logfire config: baseline out, published value in."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+from logfire.agent_control import (
+    AgentConfig,
+    AgentControl,
+    OnUnmatched,
+    Resolution,
+    apply_instructions,
+    apply_settings,
+    apply_tool_definitions,
+    build_baseline,
+    use_resolution,
+)
+
+from ._instructions import apply_instruction_blocks, instruction_blocks
+from ._settings import (
+    SUPPORTED_SETTINGS,
+    apply_managed_settings,
+    baseline_model,
+    baseline_settings,
+    managed_model,
+)
+from ._tools import (
+    managed_references,
+    rebuild_servers,
+    tool_definitions,
+    tool_names,
+)
+
+if TYPE_CHECKING:
+    from logfire import Logfire
+
+
+def baseline(options: ClaudeAgentOptions) -> AgentConfig:
+    """Describe the agent `options` states, for the Logfire editor to diff published values against.
+
+    Everything this SDK can be told is plain data on `ClaudeAgentOptions` -- the only callables it
+    carries are hooks, permission handlers, and tool implementations -- so the whole baseline is
+    knowable before a session starts, and there is nothing to wait for a first request to learn.
+    """
+    return build_baseline(
+        instructions=instruction_blocks(options),
+        model=baseline_model(options),
+        settings=baseline_settings(options),
+        tools=tool_definitions(options),
+    )
+
+
+class ManagedAgent:
+    """One Claude Agent SDK agent, configurable from Logfire.
+
+    Everything this SDK lets an adapter rewrite is decided when a session starts: the system prompt,
+    the subagents, the model, the effort, and the in-process tool definitions all become CLI arguments
+    and one `initialize` message, and nothing after that reaches the model request the CLI builds. So
+    a managed config is applied by rewriting `ClaudeAgentOptions` -- once, before `query()` or
+    `ClaudeSDKClient.connect()` -- and takes effect on the *next* session rather than the next
+    request. [`refresh_model`][logfire.agent_control.claude_agent_sdk.ManagedAgent.refresh_model] is
+    the one exception the SDK offers mid-session.
+
+    Use [`agent_control`][logfire.agent_control.claude_agent_sdk.agent_control] for a one-shot
+    `query()`; keep a `ManagedAgent` when a long-lived `ClaudeSDKClient` should pick up a newly
+    published model, or when the run's spans should carry the config version that produced them.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        label: str | None = None,
+        logfire_instance: Logfire | None = None,
+        on_unmatched: OnUnmatched = 'warn',
+        publish_baseline: bool = True,
+    ) -> None:
+        """Declare the Logfire variable backing this agent's config.
+
+        Args:
+            name: The agent's name, which its config is stored under as `agent__<name>`. Required and
+                explicit: `ClaudeAgentOptions` has no name of its own, and one inferred from a Python
+                variable would point the agent at a different config the day someone renames it.
+            label: The label to resolve, such as `'production'`. `None` lets the variable's own
+                targeting rules and rollout choose.
+            logfire_instance: The Logfire instance to resolve and publish through; defaults to the
+                one `logfire.configure()` sets up.
+            on_unmatched: What to do about a published entry this agent cannot apply -- `'warn'`
+                (the default, once per process), `'error'`, or `'ignore'`.
+            publish_baseline: Whether to publish the code baseline the Logfire editor diffs against.
+        """
+        self.control = AgentControl(
+            name,
+            label=label,
+            logfire_instance=logfire_instance,
+            on_unmatched=on_unmatched,
+            publish_baseline=publish_baseline,
+        )
+        """The underlying [`AgentControl`][logfire.agent_control.AgentControl]."""
+        self._publish_thread: threading.Thread | None = None
+        """The background baseline publish, for a process that may exit before it finishes."""
+
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}(name={self.control.name!r}, label={self.control.label!r})'
+
+    def options(self, options: ClaudeAgentOptions) -> ClaudeAgentOptions:
+        """`options` with the published config applied, ready to start a session with.
+
+        The argument is never mutated: what comes back is a new `ClaudeAgentOptions`, or the original
+        object itself when Logfire has nothing published for this agent.
+
+        The config is resolved here and the returned options carry it, but the session is started by
+        the caller, after this returns. So the resolved label and version reach the spans this
+        adapter can still get inside -- a hook, a permission check -- and not the spans of the query
+        itself. Use [`session`][logfire.agent_control.claude_agent_sdk.ManagedAgent.session] to put
+        them on the whole run.
+        """
+        return self._resolved(options)[1]
+
+    @contextmanager
+    def session(self, options: ClaudeAgentOptions) -> Generator[ClaudeAgentOptions]:
+        """`options` with the published config applied, for the session run inside this block.
+
+        Resolving *and running* inside one context is what puts the resolved label and version on the
+        spans the block emits, so a run can be traced back to the config version that produced it.
+        Run the whole session inside it:
+
+        ```python skip-run="true" skip-reason="illustrative-fragment"
+        with managed.session(code_options) as options:
+            async for message in query(prompt='Refund my last order.', options=options):
+                ...
+        ```
+        """
+        resolution, managed = self._resolved(options)
+        with use_resolution(resolution):
+            yield managed
+
+    def _resolved(self, options: ClaudeAgentOptions) -> tuple[Resolution, ClaudeAgentOptions]:
+        """Resolve this agent's config once, and apply it to `options`.
+
+        One resolution per call, held only as data: the session it configures is started by the
+        caller, so the scope it is reported in is re-entered later, at the callbacks the applied
+        options carry, rather than kept open across a session this adapter does not run.
+        """
+        self._publish_thread = self.control.publish_baseline(baseline(options))
+        with self.control.resolution() as resolution:
+            config = resolution.config
+            return resolution, options if config is None else self._applied(options, config, resolution)
+
+    async def refresh_model(self, client: ClaudeSDKClient, options: ClaudeAgentOptions) -> str | None:
+        """Re-resolve the managed model and set it on a connected client, for the turns still to come.
+
+        The model is the one thing this SDK can change without a new session, so it is the one thing a
+        long-lived client can pick up from Logfire while it runs. Everything else was sealed into the
+        CLI's arguments at connect time.
+
+        `options` is the same object the session was started from: it supplies the model to go back to
+        when the managed one is withdrawn, which is what keeps un-publishing a revert to code rather
+        than a switch to the CLI default.
+
+        Returns:
+            The model now in effect, or `None` when that is the CLI's own default.
+        """
+        with self.control.resolution() as resolution:
+            config = resolution.config
+            model = options.model
+            if config is not None and config.model is not None:
+                managed, reason = managed_model(config.model)
+                if reason is None:
+                    model = managed
+                else:
+                    self.control.report_unmatched(reason)
+            await client.set_model(model)
+            return model
+
+    def _applied(self, options: ClaudeAgentOptions, config: AgentConfig, resolution: Resolution) -> ClaudeAgentOptions:
+        """`options` rewritten by every section of `config` this SDK has somewhere to put.
+
+        Section by section, each on the options the section before it produced: a subagent's prompt
+        and its tool list live on the same `AgentDefinition`, so rewriting them in one pass over the
+        original options would have the second overwrite the first.
+        """
+        on_unmatched = self.control.on_unmatched
+
+        blocks = instruction_blocks(options)
+        instruction_changes, unapplied = apply_instruction_blocks(
+            options, apply_instructions(blocks, config, on_unmatched=on_unmatched).blocks
+        )
+        for message in unapplied:
+            self.control.report_unmatched(message)
+        options = replace(options, **instruction_changes)
+
+        code_tools = tool_definitions(options)
+        applied = apply_tool_definitions(
+            code_tools,
+            config,
+            on_unmatched=on_unmatched,
+            # Every in-process tool is advertised as `mcp__<server>__<tool>`, so two servers may each
+            # have a `search` and renaming one of them collides only inside its own server.
+            collision_scope='toolset',
+        )
+        changes: dict[str, Any] = {}
+        servers = rebuild_servers(options, code_tools, applied.tools)
+        if servers is not None:
+            changes['mcp_servers'] = servers
+        references, unpreservable = managed_references(options, tool_names(applied.forward), resolution)
+        changes.update(references)
+        for message in unpreservable:
+            self.control.report_unmatched(message)
+
+        changes.update(
+            apply_managed_settings(
+                options, apply_settings(config, supported=SUPPORTED_SETTINGS, on_unmatched=on_unmatched)
+            )
+        )
+
+        if config.model is not None:
+            model, reason = managed_model(config.model)
+            if reason is None:
+                changes['model'] = model
+            else:
+                self.control.report_unmatched(reason)
+
+        return replace(options, **changes)
+
+
+def agent_control(
+    options: ClaudeAgentOptions | None = None,
+    *,
+    name: str,
+    label: str | None = None,
+    on_unmatched: OnUnmatched = 'warn',
+    publish_baseline: bool = True,
+    logfire_instance: Logfire | None = None,
+) -> ClaudeAgentOptions:
+    """Make one agent's prompt, model, effort, and tool descriptions editable from Logfire.
+
+    Wrap the options you would pass to `query()` or `ClaudeSDKClient`, and pass what comes back
+    instead:
+
+    ```python skip-run="true" skip-reason="illustrative-fragment"
+    options = agent_control(ClaudeAgentOptions(system_prompt='...'), name='checkout_assistant')
+    async for message in query(prompt='Refund my last order.', options=options):
+        ...
+    ```
+
+    Call it last, once the options say everything your code wants them to say: what a published value
+    changes is applied over them, and anything you change afterwards wins over Logfire.
+
+    Nothing here can take the agent down. An unreachable Logfire, nothing published, or a value this
+    release cannot parse all return the options you passed in, unchanged.
+
+    Args:
+        options: The options your code would start a session with. Never mutated: what comes back is
+            a new `ClaudeAgentOptions`, or this same object when Logfire has nothing published.
+            Omitting it manages an agent that says nothing in code, so every section comes from
+            Logfire.
+        name: The agent's name, which its config is stored under as `agent__<name>`. Required and
+            explicit: `ClaudeAgentOptions` has no name of its own, and one inferred from a Python
+            variable would point the agent at a different config the day someone renames it.
+        label: The label to resolve, such as `'production'`. `None` lets the variable's own targeting
+            rules and rollout choose.
+        on_unmatched: What to do about a published entry this agent cannot apply -- `'warn'` (the
+            default, once per process), `'error'`, or `'ignore'`.
+        publish_baseline: Whether to publish the code baseline the Logfire editor diffs against.
+        logfire_instance: The Logfire instance to resolve and publish through; defaults to the one
+            `logfire.configure()` sets up.
+
+    Returns:
+        The `ClaudeAgentOptions` to start the session with.
+
+    The config is resolved when this is called, so call it where you build the options for each
+    session rather than once at import time. Because the session is started afterwards, the resolved
+    version reaches the spans of the hooks and permission checks the returned options carry, but not
+    the spans of the query itself; use
+    [`ManagedAgent.session`][logfire.agent_control.claude_agent_sdk.ManagedAgent.session] to put it on
+    the whole run, and to pick up a newly published model on a client that is already connected.
+    """
+    return ManagedAgent(
+        name,
+        label=label,
+        logfire_instance=logfire_instance,
+        on_unmatched=on_unmatched,
+        publish_baseline=publish_baseline,
+    ).options(options if options is not None else ClaudeAgentOptions())

--- a/logfire/agent_control/claude_agent_sdk/_instructions.py
+++ b/logfire/agent_control/claude_agent_sdk/_instructions.py
@@ -1,0 +1,160 @@
+"""Every prompt a `ClaudeAgentOptions` states, as addressable blocks, and back again.
+
+The SDK has no list of prompt blocks: it has one `system_prompt` (a string, a preset with an
+`append`, or a file) and one prompt per subagent in `agents`. Those seams are what an editor can
+offer overrides for, so each gets an id here, and a published value is written back to the field it
+came from.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from typing import Any, TypeAlias
+
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions
+from claude_agent_sdk.types import SystemPromptFile, SystemPromptPreset
+
+from logfire.agent_control import Block
+
+SYSTEM_ID = 'system'
+"""`system_prompt` as a plain string: the agent's own prompt, whole."""
+
+PRESET_ID = 'preset:claude_code'
+"""Claude Code's built-in system prompt, which the CLI renders and never shows the SDK."""
+
+APPEND_ID = 'append'
+"""The text a preset system prompt appends after Claude Code's own."""
+
+FILE_ID = 'system:file'
+"""A `system_prompt` read from a file by the CLI, whose contents the SDK never sees."""
+
+AGENT_PREFIX = 'agent:'
+"""Prefix for one subagent's prompt: `agent:<key>` for each key in `agents`."""
+
+_SEPARATOR = '\n\n'
+"""What blocks written into one prompt field are joined with, matching how the CLI joins its own."""
+
+
+SystemPrompt: TypeAlias = str | SystemPromptPreset | SystemPromptFile | None
+"""Every shape `ClaudeAgentOptions.system_prompt` takes; `None` is the CLI's own minimal prompt."""
+
+
+def _preset(system_prompt: SystemPrompt) -> SystemPromptPreset | None:
+    if isinstance(system_prompt, dict) and system_prompt.get('type') == 'preset':
+        preset: SystemPromptPreset = system_prompt  # type: ignore[assignment]
+        return preset
+    return None
+
+
+def _file(system_prompt: SystemPrompt) -> SystemPromptFile | None:
+    if isinstance(system_prompt, dict) and system_prompt.get('type') == 'file':
+        file: SystemPromptFile = system_prompt  # type: ignore[assignment]
+        return file
+    return None
+
+
+def instruction_blocks(options: ClaudeAgentOptions) -> list[Block]:
+    """Every prompt `options` states, in the order the agent sends them.
+
+    Two of them are dynamic, which in this SDK means "the text is never in this process": Claude
+    Code's preset prompt is assembled inside the CLI from the working directory, git status, and
+    memory files, and a `system_prompt` file is read by the CLI at session start. Both are published
+    as blocks that exist without text, so the Logfire editor shows the prompt is there and offers no
+    override for it -- and the core refuses one anyway.
+
+    `system_prompt=None` states no prompt at all (the CLI's minimal built-in one), so it contributes
+    no block; instructions published for it are added rather than replacing anything.
+    """
+    blocks: list[Block] = []
+    system_prompt = options.system_prompt
+    preset = _preset(system_prompt)
+    if isinstance(system_prompt, str):
+        blocks.append(Block(system_prompt, id=SYSTEM_ID))
+    elif preset is not None:
+        blocks.append(Block('', id=PRESET_ID, dynamic=True))
+        append = preset.get('append')
+        if append is not None:
+            blocks.append(Block(append, id=APPEND_ID))
+    elif _file(system_prompt) is not None:
+        blocks.append(Block('', id=FILE_ID, dynamic=True))
+    for key, agent in (options.agents or {}).items():
+        blocks.append(Block(agent.prompt, id=f'{AGENT_PREFIX}{key}'))
+    return blocks
+
+
+def _joined(texts: Sequence[str]) -> str:
+    return _SEPARATOR.join(text for text in texts if text)
+
+
+def apply_instruction_blocks(options: ClaudeAgentOptions, blocks: Sequence[Block]) -> tuple[dict[str, Any], list[str]]:
+    """Write applied blocks back into the fields they came from, as `ClaudeAgentOptions` changes.
+
+    `blocks` is what `apply_instructions` returned, so an id that is missing was dropped and a block
+    with no id was added. Added text is routed by its sink rather than by its position in the list:
+    every added block goes into the agent's own system prompt -- appended to a custom string, or into
+    a preset's `append` -- which is the only place this SDK has to put it.
+
+    A subagent's block cannot be dropped at all, and the attempt is reported. Removing an instruction
+    block removes *text*, and a subagent is not text: it has a description the model routes on, a
+    tool list, and a model of its own. The CLI declares a subagent by its prompt and leaves one whose
+    prompt is empty out of the session entirely -- so emptying it, the way `''` empties the agent's
+    own `system_prompt`, would take the whole subagent away, which is not something a section that
+    only describes instructions may do.
+
+    Returns the changes to apply and any messages the caller should report under `on_unmatched`, for
+    published text this agent's prompt shape has nowhere to put.
+    """
+    by_id = {block.id: block for block in blocks if block.id is not None}
+    added = [block.text for block in blocks if block.id is None]
+    changes: dict[str, Any] = {}
+    unapplied: list[str] = []
+
+    system_prompt = options.system_prompt
+    preset = _preset(system_prompt)
+    file = _file(system_prompt)
+    if isinstance(system_prompt, str):
+        block = by_id.get(SYSTEM_ID)
+        # A dropped prompt becomes `''`, which is what the SDK already sends for "no custom prompt".
+        changes['system_prompt'] = _joined([block.text if block is not None else '', *added])
+    elif preset is not None:
+        block = by_id.get(APPEND_ID)
+        append = _joined([block.text if block is not None else '', *added])
+        rewritten: dict[str, Any] = {key: value for key, value in preset.items() if key != 'append'}
+        if append:
+            rewritten['append'] = append
+        changes['system_prompt'] = rewritten
+    elif file is not None:
+        if added:
+            # The prompt lives in a file the CLI reads; there is nothing in the options to append to,
+            # and rewriting the user's file is not this adapter's to do.
+            unapplied.append(
+                f'Managed agent config adds instructions, but this agent reads its system prompt from '
+                f'the file {file["path"]!r}; the Claude Agent SDK has no way to add to a system prompt '
+                'it never sees, so those blocks are not applied.'
+            )
+    elif added:
+        changes['system_prompt'] = _joined(added)
+
+    agents = options.agents
+    if agents:
+        managed: dict[str, AgentDefinition] = {}
+        for key, agent in agents.items():
+            block = by_id.get(f'{AGENT_PREFIX}{key}')
+            if block is None:
+                # The published value removed this block. The CLI declares a subagent *by* its
+                # prompt: one whose prompt is empty is missing from the session's agent list
+                # entirely, so applying the removal would take away the subagent, its description,
+                # and its tools -- which is not something a section that only describes text may do.
+                unapplied.append(
+                    f'Managed agent config removes instruction block {AGENT_PREFIX + key!r}, but the `claude` CLI '
+                    f'drops a subagent whose prompt is empty, so removing that block would take the subagent '
+                    f'{key!r} out of the session along with its description and its tool list. That subagent keeps '
+                    'the prompt this agent was written with; publish text for the block to change it instead.'
+                )
+                managed[key] = agent
+                continue
+            managed[key] = agent if block.text == agent.prompt else replace(agent, prompt=block.text)
+        changes['agents'] = managed
+
+    return changes, unapplied

--- a/logfire/agent_control/claude_agent_sdk/_settings.py
+++ b/logfire/agent_control/claude_agent_sdk/_settings.py
@@ -1,0 +1,153 @@
+"""The model and the settings, in both directions: options -> baseline, and published value -> options.
+
+The Claude Agent SDK has no sampling knobs at all. `ClaudeAgentOptions` carries no `temperature`,
+`max_tokens`, `top_p`, `top_k`, `seed`, `stop_sequences`, penalties, or `parallel_tool_calls`: those
+are chosen inside the `claude` CLI, and the SDK's only lever on them is the environment it spawns the
+CLI with. So of the contract's eleven canonical settings this adapter can apply three -- `thinking`
+natively, and `max_tokens` and `timeout` through the CLI's own environment variables -- and reports
+the rest rather than pretending.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk.types import EffortLevel, ThinkingConfig
+
+from logfire.agent_control import to_milliseconds
+
+SUPPORTED_SETTINGS = frozenset({'max_tokens', 'thinking', 'timeout'})
+"""The canonical settings keys this framework has a knob for; `apply_settings` reports the others."""
+
+MAX_OUTPUT_TOKENS_ENV = 'CLAUDE_CODE_MAX_OUTPUT_TOKENS'
+"""The CLI environment variable that caps output tokens. The CLI clamps it to the model's own limit."""
+
+TIMEOUT_ENV = 'API_TIMEOUT_MS'
+"""The CLI environment variable holding the per-request API timeout, in milliseconds."""
+
+ANTHROPIC_PROVIDER = 'anthropic'
+"""The one provider a `provider:model` string may name here; the CLI picks its provider from `env`."""
+
+_EFFORT_FOR_THINKING: dict[str, EffortLevel] = {
+    # The contract's lowest level has no counterpart: `EffortLevel` starts at `low`, so `minimal`
+    # lands there rather than being dropped, which is the nearest thing the CLI can actually do.
+    'minimal': 'low',
+    'low': 'low',
+    'medium': 'medium',
+    'high': 'high',
+    'xhigh': 'xhigh',
+}
+
+
+def baseline_model(options: ClaudeAgentOptions) -> str | None:
+    """The code-defined model as a canonical `provider:model` string.
+
+    Every model this SDK can name is an Anthropic one -- a model id or an alias like `sonnet` -- since
+    Bedrock, Vertex, and the rest are selected by environment variables on the CLI subprocess rather
+    than by the model string. So the provider is always `anthropic`, and a `None` model (the CLI's own
+    default, chosen from settings or `ANTHROPIC_MODEL`) is not knowable from here at all.
+    """
+    return None if options.model is None else f'{ANTHROPIC_PROVIDER}:{options.model}'
+
+
+def managed_model(model: str) -> tuple[str | None, str | None]:
+    """Lower a published `provider:model` string to what `ClaudeAgentOptions.model` takes.
+
+    Returns the model to set and, when there is none, the reason to report. A string with no provider
+    is passed through untouched so a framework-native id keeps working, and any provider other than
+    `anthropic` is refused rather than silently truncated: this SDK's provider is a property of the
+    environment the CLI runs in, not of the model string, so applying the model half of
+    `bedrock:claude-fable-5-1` would send an Anthropic request under a name meant for Bedrock.
+    """
+    provider, separator, name = model.partition(':')
+    if not separator:
+        return model, None
+    if provider == ANTHROPIC_PROVIDER:
+        return name, None
+    return None, (
+        f'Managed agent config selects model {model!r}, but the Claude Agent SDK takes an Anthropic '
+        f'model id and chooses its provider from the environment the CLI runs in; that section is not '
+        'applied.'
+    )
+
+
+def _thinking_from(options: ClaudeAgentOptions) -> bool | str | None:
+    """The code's `thinking`/`effort` pair as the contract's single `thinking` value.
+
+    `effort` wins where both are set, because it is the finer statement of the same thing: a level
+    describes the agent better than "thinking is on" does.
+
+    The level is passed through as the CLI spells it, so a level the contract has no name for --
+    `'max'` -- is left out of the baseline and warned about by `canonical_settings` rather than
+    described as the nearest one that fits. `'max'` is not `'xhigh'`, and a baseline is the one
+    artifact the Logfire editor presents as the truth about the code.
+    """
+    if options.effort is not None:
+        return options.effort
+    thinking = options.thinking
+    if thinking is None:
+        return None
+    # `enabled` carries a token budget the contract cannot express, so it reports the part it can.
+    return thinking['type'] != 'disabled'
+
+
+def _int_env(options: ClaudeAgentOptions, name: str) -> int | None:
+    """One CLI environment variable as an integer, or `None` when it is absent or not a number."""
+    value = options.env.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        # The environment is the user's, and a value the CLI itself would reject is not this
+        # adapter's to report: it just is not something the baseline can describe.
+        return None
+
+
+def baseline_settings(options: ClaudeAgentOptions) -> dict[str, Any]:
+    """The canonical settings `options` states, for the baseline the Logfire editor diffs against."""
+    settings: dict[str, Any] = {}
+    thinking = _thinking_from(options)
+    if thinking is not None:
+        settings['thinking'] = thinking
+    max_tokens = _int_env(options, MAX_OUTPUT_TOKENS_ENV)
+    if max_tokens is not None:
+        settings['max_tokens'] = max_tokens
+    timeout_ms = _int_env(options, TIMEOUT_ENV)
+    if timeout_ms is not None:
+        settings['timeout'] = timeout_ms / 1000
+    return settings
+
+
+def apply_managed_settings(options: ClaudeAgentOptions, patch: dict[str, Any]) -> dict[str, Any]:
+    """Lower a settings patch to `ClaudeAgentOptions` changes.
+
+    `patch` is what `apply_settings(config, supported=SUPPORTED_SETTINGS)` returned, so every key here
+    is one this framework has a knob for. A published `thinking` sets both `thinking` and `effort`
+    together, since the two are one statement in the contract and leaving the code's half in place is
+    how you get `effort='high'` on an agent whose thinking a published value just turned off.
+    """
+    changes: dict[str, Any] = {}
+    env = dict(options.env)
+
+    if 'thinking' in patch:
+        thinking: bool | str = patch['thinking']
+        if thinking is False:
+            disabled: ThinkingConfig = {'type': 'disabled'}
+            changes['thinking'] = disabled
+            changes['effort'] = None
+        else:
+            adaptive: ThinkingConfig = {'type': 'adaptive'}
+            changes['thinking'] = adaptive
+            changes['effort'] = None if thinking is True else _EFFORT_FOR_THINKING[thinking]
+
+    if 'max_tokens' in patch:
+        env[MAX_OUTPUT_TOKENS_ENV] = str(patch['max_tokens'])
+    if 'timeout' in patch:
+        # `to_milliseconds` is the contract's own conversion, so the same published timeout becomes
+        # the same integer here as in every other adapter and in the TypeScript core.
+        env[TIMEOUT_ENV] = str(to_milliseconds(patch['timeout']))
+    if env != options.env:
+        changes['env'] = env
+    return changes

--- a/logfire/agent_control/claude_agent_sdk/_settings.py
+++ b/logfire/agent_control/claude_agent_sdk/_settings.py
@@ -15,7 +15,7 @@ from typing import Any
 from claude_agent_sdk import ClaudeAgentOptions
 from claude_agent_sdk.types import EffortLevel, ThinkingConfig
 
-from logfire.agent_control import to_milliseconds
+from logfire.agent_control import MAX_TIMEOUT_MILLISECONDS, to_milliseconds
 
 SUPPORTED_SETTINGS = frozenset({'max_tokens', 'thinking', 'timeout'})
 """The canonical settings keys this framework has a knob for; `apply_settings` reports the others."""
@@ -64,6 +64,14 @@ def managed_model(model: str) -> tuple[str | None, str | None]:
     if not separator:
         return model, None
     if provider == ANTHROPIC_PROVIDER:
+        if not name:
+            # A prefix and nothing after it is the half-filled field the contract refuses everywhere
+            # else, and applying it would start the session with no model rather than with the one
+            # the code names.
+            return None, (
+                f'Managed agent config selects model {model!r}, which names a provider and no model; '
+                'that section is not applied.'
+            )
         return name, None
     return None, (
         f'Managed agent config selects model {model!r}, but the Claude Agent SDK takes an Anthropic '
@@ -115,7 +123,10 @@ def baseline_settings(options: ClaudeAgentOptions) -> dict[str, Any]:
     if max_tokens is not None:
         settings['max_tokens'] = max_tokens
     timeout_ms = _int_env(options, TIMEOUT_ENV)
-    if timeout_ms is not None:
+    # Compared as milliseconds, before the division: a value big enough to be outside the contract's
+    # range can also be too big to turn into a float at all, and describing the environment the user
+    # set is not something that may fail the call that builds the baseline.
+    if timeout_ms is not None and 0 <= timeout_ms <= MAX_TIMEOUT_MILLISECONDS:
         settings['timeout'] = timeout_ms / 1000
     return settings
 

--- a/logfire/agent_control/claude_agent_sdk/_tools.py
+++ b/logfire/agent_control/claude_agent_sdk/_tools.py
@@ -146,7 +146,7 @@ def rebuild_servers(
         return None
 
     servers: dict[str, McpServerConfig] = dict(options.mcp_servers)  # type: ignore[arg-type]
-    for server, (_, registered) in _servers(options).items():
+    for server, (config, registered) in _servers(options).items():
         per_tool = patches.get(server)
         if per_tool is None:
             continue
@@ -167,7 +167,11 @@ def rebuild_servers(
                     annotations=tool.annotations,
                 )
             )
-        servers[server] = sdk_mcp_server(server, registered.version, rebuilt)
+        # The server's own name, not the key it is filed under: the two are usually the same, and
+        # when they are not it is the key that the model-facing `mcp__<server>__<tool>` names carry,
+        # while the name is what the CLI is told the server is called. A rebuild rewrites tool
+        # definitions and must leave the server it rebuilt identifying as the same server.
+        servers[server] = sdk_mcp_server(config['name'], registered.version, rebuilt)
     return servers
 
 

--- a/logfire/agent_control/claude_agent_sdk/_tools.py
+++ b/logfire/agent_control/claude_agent_sdk/_tools.py
@@ -1,0 +1,408 @@
+"""The one tool surface Agent Control can reach in this SDK: in-process (SDK MCP) tools.
+
+The Claude Agent SDK does not build model requests -- it spawns the `claude` CLI and talks JSON over
+stdio, and the tool list the model is shown is assembled inside that process. Built-in tools (`Read`,
+`Bash`, ...) and external MCP servers are therefore sealed: their descriptions live in the CLI binary
+or behind the CLI's own MCP client, and nothing the SDK passes can re-describe them.
+
+In-process servers are the exception, because the SDK serves them itself: it holds an
+`mcp.server.Server` and answers `tools/list` from definitions captured when the server was built. So
+a managed name or description is applied by *rebuilding the server* from rewritten tool definitions
+before a session starts -- which is why this module ships its own `sdk_mcp_server`, whose only job is
+to remember the tools each server was built from so they can be rewritten later.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, MutableMapping, Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+from weakref import WeakKeyDictionary
+
+from claude_agent_sdk import (
+    AgentDefinition,
+    CanUseTool,
+    ClaudeAgentOptions,
+    HookCallback,
+    HookContext,
+    HookInput,
+    HookJSONOutput,
+    HookMatcher,
+    PermissionResult,
+    PermissionResultAllow,
+    PermissionUpdate,
+    SdkMcpTool,
+    ToolPermissionContext,
+    _build_input_schema,  # type: ignore[reportPrivateUsage]
+    create_sdk_mcp_server,
+)
+from claude_agent_sdk.types import HookEvent, McpSdkServerConfig, McpServerConfig
+
+from logfire.agent_control import Resolution, ToolDef, ToolKey
+
+
+@dataclass(frozen=True)
+class _Registered:
+    """What it takes to rebuild an in-process server: the version and tools it was built from."""
+
+    version: str
+    tools: tuple[SdkMcpTool[Any], ...]
+
+
+_REGISTERED: MutableMapping[Any, _Registered] = WeakKeyDictionary()
+"""Servers built through `sdk_mcp_server`, keyed on the `mcp.server.Server` the SDK will serve.
+
+Keyed on the instance rather than on the server name because the name is the caller's, reused across
+processes and test runs, while the instance is the exact object a given `ClaudeAgentOptions` points
+at. Weak so a server built for one session does not outlive it.
+
+The registration cannot live on the config dict itself: for an in-process server the SDK JSON-encodes
+every key except `instance` into the CLI's `--mcp-config` argument, so an extra key would either leak
+into the command line or fail to serialize.
+"""
+
+
+def sdk_mcp_server(name: str, version: str = '1.0.0', tools: list[SdkMcpTool[Any]] | None = None) -> McpSdkServerConfig:
+    """Build an in-process MCP server whose tool definitions stay editable from Logfire.
+
+    A drop-in replacement for `claude_agent_sdk.create_sdk_mcp_server` with the same arguments and the
+    same return value. The difference is bookkeeping: `create_sdk_mcp_server` freezes each tool's
+    name, description, and schema into the server and keeps no reference to the definitions it was
+    given, so a managed description would have nothing to rewrite. This remembers them.
+
+    Tools in a server built with `create_sdk_mcp_server` still work exactly as written; they are
+    simply not listed in the baseline and not editable.
+    """
+    config = create_sdk_mcp_server(name, version, tools)
+    _REGISTERED[config['instance']] = _Registered(version=version, tools=tuple(tools or ()))
+    return config
+
+
+def _servers(options: ClaudeAgentOptions) -> dict[str, tuple[McpSdkServerConfig, _Registered]]:
+    """The in-process servers of `options` this adapter can rewrite, in the order they were declared.
+
+    Order is preserved because it becomes the order the model is shown the tools in, which is part of
+    the prompt-cache prefix; rebuilding a server must not move it.
+    """
+    configs = options.mcp_servers
+    if not isinstance(configs, dict):
+        # `mcp_servers` may also be a path to an MCP config file, which names external servers only.
+        return {}
+    found: dict[str, tuple[McpSdkServerConfig, _Registered]] = {}
+    typed_configs: dict[str, McpServerConfig] = configs
+    for name, config in typed_configs.items():
+        if config.get('type') != 'sdk':
+            continue
+        sdk_config: McpSdkServerConfig = config  # type: ignore[assignment]
+        registered = _REGISTERED.get(sdk_config['instance'])
+        if registered is not None:
+            found[name] = (sdk_config, registered)
+    return found
+
+
+def tool_definitions(options: ClaudeAgentOptions) -> list[ToolDef]:
+    """The tools of `options` whose definitions Agent Control can read and rewrite.
+
+    Each tool's `toolset` is its server name, which is both how the Logfire UI groups a long list and
+    how an override tells two servers' `search` tools apart. The name is the code-side one; the model
+    is shown `mcp__<server>__<name>`.
+    """
+    return [
+        ToolDef(
+            name=tool.name,
+            description=tool.description,
+            parameters_json_schema=_build_input_schema(tool),
+            toolset=server,
+        )
+        for server, (_, registered) in _servers(options).items()
+        for tool in registered.tools
+    ]
+
+
+def model_facing_name(server: str, tool: str) -> str:
+    """What the model calls an in-process tool: the name every permission rule is keyed on."""
+    return f'mcp__{server}__{tool}'
+
+
+def rebuild_servers(
+    options: ClaudeAgentOptions, code_tools: list[ToolDef], managed_tools: list[ToolDef]
+) -> dict[str, McpServerConfig] | None:
+    """Rebuild each in-process server whose tools were patched.
+
+    `managed_tools` is what `apply_tool_definitions` returned for `code_tools`, in the same order, so
+    the two zip. A server with no patched tool is left as the exact object the caller built, and a
+    patched server keeps every unpatched tool as its original definition -- rewriting only what a
+    published value actually changed, so nothing else about the wire format can drift.
+
+    Returns the new `mcp_servers` mapping, or `None` when nothing changed.
+    """
+    patches: dict[str, dict[str, ToolDef]] = {}
+    for code_tool, managed_tool in zip(code_tools, managed_tools):
+        if managed_tool != code_tool:
+            assert code_tool.toolset is not None  # Every tool this adapter enumerates names its server.
+            patches.setdefault(code_tool.toolset, {})[code_tool.name] = managed_tool
+    if not patches:
+        return None
+
+    servers: dict[str, McpServerConfig] = dict(options.mcp_servers)  # type: ignore[arg-type]
+    for server, (_, registered) in _servers(options).items():
+        per_tool = patches.get(server)
+        if per_tool is None:
+            continue
+        rebuilt: list[SdkMcpTool[Any]] = []
+        for tool in registered.tools:
+            managed_tool = per_tool.get(tool.name)
+            if managed_tool is None:
+                rebuilt.append(tool)
+                continue
+            rebuilt.append(
+                # The handler is carried over untouched, so a renamed tool reaches the same function
+                # object: the SDK dispatches on the advertised name and the handler is never told one.
+                SdkMcpTool(
+                    name=managed_tool.name,
+                    description=managed_tool.description or '',
+                    input_schema=managed_tool.parameters_json_schema,
+                    handler=tool.handler,
+                    annotations=tool.annotations,
+                )
+            )
+        servers[server] = sdk_mcp_server(server, registered.version, rebuilt)
+    return servers
+
+
+@dataclass(frozen=True)
+class ToolNames:
+    """What a published rename did to the names the model calls, in both directions.
+
+    Everything that refers to an in-process tool from outside its own definition -- a permission
+    rule, a hook matcher, a subagent's tool list, the name a `can_use_tool` or hook callback is
+    handed -- is keyed on `mcp__<server>__<tool>`, the name the *model* calls. A rename that stopped
+    at the definition would leave every one of those pointing at a tool that no longer answers to
+    that name, so the two directions are what the rest of this module rewrites with:
+
+    - `managed` is the way *out*, for a name the code wrote: a permission rule, a matcher, a
+      subagent's `tools` entry, and a rule a permission callback asks to add.
+    - `code` is the way *in*, for a name the CLI hands back: the `tool_name` a callback is called
+      with, and the permission suggestions that come with it.
+    """
+
+    managed: Mapping[str, str]
+    """Code-side model-facing name -> the name the model is shown."""
+    code: Mapping[str, str]
+    """The name the model is shown -> the code-side model-facing name."""
+
+    def __bool__(self) -> bool:
+        """Whether anything was renamed at all."""
+        return bool(self.managed)
+
+
+def tool_names(forward: Mapping[ToolKey, str]) -> ToolNames:
+    """The model-facing renames behind `apply_tool_definitions`'s `(toolset, name) -> advertised` map.
+
+    Built from the core's own mapping rather than re-derived by comparing definitions, so what the
+    permissions, the matchers, and the callbacks are rewritten with is the same decision the tool
+    list was rewritten with -- collisions the core refused included.
+    """
+    managed: dict[str, str] = {}
+    for (toolset, name), advertised in forward.items():
+        assert toolset is not None  # Every tool this adapter enumerates names its server.
+        if advertised != name:
+            managed[model_facing_name(toolset, name)] = model_facing_name(toolset, advertised)
+    return ToolNames(managed=managed, code={new: old for old, new in managed.items()})
+
+
+def rename_permissions(entries: Sequence[str], renames: Mapping[str, str]) -> list[str]:
+    """Rewrite `allowed_tools` / `disallowed_tools` entries that name a renamed tool.
+
+    Permissions are keyed on the name the *model* calls, so a rename that did not reach them would
+    silently un-allow a tool the user allowed. An entry may carry a specifier -- `Bash(rm *)` -- which
+    is kept as written around the rewritten name.
+    """
+    renamed: list[str] = []
+    for entry in entries:
+        name, separator, specifier = entry.partition('(')
+        renamed.append(f'{renames.get(name, name)}{separator}{specifier}')
+    return renamed
+
+
+def _renamed_agents(
+    agents: Mapping[str, AgentDefinition] | None, names: ToolNames
+) -> dict[str, AgentDefinition] | None:
+    """Rewrite the tool references in each subagent's own allow and deny lists.
+
+    A subagent's `tools` list is a permission rule like any other, keyed on the name the model calls.
+    Left alone, a rename would take a tool the subagent was explicitly allowed straight out of its
+    reach -- which is a change to what the agent can do, from an override that only meant to rename.
+    """
+    if not agents:
+        return None
+    renamed = {
+        key: replace(
+            agent,
+            tools=agent.tools if agent.tools is None else rename_permissions(agent.tools, names.managed),
+            disallowedTools=(
+                agent.disallowedTools
+                if agent.disallowedTools is None
+                else rename_permissions(agent.disallowedTools, names.managed)
+            ),
+        )
+        for key, agent in agents.items()
+    }
+    return None if renamed == agents else renamed
+
+
+def _matches(pattern: str, name: str) -> bool:
+    """Whether the CLI's regular-expression matcher `pattern` fires for tool `name`.
+
+    A pattern the `re` module cannot compile matches nothing, which is what it already did before any
+    rename: an unparseable matcher is the user's own bug, and reporting it as a rename this adapter
+    could not preserve would be blaming a published value for it.
+    """
+    try:
+        return re.search(pattern, name) is not None
+    except re.error:
+        return False
+
+
+def _unpreservable(event: HookEvent, pattern: str | None, names: ToolNames) -> list[str]:
+    """The renames a hook matcher stops firing for, which only the user can decide what to do about.
+
+    Exact names and exact `A|B` alternatives are rewritten. What is left is a matcher written as a
+    pattern, and a pattern is not something to edit on a guess -- `mcp__shop__.*` still matches a
+    renamed tool, while `mcp__shop__refund.*` no longer does, and nothing about the two says which
+    one the author meant. So the ones that visibly stopped matching are reported rather than
+    rewritten or passed over: a `PreToolUse` hook that quietly stops running is a permission check
+    that quietly stops happening.
+    """
+    if pattern is None:
+        # A matcher of `None` runs for every tool, which a rename cannot change.
+        return []
+    return [
+        f'Managed agent config renames the tool the model calls {old!r} to {new!r}, but the {event} hook matcher '
+        f'{pattern!r} matches the old name and not the new one. This adapter rewrites exact names only, since '
+        'rewriting a pattern would mean editing a regular expression on a guess; that hook no longer runs for '
+        'that tool.'
+        for old, new in names.managed.items()
+        if _matches(pattern, old) and not _matches(pattern, new)
+    ]
+
+
+def _renamed_matcher(matcher: str | None, names: ToolNames) -> str | None:
+    """Rewrite the alternatives of a hook matcher that name a renamed tool exactly."""
+    if matcher is None:
+        return None
+    return '|'.join(names.managed.get(part, part) for part in matcher.split('|'))
+
+
+def _code_side_input(payload: HookInput, names: ToolNames) -> HookInput:
+    """The hook payload with the tool named the way the code that reads it names it."""
+    fields: dict[str, Any] = dict(payload)
+    code_name = names.code.get(fields.get('tool_name', ''))
+    if code_name is None:
+        return payload
+    return {**fields, 'tool_name': code_name}  # type: ignore[return-value]
+
+
+def _code_side_hook(hook: HookCallback, names: ToolNames, resolution: Resolution) -> HookCallback:
+    """One hook callback, called with the tool's code-side name and inside the resolved config's scope."""
+
+    async def code_side(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+        with resolution.reported():
+            return await hook(_code_side_input(payload, names), tool_use_id, context)
+
+    return code_side
+
+
+def _renamed_update(update: PermissionUpdate, renames: Mapping[str, str]) -> PermissionUpdate:
+    """One permission update with the tool names of its rules translated."""
+    if update.rules is None:
+        return update
+    return replace(
+        update,
+        rules=[replace(rule, tool_name=renames.get(rule.tool_name, rule.tool_name)) for rule in update.rules],
+    )
+
+
+def _code_side_context(context: ToolPermissionContext, names: ToolNames) -> ToolPermissionContext:
+    """The permission context with the CLI's suggested rules named the way the code names them."""
+    suggestions = [_renamed_update(update, names.code) for update in context.suggestions]
+    return context if suggestions == context.suggestions else replace(context, suggestions=suggestions)
+
+
+def _code_side_can_use_tool(can_use_tool: CanUseTool, names: ToolNames, resolution: Resolution) -> CanUseTool:
+    """The permission handler, called with the tool's code-side name and answering in managed ones.
+
+    A handler branching on `tool_name` is the whole point of the callback, so handing it the managed
+    name would make a rename change which branch runs -- from an override that only meant to change
+    what the model is told. It is therefore called with the name the code gave the tool, and the one
+    thing it says back that carries a name -- the permission rules it asks to add -- is translated
+    into the model's names again, because those go to the CLI.
+    """
+
+    async def code_side(tool_name: str, tool_input: dict[str, Any], context: ToolPermissionContext) -> PermissionResult:
+        with resolution.reported():
+            result = await can_use_tool(
+                names.code.get(tool_name, tool_name), tool_input, _code_side_context(context, names)
+            )
+            if isinstance(result, PermissionResultAllow) and result.updated_permissions is not None:
+                return replace(
+                    result,
+                    updated_permissions=[
+                        _renamed_update(update, names.managed) for update in result.updated_permissions
+                    ],
+                )
+            return result
+
+    return code_side
+
+
+def managed_references(
+    options: ClaudeAgentOptions, names: ToolNames, resolution: Resolution
+) -> tuple[dict[str, Any], list[str]]:
+    """Everything on `options` that names a tool, rewritten around a rename.
+
+    Returns the `ClaudeAgentOptions` changes and the messages the caller reports under its
+    `on_unmatched` policy. The callbacks are wrapped whether or not anything was renamed: the
+    wrapper is also what puts the resolved config's label and version on the spans a hook or a
+    permission check emits, which is the only place this adapter gets to re-enter that scope once the
+    options it built have been handed to a session it does not run.
+    """
+    changes: dict[str, Any] = {}
+    unapplied: list[str] = []
+
+    if names:
+        # Permissions and subagent tool lists are keyed on the name the model calls, so a rename that
+        # stopped at the tool definition would quietly un-allow a tool the user allowed.
+        if options.allowed_tools:
+            changes['allowed_tools'] = rename_permissions(options.allowed_tools, names.managed)
+        if options.disallowed_tools:
+            changes['disallowed_tools'] = rename_permissions(options.disallowed_tools, names.managed)
+        prompt_tool = options.permission_prompt_tool_name
+        if prompt_tool is not None and prompt_tool in names.managed:
+            changes['permission_prompt_tool_name'] = names.managed[prompt_tool]
+        agents = _renamed_agents(options.agents, names)
+        if agents is not None:
+            changes['agents'] = agents
+
+    if options.hooks:
+        hooks: dict[HookEvent, list[HookMatcher]] = {}
+        for event, matchers in options.hooks.items():
+            rewritten: list[HookMatcher] = []
+            for matcher in matchers:
+                pattern = _renamed_matcher(matcher.matcher, names)
+                unapplied.extend(_unpreservable(event, pattern, names))
+                rewritten.append(
+                    replace(
+                        matcher,
+                        matcher=pattern,
+                        hooks=[_code_side_hook(hook, names, resolution) for hook in matcher.hooks],
+                    )
+                )
+            hooks[event] = rewritten
+        changes['hooks'] = hooks
+
+    if options.can_use_tool is not None:
+        changes['can_use_tool'] = _code_side_can_use_tool(options.can_use_tool, names, resolution)
+
+    return changes, unapplied

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dspy = ["openinference-instrumentation-dspy >= 0"]
 datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.0.0"]
 variables = ["pydantic>=2", "pydantic-handlebars>=0.2.1"]
 agent-control = ["logfire[variables]", "pydantic>=2.10"]
-agent-control-claude-agent-sdk = ["logfire[agent-control]", "claude-agent-sdk>=0.2"]
+agent-control-claude-agent-sdk = ["logfire[agent-control]", "claude-agent-sdk>=0.2.82"]
 
 [project.urls]
 Homepage = "https://pydantic.dev/logfire"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ dspy = ["openinference-instrumentation-dspy >= 0"]
 datasets = ["httpx>=0.27.2", "pydantic>=2", "pydantic-evals>=1.0.0"]
 variables = ["pydantic>=2", "pydantic-handlebars>=0.2.1"]
 agent-control = ["logfire[variables]", "pydantic>=2.10"]
+agent-control-claude-agent-sdk = ["logfire[agent-control]", "claude-agent-sdk>=0.2"]
 
 [project.urls]
 Homepage = "https://pydantic.dev/logfire"

--- a/tests/agent_control/claude_agent_sdk/agents.py
+++ b/tests/agent_control/claude_agent_sdk/agents.py
@@ -1,0 +1,34 @@
+"""One example agent, built the way a user would, reused across the tests."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, SdkMcpTool, tool
+
+from logfire.agent_control.claude_agent_sdk import sdk_mcp_server
+
+
+@tool('refund_order', 'Refund an order.', {'order_id': Annotated[str, 'The order to refund.']})
+async def refund_order(args: dict[str, Any]) -> dict[str, Any]:
+    return {'content': [{'type': 'text', 'text': f'refunded {args["order_id"]}'}]}
+
+
+@tool('search', 'Search the catalogue.', {'query': str})
+async def search(args: dict[str, Any]) -> dict[str, Any]:
+    return {'content': [{'type': 'text', 'text': f'found {args["query"]}'}]}
+
+
+def checkout_options(**overrides: Any) -> ClaudeAgentOptions:
+    """The agent every test starts from: a custom prompt, a subagent, and two in-process tools."""
+    tools: list[SdkMcpTool[Any]] = [refund_order, search]
+    defaults: dict[str, Any] = dict(
+        system_prompt='You are a concise checkout assistant.',
+        model='claude-fable-5-1',
+        effort='high',
+        agents={'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.')},
+        mcp_servers={'shop': sdk_mcp_server('shop', tools=tools)},
+        allowed_tools=['mcp__shop__refund_order', 'Read(*.py)'],
+    )
+    defaults.update(overrides)
+    return ClaudeAgentOptions(**defaults)

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_max_tokens_reaches_the_cli.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_max_tokens_reaches_the_cli.json
@@ -553,7 +553,7 @@
         "product_feedback_disabled": false,
         "uuid": "0ff054b5-3f6d-43e8-bc5a-717c4c76c2b2",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_published_max_tokens_re0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1908273.sock",
         "fast_mode_state": "off",

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_max_tokens_reaches_the_cli.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_max_tokens_reaches_the_cli.json
@@ -1,0 +1,891 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_477706c6",
+        "request": {
+          "subtype": "initialize",
+          "hooks": null
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_477706c6",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1908273,
+            "current_permission_mode": "default",
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "Write a 200 word essay about bananas."
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write"
+        ],
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "0ff054b5-3f6d-43e8-bc5a-717c4c76c2b2",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_published_max_tokens_re0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1908273.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjBkXQX5JBPV47RMjSy",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EtICCrIBCBEYAipAXL3Lq0jRwrgn61SqSoNoQG7YgMkmUup54PMbyJ2QgEQMqq2cH5BXGeqyCsQl9kK4fmJzsQ7qsDjZ6E3p6QPRcjIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichAE4bdS4hy/szOXBN8yXFnFiAEBqAGs1YfVBrABAhIMBe9hyRWvDqbHCeQhGgxASLbov+z/cwLLTtQiMH4ppHCsiQ9GcNB0vM1XbUDC5zQLqOw4iVDfuC41TXSgUseYeWTpRBtgWJE/LyArmSpN93vVa2nvpKQZG/b4XlOLkHSlOyInrUa6OfnDmg4vkGg7Zb57CAa7eKD7pChQk1xRG2UVrGAMz4WZ93OStEwmRip1Bmtoh06onZadLP4YAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 2711,
+            "cache_read_input_tokens": 11412,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 2711,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "uuid": "0303a87c-6110-4d49-9c02-ecd9f04a1c6f",
+        "timestamp": "2026-09-09T23:24:28.966Z",
+        "request_id": "req_011CetjBjRAoqhwLhPXQYdzP"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjBpyY6kpC8BhL4EGEW",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EtICCrIBCBEYAipAXL3Lq0jRwrgn61SqSoNoQG7YgMkmUup54PMbyJ2QgEQMqq2cH5BXGeqyCsQl9kK4fmJzsQ7qsDjZ6E3p6QPRcjIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichAE4bdS4hy/szOXBN8yXFnFiAEBqAGu1YfVBrABAhIMTA6e/4XxSTBAbwxtGgwyzOYrN4vOduNY1zgiME1XftDC/sdVEkNBdP9n5TRc99MdVLyWj0bS8i1CgTGV5LFhKX2b79fLCSbYot5GTipNObBkl0XKey9mRR11KTNc1iSgx2vsqJup3BX2ZBdcwue/jBUZsPwdjmzmaMkvcnCmVltLK/1vj1Y3nWfb1WsMdvSscc1p/liiQ/49g/UYAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 41,
+            "cache_read_input_tokens": 14123,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 41,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "uuid": "9edf3066-2b0f-4cbb-9743-a673a11d67b4",
+        "timestamp": "2026-09-09T23:24:30.069Z",
+        "request_id": "req_011CetjBpCfBSpKaoBB9uLHk"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjBucbcvukLHotNfy3i",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EtICCrIBCBEYAipAXL3Lq0jRwrgn61SqSoNoQG7YgMkmUup54PMbyJ2QgEQMqq2cH5BXGeqyCsQl9kK4fmJzsQ7qsDjZ6E3p6QPRcjIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichAE4bdS4hy/szOXBN8yXFnFiAEBqAGu1YfVBrABAhIMoBebYEJOXf1Lb5zOGgxd+5jmbgtPngnpSqoiMHDM+BgqBEt+KY57CYQccDd9sEPEbNeJNgb2mfzrAohrrq8Kh4B52KGxB2VbtGoueCpNL2JqPay6FnYLQY+kQwRaiRPUFU3kcu2mSSJSMNMtN+JMHspEp17fkoINRgLKQBf7jiO8UFfahcLJ7/0IP7by9vp2ujteGCzJJjUJhIcYAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 41,
+            "cache_read_input_tokens": 14164,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 41,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "uuid": "d48511ae-208d-4354-82fc-c877b20831f8",
+        "timestamp": "2026-09-09T23:24:30.939Z",
+        "request_id": "req_011CetjBu9KHugg2zTFutopr"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjByLb3MQYQ2f5xqKW2",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EtICCrIBCBEYAipAXL3Lq0jRwrgn61SqSoNoQG7YgMkmUup54PMbyJ2QgEQMqq2cH5BXGeqyCsQl9kK4fmJzsQ7qsDjZ6E3p6QPRcjIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichAE4bdS4hy/szOXBN8yXFnFiAEBqAGv1YfVBrABAhIMOgvCwOf2NIzMh8YSGgxeaXzPETS0zXkIEvMiMFns2Th2vMsyUPF5Qu39ttNN3RJkdT28J1PEKoYT1WeHbw+Z8qcydY48E6Hx5BiAwipNlReImk4UKQZ6LDL6FgfJOyM8zp3yQsUBy0PcsO30uNAXPtbD8GrVpPcDrMQADuze7vkeQ26FMcG8tHTDZF7pgxJ+C+Fd0cQ0fjA9J2sYAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 41,
+            "cache_read_input_tokens": 14205,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 41,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "uuid": "23d8a5ab-a8db-401d-9086-b56a4cd8b0f4",
+        "timestamp": "2026-09-09T23:24:31.721Z",
+        "request_id": "req_011CetjBxrK3NUkfMEFoDtAP"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "diagnostics": null,
+          "id": "2dc275a4-30e6-423a-a1e4-f78e16e9b04c",
+          "container": null,
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "output_tokens_details": null,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "server_tool_use": {
+              "web_search_requests": 0,
+              "web_fetch_requests": 0
+            },
+            "service_tier": null,
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "inference_geo": null,
+            "iterations": null,
+            "speed": null
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "API Error: Claude's response exceeded the 16 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable."
+            }
+          ],
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "uuid": "ccbb8cbf-3470-49a3-9a1f-4e50c71c647e",
+        "timestamp": "2026-09-09T23:24:31.726Z",
+        "error": "max_output_tokens",
+        "is_api_error_message": true,
+        "api_error": "max_output_tokens"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 5223,
+        "stop_reason": "stop_sequence",
+        "session_id": "03b8a59c-6c49-4611-8152-2c15d4179019",
+        "total_cost_usd": 0.0102559,
+        "usage": {
+          "input_tokens": 40,
+          "cache_creation_input_tokens": 2834,
+          "cache_read_input_tokens": 53904,
+          "output_tokens": 64,
+          "output_tokens_details": {
+            "thinking_tokens": 64
+          },
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 2834
+          },
+          "inference_geo": "not_available",
+          "iterations": [
+            {
+              "input_tokens": 10,
+              "output_tokens": 16,
+              "cache_read_input_tokens": 14205,
+              "cache_creation_input_tokens": 41,
+              "cache_creation": {
+                "ephemeral_5m_input_tokens": 41,
+                "ephemeral_1h_input_tokens": 0
+              },
+              "type": "message"
+            }
+          ],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-haiku-4-5": {
+            "inputTokens": 40,
+            "outputTokens": 64,
+            "cacheReadInputTokens": 53904,
+            "cacheCreationInputTokens": 2834,
+            "webSearchRequests": 0,
+            "costUSD": 0.0092929,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 64,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          },
+          "claude-haiku-4-5-20251001": {
+            "inputTokens": 903,
+            "outputTokens": 12,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.0009630000000000001,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 0,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          }
+        },
+        "permission_denials": [],
+        "terminal_reason": "api_error",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": true,
+        "num_turns": 1,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "API Error: Claude's response exceeded the 16 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.",
+        "type": "result",
+        "duration_ms": 3959,
+        "uuid": "a4723519-d7ff-48a9-a3b7-288d69cfc786",
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_prompt_and_effort_are_what_the_session_runs_on.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_prompt_and_effort_are_what_the_session_runs_on.json
@@ -1,0 +1,782 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_e65e9438",
+        "request": {
+          "subtype": "initialize",
+          "hooks": null
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_e65e9438",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1893657,
+            "current_permission_mode": "default",
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "What is 2 + 2?"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write"
+        ],
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "65767685-bd67-48f8-951c-88d640031f8e",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_published_prompt_and_ef0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1893657.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "thinking_tokens",
+        "estimated_tokens": 50,
+        "estimated_tokens_delta": 50,
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "uuid": "a026786b-0ae6-4d0a-a729-77dd9219f04c"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "thinking_tokens",
+        "estimated_tokens": 200,
+        "estimated_tokens_delta": 150,
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "uuid": "ca31f74c-7c25-440f-bf95-876ee3520cdb"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7Lnn9JHZbekj94rqP",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EpkGCrIBCBEYAipAt2ZbqyIKUPAlh8hdt+f/Jxt792ndEZX0m6H30YlEhkOayNxsVelD9JfxUpirupuGNyCPFOZXytER2ohTEONv4zIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichDXLX6tomKWPDAFMUZxok8niAEBqAHy1IfVBrABAhIMOJ07i/98ruZhSUymGgwshymLOt8vkPJBUWoiMNS038L4i0GZWZK/YOfqeZqnjAmBYGhqQY/fW5HSJtL4/DebgFk+waPdfbPXPYTu4yqTBIQU/BPdNH20KzPHxgrarLo1Jy8ieGNykEE4StoDqzU77/VgXrNy8xT2EPJYHFros7VrL8OeqwQ2v4Igl3RVUMUIP4602PM1wPZweQQBOwiN5hCYHnInY3Q30itBV1l/fVonw7o7b+rysBd4Tuw52mLOU9X316xX4WdpRXiD19B6FDsBsJ+bsGnTQ+ffr+kyLZjW5RvnvaOU71koUBlFcpzE6IG4mZQ+S/GACrK/qnP58s3+jNLdJRqyW38IjxoTNDY1Txur52gaHExtuUy0WuPh1z9yUFjUYELaO7J6S5bN1DUtDyelZmsmP3kOguRcDQOtgl08rY1vEHyWewGPzCemNmi1QBhHZpzxY87XwAKYYGse9egt8pGu/ZN9wDb9C4Zuhj3IwSiC03PtRS5dCe/wJK+wLgghQNFtz/zLyU3fZwOAQ/3L37eJKnAHJwiCQ/16vxow5iYxLiiSmY9IPaXv2mY4wzrVEUJyJPi/kkzmKE450u9IzEzTKtBWNKIFpM/lpOuElEGY4Jz8VrUtKuxYZm9qxkI8bnqMWGL0VvEl/10eKKjS+PDmjWtL+d6UVUac2kdRTThULJYO99EvtLV7W5n6dcbknZBANg24szYN09IIRHdhU5CQaN72VCEzvU5ay8IrJteUiRYRtkKeuMjAGSXXOQM6n82/R4tuZF1d8bkwp1Eb/WxClIRxpYbARE5gORgB"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14254,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "uuid": "1b7be9a9-b5c3-4e89-b0cb-eb3b8a18988c",
+        "timestamp": "2026-09-09T23:23:30.291Z",
+        "request_id": "req_011Cetj7L57vQQznmRJoSZMw"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7Lnn9JHZbekj94rqP",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "BANANA"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14254,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 4,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "uuid": "a27660fc-9f84-47c5-ba8a-bfb699237026",
+        "timestamp": "2026-09-09T23:23:30.296Z",
+        "request_id": "req_011Cetj7L57vQQznmRJoSZMw"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 2850,
+        "stop_reason": "end_turn",
+        "session_id": "fb07e8f9-0be7-425e-9727-d7f2e1efdaff",
+        "total_cost_usd": 0.0031214,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 14254,
+          "output_tokens": 146,
+          "output_tokens_details": {
+            "thinking_tokens": 139
+          },
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "inference_geo": "not_available",
+          "iterations": [
+            {
+              "input_tokens": 10,
+              "output_tokens": 146,
+              "cache_read_input_tokens": 14254,
+              "cache_creation_input_tokens": 0,
+              "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0
+              },
+              "type": "message"
+            }
+          ],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "inputTokens": 901,
+            "outputTokens": 11,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.000956,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 0,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          },
+          "claude-haiku-4-5": {
+            "inputTokens": 10,
+            "outputTokens": 146,
+            "cacheReadInputTokens": 14254,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.0021654,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 139,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          }
+        },
+        "permission_denials": [],
+        "terminal_reason": "completed",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": false,
+        "num_turns": 1,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "BANANA",
+        "ttft_ms": 2217,
+        "type": "result",
+        "duration_ms": 2242,
+        "uuid": "0e2ece3f-e900-4551-8a29-27afce0bcbc9",
+        "ttft_stream_ms": 795,
+        "time_to_request_ms": 46,
+        "first_content_frame_ms": 1094,
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_prompt_and_effort_are_what_the_session_runs_on.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_prompt_and_effort_are_what_the_session_runs_on.json
@@ -553,7 +553,7 @@
         "product_feedback_disabled": false,
         "uuid": "65767685-bd67-48f8-951c-88d640031f8e",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_published_prompt_and_ef0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1893657.sock",
         "fast_mode_state": "off",

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_timeout_reaches_the_cli.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_timeout_reaches_the_cli.json
@@ -553,7 +553,7 @@
         "product_feedback_disabled": false,
         "uuid": "9d78d79b-da74-454c-90f9-03e121bf7225",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5052/test_a_published_timeout_reach0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1940450.sock",
         "fast_mode_state": "off",

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_timeout_reaches_the_cli.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_published_timeout_reaches_the_cli.json
@@ -1,0 +1,821 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_cf2a3d23",
+        "request": {
+          "subtype": "initialize",
+          "hooks": null
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_cf2a3d23",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1940450,
+            "current_permission_mode": "default",
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "Reply with only: OK"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write"
+        ],
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "9d78d79b-da74-454c-90f9-03e121bf7225",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5052/test_a_published_timeout_reach0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1940450.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 1,
+        "max_retries": 10,
+        "retry_delay_ms": 531,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "1f6cbd5b-b1ed-4572-82dc-8fff2017fefb"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 2,
+        "max_retries": 10,
+        "retry_delay_ms": 1163,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "174b9e53-03ef-429d-9f63-96141811e6f8"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 3,
+        "max_retries": 10,
+        "retry_delay_ms": 2187,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "f5284b77-a966-44a6-955c-f6ec47941907"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 4,
+        "max_retries": 10,
+        "retry_delay_ms": 4199,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "874dbcc9-cfc2-42f0-b246-17bc228b4961"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 5,
+        "max_retries": 10,
+        "retry_delay_ms": 8276,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "43224da1-2a3a-443f-8bd2-74aafad2e70d"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 6,
+        "max_retries": 10,
+        "retry_delay_ms": 18738,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "80766d32-3c3e-4f67-9b36-a1479a05a91b"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 7,
+        "max_retries": 10,
+        "retry_delay_ms": 38337,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "4ccb8109-ea0c-4630-bcbd-d22588fe36a4"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 8,
+        "max_retries": 10,
+        "retry_delay_ms": 36657,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "a934d1d2-1628-43cd-8b9c-7d88838c625a"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 9,
+        "max_retries": 10,
+        "retry_delay_ms": 33518,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "d234b383-7f13-4f3c-86b0-833e88bc1201"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "api_retry",
+        "attempt": 10,
+        "max_retries": 10,
+        "retry_delay_ms": 38188,
+        "error_status": null,
+        "error": "unknown",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "ecbe4b08-5185-4874-b21d-479be3ea88f8"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "diagnostics": null,
+          "id": "db1770c2-21bd-4aef-a58d-bea259dc26c3",
+          "container": null,
+          "model": "<synthetic>",
+          "role": "assistant",
+          "stop_details": null,
+          "stop_reason": "stop_sequence",
+          "stop_sequence": "",
+          "type": "message",
+          "usage": {
+            "output_tokens_details": null,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+            "server_tool_use": {
+              "web_search_requests": 0,
+              "web_fetch_requests": 0
+            },
+            "service_tier": null,
+            "cache_creation": {
+              "ephemeral_1h_input_tokens": 0,
+              "ephemeral_5m_input_tokens": 0
+            },
+            "inference_geo": null,
+            "iterations": null,
+            "speed": null
+          },
+          "content": [
+            {
+              "type": "text",
+              "text": "Request timed out"
+            }
+          ],
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "uuid": "d33e5105-79c0-4349-bfe0-1ba8ea51a476",
+        "timestamp": "2026-09-09T23:27:57.349Z",
+        "error": "server_error",
+        "is_api_error_message": true
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 0,
+        "stop_reason": "stop_sequence",
+        "session_id": "9ec38428-0c13-482b-b78e-7425e2c95718",
+        "total_cost_usd": 0,
+        "usage": {
+          "output_tokens_details": {
+            "thinking_tokens": 0
+          },
+          "input_tokens": 0,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 0,
+          "output_tokens": 0,
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "inference_geo": "",
+          "iterations": [],
+          "speed": "standard"
+        },
+        "modelUsage": {},
+        "permission_denials": [],
+        "terminal_reason": "api_error",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": true,
+        "num_turns": 1,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "Request timed out",
+        "type": "result",
+        "duration_ms": 181923,
+        "uuid": "c0d0659b-e3a5-4112-9461-19d8b1c8f4e6",
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_code.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_code.json
@@ -1,0 +1,1316 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_b925fc9e",
+        "request": {
+          "subtype": "initialize",
+          "hooks": {
+            "PreToolUse": [
+              {
+                "matcher": "mcp__shop__issue_refund",
+                "hookCallbackIds": [
+                  "hook_0"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_request",
+        "request_id": "92f5b5b1-18bd-48e4-98e3-f3f2f4a77035",
+        "request": {
+          "subtype": "mcp_message",
+          "server_name": "shop",
+          "message": {
+            "method": "initialize",
+            "params": {
+              "protocolVersion": "2025-11-25",
+              "capabilities": {},
+              "clientInfo": {
+                "name": "claude-code",
+                "title": "Claude Code",
+                "description": "Anthropic's agentic coding tool",
+                "websiteUrl": "https://claude.com/claude-code",
+                "version": "2.1.267"
+              }
+            },
+            "jsonrpc": "2.0",
+            "id": 0
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "92f5b5b1-18bd-48e4-98e3-f3f2f4a77035",
+          "response": {
+            "mcp_response": {
+              "jsonrpc": "2.0",
+              "id": 0,
+              "result": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {
+                  "experimental": {},
+                  "tools": {
+                    "listChanged": false
+                  }
+                },
+                "serverInfo": {
+                  "name": "shop",
+                  "version": "1.0.0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_b925fc9e",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1895863,
+            "current_permission_mode": "default",
+            "hooks_applied": true,
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "Refund order A-1234, then reply DONE."
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_request",
+        "request_id": "ef3b011f-edef-4a77-88a8-69f38659996f",
+        "request": {
+          "subtype": "mcp_message",
+          "server_name": "shop",
+          "message": {
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "ef3b011f-edef-4a77-88a8-69f38659996f",
+          "response": {
+            "mcp_response": {
+              "jsonrpc": "2.0",
+              "result": {}
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_request",
+        "request_id": "e40748cc-ae07-4c96-852a-f8392225b3cf",
+        "request": {
+          "subtype": "mcp_message",
+          "server_name": "shop",
+          "message": {
+            "method": "tools/list",
+            "jsonrpc": "2.0",
+            "id": 1
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "e40748cc-ae07-4c96-852a-f8392225b3cf",
+          "response": {
+            "mcp_response": {
+              "jsonrpc": "2.0",
+              "id": 1,
+              "result": {
+                "tools": [
+                  {
+                    "name": "issue_refund",
+                    "description": "Issue a refund for one order. Use this whenever a refund is requested.",
+                    "inputSchema": {
+                      "type": "object",
+                      "properties": {
+                        "order_id": {
+                          "type": "string",
+                          "description": "The order's id, e.g. 'A-1234'."
+                        }
+                      },
+                      "required": [
+                        "order_id"
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write",
+          "mcp__shop__issue_refund"
+        ],
+        "mcp_servers": [
+          {
+            "name": "shop",
+            "status": "connected"
+          }
+        ],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "045c9d06-eeba-43de-a48d-0a6644f5c26c",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_renamed_tool_is_called_0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1895863.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "thinking_tokens",
+        "estimated_tokens": 50,
+        "estimated_tokens_delta": 50,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "e942982d-b7fe-42d6-b542-8d2a33d5a079"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "thinking_tokens",
+        "estimated_tokens": 155,
+        "estimated_tokens_delta": 105,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "6e2a003d-0f70-41ca-b9c0-b4b23613e988"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7dEVK59wAn2RwJaTt",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EuUECrIBCBEYAipAjHMl29YE9UqSMldGd0zajh1U0itB/4aa60MZpVTPkblqJGqZ8nXOELhYQCylXr+Cs8wpE1kD0p+WhQPTh24/4jIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichCXogzBpBt2rXC3NuX2ICCxiAEBqAH11IfVBrABAhIMkaWCKO45ke+PVOp6GgyZ0fqE3EfZUE8VH2oiMKDY+2s2NLRNJsWM4Z2tnNhwq1ePNqltU4qoL7PFI3V91c0gcCoc/rCIDElwXmWFXSrfAmzuNiD8/sUI4nl31xfiHRjEqx5h9wK9zJkhZJxgy3SRiZ/F9P1PBiO0NZFukax0y4u5AZG1LioS+ppFfgY/Ck4yBo5XhC53Hsxz/sg2RNg6wwFZEU9nXAd7sfq3L2/CL3am0sIgs+hIi5BxXA8Ug3nqqyM0ySLY7qTHQ4sJQGnBVNcHrQfr9UgPiAvqs11hrD/473n0fNxLJW2OCKW/SqsDOpclRhMWAXWj3cI6/49x55OJ8Ic6GxJ569Y9Qgi+9E5Yrib4gDVWAU0fkVxiTAp7LZjFeOsirOwO1o7rUQlL2rX4dvl8px6pH9NL7AHJJdnBWV6f9pkM6WC4XqJeuzkjh0cZhe2RlIwIbwnVnCMBtxRE/b1S5yR1cDcSivnLs53qvLor5bXItGzbiNva8uybQ0oqX82XFUa3tv4c9Xq4MEhuBoTI0SjUT5UL/+V3Hw/KhuzUmLOBn7WD05mMrRgB"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14144,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "7277ce75-278e-4330-9bf2-91ddd57875d0",
+        "timestamp": "2026-09-09T23:23:33.829Z",
+        "request_id": "req_011Cetj7ckU2quXrDnLtMU6i"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7dEVK59wAn2RwJaTt",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "I'll load the refund tool schema and process the refund for order A-1234."
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14144,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "e5565783-0a69-40a8-bf49-28c5ccbb03e0",
+        "timestamp": "2026-09-09T23:23:34.179Z",
+        "request_id": "req_011Cetj7ckU2quXrDnLtMU6i"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7dEVK59wAn2RwJaTt",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "toolu_01A7s7Xg6ju737okSvcMAKpg",
+              "name": "ToolSearch",
+              "input": {
+                "query": "select:mcp__shop__issue_refund",
+                "max_results": 1
+              },
+              "caller": {
+                "type": "direct"
+              }
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14144,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "84f75efe-b140-411e-bb58-14988273b567",
+        "timestamp": "2026-09-09T23:23:34.711Z",
+        "request_id": "req_011Cetj7ckU2quXrDnLtMU6i"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": [
+            {
+              "type": "tool_result",
+              "tool_use_id": "toolu_01A7s7Xg6ju737okSvcMAKpg",
+              "content": [
+                {
+                  "type": "tool_reference",
+                  "tool_name": "mcp__shop__issue_refund"
+                }
+              ]
+            }
+          ]
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "44c91ddf-9772-488b-bad8-efd621683eaa",
+        "timestamp": "2026-09-09T23:23:34.718Z",
+        "tool_use_result": {
+          "matches": [
+            "mcp__shop__issue_refund"
+          ],
+          "query": "select:mcp__shop__issue_refund",
+          "total_deferred_tools": 19
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7qAaw9vGkyXPy9MGG",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EvwCCrIBCBEYAipAwn6519RB2KAPGzv1cczdzJ29BCOj3Gg6ftynmOAcS/Kkxrz1B01arTR+lpYmzBJ8DhGXbeJUss4oiC2OsbYawTIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichCXogzBpBt2rXC3NuX2ICCxiAEBqAH41IfVBrABAhIM8ha+nugMJQXDwSbbGgypzIF9PkWKpTt8+TEiMGNtGjt87EgHsyNOn12MVESMeSXdVPlAW5zwuwBk3MYDJwPNWZwqlF4/s+8hH0waGCp3pOVDgNlC8UFbIaIdtxHi25R1LPACxPsZ7m7AQYQSkEuUzfnnbM1WOxjkX1jSwjvJdzq7ZrkG+azl1ySgVM8X6qFdpQKwIGMX+ioMkKnYMcCZr+exzJv57T+6P/XSu1BbhMnaWkAs//nSryhsORAfNZCgou4ip30YAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 367,
+            "cache_read_input_tokens": 14144,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 367,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 1,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "4784b7b7-e172-4b58-9704-709b155765c8",
+        "timestamp": "2026-09-09T23:23:36.422Z",
+        "request_id": "req_011Cetj7pYP1cbcZ4PqVNoAd"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7qAaw9vGkyXPy9MGG",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "tool_use",
+              "id": "toolu_019j6tsDXJR1n3Ab5kbAMniT",
+              "name": "mcp__shop__issue_refund",
+              "input": {
+                "order_id": "A-1234"
+              },
+              "caller": {
+                "type": "direct"
+              }
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 367,
+            "cache_read_input_tokens": 14144,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 367,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 1,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "d698ed51-4e88-4577-8e6e-82f85b9b9316",
+        "timestamp": "2026-09-09T23:23:36.521Z",
+        "request_id": "req_011Cetj7pYP1cbcZ4PqVNoAd",
+        "tool_use_meta": [
+          {
+            "id": "toolu_019j6tsDXJR1n3Ab5kbAMniT",
+            "display_name": "Issue Refund",
+            "server_display_name": "shop"
+          }
+        ]
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_request",
+        "request_id": "c47d9c5c-8fd9-4097-87ce-f79c3736dae7",
+        "request": {
+          "subtype": "hook_callback",
+          "callback_id": "hook_0",
+          "input": {
+            "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+            "transcript_path": "/tmp/pytest-of-user/pytest-5048/test_a_renamed_tool_is_called_0/projects/-agent/50deb978-8a97-4642-9c9f-2626c29d90de.jsonl",
+            "cwd": "/agent",
+            "prompt_id": "933482cd-37ed-4deb-94d0-bf310e1c2f76",
+            "permission_mode": "default",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "mcp__shop__issue_refund",
+            "tool_input": {
+              "order_id": "A-1234"
+            },
+            "tool_use_id": "toolu_019j6tsDXJR1n3Ab5kbAMniT"
+          },
+          "tool_use_id": "toolu_019j6tsDXJR1n3Ab5kbAMniT"
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "c47d9c5c-8fd9-4097-87ce-f79c3736dae7",
+          "response": {}
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_request",
+        "request_id": "f761ad85-1c69-4f79-a153-966b5f207e5e",
+        "request": {
+          "subtype": "mcp_message",
+          "server_name": "shop",
+          "message": {
+            "method": "tools/call",
+            "params": {
+              "name": "issue_refund",
+              "arguments": {
+                "order_id": "A-1234"
+              },
+              "_meta": {
+                "claudecode/toolUseId": "toolu_019j6tsDXJR1n3Ab5kbAMniT",
+                "progressToken": 2
+              }
+            },
+            "jsonrpc": "2.0",
+            "id": 2
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "f761ad85-1c69-4f79-a153-966b5f207e5e",
+          "response": {
+            "mcp_response": {
+              "jsonrpc": "2.0",
+              "id": 2,
+              "result": {
+                "content": [
+                  {
+                    "type": "text",
+                    "text": "Refunded A-1234."
+                  }
+                ],
+                "isError": false
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": [
+            {
+              "tool_use_id": "toolu_019j6tsDXJR1n3Ab5kbAMniT",
+              "type": "tool_result",
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Refunded A-1234."
+                }
+              ]
+            }
+          ]
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "d67aac96-9b34-43e6-8ddc-9bc95c066075",
+        "timestamp": "2026-09-09T23:23:36.534Z",
+        "tool_use_result": [
+          {
+            "type": "text",
+            "text": "Refunded A-1234."
+          }
+        ]
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7xeYkWRfNf4RZH8CV",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EokDCrIBCBEYAipAqhmKrq0aztvVThkgD8eKFPSL3VX12IZ8n26D1DZwXLa67L8g9N0o3t3UUIyNRZzTj17OjnXEeWgFW2QKmDi60TIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichCXogzBpBt2rXC3NuX2ICCxiAEBqAH51IfVBrABAhIMXtcPkN46Zlaq688yGgx864F/hf2zGVCQs40iMH9hgKn1Ekywqn5wr0heveCYWtw+YkgQqsxNW60Sp9iKBxkxWAZRihWus3LFCGkG8SqDAcXQdEpMBxkzKUE55A79qiaX+Xn4m0IyOs19n/DBv6//aiADw2+gRSK0ZfcS1SZtFj/R8qKWjJ0qlWXylWJl70HXWvjDnJ3B4OHpluUdg2FGkWFrDW4cBkOPfxAIsOvGg0OCwjzdtOzI6/ixAzMFdO30VZSN/io39ljLilNSY0+bHbSFGAE="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 164,
+            "cache_read_input_tokens": 14511,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 164,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 2,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "c6d2057c-d051-46ba-8134-d053c069545b",
+        "timestamp": "2026-09-09T23:23:37.839Z",
+        "request_id": "req_011Cetj7wzbtKTxSNhwXPQUb"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj7xeYkWRfNf4RZH8CV",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "DONE."
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 164,
+            "cache_read_input_tokens": 14511,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 164,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 2,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "uuid": "85d2470a-4fa7-42f3-bc93-98036cd2011d",
+        "timestamp": "2026-09-09T23:23:37.849Z",
+        "request_id": "req_011Cetj7wzbtKTxSNhwXPQUb"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 7129,
+        "stop_reason": "end_turn",
+        "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
+        "total_cost_usd": 0.0077446500000000005,
+        "usage": {
+          "input_tokens": 30,
+          "cache_creation_input_tokens": 531,
+          "cache_read_input_tokens": 42799,
+          "output_tokens": 357,
+          "output_tokens_details": {
+            "thinking_tokens": 176
+          },
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 531
+          },
+          "inference_geo": "not_available",
+          "iterations": [
+            {
+              "input_tokens": 10,
+              "output_tokens": 43,
+              "cache_read_input_tokens": 14511,
+              "cache_creation_input_tokens": 164,
+              "cache_creation": {
+                "ephemeral_5m_input_tokens": 164,
+                "ephemeral_1h_input_tokens": 0
+              },
+              "type": "message"
+            }
+          ],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "inputTokens": 906,
+            "outputTokens": 16,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.000986,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 0,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          },
+          "claude-haiku-4-5": {
+            "inputTokens": 30,
+            "outputTokens": 357,
+            "cacheReadInputTokens": 42799,
+            "cacheCreationInputTokens": 531,
+            "webSearchRequests": 0,
+            "costUSD": 0.006758650000000001,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 176,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          }
+        },
+        "permission_denials": [],
+        "terminal_reason": "completed",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": false,
+        "num_turns": 3,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "DONE.",
+        "ttft_ms": 1835,
+        "type": "result",
+        "duration_ms": 5889,
+        "uuid": "78575bd9-189b-4882-9451-d0f827d85353",
+        "ttft_stream_ms": 672,
+        "time_to_request_ms": 32,
+        "first_content_frame_ms": 914,
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_code.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_code.json
@@ -708,7 +708,7 @@
         "product_feedback_disabled": false,
         "uuid": "045c9d06-eeba-43de-a48d-0a6644f5c26c",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_renamed_tool_is_called_0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1895863.sock",
         "fast_mode_state": "off",
@@ -1008,7 +1008,7 @@
           "callback_id": "hook_0",
           "input": {
             "session_id": "50deb978-8a97-4642-9c9f-2626c29d90de",
-            "transcript_path": "/tmp/pytest-of-user/pytest-5048/test_a_renamed_tool_is_called_0/projects/-agent/50deb978-8a97-4642-9c9f-2626c29d90de.jsonl",
+            "transcript_path": "/config/projects/-agent/50deb978-8a97-4642-9c9f-2626c29d90de.jsonl",
             "cwd": "/agent",
             "prompt_id": "933482cd-37ed-4deb-94d0-bf310e1c2f76",
             "permission_mode": "default",

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_subagent_whose_block_was_removed_is_still_in_the_session.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_subagent_whose_block_was_removed_is_still_in_the_session.json
@@ -1,0 +1,757 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_9e8292b6",
+        "request": {
+          "subtype": "initialize",
+          "hooks": null,
+          "agents": {
+            "reviewer": {
+              "description": "Reviews refunds.",
+              "prompt": "You review refunds."
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_9e8292b6",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "reviewer",
+                "description": "Reviews refunds."
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1902612,
+            "current_permission_mode": "default",
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "Reply with only: OK"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "cf13211a-0630-4e2d-83b7-9a887fd00886",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write"
+        ],
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "reviewer",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "bbda3242-330f-4dd8-9f52-dfe45349b745",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_subagent_whose_block_wa0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1902612.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjBaSvjML377m9ZTmcr",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EogDCrIBCBEYAipAYVsOfgpYB2I4rvB7PrEet0wEOZKHjCJ+GUfY5lW9lWUweCc9prFnB6qzdaeQ/IvFz+b9mdWutkL5GAytN1YA4DIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichDg4cWzSUqBQfV27TzBvcneiAEBqAGq1YfVBrABAhIMsBYJmiIWKhMhHlusGgzlRop1xg7IVZZREskiMHuaOdTPXE00Up3v4rxPaWMVCTWBqDD0/9rGeAmJC3aNxRHlo4hgC+rzEIVpujVGkiqCAVQIWJVl58IAwKkHaX0I9c8fTd6K52E6hsxj8RRxuuC/GvOQl/wtwzrw/jNbqwvi13dyyN9ATkp3a2N/u7U5Z/s5zpNktRCd9ehHcT4ztjCxDtB6tAZBbbpK1gZApM9D5IzozgvKhFhZnZs+/+B5qXJcbOsPWSD5P7OwLNaC7Wv/up0YAQ=="
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14261,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "cf13211a-0630-4e2d-83b7-9a887fd00886",
+        "uuid": "51606ca7-a119-4e5e-ba0d-bc052e19a09e",
+        "timestamp": "2026-09-09T23:24:26.583Z",
+        "request_id": "req_011CetjBZqxMmBAjd5eEaUUj"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011CetjBaSvjML377m9ZTmcr",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "OK"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14261,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "cf13211a-0630-4e2d-83b7-9a887fd00886",
+        "uuid": "60c094d9-c11e-4cb1-84a7-6b7bc0bb0e28",
+        "timestamp": "2026-09-09T23:24:26.602Z",
+        "request_id": "req_011CetjBZqxMmBAjd5eEaUUj"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 1020,
+        "stop_reason": "end_turn",
+        "session_id": "cf13211a-0630-4e2d-83b7-9a887fd00886",
+        "total_cost_usd": 0.0016211,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 14261,
+          "output_tokens": 37,
+          "output_tokens_details": {
+            "thinking_tokens": 30
+          },
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "inference_geo": "not_available",
+          "iterations": [
+            {
+              "input_tokens": 10,
+              "output_tokens": 37,
+              "cache_read_input_tokens": 14261,
+              "cache_creation_input_tokens": 0,
+              "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0
+              },
+              "type": "message"
+            }
+          ],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-haiku-4-5": {
+            "inputTokens": 10,
+            "outputTokens": 37,
+            "cacheReadInputTokens": 14261,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.0016211,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 30,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          }
+        },
+        "permission_denials": [],
+        "terminal_reason": "completed",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": false,
+        "num_turns": 1,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "OK",
+        "ttft_ms": 1114,
+        "type": "result",
+        "duration_ms": 1161,
+        "uuid": "6761d4ec-44e3-4f89-9fa5-9c33b25cf3b0",
+        "ttft_stream_ms": 967,
+        "time_to_request_ms": 138,
+        "first_content_frame_ms": 1076,
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_a_subagent_whose_block_was_removed_is_still_in_the_session.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_a_subagent_whose_block_was_removed_is_still_in_the_session.json
@@ -564,7 +564,7 @@
         "product_feedback_disabled": false,
         "uuid": "bbda3242-330f-4dd8-9f52-dfe45349b745",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5048/test_a_subagent_whose_block_wa0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1902612.sock",
         "fast_mode_state": "off",

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_the_cli_leaves_out_a_subagent_with_no_prompt.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_the_cli_leaves_out_a_subagent_with_no_prompt.json
@@ -1,0 +1,766 @@
+{
+  "metadata": {
+    "cli_version": "2.1.267 (Claude Code)"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_620667b9",
+        "request": {
+          "subtype": "initialize",
+          "hooks": null,
+          "agents": {
+            "reviewer": {
+              "description": "Reviews refunds.",
+              "prompt": ""
+            }
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_620667b9",
+          "response": {
+            "commands": [
+              {
+                "name": "deep-research",
+                "description": "Deep research harness \u2014 fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. (dynamic workflow)",
+                "argumentHint": ""
+              },
+              {
+                "name": "design",
+                "description": "Grant or revoke Claude agent access to your Design projects",
+                "argumentHint": "consent | revoke"
+              },
+              {
+                "name": "design-sync",
+                "description": "Push a React design system to claude.ai/design. This runs a converter that bundles the real component code (from Storybook or a bare package) and uploads it. Use when the user runs /design-sync or says \"sync my design system to Claude Design\".",
+                "argumentHint": "[<project hint, e.g. \"Acme DS\">]"
+              },
+              {
+                "name": "dataviz",
+                "description": "Use this skill whenever you are about to create ANY chart, graph, plot, dashboard, or data visualization, in ANY output medium \u2014 an HTML or React artifact, inline SVG, plotting code in any library (matplotlib, plotly, d3, Recharts, \u2026), an image/PNG you will render and upload, or a chart shared into Slack. Read it BEFORE writing the first line of chart code, choosing chart colors, building a stat tile / meter / KPI row, or laying out a dashboard. When the destination is a first-party document connector (host-designated, never self-described) that renders live charts, hand it the rows (inline, or as an uploaded data file the chart cites) rather than a rendered PNG/SVG \u2014 a picture of a chart loses hover, data inspection and per-value comments. Produces visualizations that read as one system \u2014 elegant, accessible, consistent in light and dark \u2014 using a brand-neutral placeholder palette you swap for your own. Teaches a design-system-agnostic method: a form heuristic, a color formula with a runnable validator, mark specs, and interaction rules. A validated default palette is documented in `references/palette.md` \u2014 swap that file's values for your brand's. Triggers on: \"chart\", \"graph\", \"plot\", \"data viz\", \"visualization\", \"dashboard\", \"analytics\", \"visualize data\", \"categorical colors\", \"sequential / diverging palette\", \"stat tile\", \"sparkline\", \"heatmap\", \"legend\", \"axis\", \"tooltip\", \"chart colors\", \"color by series\".",
+                "argumentHint": ""
+              },
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, suggest the /config command.",
+                "argumentHint": ""
+              },
+              {
+                "name": "verify",
+                "description": "Verify that a code change actually does what it's supposed to by exercising it end-to-end and observing behavior \u2014 drive the affected flow, not just tests or typecheck. Run before committing nontrivial changes; bootstraps this repo's project verify skill if none exists yet. Don't invoke it on a diff that only touches tests, docs, or other code with no runtime surface to drive (a change to product source always has one) \u2014 there's nothing to observe.",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "code-review",
+                "description": "Review the current diff, or a PR number/branch/path target, for correctness bugs and reuse/simplification/efficiency cleanups at the given effort level (low/medium: fewer, high-confidence findings; high\u2192max: broader coverage, may include uncertain findings); with no level given, it reuses the level you typed last. Pass --comment to post findings as inline PR comments, or --fix to apply the findings to the working tree after the review.",
+                "argumentHint": "[low|medium|high|xhigh|max] [--fix] [--comment] [<pr#>|<branch>|<path>]",
+                "aliases": [
+                  "review"
+                ]
+              },
+              {
+                "name": "simplify",
+                "description": "Review the changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only \u2014 it does not hunt for bugs; use /code-review for that.",
+                "argumentHint": "[<target>]"
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR.",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "fewer-permission-prompts",
+                "description": "Scan your transcripts for common read-only Bash and MCP tool calls, then add a prioritized allowlist to project .claude/settings.json to reduce permission prompts.",
+                "argumentHint": ""
+              },
+              {
+                "name": "doctor",
+                "description": "Health-check the user's Claude Code setup and fix issues: diagnose installation health \u2014 what the `claude doctor` terminal diagnostics cover \u2014 from local data (duplicate or leftover installs, PATH, unparseable settings files, broken or colliding agent definitions, skills whose frontmatter fails to parse); find unused skills, MCP servers, and plugins versus their context cost and disable dead weight; deduplicate local CLAUDE.md files against checked-in ones; trim checked-in CLAUDE.md files by cutting content a session could derive from the codebase (directory layouts, tech-stack lists, architecture overviews) while keeping gotchas, rationale, and non-standard conventions; migrate always-loaded CLAUDE.md guidance into lazy skills and nested CLAUDE.md files; flag slow hooks and context-heavy extensions; check the installed version is current; make auto mode the default permission mode; and pre-approve frequently denied read-only commands. Use when the user asks for a doctor run, checkup, audit, tune-up, or cleanup of their Claude Code setup or configuration.",
+                "argumentHint": "",
+                "aliases": [
+                  "checkup"
+                ]
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the interval to let the model self-pace.",
+                "argumentHint": "[interval] [prompt]",
+                "aliases": [
+                  "proactive"
+                ]
+              },
+              {
+                "name": "claude-api",
+                "description": "Reference for the Claude API / Anthropic SDK \u2014 model ids, pricing, params, streaming, tool use, MCP, agents, caching, token counting, model migration.\nTRIGGER \u2014 read BEFORE opening the target file; don't skip because it \"looks like a one-liner\" \u2014 whenever: the prompt names Claude/Anthropic in any form (Claude, Anthropic, Fable, Opus, Sonnet, Haiku, `anthropic`, `@anthropic-ai`, `claude-*`, `us.anthropic.*`, `[1m]`); the user asks about an LLM (pricing/model choice/limits/caching) \u2014 never answer from memory; OR the task is LLM-shaped with provider unstated (agent/MCP/tool-definition/multi-agent/RAG/LLM-judge/computer-use; generate/summarize/extract/classify/rewrite/converse over NL; debugging refusals/cutoffs/streaming/tool-calls/tokens).\nSKIP only when another provider is being worked on (overrides all triggers): OpenAI/GPT/Gemini/Llama/Mistral/Cohere/Ollama named in the query; OR `grep -rE 'openai|langchain_openai|google.generativeai|genai|mistralai|cohere|ollama'` over the project hits (run this grep FIRST if no provider named \u2014 don't Read the file).",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-authoring",
+                "description": "Reference for writing a Workflow tool script (script API and gotchas, resume, quality patterns, worked examples). Load before authoring a script for a workflow the user already opted into; it does not itself authorize running one.",
+                "argumentHint": ""
+              },
+              {
+                "name": "run",
+                "description": "Launch and drive this project's app to see a change working. Use when asked to run, start, or screenshot the app, or to confirm a change works in the real app (not just tests). First looks for a project skill that already covers launching the app; otherwise falls back to built-in patterns per project type (CLI, server, TUI, Electron, browser-driven, library).",
+                "argumentHint": ""
+              },
+              {
+                "name": "run-skill-generator",
+                "description": "Author or improve the run-<unit> skill - a per-project skill that tells agents how to build, launch, and drive this project's app. Use when the user asks to set up the project, get it running, write run instructions, or verify build/run steps work from a clean environment.",
+                "argumentHint": ""
+              },
+              {
+                "name": "advisor",
+                "description": "Let Claude consult a stronger model at key moments",
+                "argumentHint": "[fable|opus|sonnet|off]"
+              },
+              {
+                "name": "agents",
+                "description": "(removed) Ask Claude to create/manage subagents, or edit .claude/agents/",
+                "argumentHint": ""
+              },
+              {
+                "name": "auto-mode-setup",
+                "description": "Teach auto mode about your environment, plus optional rule tweaks",
+                "argumentHint": "[--request-id <uuid>] (--wizard posture=\u2026 scope=\u2026 depth=\u2026 --propose | --expect-sha256 <64-hex> --apply-file <path>)"
+              },
+              {
+                "name": "autocompact",
+                "description": "Configure the auto-compact window size",
+                "argumentHint": "[auto|<tokens>]"
+              },
+              {
+                "name": "clear",
+                "description": "Start a new session with empty context; previous session stays on disk (resumable with /resume)",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "reset",
+                  "new"
+                ]
+              },
+              {
+                "name": "color",
+                "description": "Set the prompt bar color for this session",
+                "argumentHint": "[red|blue|green|yellow|purple|orange|pink|cyan|default]"
+              },
+              {
+                "name": "compact",
+                "description": "Free up context by summarizing the conversation so far",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "config",
+                "description": "Set a setting by key",
+                "argumentHint": "key=value",
+                "aliases": [
+                  "settings"
+                ]
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "effort",
+                "description": "Set effort level for model usage",
+                "argumentHint": "<low|medium|high|xhigh|max|auto>"
+              },
+              {
+                "name": "fast",
+                "description": "Toggle fast mode (Opus 5)",
+                "argumentHint": "[on|off]"
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "mcp",
+                "description": "Manage MCP servers",
+                "argumentHint": "[reconnect|enable|disable [<server>|all]]"
+              },
+              {
+                "name": "import",
+                "description": "Import config from another AI coding agent",
+                "argumentHint": ""
+              },
+              {
+                "name": "model",
+                "description": "Set the AI model for Claude Code",
+                "argumentHint": "<model>"
+              },
+              {
+                "name": "__remote-workflow",
+                "description": "Run the workflow script delivered in this session environment (server-launched sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "workflow-launch-exec",
+                "description": "Execute a server-launched workflow handoff (workflow_launch event sessions only)",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": "[--force]"
+              },
+              {
+                "name": "reload-skills",
+                "description": "Pick up skills added or changed on disk during this session",
+                "argumentHint": ""
+              },
+              {
+                "name": "rename",
+                "description": "Rename the current conversation",
+                "argumentHint": "[name]",
+                "aliases": [
+                  "name"
+                ]
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "usage",
+                "description": "Show session cost, plan usage, and what's contributing to your limits",
+                "argumentHint": "",
+                "aliases": [
+                  "cost",
+                  "stats"
+                ]
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              },
+              {
+                "name": "recap",
+                "description": "Generate a one-line session recap now",
+                "argumentHint": ""
+              },
+              {
+                "name": "skill-doctor",
+                "description": "Show which loaded skills are unused and costing context",
+                "argumentHint": ""
+              },
+              {
+                "name": "goal",
+                "description": "Set a goal \u2014 keep working until the condition is met",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-consent",
+                "description": "Grant Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "design-revoke",
+                "description": "Revoke Claude agent access to your Design projects",
+                "argumentHint": ""
+              },
+              {
+                "name": "list-agents",
+                "description": "List subagents, teammates, and other Claude sessions you can message",
+                "argumentHint": "",
+                "aliases": [
+                  "peers"
+                ]
+              },
+              {
+                "name": "team-onboarding",
+                "description": "Help teammates ramp on Claude Code with a guide from your usage",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "claude",
+                "description": "Catch-all for any task that doesn't fit a more specific agent. FleetView's default when no agent name is typed."
+              },
+              {
+                "name": "Explore",
+                "description": "Fast read-only search agent for locating code. Use it to find files by pattern (eg. \"src/components/**/*.tsx\"), grep for symbols or keywords (eg. \"API endpoints\"), or answer \"where is X defined / which files reference Y.\" Do NOT use it for code review, design-doc auditing, cross-file consistency checks, or open-ended analysis \u2014 it reads excerpts rather than whole files and will miss content past its read window. When calling, specify search breadth: \"quick\" for a single targeted lookup, \"medium\" for moderate exploration, or \"very thorough\" to search across multiple locations and naming conventions.",
+                "model": "inherit"
+              },
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs.",
+                "model": "inherit"
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Proactive",
+              "Concise",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Opus 5 (1M context)) \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "resolvedModel": "claude-opus-5[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 5 with 1M context \u00b7 Best for everyday, complex tasks \u00b7 $5/$25 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet",
+                "resolvedModel": "claude-sonnet-5",
+                "displayName": "Sonnet",
+                "description": "Sonnet 5 \u00b7 Efficient for routine tasks \u00b7 $2/$10 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              },
+              {
+                "value": "claude-haiku-4-5",
+                "resolvedModel": "claude-haiku-4-5",
+                "displayName": "Haiku 4.5",
+                "description": "Fastest for quick answers (claude-haiku-4-5)"
+              }
+            ],
+            "account": {
+              "tokenSource": "none",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 1901162,
+            "current_permission_mode": "default",
+            "analytics_disabled": false,
+            "remote_control_auto_enable": false,
+            "remote_control_available": true,
+            "remote_control_auto_on_by_default": false,
+            "ide_rc_auto_enable_gate": true,
+            "fast_mode_state": "off",
+            "fast_mode_disabled_reason": "sdk_opt_in_required",
+            "session_state": "idle"
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "Reply with only: OK"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/agent",
+        "session_id": "dd7ec490-92dd-4bd6-abc6-3d271d21f838",
+        "tools": [
+          "Task",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "DesignSync",
+          "Edit",
+          "EnterWorktree",
+          "ExitWorktree",
+          "ListAgents",
+          "Monitor",
+          "NotebookEdit",
+          "PushNotification",
+          "Read",
+          "ReportFindings",
+          "ScheduleWakeup",
+          "SendMessage",
+          "Skill",
+          "TaskCreate",
+          "TaskGet",
+          "TaskList",
+          "TaskOutput",
+          "TaskStop",
+          "TaskUpdate",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Workflow",
+          "Write"
+        ],
+        "mcp_servers": [],
+        "model": "claude-haiku-4-5",
+        "permissionMode": "default",
+        "slash_commands": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator",
+          "advisor",
+          "agents",
+          "auto-mode-setup",
+          "autocompact",
+          "clear",
+          "color",
+          "compact",
+          "config",
+          "context",
+          "effort",
+          "fast",
+          "heapdump",
+          "init",
+          "mcp",
+          "import",
+          "model",
+          "__remote-workflow",
+          "workflow-launch-exec",
+          "reload-plugins",
+          "reload-skills",
+          "rename",
+          "security-review",
+          "usage",
+          "insights",
+          "recap",
+          "skill-doctor",
+          "goal",
+          "design-consent",
+          "design-revoke",
+          "list-agents",
+          "team-onboarding"
+        ],
+        "terminal_slash_commands": [
+          "doctor",
+          "color",
+          "reload-plugins"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.267",
+        "output_style": "default",
+        "agents": [
+          "claude",
+          "Explore",
+          "general-purpose",
+          "Plan",
+          "statusline-setup"
+        ],
+        "skills": [
+          "deep-research",
+          "design",
+          "design-sync",
+          "dataviz",
+          "update-config",
+          "verify",
+          "debug",
+          "code-review",
+          "simplify",
+          "batch",
+          "fewer-permission-prompts",
+          "doctor",
+          "loop",
+          "claude-api",
+          "workflow-authoring",
+          "run",
+          "run-skill-generator"
+        ],
+        "plugins": [],
+        "capabilities": [
+          "interrupt_receipt_v1",
+          "interrupt_cancel_queued_v1",
+          "msg_lifecycle_v1"
+        ],
+        "analytics_disabled": false,
+        "product_feedback_disabled": false,
+        "uuid": "a3577813-5f6e-4617-bc25-9d891cab8ea8",
+        "memory_paths": {
+          "auto": "/tmp/pytest-of-user/pytest-5048/test_the_cli_leaves_out_a_suba0/projects/-agent/memory/"
+        },
+        "messaging_socket_path": "/tmp/cc-socks/1901162.sock",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj8AZQ77F5d9SkdXxgL",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "thinking",
+              "thinking": "",
+              "signature": "EqUDCrIBCBEYAipABumEN8Gd+2RxXkt2zLP9UEbqVrmlRwiuUdrDpagqvs/mObQ1hPfU2vayZQQs+1D1cv6oqt0QqPxu+2LymnyKsTIZY2xhdWRlLWhhaWt1LTQtNS0yMDI1MTAwMTgAQgh0aGlua2luZ1okNDRhZTY3NmMtOTU4Zi00ZDY4LTkxMDgtZWFlOWRlN2IzNjZichDPR46yA4sdQPSSuznKz1DIiAEBqAH81IfVBrABAhIMNw1nc0hlaBBf0Eu9GgxuvwncdA1nPzvthCYiME7pRr0fapjGvI0nB7ZRmj63JTFzzBte1Iqj5jrPyL7xAnZMWJ7ybcxFh4aeeCS+3iqfATpbD1mKaunMcqf4bXKCxXvwC4gBxUbNfjWEn9Xf7ShBDB+tYap6XdOQ+4feS77kPgS/c1UNriOZncisvPMrVkqYjx3obz9JpMYFIj3dBk5a1lqIJfR0p9XsXerhEPhGrAKqhLKxbFfBZa1CdYcmGJKrtP0eslZyCuuW0SDSyckBD2GtGMWSn6A99wVwYCyJMPaJqh4u+7A1TCVkWE26IxgB"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14247,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "dd7ec490-92dd-4bd6-abc6-3d271d21f838",
+        "uuid": "85d0e5a6-7cf4-4e92-afff-40e6f88c66ca",
+        "timestamp": "2026-09-09T23:23:40.526Z",
+        "request_id": "req_011Cetj89mXPmxJWZK8aFDrz"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-haiku-4-5-20251001",
+          "id": "msg_011Cetj8AZQ77F5d9SkdXxgL",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "OK"
+            }
+          ],
+          "container": null,
+          "stop_reason": null,
+          "stop_sequence": null,
+          "stop_details": null,
+          "usage": {
+            "input_tokens": 10,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 14247,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 0,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 3,
+            "service_tier": "standard",
+            "inference_geo": "not_available"
+          },
+          "diagnostics": null,
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "dd7ec490-92dd-4bd6-abc6-3d271d21f838",
+        "uuid": "3a6d794a-390c-4f0d-b5bb-3173dd3a8a4c",
+        "timestamp": "2026-09-09T23:23:40.530Z",
+        "request_id": "req_011Cetj89mXPmxJWZK8aFDrz"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "duration_api_ms": 2533,
+        "stop_reason": "end_turn",
+        "session_id": "dd7ec490-92dd-4bd6-abc6-3d271d21f838",
+        "total_cost_usd": 0.0025967,
+        "usage": {
+          "input_tokens": 10,
+          "cache_creation_input_tokens": 0,
+          "cache_read_input_tokens": 14247,
+          "output_tokens": 45,
+          "output_tokens_details": {
+            "thinking_tokens": 38
+          },
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 0
+          },
+          "inference_geo": "not_available",
+          "iterations": [
+            {
+              "input_tokens": 10,
+              "output_tokens": 45,
+              "cache_read_input_tokens": 14247,
+              "cache_creation_input_tokens": 0,
+              "cache_creation": {
+                "ephemeral_5m_input_tokens": 0,
+                "ephemeral_1h_input_tokens": 0
+              },
+              "type": "message"
+            }
+          ],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-haiku-4-5-20251001": {
+            "inputTokens": 897,
+            "outputTokens": 8,
+            "cacheReadInputTokens": 0,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.000937,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 0,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          },
+          "claude-haiku-4-5": {
+            "inputTokens": 10,
+            "outputTokens": 45,
+            "cacheReadInputTokens": 14247,
+            "cacheCreationInputTokens": 0,
+            "webSearchRequests": 0,
+            "costUSD": 0.0016597,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000,
+            "thinkingTokens": 38,
+            "canonicalModel": "claude-haiku-4-5",
+            "provider": "firstParty",
+            "costBasis": "list"
+          }
+        },
+        "permission_denials": [],
+        "terminal_reason": "completed",
+        "fast_mode_state": "off",
+        "fast_mode_disabled_reason": "sdk_opt_in_required",
+        "subagent_stats": {
+          "spawned": 0,
+          "requested": {
+            "background": 0,
+            "foreground": 0,
+            "unset": 0
+          },
+          "started_in_background": 0,
+          "max_depth": 0,
+          "spawned_by_subagents": 0,
+          "completed": 0,
+          "failed": 0,
+          "killed": {
+            "parent": 0,
+            "user": 0,
+            "system": 0
+          },
+          "refused": {
+            "depth_limit": 0,
+            "concurrency_limit": 0,
+            "budget": 0
+          },
+          "by_type": {}
+        },
+        "is_error": false,
+        "num_turns": 1,
+        "subtype": "success",
+        "api_error_status": null,
+        "result": "OK",
+        "ttft_ms": 1277,
+        "type": "result",
+        "duration_ms": 1311,
+        "uuid": "6245ef99-3cb6-4d67-9483-2b24e72c2687",
+        "ttft_stream_ms": 822,
+        "time_to_request_ms": 35,
+        "first_content_frame_ms": 1125,
+        "queued_turn_count": 0
+      }
+    }
+  ]
+}

--- a/tests/agent_control/claude_agent_sdk/cassettes/test_the_cli_leaves_out_a_subagent_with_no_prompt.json
+++ b/tests/agent_control/claude_agent_sdk/cassettes/test_the_cli_leaves_out_a_subagent_with_no_prompt.json
@@ -559,7 +559,7 @@
         "product_feedback_disabled": false,
         "uuid": "a3577813-5f6e-4617-bc25-9d891cab8ea8",
         "memory_paths": {
-          "auto": "/tmp/pytest-of-user/pytest-5048/test_the_cli_leaves_out_a_suba0/projects/-agent/memory/"
+          "auto": "/config/projects/-agent/memory/"
         },
         "messaging_socket_path": "/tmp/cc-socks/1901162.sock",
         "fast_mode_state": "off",

--- a/tests/agent_control/claude_agent_sdk/conftest.py
+++ b/tests/agent_control/claude_agent_sdk/conftest.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import threading
-from collections.abc import Iterator
 from typing import Any, cast
 
 import anyio
@@ -39,26 +38,27 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _join_baseline_publishes(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
-    """Wait for the baseline publishers a test started before the next test begins.
+def _finish_baseline_publishes(monkeypatch: pytest.MonkeyPatch) -> None:  # pyright: ignore[reportUnusedFunction]
+    """Let a baseline publish finish inside the call that started it, rather than after the test.
 
     `agent_control()` publishes the baseline on a daemon thread and hands the caller options rather
-    than the thread, which is the right shape for an agent and the wrong one for a test suite: the
-    thread builds pydantic models, and the suite asserts between tests that no pydantic plugin load
-    is in flight.
+    than the thread, which is the right shape for an agent and the wrong one for a test: a thread
+    still running when the test ends does its work against whatever process-wide state the *next*
+    fixture teardown or test has left behind. It warns into a suite whose `filterwarnings = error`
+    turns that into an unhandled thread exception nobody can catch, and it builds pydantic models
+    while the suite is asserting that no pydantic plugin load is in flight.
+
+    The thread is still spawned and still returned, so nothing about the API under test changes; it
+    is only waited for immediately, which puts everything it does inside the test that asked for it.
     """
-    spawned: list[threading.Thread] = []
     spawn = _control._spawn_baseline_publish
 
-    def record(*args: Any, **kwargs: Any) -> threading.Thread:
+    def spawn_and_wait(*args: Any, **kwargs: Any) -> threading.Thread:
         thread = spawn(*args, **kwargs)
-        spawned.append(thread)
+        thread.join(timeout=10)
         return thread
 
-    monkeypatch.setattr(_control, '_spawn_baseline_publish', record)
-    yield
-    for thread in spawned:
-        thread.join(timeout=10)
+    monkeypatch.setattr(_control, '_spawn_baseline_publish', spawn_and_wait)
 
 
 def publish(provider: LocalVariableProvider, name: str, value: Any, *, label: str = 'production') -> VariableConfig:

--- a/tests/agent_control/claude_agent_sdk/conftest.py
+++ b/tests/agent_control/claude_agent_sdk/conftest.py
@@ -1,0 +1,137 @@
+# pyright: reportPrivateUsage=false
+"""Fixtures for the adapter tests, and the two ways to see what options actually do.
+
+The offline tests here never spawn the `claude` CLI or reach the network. Instead both halves of what
+options mean are read offline: the arguments the SDK would spawn the CLI with, and the tool
+definitions the SDK would serve an in-process MCP server's tools as. The Logfire project, the reset
+of once-per-process state, and the credential scrubbing all come from the conftests above this one.
+
+`test_live.py` is the exception: it drives the real CLI through a recorded cassette, and registers
+the flag that records one.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from typing import Any, cast
+
+import anyio
+import pytest
+from claude_agent_sdk import ClaudeAgentOptions
+from claude_agent_sdk._internal.sdk_mcp_bridge import SdkMcpBridge
+from claude_agent_sdk._internal.transport.subprocess_cli import SubprocessCLITransport
+from claude_agent_sdk.types import McpSdkServerConfig
+
+from logfire.agent_control import _control
+from logfire.variables import LabeledValue, Rollout, VariableConfig
+from logfire.variables.local import LocalVariableProvider
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        '--record-agent-control-cassettes',
+        action='store_true',
+        default=False,
+        help='Record the Agent Control cassettes in this directory against a real `claude` CLI.',
+    )
+
+
+@pytest.fixture(autouse=True)
+def _join_baseline_publishes(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:  # pyright: ignore[reportUnusedFunction]
+    """Wait for the baseline publishers a test started before the next test begins.
+
+    `agent_control()` publishes the baseline on a daemon thread and hands the caller options rather
+    than the thread, which is the right shape for an agent and the wrong one for a test suite: the
+    thread builds pydantic models, and the suite asserts between tests that no pydantic plugin load
+    is in flight.
+    """
+    spawned: list[threading.Thread] = []
+    spawn = _control._spawn_baseline_publish
+
+    def record(*args: Any, **kwargs: Any) -> threading.Thread:
+        thread = spawn(*args, **kwargs)
+        spawned.append(thread)
+        return thread
+
+    monkeypatch.setattr(_control, '_spawn_baseline_publish', record)
+    yield
+    for thread in spawned:
+        thread.join(timeout=10)
+
+
+def publish(provider: LocalVariableProvider, name: str, value: Any, *, label: str = 'production') -> VariableConfig:
+    """Put `value` in the project under one label, the shape a project has once someone saved in the UI.
+
+    Publishing again bumps that label's version and leaves the other labels alone, so a test can
+    publish, change, and withdraw the way someone editing in Logfire does.
+    """
+    existing = provider.get_variable_config(name)
+    labels = dict(existing.labels) if existing is not None else {}
+    published = labels.get(label)
+    version = 1 if not isinstance(published, LabeledValue) else published.version + 1
+    labels[label] = LabeledValue(version=version, serialized_value=json.dumps(value))
+    config = VariableConfig(name=name, labels=labels, rollout=Rollout(labels={label: 1.0}), overrides=[])
+    return provider.create_variable(config) if existing is None else provider.update_variable(name, config)
+
+
+def withdraw(provider: LocalVariableProvider, name: str) -> None:
+    """Take the whole config back out of the project, the way removing it in Logfire does."""
+    provider.delete_variable(name)
+
+
+def cli_args(options: ClaudeAgentOptions) -> list[str]:
+    """The command line the SDK would spawn the `claude` CLI with for these options.
+
+    This reaches into the SDK's transport, which is the only place the mapping from options to CLI
+    arguments exists -- and that mapping is the whole of what an applied config *does* here, since the
+    prompt, the model, and the effort are all decided inside the process those arguments start. The
+    CLI path is stubbed so nothing is looked up or spawned.
+    """
+    transport = SubprocessCLITransport(prompt='hi', options=options)
+    transport._cli_path = '/stub/claude'
+    return transport._build_command()
+
+
+def cli_arg(options: ClaudeAgentOptions, flag: str) -> str | None:
+    """The value the CLI would be given for one flag, or `None` when the flag is absent."""
+    args = cli_args(options)
+    return args[args.index(flag) + 1] if flag in args else None
+
+
+async def _bridged(config: McpSdkServerConfig, request: dict[str, Any]) -> dict[str, Any]:
+    """Run one MCP request against an in-process server the way the SDK serves it to the CLI."""
+    bridge = SdkMcpBridge(config['name'], config['instance'])
+    await bridge.handle(
+        {
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': 'initialize',
+            'params': {
+                'protocolVersion': '2025-06-18',
+                'capabilities': {},
+                'clientInfo': {'name': 'test', 'version': '0'},
+            },
+        }
+    )
+    await bridge.handle({'jsonrpc': '2.0', 'method': 'notifications/initialized'})
+    response = await bridge.handle({'jsonrpc': '2.0', 'id': 2, **request})
+    await bridge.aclose()
+    assert response is not None
+    return cast(dict[str, Any], response['result'])
+
+
+def wire_tools(options: ClaudeAgentOptions, server: str) -> list[dict[str, Any]]:
+    """The tool definitions the model is shown for one in-process server."""
+    servers = cast(dict[str, McpSdkServerConfig], options.mcp_servers)
+    result = anyio.run(_bridged, servers[server], {'method': 'tools/list'})
+    return cast(list[dict[str, Any]], result['tools'])
+
+
+def call_tool(options: ClaudeAgentOptions, server: str, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Call one in-process tool by the name the model would call it, and return the MCP result."""
+    servers = cast(dict[str, McpSdkServerConfig], options.mcp_servers)
+    return anyio.run(
+        _bridged, servers[server], {'method': 'tools/call', 'params': {'name': name, 'arguments': arguments}}
+    )

--- a/tests/agent_control/claude_agent_sdk/test_baseline.py
+++ b/tests/agent_control/claude_agent_sdk/test_baseline.py
@@ -1,0 +1,131 @@
+"""What the adapter tells Logfire the agent does today."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, create_sdk_mcp_server
+from inline_snapshot import snapshot
+
+from logfire.agent_control.claude_agent_sdk import ManagedAgent, sdk_mcp_server
+from logfire.agent_control.claude_agent_sdk._control import baseline
+from logfire.variables.local import LocalVariableProvider
+
+from .agents import checkout_options, refund_order
+
+
+def test_the_baseline_describes_every_seam_the_agent_has() -> None:
+    assert baseline(checkout_options()).model_dump(exclude_none=True) == snapshot(
+        {
+            'instructions': [
+                {'id': 'system', 'instructions': 'You are a concise checkout assistant.', 'dynamic': False},
+                {'id': 'agent:reviewer', 'instructions': 'You review refunds.', 'dynamic': False},
+            ],
+            'model': 'anthropic:claude-fable-5-1',
+            'settings': {'thinking': 'high'},
+            'tool_definitions': [
+                {
+                    'name': 'refund_order',
+                    'description': 'Refund an order.',
+                    'parameters': {'order_id': {'description': 'The order to refund.'}},
+                    'toolset': 'shop',
+                },
+                {
+                    'name': 'search',
+                    'description': 'Search the catalogue.',
+                    'parameters': {'query': {}},
+                    'toolset': 'shop',
+                },
+            ],
+        }
+    )
+
+
+def test_a_preset_prompt_is_listed_without_its_text() -> None:
+    options = ClaudeAgentOptions(
+        system_prompt={'type': 'preset', 'preset': 'claude_code', 'append': 'Be terse.'},
+        agents={'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.')},
+    )
+    assert baseline(options).model_dump(exclude_none=True) == snapshot(
+        {
+            'instructions': [
+                {'id': 'preset:claude_code', 'dynamic': True},
+                {'id': 'append', 'instructions': 'Be terse.', 'dynamic': False},
+                {'id': 'agent:reviewer', 'instructions': 'You review refunds.', 'dynamic': False},
+            ]
+        }
+    )
+
+
+def test_a_file_prompt_is_listed_without_its_text() -> None:
+    options = ClaudeAgentOptions(system_prompt={'type': 'file', 'path': '/prompts/checkout.md'})
+    assert baseline(options).model_dump(exclude_none=True) == snapshot(
+        {'instructions': [{'id': 'system:file', 'dynamic': True}]}
+    )
+
+
+def test_an_agent_with_nothing_stated_describes_nothing() -> None:
+    assert baseline(ClaudeAgentOptions()).model_dump(exclude_none=True) == snapshot({})
+
+
+def test_tools_of_a_server_built_the_sdks_own_way_are_not_listed() -> None:
+    # `create_sdk_mcp_server` keeps no reference to the definitions it was given, so there is nothing
+    # to describe and nothing a published override could rewrite.
+    options = ClaudeAgentOptions(mcp_servers={'shop': create_sdk_mcp_server('shop', tools=[refund_order])})
+    assert baseline(options).tool_definitions is None
+
+
+def test_external_and_file_backed_mcp_servers_are_not_listed() -> None:
+    external = baseline(ClaudeAgentOptions(mcp_servers={'crm': {'type': 'http', 'url': 'https://crm.example'}}))
+    assert external.tool_definitions is None
+    assert baseline(ClaudeAgentOptions(mcp_servers='/etc/mcp.json')).tool_definitions is None
+
+
+def test_the_baseline_is_what_the_variable_is_created_with(project: LocalVariableProvider) -> None:
+    options = checkout_options()
+    managed = ManagedAgent('checkout_assistant')
+    with managed.session(options) as applied:
+        assert applied is options  # Nothing published: the agent runs exactly as written.
+    assert managed._publish_thread is not None  # pyright: ignore[reportPrivateUsage]
+    managed._publish_thread.join()  # pyright: ignore[reportPrivateUsage]
+
+    config = project.get_variable_config('agent__checkout_assistant')
+    assert config is not None
+    assert config.example == json.dumps(baseline(options).model_dump(exclude_none=True), indent=2)
+
+
+def test_environment_settings_the_cli_reads_are_described() -> None:
+    options = ClaudeAgentOptions(
+        env={'CLAUDE_CODE_MAX_OUTPUT_TOKENS': '4096', 'API_TIMEOUT_MS': '30000', 'ANTHROPIC_BASE_URL': 'x'},
+        thinking={'type': 'disabled'},
+    )
+    assert baseline(options).model_dump(exclude_none=True) == snapshot(
+        {'settings': {'max_tokens': 4096, 'timeout': 30.0, 'thinking': False}}
+    )
+
+
+def test_an_unreadable_environment_setting_is_simply_not_described() -> None:
+    options = ClaudeAgentOptions(env={'CLAUDE_CODE_MAX_OUTPUT_TOKENS': 'lots'})
+    assert baseline(options).settings is None
+
+
+def test_a_thinking_budget_is_described_as_the_part_the_contract_can_say() -> None:
+    options = ClaudeAgentOptions(thinking={'type': 'enabled', 'budget_tokens': 8000})
+    settings = baseline(options).settings
+    assert settings is not None and settings.thinking is True
+
+
+def test_an_effort_level_the_contract_cannot_name_is_left_out_rather_than_approximated() -> None:
+    # `'max'` is not `'xhigh'`, and the baseline is the one artifact the Logfire editor presents as
+    # the truth about the code, so the level is omitted and reported rather than rounded to a name.
+    with pytest.warns(UserWarning, match="thinking='max', which the Agent Control contract cannot describe"):
+        assert baseline(ClaudeAgentOptions(effort='max')).settings is None
+
+
+def test_a_server_built_by_this_adapter_after_a_rebuild_is_still_described() -> None:
+    # `sdk_mcp_server` is what the adapter rebuilds patched servers with, so its registration has to
+    # survive being called on tools it produced itself.
+    rebuilt = sdk_mcp_server('shop', '2.0.0', [refund_order])
+    definitions = baseline(ClaudeAgentOptions(mcp_servers={'shop': rebuilt})).tool_definitions
+    assert definitions is not None and [tool.name for tool in definitions] == ['refund_order']

--- a/tests/agent_control/claude_agent_sdk/test_baseline.py
+++ b/tests/agent_control/claude_agent_sdk/test_baseline.py
@@ -110,6 +110,13 @@ def test_an_unreadable_environment_setting_is_simply_not_described() -> None:
     assert baseline(options).settings is None
 
 
+@pytest.mark.parametrize('timeout_ms', ['-5', str(10**400)])
+def test_a_timeout_the_contract_cannot_hold_is_simply_not_described(timeout_ms: str) -> None:
+    # Compared before the division: a value this far out of range is also too big to turn into a
+    # float, and describing the environment the user set may not fail the call.
+    assert baseline(ClaudeAgentOptions(env={'API_TIMEOUT_MS': timeout_ms})).settings is None
+
+
 def test_a_thinking_budget_is_described_as_the_part_the_contract_can_say() -> None:
     options = ClaudeAgentOptions(thinking={'type': 'enabled', 'budget_tokens': 8000})
     settings = baseline(options).settings

--- a/tests/agent_control/claude_agent_sdk/test_control.py
+++ b/tests/agent_control/claude_agent_sdk/test_control.py
@@ -1,0 +1,370 @@
+"""Wiring the adapter to a real session: what reaches the CLI, and what happens when Logfire cannot."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any, cast
+
+import anyio
+import pytest
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    HookCallback,
+    HookContext,
+    HookInput,
+    HookJSONOutput,
+    HookMatcher,
+)
+from claude_agent_sdk._internal.transport import Transport
+from inline_snapshot import snapshot
+
+import logfire
+from logfire.agent_control.claude_agent_sdk import ManagedAgent, agent_control
+from logfire.testing import CaptureLogfire
+from logfire.variables import Variable
+from logfire.variables.local import LocalVariableProvider
+
+from .agents import checkout_options
+from .conftest import call_tool, cli_arg, publish, wire_tools, withdraw
+
+
+class CaptureTransport(Transport):
+    """A stand-in for the `claude` subprocess: it records what the SDK sends and answers control requests.
+
+    The SDK talks to the CLI over stdio and nothing else, so replacing the transport is enough to
+    drive a real `ClaudeSDKClient` through a real connect, initialize, and model switch offline.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+        self._send, self._receive = anyio.create_memory_object_stream[dict[str, Any]](100)
+
+    async def connect(self) -> None:
+        pass
+
+    async def write(self, data: str) -> None:
+        message: dict[str, Any] = json.loads(data)
+        self.sent.append(message)
+        if message.get('type') == 'control_request':
+            await self._send.send(
+                {
+                    'type': 'control_response',
+                    'response': {'subtype': 'success', 'request_id': message['request_id'], 'response': {}},
+                }
+            )
+
+    async def read_messages(self) -> AsyncIterator[dict[str, Any]]:
+        async for message in self._receive:
+            yield message
+
+    async def close(self) -> None:
+        await self._send.aclose()
+        await self._receive.aclose()
+
+    def is_ready(self) -> bool:
+        return True
+
+    async def end_input(self) -> None:
+        pass
+
+    def requests(self, subtype: str) -> list[dict[str, Any]]:
+        return [
+            message['request']
+            for message in self.sent
+            if message.get('type') == 'control_request' and message['request']['subtype'] == subtype
+        ]
+
+
+def test_the_agent_has_to_be_named() -> None:
+    with pytest.raises(ValueError, match='has nothing a variable key can be made of'):
+        agent_control(checkout_options(), name='  ')
+
+
+def test_a_managed_agent_says_what_it_manages() -> None:
+    assert repr(ManagedAgent('checkout-assistant', label='canary')) == snapshot(
+        "ManagedAgent(name='checkout-assistant', label='canary')"
+    )
+
+
+def test_every_section_reaches_the_command_line_at_once(project: LocalVariableProvider) -> None:
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {
+            'instructions': [{'id': 'system', 'instructions': 'You are a refund specialist.'}],
+            'model': 'anthropic:claude-opus-4-5',
+            'settings': {'thinking': 'medium', 'max_tokens': 2048},
+            'tool_definitions': [{'name': 'refund_order', 'new_name': 'issue_refund'}],
+        },
+    )
+    options = agent_control(checkout_options(), name='checkout_assistant', label='production')
+    assert cli_arg(options, '--system-prompt') == 'You are a refund specialist.'
+    assert cli_arg(options, '--model') == 'claude-opus-4-5'
+    assert cli_arg(options, '--effort') == 'medium'
+    assert cli_arg(options, '--allowedTools') == 'mcp__shop__issue_refund,Read(*.py)'
+    assert options.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] == '2048'
+
+
+def test_what_the_caller_passes_afterwards_beats_what_was_published(project: LocalVariableProvider) -> None:
+    from dataclasses import replace
+
+    publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'})
+    options = agent_control(checkout_options(), name='checkout_assistant', label='production')
+    # The adapter returns options; anything a caller changes after the call is the last word.
+    assert replace(options, model='claude-haiku-4-5').model == 'claude-haiku-4-5'
+
+
+def test_the_options_the_caller_built_are_never_mutated(project: LocalVariableProvider) -> None:
+    publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'})
+    code = checkout_options()
+    managed = agent_control(code, name='checkout_assistant', label='production')
+    assert managed is not code
+    assert code.model == 'claude-fable-5-1'
+
+
+def test_a_config_that_reaches_nothing_can_fail_the_call_instead(project: LocalVariableProvider) -> None:
+    publish(
+        project, 'agent__checkout_assistant', {'instructions': [{'id': 'agent:auditor', 'instructions': 'You audit.'}]}
+    )
+    with pytest.raises(ValueError, match="addresses instruction block 'agent:auditor'"):
+        agent_control(checkout_options(), name='checkout_assistant', label='production', on_unmatched='error')
+
+
+def test_a_config_that_reaches_nothing_can_be_left_unsaid(project: LocalVariableProvider) -> None:
+    publish(project, 'agent__checkout_assistant', {'settings': {'temperature': 0.4}})
+    # `filterwarnings = ['error']` makes this fail if anything is warned.
+    assert (
+        agent_control(checkout_options(), name='checkout_assistant', label='production', on_unmatched='ignore')
+        is not None
+    )
+
+
+def test_no_logfire_project_runs_the_agent_on_its_code() -> None:
+    code = checkout_options()
+    assert agent_control(code, name='checkout_assistant') is code
+
+
+def test_an_unreachable_logfire_runs_the_agent_on_its_code(
+    project: LocalVariableProvider, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def boom(*_args: Any, **_kwargs: Any) -> Any:
+        raise RuntimeError('the variables API is down')
+
+    monkeypatch.setattr(Variable, 'get', boom)
+    code = checkout_options()
+    with pytest.warns(UserWarning, match='the variables API is down'):
+        assert agent_control(code, name='checkout_assistant') is code
+
+
+def test_the_baseline_is_not_published_when_it_must_not_be(project: LocalVariableProvider) -> None:
+    managed = ManagedAgent('checkout_assistant', publish_baseline=False)
+    managed.options(checkout_options())
+    assert managed._publish_thread is None  # pyright: ignore[reportPrivateUsage]
+    assert project.get_variable_config('agent__checkout_assistant') is None
+
+
+def test_a_session_carries_the_version_that_produced_it(
+    project: LocalVariableProvider, capfire: CaptureLogfire
+) -> None:
+    publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'}, label='canary')
+    managed = ManagedAgent('checkout_assistant', label='canary')
+    with managed.session(checkout_options()) as options:
+        assert options.model == 'claude-opus-4-5'
+        logfire.info('the session')
+    [session] = [span for span in capfire.exporter.exported_spans_as_dict() if span['name'] == 'the session']
+    assert session['attributes']['logfire.variables.agent__checkout_assistant'] == 'canary'
+    assert session['attributes']['logfire.variables.agent__checkout_assistant.version'] == '1'
+
+
+def test_a_managed_subagent_prompt_reaches_the_session(project: LocalVariableProvider) -> None:
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {'instructions': [{'id': 'agent:reviewer', 'instructions': 'You review refunds carefully.'}]},
+    )
+    options = agent_control(checkout_options(), name='checkout_assistant', label='production')
+
+    async def connect() -> list[dict[str, Any]]:
+        transport = CaptureTransport()
+        client = ClaudeSDKClient(options=options, transport=transport)
+        await client.connect()
+        await client.query('Refund my last order.')
+        await transport.end_input()
+        await client.disconnect()
+        assert transport.is_ready()
+        return transport.requests('initialize')
+
+    # Subagents travel in the `initialize` control request rather than on the command line, so this
+    # is the only place a managed subagent prompt can be seen going out.
+    [initialize] = anyio.run(connect)
+    assert initialize['agents']['reviewer']['prompt'] == 'You review refunds carefully.'
+
+
+def test_a_model_published_mid_session_reaches_a_connected_client(project: LocalVariableProvider) -> None:
+    options = checkout_options()
+    managed = ManagedAgent('checkout_assistant', label='production')
+
+    async def run() -> list[dict[str, Any]]:
+        transport = CaptureTransport()
+        client = ClaudeSDKClient(options=options, transport=transport)
+        await client.connect()
+        assert await managed.refresh_model(client, options) == 'claude-fable-5-1'
+        publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'})
+        assert await managed.refresh_model(client, options) == 'claude-opus-4-5'
+        await client.disconnect()
+        return transport.requests('set_model')
+
+    assert [request['model'] for request in anyio.run(run)] == ['claude-fable-5-1', 'claude-opus-4-5']
+
+
+def test_refreshing_to_a_model_this_sdk_cannot_run_keeps_the_code_model(project: LocalVariableProvider) -> None:
+    publish(project, 'agent__checkout_assistant', {'model': 'bedrock:claude-fable-5-1'})
+    options = checkout_options()
+    managed = ManagedAgent('checkout_assistant', label='production')
+
+    async def run() -> str | None:
+        transport = CaptureTransport()
+        client = ClaudeSDKClient(options=options, transport=transport)
+        await client.connect()
+        try:
+            return await managed.refresh_model(client, options)
+        finally:
+            await client.disconnect()
+
+    with pytest.warns(UserWarning, match="selects model 'bedrock:claude-fable-5-1'"):
+        assert anyio.run(run) == 'claude-fable-5-1'
+
+
+def test_refreshing_without_a_project_keeps_the_code_model() -> None:
+    options = ClaudeAgentOptions()
+    managed = ManagedAgent('checkout_assistant')
+
+    async def run() -> str | None:
+        transport = CaptureTransport()
+        client = ClaudeSDKClient(options=options, transport=transport)
+        await client.connect()
+        try:
+            return await managed.refresh_model(client, options)
+        finally:
+            await client.disconnect()
+
+    assert anyio.run(run) is None
+
+
+async def _noop_hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+    return {}  # pragma: no cover
+
+
+def _hooks(hook: HookCallback = _noop_hook) -> dict[str, list[HookMatcher]]:
+    return {'PreToolUse': [HookMatcher(hooks=[hook])]}
+
+
+def _pre_tool_use(tool_name: str) -> HookInput:
+    payload: dict[str, Any] = {
+        'hook_event_name': 'PreToolUse',
+        'session_id': 's',
+        'transcript_path': '/t',
+        'cwd': '/c',
+        'tool_name': tool_name,
+        'tool_input': {'order_id': 'A-1234'},
+        'tool_use_id': 'call-1',
+    }
+    return cast(HookInput, payload)
+
+
+def _run_hook(options: ClaudeAgentOptions, tool_name: str) -> None:
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['PreToolUse']
+    anyio.run(matchers[0].hooks[0], _pre_tool_use(tool_name), 'call-1', HookContext(signal=None))
+
+
+def test_a_hook_carries_the_version_that_configured_the_session(
+    project: LocalVariableProvider, capfire: CaptureLogfire
+) -> None:
+    async def hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+        logfire.info('the hook')
+        return {}
+
+    publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'}, label='canary')
+    options = agent_control(checkout_options(hooks=_hooks(hook)), name='checkout_assistant', label='canary')
+    # The session is started by the caller, long after this returned, so the resolution is re-entered
+    # at the one seam left: the callbacks the applied options carry.
+    _run_hook(options, 'Read')
+    [span] = [span for span in capfire.exporter.exported_spans_as_dict() if span['name'] == 'the hook']
+    assert span['attributes']['logfire.variables.agent__checkout_assistant'] == 'canary'
+    assert span['attributes']['logfire.variables.agent__checkout_assistant.version'] == '1'
+
+
+def test_two_sessions_with_different_configs_never_see_each_others(
+    project: LocalVariableProvider, capfire: CaptureLogfire
+) -> None:
+    seen: list[str] = []
+
+    async def hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+        seen.append(cast(dict[str, Any], payload)['tool_name'])
+        logfire.info('the hook')
+        return {}
+
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {'tool_definitions': [{'name': 'refund_order', 'new_name': 'issue_refund'}]},
+        label='production',
+    )
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {'tool_definitions': [{'name': 'refund_order', 'new_name': 'send_refund'}]},
+        label='canary',
+    )
+    code = checkout_options(hooks=_hooks(hook))
+    live = ManagedAgent('checkout_assistant', label='production')
+    trial = ManagedAgent('checkout_assistant', label='canary')
+
+    # Interleaved on purpose: nothing about one session may be reachable from the other, and the
+    # adapter keeps no per-instance state a second run could overwrite.
+    with live.session(code) as live_options, trial.session(code) as trial_options:
+        assert [tool['name'] for tool in wire_tools(live_options, 'shop')] == ['issue_refund', 'search']
+        assert [tool['name'] for tool in wire_tools(trial_options, 'shop')] == ['send_refund', 'search']
+        _run_hook(trial_options, 'mcp__shop__send_refund')
+        _run_hook(live_options, 'mcp__shop__issue_refund')
+
+    assert seen == ['mcp__shop__refund_order', 'mcp__shop__refund_order']
+    labels = [
+        span['attributes']['logfire.variables.agent__checkout_assistant']
+        for span in capfire.exporter.exported_spans_as_dict()
+        if span['name'] == 'the hook'
+    ]
+    assert labels == ['canary', 'production']
+
+
+def test_a_rename_published_changed_and_withdrawn_over_a_tool_loop(project: LocalVariableProvider) -> None:
+    seen: list[str] = []
+
+    async def hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+        seen.append(cast(dict[str, Any], payload)['tool_name'])
+        return {}
+
+    def session(advertised: str) -> None:
+        """One session's worth of what a rename touches: the tool list, a hook, and the handler."""
+        options = agent_control(checkout_options(hooks=_hooks(hook)), name='checkout_assistant', label='production')
+        assert [tool['name'] for tool in wire_tools(options, 'shop')] == [advertised, 'search']
+        assert options.allowed_tools == [f'mcp__shop__{advertised}', 'Read(*.py)']
+        _run_hook(options, f'mcp__shop__{advertised}')
+        assert call_tool(options, 'shop', advertised, {'order_id': 'A-1234'})['content'][0]['text'] == 'refunded A-1234'
+
+    publish(project, 'agent__checkout_assistant', {'tool_definitions': [{'name': 'refund_order', 'new_name': 'a'}]})
+    session('a')
+    publish(project, 'agent__checkout_assistant', {'tool_definitions': [{'name': 'refund_order', 'new_name': 'b'}]})
+    session('b')
+    withdraw(project, 'agent__checkout_assistant')
+    session('refund_order')
+    # Every session's hook was told the name the code declared, whatever the model was calling it.
+    assert seen == ['mcp__shop__refund_order', 'mcp__shop__refund_order', 'mcp__shop__refund_order']
+
+
+def test_an_agent_can_be_all_config_and_no_code(project: LocalVariableProvider) -> None:
+    publish(project, 'agent__checkout_assistant', {'instructions': 'You are a checkout assistant.'})
+    options = agent_control(name='checkout_assistant', label='production')
+    assert cli_arg(options, '--system-prompt') == 'You are a checkout assistant.'

--- a/tests/agent_control/claude_agent_sdk/test_instructions.py
+++ b/tests/agent_control/claude_agent_sdk/test_instructions.py
@@ -1,0 +1,136 @@
+"""What a published `instructions` section does to the prompts a session starts with."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions
+
+from logfire.agent_control.claude_agent_sdk import agent_control
+from logfire.variables.local import LocalVariableProvider
+
+from .agents import checkout_options
+from .conftest import cli_arg, publish
+
+
+def managed(project: LocalVariableProvider, instructions: object, **overrides: object) -> ClaudeAgentOptions:
+    publish(project, 'agent__checkout_assistant', {'instructions': instructions})
+    return agent_control(checkout_options(**overrides), name='checkout_assistant', label='production')
+
+
+def test_the_agents_own_prompt_is_rewritten(project: LocalVariableProvider) -> None:
+    options = managed(project, [{'id': 'system', 'instructions': 'You are a refund specialist.'}])
+    assert options.system_prompt == 'You are a refund specialist.'
+    assert cli_arg(options, '--system-prompt') == 'You are a refund specialist.'
+
+
+def test_dropping_the_prompt_leaves_the_clis_own(project: LocalVariableProvider) -> None:
+    options = managed(project, [{'id': 'system'}])
+    # `''` is exactly what the SDK sends for `system_prompt=None`: no custom prompt at all.
+    assert options.system_prompt == ''
+    assert cli_arg(options, '--system-prompt') == ''
+
+
+def test_an_added_block_lands_after_the_agents_own_prompt(project: LocalVariableProvider) -> None:
+    options = managed(project, ['Escalate anything over $500 to a human.'])
+    assert cli_arg(options, '--system-prompt') == (
+        'You are a concise checkout assistant.\n\nEscalate anything over $500 to a human.'
+    )
+
+
+def test_an_added_block_becomes_the_prompt_when_there_is_none(project: LocalVariableProvider) -> None:
+    options = managed(project, 'Escalate anything over $500 to a human.', system_prompt=None)
+    assert cli_arg(options, '--system-prompt') == 'Escalate anything over $500 to a human.'
+
+
+def test_a_presets_append_is_rewritten_and_added_to(project: LocalVariableProvider) -> None:
+    preset = {'type': 'preset', 'preset': 'claude_code', 'append': 'Be terse.', 'exclude_dynamic_sections': True}
+    options = managed(
+        project,
+        [{'id': 'append', 'instructions': 'Be very terse.'}, 'Escalate anything over $500 to a human.'],
+        system_prompt=preset,
+    )
+    assert options.system_prompt == {
+        'type': 'preset',
+        'preset': 'claude_code',
+        'exclude_dynamic_sections': True,
+        'append': 'Be very terse.\n\nEscalate anything over $500 to a human.',
+    }
+    assert cli_arg(options, '--append-system-prompt') == ('Be very terse.\n\nEscalate anything over $500 to a human.')
+
+
+def test_dropping_the_append_sends_the_preset_alone(project: LocalVariableProvider) -> None:
+    preset = {'type': 'preset', 'preset': 'claude_code', 'append': 'Be terse.'}
+    options = managed(project, [{'id': 'append'}], system_prompt=preset)
+    assert options.system_prompt == {'type': 'preset', 'preset': 'claude_code'}
+    assert cli_arg(options, '--append-system-prompt') is None
+
+
+def test_a_preset_without_an_append_can_be_given_one(project: LocalVariableProvider) -> None:
+    preset = {'type': 'preset', 'preset': 'claude_code'}
+    options = managed(project, 'Escalate anything over $500 to a human.', system_prompt=preset)
+    assert cli_arg(options, '--append-system-prompt') == 'Escalate anything over $500 to a human.'
+
+
+def test_claude_codes_own_prompt_cannot_be_addressed(project: LocalVariableProvider) -> None:
+    preset = {'type': 'preset', 'preset': 'claude_code', 'append': 'Be terse.'}
+    with pytest.warns(UserWarning, match="addresses instruction block 'preset:claude_code', which the agent"):
+        options = managed(project, [{'id': 'preset:claude_code', 'instructions': 'Nice try.'}], system_prompt=preset)
+    assert options.system_prompt == preset
+
+
+def test_a_prompt_read_from_a_file_cannot_be_addressed(project: LocalVariableProvider) -> None:
+    file = {'type': 'file', 'path': '/prompts/checkout.md'}
+    with pytest.warns(UserWarning, match="addresses instruction block 'system:file', which the agent recomputes"):
+        options = managed(project, [{'id': 'system:file', 'instructions': 'Nice try.'}], system_prompt=file)
+    assert options.system_prompt == file
+
+
+def test_a_prompt_read_from_a_file_has_nowhere_to_add_to(project: LocalVariableProvider) -> None:
+    file = {'type': 'file', 'path': '/prompts/checkout.md'}
+    with pytest.warns(UserWarning, match="reads its system prompt from the file '/prompts/checkout.md'"):
+        options = managed(project, 'Escalate anything over $500 to a human.', system_prompt=file)
+    assert options.system_prompt == file
+
+
+def test_a_subagents_prompt_is_rewritten(project: LocalVariableProvider) -> None:
+    options = managed(project, [{'id': 'agent:reviewer', 'instructions': 'You review refunds carefully.'}])
+    assert options.agents == {
+        'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds carefully.')
+    }
+
+
+def test_a_subagents_prompt_cannot_be_removed(project: LocalVariableProvider) -> None:
+    # Removing a block removes text. A subagent is not text: the CLI declares one *by* its prompt and
+    # leaves a subagent whose prompt is empty out of the session, so applying the removal would take
+    # away the subagent, its description, and its tools -- see `test_live.py`, which pins both halves.
+    with pytest.warns(UserWarning, match="removes instruction block 'agent:reviewer', but the `claude` CLI drops"):
+        options = managed(project, [{'id': 'agent:reviewer'}])
+    assert options.agents == {'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.')}
+
+
+def test_a_subagent_the_agent_does_not_have_is_reported(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="addresses instruction block 'agent:auditor', which this request"):
+        options = managed(project, [{'id': 'agent:auditor', 'instructions': 'You audit.'}])
+    assert options.agents == {'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.')}
+
+
+def test_one_subagent_of_several_is_rewritten_alone(project: LocalVariableProvider) -> None:
+    agents = {
+        'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.'),
+        'auditor': AgentDefinition(description='Audits refunds.', prompt='You audit refunds.'),
+    }
+    options = managed(project, [{'id': 'agent:reviewer', 'instructions': 'You review refunds twice.'}], agents=agents)
+    assert options.agents == {
+        'reviewer': replace(agents['reviewer'], prompt='You review refunds twice.'),
+        'auditor': agents['auditor'],
+    }
+
+
+def test_an_agent_with_no_prompt_of_its_own_is_left_that_way(project: LocalVariableProvider) -> None:
+    publish(project, 'agent__checkout_assistant', {'model': 'anthropic:claude-opus-4-5'})
+    options = agent_control(ClaudeAgentOptions(), name='checkout_assistant', label='production')
+    assert options.system_prompt is None
+    assert options.agents is None
+    assert cli_arg(options, '--system-prompt') == ''

--- a/tests/agent_control/claude_agent_sdk/test_live.py
+++ b/tests/agent_control/claude_agent_sdk/test_live.py
@@ -33,6 +33,7 @@ from getpass import getuser
 from pathlib import Path
 from typing import Annotated, Any, cast
 
+import anyio
 import pytest
 from claude_agent_sdk import (
     AgentDefinition,
@@ -82,6 +83,13 @@ def cli_path(
     if not mode & stat.S_IEXEC:  # pragma: no cover
         os.chmod(fake_claude, mode | stat.S_IEXEC)
 
+    # A cassette replays the CLI's callback requests under the ids the SDK assigned while it was
+    # recorded, and `logfire.instrument_claude_agent_sdk()` inserts hook matchers of its own ahead of
+    # this agent's, which shifts them. That patching is process-wide and outlives the test that
+    # applied it, so say what happened here rather than fail later on a hook that never ran.
+    assert not getattr(ClaudeSDKClient, '_is_instrumented_by_logfire', False), (
+        'The Claude Agent SDK is instrumented process-wide, and these cassettes were recorded without it.'
+    )
     monkeypatch.setenv('CASSETTE_PATH', str(cassette))
     monkeypatch.setenv('CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK', '1')
     if record:  # pragma: no cover
@@ -107,15 +115,17 @@ def cli_path(
         monkeypatch.delenv('REAL_CLAUDE_PATH', raising=False)
     yield fake_claude
     if record:  # pragma: no cover
-        _scrub(cassette)
+        _scrub(cassette, tmp_path)
 
 
-def _scrub(cassette: Path) -> None:  # pragma: no cover
+def _scrub(cassette: Path, config_dir: Path) -> None:  # pragma: no cover
     """Take the recording machine out of a freshly recorded cassette.
 
-    A session the CLI ran here carries where it ran: absolute paths under the recorder's home
-    directory, and the account's own rate-limit standing. None of it is what these tests assert on,
-    and all of it would be committed, so it is replaced or dropped before the file is kept.
+    A session the CLI ran here carries where it ran: the account name, the directories it read and
+    wrote, and the account's own rate-limit standing. None of it is what these tests assert on, and
+    all of it would be committed, so the paths this test controls and anything carrying the account
+    name are replaced, and the rate-limit messages dropped, before the file is kept. What is left is
+    the run's own ephemera, such as the CLI's socket path, which names nobody.
     """
     recorded = json.loads(cassette.read_text())
     kept = [entry for entry in recorded['messages'] if entry['message'].get('type') != 'rate_limit_event']
@@ -124,6 +134,7 @@ def _scrub(cassette: Path) -> None:  # pragma: no cover
     # on its own, for anything the first two did not carry away with them.
     cwd, home = str(Path.cwd()), str(Path.home())
     for value, placeholder in (
+        (str(config_dir), '/config'),
         (cwd, '/agent'),
         (home, '/home/user'),
         (cwd.replace('/', '-'), '-agent'),
@@ -133,8 +144,14 @@ def _scrub(cassette: Path) -> None:  # pragma: no cover
     cassette.write_text(text + '\n')
 
 
-async def run(options: ClaudeAgentOptions, prompt: str) -> list[Message]:
-    """One whole session: connect, ask, and collect everything the CLI said back."""
+async def run(options: ClaudeAgentOptions, prompt: str, *, until: anyio.Event | None = None) -> list[Message]:
+    """One whole session: connect, ask, and collect everything the CLI said back.
+
+    A callback the CLI asks for -- a hook, a permission check -- is dispatched by the SDK as its own
+    task, so it can still be pending when the last message arrives. `until` is waited for before the
+    client is disconnected, which is the last moment such a task can run at all: a test that asserts
+    on a callback passes the event that callback sets, rather than racing it.
+    """
     client = ClaudeSDKClient(options=options)
     messages: list[Message] = []
     try:
@@ -142,6 +159,9 @@ async def run(options: ClaudeAgentOptions, prompt: str) -> list[Message]:
         await client.query(prompt)
         async for message in client.receive_response():
             messages.append(message)
+        if until is not None:
+            with anyio.fail_after(10):
+                await until.wait()
     finally:
         await _close(client)
         await client.disconnect()
@@ -246,9 +266,11 @@ async def test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_cod
     """The model calls `mcp__shop__issue_refund`; the handler and the hook see the code's own name."""
     _REFUNDED.clear()
     seen: list[str] = []
+    fired = anyio.Event()
 
     async def hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
         seen.append(cast(dict[str, Any], payload)['tool_name'])
+        fired.set()
         return {}
 
     publish(
@@ -282,7 +304,7 @@ async def test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_cod
     )
     assert options.allowed_tools == ['mcp__shop__issue_refund']
 
-    messages = await run(options, 'Refund order A-1234, then reply DONE.')
+    messages = await run(options, 'Refund order A-1234, then reply DONE.', until=fired)
 
     # The model called the managed name, and the arguments arrived under the code's own parameter
     # name. Anything the CLI's own tools did on the way -- looking the tool up by name, here -- is

--- a/tests/agent_control/claude_agent_sdk/test_live.py
+++ b/tests/agent_control/claude_agent_sdk/test_live.py
@@ -1,0 +1,389 @@
+# pyright: reportPrivateUsage=false
+"""What a published config does to a session the real `claude` CLI ran.
+
+Every other test in this directory reads what the SDK *would* send: the command line it would spawn,
+the tool definitions it would serve. That leaves the other half of every claim open, because this
+adapter's whole surface is arguments to a process it does not implement -- only the CLI can say
+whether it accepts an empty subagent prompt, reads `CLAUDE_CODE_MAX_OUTPUT_TOKENS` out of the
+environment it was spawned with, or lets a model call an in-process tool under a managed name.
+
+So these tests run the real CLI once and keep what it said. The recording machinery is the repository's
+own [`fake_claude.py`][], which the SDK spawns instead of `claude`: in record mode it proxies to the
+real CLI and tees the stdio protocol to a JSON cassette, and in replay mode -- the default, and what
+CI runs -- it replays that cassette, so no credentials, no network, and no `claude` binary are needed.
+
+Re-record with a `claude` binary on the PATH and a real `ANTHROPIC_API_KEY` in the environment, which
+is what lets the CLI run without the recorder's own Claude Code configuration:
+
+    uv run --env-file .env pytest tests/agent_control/claude_agent_sdk/test_live.py \
+        --record-agent-control-cassettes
+
+[`fake_claude.py`]: ../../otel_integrations/fake_claude.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+from collections.abc import Iterator
+from contextlib import suppress
+from getpass import getuser
+from pathlib import Path
+from typing import Annotated, Any, cast
+
+import pytest
+from claude_agent_sdk import (
+    AgentDefinition,
+    AssistantMessage,
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    HookContext,
+    HookInput,
+    HookJSONOutput,
+    HookMatcher,
+    Message,
+    ResultMessage,
+    SystemMessage,
+    TextBlock,
+    ToolUseBlock,
+    tool,
+)
+
+from logfire.agent_control.claude_agent_sdk import agent_control, sdk_mcp_server
+from logfire.variables.local import LocalVariableProvider
+
+from .conftest import publish
+
+MODEL = 'claude-haiku-4-5'
+"""The cheapest current Claude model, since what is being tested is the CLI rather than the model."""
+
+FAKE_CLAUDE = Path(__file__).parents[2] / 'otel_integrations' / 'fake_claude.py'
+"""The record-and-replay stand-in for the `claude` binary, shared with the instrumentation tests."""
+
+CASSETTES = Path(__file__).parent / 'cassettes'
+
+
+@pytest.fixture
+def record(request: pytest.FixtureRequest) -> bool:
+    """Whether to run the real CLI and re-record, rather than replay what it said last time."""
+    return bool(request.config.getoption('--record-agent-control-cassettes', default=False))
+
+
+@pytest.fixture
+def cli_path(
+    request: pytest.FixtureRequest, record: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[str]:
+    """The `cli_path` to give the options, wired to the cassette named for the test that asks for it."""
+    cassette = CASSETTES / f'{request.node.name}.json'  # pyright: ignore[reportUnknownMemberType]
+    fake_claude = str(FAKE_CLAUDE)
+    mode = os.stat(fake_claude).st_mode
+    if not mode & stat.S_IEXEC:  # pragma: no cover
+        os.chmod(fake_claude, mode | stat.S_IEXEC)
+
+    monkeypatch.setenv('CASSETTE_PATH', str(cassette))
+    monkeypatch.setenv('CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK', '1')
+    if record:  # pragma: no cover
+        real_claude = shutil.which('claude')
+        if real_claude is None:
+            pytest.skip('No `claude` on PATH to record against.')
+        if os.environ.get('ANTHROPIC_API_KEY', 'foo') == 'foo':
+            # The suite pins a placeholder key for the offline tests, and the CLI cannot authenticate
+            # with it. Recording deliberately does not fall back to whatever the recorder is logged
+            # in as, because a real key is also what lets the session run without their config.
+            pytest.skip('Recording needs a real ANTHROPIC_API_KEY in the environment.')
+        CASSETTES.mkdir(exist_ok=True)
+        monkeypatch.setenv('CASSETTE_MODE', 'record')
+        monkeypatch.setenv('REAL_CLAUDE_PATH', real_claude)
+        # An empty config directory, so what gets recorded is a session of *this* agent rather than
+        # of the recorder's own Claude Code install: their subagents, their slash commands, and their
+        # session hooks would otherwise be in the initialize response, and then in the repository.
+        monkeypatch.setenv('CLAUDE_CONFIG_DIR', str(tmp_path))
+    else:
+        if not cassette.exists():  # pragma: no cover
+            pytest.fail(f'No cassette at {cassette}; record it with --record-agent-control-cassettes.')
+        monkeypatch.setenv('CASSETTE_MODE', 'replay')
+        monkeypatch.delenv('REAL_CLAUDE_PATH', raising=False)
+    yield fake_claude
+    if record:  # pragma: no cover
+        _scrub(cassette)
+
+
+def _scrub(cassette: Path) -> None:  # pragma: no cover
+    """Take the recording machine out of a freshly recorded cassette.
+
+    A session the CLI ran here carries where it ran: absolute paths under the recorder's home
+    directory, and the account's own rate-limit standing. None of it is what these tests assert on,
+    and all of it would be committed, so it is replaced or dropped before the file is kept.
+    """
+    recorded = json.loads(cassette.read_text())
+    kept = [entry for entry in recorded['messages'] if entry['message'].get('type') != 'rate_limit_event']
+    text = json.dumps({**recorded, 'messages': kept}, indent=2)
+    # Whole paths, then the slug the CLI names a transcript directory after, then the account name
+    # on its own, for anything the first two did not carry away with them.
+    cwd, home = str(Path.cwd()), str(Path.home())
+    for value, placeholder in (
+        (cwd, '/agent'),
+        (home, '/home/user'),
+        (cwd.replace('/', '-'), '-agent'),
+        (getuser(), 'user'),
+    ):
+        text = text.replace(json.dumps(value)[1:-1], placeholder)
+    cassette.write_text(text + '\n')
+
+
+async def run(options: ClaudeAgentOptions, prompt: str) -> list[Message]:
+    """One whole session: connect, ask, and collect everything the CLI said back."""
+    client = ClaudeSDKClient(options=options)
+    messages: list[Message] = []
+    try:
+        await client.connect()
+        await client.query(prompt)
+        async for message in client.receive_response():
+            messages.append(message)
+    finally:
+        await _close(client)
+        await client.disconnect()
+    return messages
+
+
+async def _close(client: ClaudeSDKClient) -> None:
+    """Close the streams the SDK leaves open, which `filterwarnings = error` would otherwise fail on."""
+    query = client._query
+    if query is not None:  # pragma: no branch
+        for close in (query.close, query._message_send.aclose, query._message_receive.aclose):
+            with suppress(Exception):
+                await close()
+        client._query = None
+    transport = client._transport
+    stdout = getattr(transport, '_stdout_stream', None)
+    if stdout is not None:  # pragma: no branch
+        with suppress(Exception):
+            await stdout.aclose()
+
+
+def text_of(messages: list[Message]) -> str:
+    """Everything the assistant said, as one string."""
+    return '\n'.join(
+        block.text
+        for message in messages
+        if isinstance(message, AssistantMessage)
+        for block in message.content
+        if isinstance(block, TextBlock)
+    )
+
+
+def tool_calls(messages: list[Message]) -> list[tuple[str, dict[str, Any]]]:
+    """The name the model called each tool by, with the arguments it called it with."""
+    return [
+        (block.name, block.input)
+        for message in messages
+        if isinstance(message, AssistantMessage)
+        for block in message.content
+        if isinstance(block, ToolUseBlock)
+    ]
+
+
+def result_of(messages: list[Message]) -> ResultMessage:
+    [result] = [message for message in messages if isinstance(message, ResultMessage)]
+    return result
+
+
+def init_of(messages: list[Message]) -> dict[str, Any]:
+    """The CLI's own account of the session it just started."""
+    [init] = [message for message in messages if isinstance(message, SystemMessage) and message.subtype == 'init']
+    return init.data
+
+
+@pytest.mark.anyio
+async def test_a_published_prompt_and_effort_are_what_the_session_runs_on(
+    project: LocalVariableProvider, cli_path: str
+) -> None:
+    """A published block reaches the model, and the CLI accepts the effort a published level sets."""
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {
+            'instructions': [{'id': 'system', 'instructions': 'Whatever you are asked, reply with only: BANANA'}],
+            'settings': {'thinking': 'low'},
+        },
+    )
+    options = agent_control(
+        ClaudeAgentOptions(
+            system_prompt='You are a concise checkout assistant.', model=MODEL, cli_path=cli_path, setting_sources=[]
+        ),
+        name='checkout_assistant',
+        label='production',
+    )
+    # The code's prompt is replaced, and `thinking` sets both halves of what the CLI is told.
+    assert options.system_prompt == 'Whatever you are asked, reply with only: BANANA'
+    assert options.thinking == {'type': 'adaptive'}
+    assert options.effort == 'low'
+
+    messages = await run(options, 'What is 2 + 2?')
+
+    # Only the published prompt explains this answer, and the CLI ran the session rather than
+    # rejecting `--thinking adaptive --effort low`.
+    assert 'BANANA' in text_of(messages)
+    assert result_of(messages).is_error is False
+
+
+@tool('refund_order', 'Refund an order.', {'order_id': Annotated[str, 'The order to refund.']})
+async def refund_order(args: dict[str, Any]) -> dict[str, Any]:
+    _REFUNDED.append(cast(str, args['order_id']))
+    return {'content': [{'type': 'text', 'text': f'Refunded {args["order_id"]}.'}]}
+
+
+_REFUNDED: list[str] = []
+"""The orders the handler above was actually asked to refund, which is what a rename must not change."""
+
+
+@pytest.mark.anyio
+async def test_a_renamed_tool_is_called_under_its_managed_name_and_runs_your_code(
+    project: LocalVariableProvider, cli_path: str
+) -> None:
+    """The model calls `mcp__shop__issue_refund`; the handler and the hook see the code's own name."""
+    _REFUNDED.clear()
+    seen: list[str] = []
+
+    async def hook(payload: HookInput, tool_use_id: str | None, context: HookContext) -> HookJSONOutput:
+        seen.append(cast(dict[str, Any], payload)['tool_name'])
+        return {}
+
+    publish(
+        project,
+        'agent__checkout_assistant',
+        {
+            'tool_definitions': [
+                {
+                    'name': 'refund_order',
+                    'new_name': 'issue_refund',
+                    'description': 'Issue a refund for one order. Use this whenever a refund is requested.',
+                    'parameters': {'order_id': {'description': "The order's id, e.g. 'A-1234'."}},
+                }
+            ]
+        },
+    )
+    options = agent_control(
+        ClaudeAgentOptions(
+            system_prompt='You are a checkout assistant. Use your tools; do not ask for confirmation.',
+            model=MODEL,
+            cli_path=cli_path,
+            setting_sources=[],
+            mcp_servers={'shop': sdk_mcp_server('shop', tools=[refund_order])},
+            # Written against the name the *code* gave the tool; the rename has to carry it along, or
+            # the model would be shown a tool it is not allowed to call.
+            allowed_tools=['mcp__shop__refund_order'],
+            hooks={'PreToolUse': [HookMatcher(matcher='mcp__shop__refund_order', hooks=[hook])]},
+        ),
+        name='checkout_assistant',
+        label='production',
+    )
+    assert options.allowed_tools == ['mcp__shop__issue_refund']
+
+    messages = await run(options, 'Refund order A-1234, then reply DONE.')
+
+    # The model called the managed name, and the arguments arrived under the code's own parameter
+    # name. Anything the CLI's own tools did on the way -- looking the tool up by name, here -- is
+    # not what this is about, so only the in-process calls are compared.
+    assert [call for call in tool_calls(messages) if call[0].startswith('mcp__')] == [
+        ('mcp__shop__issue_refund', {'order_id': 'A-1234'})
+    ]
+    # It reached the handler your code wrote, which was never told a name.
+    assert _REFUNDED == ['A-1234']
+    # The hook matcher still fired, and was handed the name the code declared.
+    assert seen == ['mcp__shop__refund_order']
+    assert result_of(messages).is_error is False
+
+
+def subagent_options(cli_path: str, prompt: str) -> ClaudeAgentOptions:
+    """An agent with one subagent, which is the only thing these two tests differ on."""
+    return ClaudeAgentOptions(
+        system_prompt='You are a concise checkout assistant.',
+        model=MODEL,
+        cli_path=cli_path,
+        setting_sources=[],
+        agents={'reviewer': AgentDefinition(description='Reviews refunds.', prompt=prompt)},
+    )
+
+
+@pytest.mark.anyio
+async def test_the_cli_leaves_out_a_subagent_with_no_prompt(cli_path: str) -> None:
+    """The CLI behaviour the adapter refuses a removal on, pinned so the refusal keeps its reason.
+
+    Nothing about Agent Control is exercised here. This is the fact the test below is built on: a
+    subagent is declared to the CLI *by* its prompt, and one whose prompt is empty is not in the
+    session's agent list at all -- so "empty the prompt and keep the subagent", which is what
+    removing a block would otherwise mean, is not a state this SDK can be in.
+    """
+    messages = await run(subagent_options(cli_path, ''), 'Reply with only: OK')
+
+    assert 'reviewer' not in init_of(messages)['agents']
+    assert result_of(messages).is_error is False
+
+
+@pytest.mark.anyio
+async def test_a_subagent_whose_block_was_removed_is_still_in_the_session(
+    project: LocalVariableProvider, cli_path: str
+) -> None:
+    """A removal the CLI cannot express is reported, and the subagent is still there."""
+    publish(project, 'agent__checkout_assistant', {'instructions': [{'id': 'agent:reviewer'}]})
+    with pytest.warns(UserWarning, match="removes instruction block 'agent:reviewer'"):
+        options = agent_control(
+            subagent_options(cli_path, 'You review refunds.'), name='checkout_assistant', label='production'
+        )
+    assert options.agents == {'reviewer': AgentDefinition(description='Reviews refunds.', prompt='You review refunds.')}
+
+    messages = await run(options, 'Reply with only: OK')
+
+    # Which is what keeps the subagent -- its description and its tool list included -- in a session
+    # that a published removal would otherwise have taken it out of.
+    assert 'reviewer' in init_of(messages)['agents']
+    assert result_of(messages).is_error is False
+
+
+@pytest.mark.anyio
+async def test_a_published_max_tokens_reaches_the_cli(project: LocalVariableProvider, cli_path: str) -> None:
+    """`max_tokens` is applied through the CLI's environment, and the CLI reads it from there."""
+    publish(project, 'agent__checkout_assistant', {'settings': {'max_tokens': 16}})
+    options = agent_control(
+        ClaudeAgentOptions(
+            system_prompt='You are a concise checkout assistant.', model=MODEL, cli_path=cli_path, setting_sources=[]
+        ),
+        name='checkout_assistant',
+        label='production',
+    )
+    assert options.env['CLAUDE_CODE_MAX_OUTPUT_TOKENS'] == '16'
+
+    messages = await run(options, 'Write a 200 word essay about bananas.')
+
+    # The CLI stopped the response at exactly the published cap and named the variable it read it
+    # from, which is what "this setting is editable" has to mean for a setting this SDK has no field
+    # for. A CLI that ignored the environment would have answered the question.
+    result = result_of(messages)
+    assert result.is_error is True
+    assert '16 output token maximum' in cast(str, result.result)
+
+
+@pytest.mark.anyio
+async def test_a_published_timeout_reaches_the_cli(project: LocalVariableProvider, cli_path: str) -> None:
+    """`timeout` is applied through the CLI's environment too, and the CLI honours it as a deadline."""
+    publish(project, 'agent__checkout_assistant', {'settings': {'timeout': 0.001}})
+    options = agent_control(
+        ClaudeAgentOptions(
+            system_prompt='You are a concise checkout assistant.', model=MODEL, cli_path=cli_path, setting_sources=[]
+        ),
+        name='checkout_assistant',
+        label='production',
+    )
+    # Seconds in the contract, whole milliseconds in the environment, by the core's own conversion.
+    assert options.env['API_TIMEOUT_MS'] == '1'
+
+    messages = await run(options, 'Reply with only: OK')
+
+    # A millisecond is not enough for any request, so the CLI gave up on its own deadline rather than
+    # on one nobody set -- which is the whole of what this setting being editable means here.
+    result = result_of(messages)
+    assert result.is_error is True
+    assert 'timed out' in cast(str, result.result).lower()

--- a/tests/agent_control/claude_agent_sdk/test_settings.py
+++ b/tests/agent_control/claude_agent_sdk/test_settings.py
@@ -1,0 +1,92 @@
+"""What a published `model` and `settings` section do to the process the SDK spawns."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from claude_agent_sdk import ClaudeAgentOptions
+
+from logfire.agent_control.claude_agent_sdk import agent_control
+from logfire.variables.local import LocalVariableProvider
+
+from .agents import checkout_options
+from .conftest import cli_arg, cli_args, publish
+
+
+def managed(project: LocalVariableProvider, value: dict[str, Any], **options: Any) -> ClaudeAgentOptions:
+    publish(project, 'agent__checkout_assistant', value)
+    return agent_control(checkout_options(**options), name='checkout_assistant', label='production')
+
+
+def test_an_anthropic_model_is_lowered_to_the_bare_id(project: LocalVariableProvider) -> None:
+    options = managed(project, {'model': 'anthropic:claude-opus-4-5'})
+    assert options.model == 'claude-opus-4-5'
+    assert cli_arg(options, '--model') == 'claude-opus-4-5'
+
+
+def test_an_alias_is_a_model_like_any_other(project: LocalVariableProvider) -> None:
+    assert managed(project, {'model': 'anthropic:sonnet'}).model == 'sonnet'
+
+
+def test_a_model_with_no_provider_is_passed_through(project: LocalVariableProvider) -> None:
+    assert managed(project, {'model': 'claude-fable-5-1-20260901'}).model == 'claude-fable-5-1-20260901'
+
+
+def test_another_providers_model_is_refused(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="selects model 'bedrock:claude-fable-5-1', but the Claude Agent SDK"):
+        options = managed(project, {'model': 'bedrock:claude-fable-5-1'})
+    assert options.model == 'claude-fable-5-1'  # The code's own model, untouched.
+
+
+@pytest.mark.parametrize(
+    ('thinking', 'expected_thinking', 'expected_effort'),
+    [
+        (False, 'disabled', None),
+        (True, 'adaptive', None),
+        ('minimal', 'adaptive', 'low'),
+        ('low', 'adaptive', 'low'),
+        ('xhigh', 'adaptive', 'xhigh'),
+    ],
+)
+def test_thinking_sets_both_halves_of_what_the_cli_is_told(
+    project: LocalVariableProvider, thinking: bool | str, expected_thinking: str, expected_effort: str | None
+) -> None:
+    options = managed(project, {'settings': {'thinking': thinking}})
+    assert cli_arg(options, '--thinking') == expected_thinking
+    assert cli_arg(options, '--effort') == expected_effort
+
+
+def test_output_and_timeout_settings_reach_the_cli_environment(project: LocalVariableProvider) -> None:
+    options = managed(project, {'settings': {'max_tokens': 4096, 'timeout': 12.5}}, env={'ANTHROPIC_LOG': 'debug'})
+    assert options.env == {
+        'ANTHROPIC_LOG': 'debug',
+        'CLAUDE_CODE_MAX_OUTPUT_TOKENS': '4096',
+        'API_TIMEOUT_MS': '12500',
+    }
+
+
+def test_the_callers_environment_is_never_mutated(project: LocalVariableProvider) -> None:
+    env = {'ANTHROPIC_LOG': 'debug'}
+    managed(project, {'settings': {'max_tokens': 4096}}, env=env)
+    assert env == {'ANTHROPIC_LOG': 'debug'}
+
+
+def test_settings_this_framework_has_no_knob_for_are_reported(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="sets 'temperature', which this agent framework has no equivalent"):
+        options = managed(project, {'settings': {'temperature': 0.4, 'thinking': 'low'}})
+    # The one it can apply still applies.
+    assert cli_arg(options, '--effort') == 'low'
+    assert '--temperature' not in cli_args(options)
+
+
+def test_a_settings_section_that_changes_nothing_leaves_the_environment_alone(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="sets 'seed', which this agent framework has no equivalent"):
+        options = managed(project, {'settings': {'seed': 7}}, env={'ANTHROPIC_LOG': 'debug'})
+    assert options.env == {'ANTHROPIC_LOG': 'debug'}
+    assert cli_arg(options, '--effort') == 'high'  # Still the code's own effort.
+
+
+def test_settings_the_contract_itself_does_not_know_are_reported(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="sets 'service_tier', which this version of the Agent Control"):
+        managed(project, {'settings': {'service_tier': 'flex'}})

--- a/tests/agent_control/claude_agent_sdk/test_settings.py
+++ b/tests/agent_control/claude_agent_sdk/test_settings.py
@@ -29,6 +29,14 @@ def test_an_alias_is_a_model_like_any_other(project: LocalVariableProvider) -> N
     assert managed(project, {'model': 'anthropic:sonnet'}).model == 'sonnet'
 
 
+def test_a_provider_with_no_model_after_it_is_refused(project: LocalVariableProvider) -> None:
+    # A prefix and nothing after it would start the session with no model at all, rather than with
+    # the one the code names.
+    with pytest.warns(UserWarning, match="selects model 'anthropic:', which names a provider and no model"):
+        options = managed(project, {'model': 'anthropic:'})
+    assert options.model == 'claude-fable-5-1'
+
+
 def test_a_model_with_no_provider_is_passed_through(project: LocalVariableProvider) -> None:
     assert managed(project, {'model': 'claude-fable-5-1-20260901'}).model == 'claude-fable-5-1-20260901'
 

--- a/tests/agent_control/claude_agent_sdk/test_tools.py
+++ b/tests/agent_control/claude_agent_sdk/test_tools.py
@@ -1,0 +1,358 @@
+"""What a published `tool_definitions` section does to the tools the model is shown."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import anyio
+import pytest
+from claude_agent_sdk import (
+    AgentDefinition,
+    ClaudeAgentOptions,
+    HookContext,
+    HookInput,
+    HookJSONOutput,
+    HookMatcher,
+    PermissionResult,
+    PermissionResultAllow,
+    PermissionResultDeny,
+    PermissionUpdate,
+    ToolPermissionContext,
+    create_sdk_mcp_server,
+)
+from claude_agent_sdk.types import PermissionRuleValue
+from inline_snapshot import snapshot
+
+from logfire.agent_control.claude_agent_sdk import ManagedAgent, agent_control, sdk_mcp_server
+from logfire.variables.local import LocalVariableProvider
+
+from .agents import checkout_options, refund_order, search
+from .conftest import call_tool, cli_arg, publish, wire_tools
+
+RENAME: dict[str, Any] = {
+    'name': 'refund_order',
+    'new_name': 'issue_refund',
+    'description': 'Issue a refund for an order.',
+    'parameters': {'order_id': {'description': "The order's id, e.g. 'A-1234'."}},
+}
+
+
+def managed(project: LocalVariableProvider, overrides: list[dict[str, Any]], **options: Any) -> ClaudeAgentOptions:
+    publish(project, 'agent__checkout_assistant', {'tool_definitions': overrides})
+    return agent_control(checkout_options(**options), name='checkout_assistant', label='production')
+
+
+def test_a_managed_definition_is_what_the_model_is_shown(project: LocalVariableProvider) -> None:
+    options = managed(project, [RENAME])
+    assert wire_tools(options, 'shop') == snapshot(
+        [
+            {
+                'description': 'Issue a refund for an order.',
+                'inputSchema': {
+                    'properties': {'order_id': {'type': 'string', 'description': "The order's id, e.g. 'A-1234'."}},
+                    'required': ['order_id'],
+                    'type': 'object',
+                },
+                'name': 'issue_refund',
+            },
+            {
+                'description': 'Search the catalogue.',
+                'inputSchema': {'properties': {'query': {'type': 'string'}}, 'required': ['query'], 'type': 'object'},
+                'name': 'search',
+            },
+        ]
+    )
+
+
+def test_an_untouched_tool_keeps_its_exact_definition(project: LocalVariableProvider) -> None:
+    code = checkout_options()
+    options = managed(project, [RENAME])
+    assert wire_tools(options, 'shop')[1] == wire_tools(code, 'shop')[1]
+
+
+def test_a_renamed_tool_still_reaches_the_code_that_implements_it(project: LocalVariableProvider) -> None:
+    options = managed(project, [RENAME])
+    # The model calls the managed name; the handler is the same function object and is never told one.
+    assert call_tool(options, 'shop', 'issue_refund', {'order_id': 'A-1234'}) == snapshot(
+        {'content': [{'text': 'refunded A-1234', 'type': 'text'}], 'isError': False}
+    )
+
+
+def test_a_rename_follows_through_to_permissions_and_hooks(project: LocalVariableProvider) -> None:
+    async def hook(*args: Any) -> HookJSONOutput:
+        return {}  # pragma: no cover
+
+    hooks = {
+        'PreToolUse': [
+            HookMatcher(matcher='mcp__shop__refund_order|Bash', hooks=[hook]),
+            HookMatcher(matcher='mcp__shop__.*', hooks=[hook]),
+            HookMatcher(hooks=[hook]),
+        ]
+    }
+    options = managed(
+        project,
+        [RENAME],
+        disallowed_tools=['mcp__shop__refund_order(A-*)'],
+        hooks=hooks,
+    )
+    assert options.allowed_tools == ['mcp__shop__issue_refund', 'Read(*.py)']
+    assert options.disallowed_tools == ['mcp__shop__issue_refund(A-*)']
+    assert cli_arg(options, '--allowedTools') == 'mcp__shop__issue_refund,Read(*.py)'
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['PreToolUse']
+    assert [matcher.matcher for matcher in matchers] == ['mcp__shop__issue_refund|Bash', 'mcp__shop__.*', None]
+
+
+def test_a_description_only_change_renames_nothing(project: LocalVariableProvider) -> None:
+    options = managed(project, [{'name': 'search', 'description': 'Search the shop catalogue.'}])
+    assert options.allowed_tools == ['mcp__shop__refund_order', 'Read(*.py)']
+    assert call_tool(options, 'shop', 'search', {'query': 'shoes'})['content'][0]['text'] == 'found shoes'
+    assert [(tool['name'], tool['description']) for tool in wire_tools(options, 'shop')] == snapshot(
+        [('refund_order', 'Refund an order.'), ('search', 'Search the shop catalogue.')]
+    )
+
+
+def test_an_override_narrowed_to_one_server_leaves_the_other_alone(project: LocalVariableProvider) -> None:
+    servers = {
+        'shop': sdk_mcp_server('shop', tools=[search]),
+        'crm': sdk_mcp_server('crm', tools=[search]),
+    }
+    options = managed(
+        project,
+        [{'name': 'search', 'toolset': 'crm', 'description': 'Search CRM records.'}],
+        mcp_servers=servers,
+    )
+    assert wire_tools(options, 'shop')[0]['description'] == 'Search the catalogue.'
+    assert wire_tools(options, 'crm')[0]['description'] == 'Search CRM records.'
+
+
+def test_a_tool_no_server_advertises_is_reported(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="patches tool 'cancel_order', which no toolset advertises"):
+        options = managed(project, [{'name': 'cancel_order', 'description': 'Cancel it.'}])
+    assert wire_tools(options, 'shop') == wire_tools(checkout_options(), 'shop')
+
+
+def test_tools_of_a_server_the_adapter_cannot_rebuild_are_reported(project: LocalVariableProvider) -> None:
+    # `create_sdk_mcp_server` keeps no reference to its definitions, so its tools are neither listed
+    # in the baseline nor patchable -- and an override naming one has to say so rather than vanish.
+    sealed = {'shop': create_sdk_mcp_server('shop', tools=[refund_order])}
+    with pytest.warns(UserWarning, match="patches tool 'refund_order', which no toolset advertises"):
+        options = managed(project, [{'name': 'refund_order', 'description': 'Issue a refund.'}], mcp_servers=sealed)
+    assert wire_tools(options, 'shop')[0]['description'] == 'Refund an order.'
+
+
+def test_a_rename_onto_a_name_in_use_keeps_every_tool_callable(project: LocalVariableProvider) -> None:
+    with pytest.warns(UserWarning, match="renames 'refund_order' to 'search', which is already advertised"):
+        options = managed(project, [{'name': 'refund_order', 'new_name': 'search'}])
+    assert [tool['name'] for tool in wire_tools(options, 'shop')] == ['refund_order', 'search']
+
+
+def test_a_rebuilt_server_keeps_its_place_and_its_version(project: LocalVariableProvider) -> None:
+    servers = {
+        'shop': sdk_mcp_server('shop', '2.0.0', [refund_order]),
+        'crm': {'type': 'http', 'url': 'https://crm.example'},
+    }
+    options = managed(project, [RENAME], mcp_servers=servers)
+    assert list(options.mcp_servers) == ['shop', 'crm']  # type: ignore[arg-type]
+    assert options.mcp_servers['shop']['instance'].version == '2.0.0'  # type: ignore[index]
+
+
+def test_the_adapters_bookkeeping_never_reaches_the_command_line(project: LocalVariableProvider) -> None:
+    # Everything but `instance` is JSON-encoded into `--mcp-config`, so remembering a server's tools
+    # on the config dict would either leak them onto the command line or fail to serialize.
+    options = managed(project, [RENAME])
+    mcp_config = cli_arg(options, '--mcp-config')
+    assert mcp_config is not None
+    assert json.loads(mcp_config) == {'mcpServers': {'shop': {'type': 'sdk', 'name': 'shop'}}}
+
+
+def test_nothing_published_leaves_the_servers_the_caller_built(project: LocalVariableProvider) -> None:
+    code = checkout_options()
+    options = ManagedAgent('checkout_assistant', label='production').options(code)
+    assert options is code
+
+
+def test_a_rename_with_nothing_else_naming_the_tool_touches_nothing_else(project: LocalVariableProvider) -> None:
+    options = managed(project, [RENAME], allowed_tools=[], agents=None)
+    assert options.allowed_tools == []
+    assert options.disallowed_tools == []
+    assert options.agents is None
+    assert options.hooks is None
+    assert options.can_use_tool is None
+    assert [tool['name'] for tool in wire_tools(options, 'shop')] == ['issue_refund', 'search']
+
+
+def test_a_rename_reaches_every_subagents_own_tool_lists(project: LocalVariableProvider) -> None:
+    agents = {
+        'reviewer': AgentDefinition(
+            description='Reviews refunds.',
+            prompt='You review refunds.',
+            tools=['mcp__shop__refund_order', 'Read'],
+            disallowedTools=['mcp__shop__refund_order(A-*)'],
+        )
+    }
+    options = managed(project, [RENAME], agents=agents)
+    # A subagent's `tools` list is a permission rule like any other: left alone, the rename would
+    # take a tool the subagent was explicitly allowed straight out of its reach.
+    assert options.agents == snapshot(
+        {
+            'reviewer': AgentDefinition(
+                description='Reviews refunds.',
+                prompt='You review refunds.',
+                tools=['mcp__shop__issue_refund', 'Read'],
+                disallowedTools=['mcp__shop__issue_refund(A-*)'],
+            )
+        }
+    )
+
+
+def test_a_subagent_that_names_no_renamed_tool_is_the_object_the_caller_built(
+    project: LocalVariableProvider,
+) -> None:
+    options = managed(project, [RENAME])
+    assert options.agents == checkout_options().agents
+
+
+def test_a_rename_reaches_the_tool_that_asks_for_permission(project: LocalVariableProvider) -> None:
+    options = managed(project, [RENAME], permission_prompt_tool_name='mcp__shop__refund_order')
+    assert options.permission_prompt_tool_name == 'mcp__shop__issue_refund'
+
+
+def test_a_permission_tool_that_was_not_renamed_is_left_as_written(project: LocalVariableProvider) -> None:
+    options = managed(project, [RENAME], permission_prompt_tool_name='mcp__approvals__ask')
+    assert options.permission_prompt_tool_name == 'mcp__approvals__ask'
+
+
+def test_two_servers_may_each_advertise_the_same_name(project: LocalVariableProvider) -> None:
+    # The model calls an in-process tool `mcp__<server>__<tool>`, so a name is only taken inside its
+    # own server: renaming the shop's `search` to `refund_order` does not collide with the CRM's.
+    servers = {'shop': sdk_mcp_server('shop', tools=[search]), 'crm': sdk_mcp_server('crm', tools=[refund_order])}
+    options = managed(
+        project,
+        [{'name': 'search', 'toolset': 'shop', 'new_name': 'refund_order'}],
+        mcp_servers=servers,
+        allowed_tools=['mcp__shop__search'],
+    )
+    assert [tool['name'] for tool in wire_tools(options, 'shop')] == ['refund_order']
+    assert [tool['name'] for tool in wire_tools(options, 'crm')] == ['refund_order']
+    assert options.allowed_tools == ['mcp__shop__refund_order']
+
+
+def test_a_permission_callback_is_asked_about_the_tool_your_code_declared(project: LocalVariableProvider) -> None:
+    asked: list[str] = []
+    suggested: list[str] = []
+
+    async def can_use_tool(name: str, _input: dict[str, Any], context: ToolPermissionContext) -> PermissionResult:
+        asked.append(name)
+        suggested.extend(rule.tool_name for update in context.suggestions for rule in update.rules or [])
+        return PermissionResultAllow(
+            updated_permissions=[
+                PermissionUpdate(type='addRules', rules=[PermissionRuleValue(tool_name=name)], behavior='allow'),
+                PermissionUpdate(type='setMode', mode='acceptEdits'),
+            ]
+        )
+
+    options = managed(project, [RENAME], can_use_tool=can_use_tool)
+    assert options.can_use_tool is not None
+    suggestions = [
+        PermissionUpdate(
+            type='addRules', rules=[PermissionRuleValue(tool_name='mcp__shop__issue_refund')], behavior='allow'
+        ),
+        # An update that names no tool -- a mode change -- has nothing to translate either way.
+        PermissionUpdate(type='setMode', mode='acceptEdits'),
+    ]
+    result = anyio.run(
+        options.can_use_tool,
+        'mcp__shop__issue_refund',
+        {'order_id': 'A-1234'},
+        ToolPermissionContext(suggestions=suggestions),
+    )
+    # The callback branches on the name your code gave the tool, in the argument and in the rules the
+    # CLI suggested; what it asks for back is in the names the CLI knows.
+    assert asked == ['mcp__shop__refund_order']
+    assert suggested == ['mcp__shop__refund_order']
+    assert isinstance(result, PermissionResultAllow)
+    assert result.updated_permissions is not None
+    assert [rule.tool_name for update in result.updated_permissions for rule in update.rules or []] == [
+        'mcp__shop__issue_refund'
+    ]
+
+
+def test_a_permission_callback_asked_about_another_tool_sees_it_unchanged(project: LocalVariableProvider) -> None:
+    async def can_use_tool(name: str, _input: dict[str, Any], _context: ToolPermissionContext) -> PermissionResult:
+        return PermissionResultDeny(message=f'no {name}')
+
+    options = managed(project, [RENAME], can_use_tool=can_use_tool)
+    assert options.can_use_tool is not None
+    no_input: dict[str, Any] = {}
+    result = anyio.run(options.can_use_tool, 'Bash', no_input, ToolPermissionContext())
+    assert result == PermissionResultDeny(message='no Bash')
+
+
+def test_a_hook_is_told_the_tool_your_code_declared(project: LocalVariableProvider) -> None:
+    seen: list[str] = []
+
+    async def hook(payload: HookInput, _tool_use_id: str | None, _context: HookContext) -> HookJSONOutput:
+        seen.append(cast(dict[str, Any], payload)['tool_name'])
+        return {}
+
+    options = managed(
+        project, [RENAME], hooks={'PreToolUse': [HookMatcher(matcher='mcp__shop__refund_order', hooks=[hook])]}
+    )
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['PreToolUse']
+    payload: dict[str, Any] = {
+        'hook_event_name': 'PreToolUse',
+        'session_id': 's',
+        'transcript_path': '/t',
+        'cwd': '/c',
+        'tool_name': 'mcp__shop__issue_refund',
+        'tool_input': {'order_id': 'A-1234'},
+        'tool_use_id': 'call-1',
+    }
+    assert anyio.run(matchers[0].hooks[0], cast(HookInput, payload), 'call-1', HookContext(signal=None)) == {}
+    assert seen == ['mcp__shop__refund_order']
+
+
+def test_a_hook_about_anything_else_is_handed_what_the_cli_sent(project: LocalVariableProvider) -> None:
+    seen: list[dict[str, Any]] = []
+
+    async def hook(payload: HookInput, _tool_use_id: str | None, _context: HookContext) -> HookJSONOutput:
+        seen.append(cast(dict[str, Any], payload))
+        return {}
+
+    options = managed(project, [RENAME], hooks={'Stop': [HookMatcher(hooks=[hook])]})
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['Stop']
+    payload: dict[str, Any] = {
+        'hook_event_name': 'Stop',
+        'session_id': 's',
+        'transcript_path': '/t',
+        'cwd': '/c',
+        'stop_hook_active': False,
+    }
+    anyio.run(matchers[0].hooks[0], cast(HookInput, payload), None, HookContext(signal=None))
+    assert seen == [payload]
+
+
+def test_a_hook_matcher_a_rename_breaks_is_reported(project: LocalVariableProvider) -> None:
+    async def hook(*args: Any) -> HookJSONOutput:
+        return {}  # pragma: no cover
+
+    hooks = {'PreToolUse': [HookMatcher(matcher='mcp__shop__refund.*', hooks=[hook])]}
+    with pytest.warns(UserWarning, match='PreToolUse hook matcher'):
+        options = managed(project, [RENAME], hooks=hooks)
+    # Rewriting a regular expression would be editing one on a guess, so it is left as written.
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['PreToolUse']
+    assert matchers[0].matcher == 'mcp__shop__refund.*'
+
+
+@pytest.mark.parametrize('matcher', ['mcp__shop__.*', 'mcp__crm__refund.*', 'mcp__shop__[', None])
+def test_a_hook_matcher_a_rename_does_not_break_is_left_alone(
+    project: LocalVariableProvider, matcher: str | None
+) -> None:
+    async def hook(*args: Any) -> HookJSONOutput:
+        return {}  # pragma: no cover
+
+    # Still matching, never matching, and unparseable are all cases a rename did not change.
+    options = managed(project, [RENAME], hooks={'PreToolUse': [HookMatcher(matcher=matcher, hooks=[hook])]})
+    matchers = cast(dict[str, list[HookMatcher]], options.hooks)['PreToolUse']
+    assert matchers[0].matcher == matcher

--- a/tests/agent_control/claude_agent_sdk/test_tools.py
+++ b/tests/agent_control/claude_agent_sdk/test_tools.py
@@ -157,6 +157,16 @@ def test_a_rebuilt_server_keeps_its_place_and_its_version(project: LocalVariable
     assert options.mcp_servers['shop']['instance'].version == '2.0.0'  # type: ignore[index]
 
 
+def test_a_rebuilt_server_keeps_the_name_the_cli_knows_it_by(project: LocalVariableProvider) -> None:
+    # A server filed under a different key than it was built with keeps both: the key is what the
+    # model-facing names carry, the name is what the CLI is told, and a rebuild changes neither.
+    options = managed(project, [RENAME], mcp_servers={'shop': sdk_mcp_server('store', tools=[refund_order])})
+    mcp_config = cli_arg(options, '--mcp-config')
+    assert mcp_config is not None
+    assert json.loads(mcp_config) == {'mcpServers': {'shop': {'type': 'sdk', 'name': 'store'}}}
+    assert [tool['name'] for tool in wire_tools(options, 'shop')] == ['issue_refund']
+
+
 def test_the_adapters_bookkeeping_never_reaches_the_command_line(project: LocalVariableProvider) -> None:
     # Everything but `instance` is JSON-encoded into `--mcp-config`, so remembering a server's tools
     # on the config dict would either leak them onto the command line or fail to serialize.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,10 @@ if get_version(pydantic_version) < get_version('2.10.0'):  # pragma: no cover
     # from 2.10; the `agent-control` extra requires that floor. Skipping the directory (rather than
     # each module) also skips its conftest, which imports the package at module level.
     collect_ignore = ['agent_control']
+elif get_version(pydantic_version) < get_version('2.11.0'):  # pragma: no cover
+    # The Claude Agent SDK itself needs pydantic 2.11, so its adapter and tests cannot even be
+    # imported below that floor; the rest of `agent_control` still can.
+    collect_ignore = ['agent_control/claude_agent_sdk']
 
 
 # Emit both new and old semantic convention attribute names

--- a/tests/test_logfire_api.py
+++ b/tests/test_logfire_api.py
@@ -298,7 +298,11 @@ def test_runtime(logfire_api_factory: Callable[[], ModuleType], module_name: str
     except ImportError:
         pass
     else:
-        logfire_api.instrument_claude_agent_sdk()
+        # Entered and exited, so the patching reverts: it is applied to the SDK's classes process-wide
+        # the moment this is called, and left in place it decides what every later test in the same
+        # process runs against.
+        with logfire_api.instrument_claude_agent_sdk():
+            pass
     logfire__all__.remove('instrument_claude_agent_sdk')
 
     assert hasattr(logfire_api, 'instrument_google_genai')

--- a/uv.lock
+++ b/uv.lock
@@ -3081,7 +3081,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "claude-agent-sdk", marker = "extra == 'agent-control-claude-agent-sdk'", specifier = ">=0.2" },
+    { name = "claude-agent-sdk", marker = "extra == 'agent-control-claude-agent-sdk'", specifier = ">=0.2.82" },
     { name = "executing", specifier = ">=2.0.1" },
     { name = "httpx", marker = "extra == 'datasets'", specifier = ">=0.27.2" },
     { name = "httpx", marker = "extra == 'gateway'", specifier = ">=0.27.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2869,6 +2869,11 @@ agent-control = [
     { name = "pydantic" },
     { name = "pydantic-handlebars" },
 ]
+agent-control-claude-agent-sdk = [
+    { name = "claude-agent-sdk" },
+    { name = "pydantic" },
+    { name = "pydantic-handlebars" },
+]
 aiohttp = [
     { name = "opentelemetry-instrumentation-aiohttp-client" },
 ]
@@ -3076,10 +3081,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "claude-agent-sdk", marker = "extra == 'agent-control-claude-agent-sdk'", specifier = ">=0.2" },
     { name = "executing", specifier = ">=2.0.1" },
     { name = "httpx", marker = "extra == 'datasets'", specifier = ">=0.27.2" },
     { name = "httpx", marker = "extra == 'gateway'", specifier = ">=0.27.0" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.11.0" },
+    { name = "logfire", extras = ["agent-control"], marker = "extra == 'agent-control-claude-agent-sdk'" },
     { name = "logfire", extras = ["variables"], marker = "extra == 'agent-control'" },
     { name = "openinference-instrumentation-dspy", marker = "extra == 'dspy'", specifier = ">=0" },
     { name = "openinference-instrumentation-litellm", marker = "extra == 'litellm'", specifier = ">=0" },
@@ -3127,7 +3134,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.13.0" },
     { name = "uvicorn", marker = "extra == 'gateway'", specifier = ">=0.30.0" },
 ]
-provides-extras = ["gateway", "system-metrics", "asgi", "wsgi", "aiohttp", "aiohttp-client", "aiohttp-server", "celery", "django", "fastapi", "flask", "httpx", "starlette", "litestar", "sqlalchemy", "asyncpg", "psycopg", "psycopg2", "pymongo", "redis", "requests", "mysql", "sqlite3", "urllib", "aws-lambda", "google-genai", "litellm", "dspy", "datasets", "variables", "agent-control"]
+provides-extras = ["gateway", "system-metrics", "asgi", "wsgi", "aiohttp", "aiohttp-client", "aiohttp-server", "celery", "django", "fastapi", "flask", "httpx", "starlette", "litestar", "sqlalchemy", "asyncpg", "psycopg", "psycopg2", "pymongo", "redis", "requests", "mysql", "sqlite3", "urllib", "aws-lambda", "google-genai", "litellm", "dspy", "datasets", "variables", "agent-control", "agent-control-claude-agent-sdk"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Stacked on #2389 (`agent-control-core`). It will retarget to `main` when that merges.

**Parked as a draft on sequencing, not on anything in the PR:** the release was narrowed to the Pydantic AI path — the `pydantic-ai-harness` capability and the parts of the Logfire Python SDK it exercises — rather than carry maintenance for the framework adapters before the contract is settled. See the handover comment on this PR.

## What this is

The [Claude Agent SDK](https://platform.claude.com/docs/en/agent-sdk/overview) adapter for Agent Control: `logfire/agent_control/claude_agent_sdk/`, behind its own extra. Wrap the `ClaudeAgentOptions` your code already builds, and the agent's system prompt, its subagents' prompts, its model, how hard it thinks, and the descriptions its in-process tools show the model become editable from the Logfire UI — versioned, labelled, rolled out, and rolled back as one unit, without a redeploy. Everything you don't change in Logfire keeps doing what your code says.

```bash
pip install 'logfire[agent-control-claude-agent-sdk]'
```

```python
from claude_agent_sdk import ClaudeAgentOptions, query

from logfire.agent_control.claude_agent_sdk import agent_control, sdk_mcp_server

options = agent_control(
    ClaudeAgentOptions(
        system_prompt='You are a concise checkout assistant.',
        model='claude-sonnet-4-5',
        mcp_servers={'shop': sdk_mcp_server('shop', tools=[refund_order])},
        allowed_tools=['mcp__shop__refund_order'],
    ),
    name='checkout_assistant',
    label='production',
)
async for message in query(prompt='Refund my last order.', options=options):
    ...
```

It returns a **new** `ClaudeAgentOptions` and never touches the one you passed, nor its `env` dictionary, nor its `mcp_servers` mapping; with nothing published it hands back the very object it was given. The name is required and explicit, because `ClaudeAgentOptions` has no name of its own and a name inferred from a Python variable would point at a different config the day someone renames that variable.

`sdk_mcp_server` is the third export and the reason tool definitions are editable at all: it is `create_sdk_mcp_server`'s arguments, remembered, so a server can be rebuilt from rewritten definitions. `ManagedAgent` is the fourth seam, for putting a resolved label and version on a whole run.

## There is no per-request hook, because there is no request

This SDK does not call the Messages API. It starts the `claude` CLI as a subprocess and talks JSON over its stdio, and the system prompt, the tool list, the model and every sampling parameter are assembled *inside that process*. No hook, no callback and no transport in the SDK sees an outgoing model request.

So the config is applied at the only seam there is — the options a session starts from — and **the unit of resolution is one session**, not one request. Publishing takes effect on the next session your code starts. Two consequences: call `agent_control` where you build the options for each `query()`, not once at import, or a long-running process never sees anything you publish; and Claude Code snapshots the rendered system prompt on a conversation's first request, so a changed prompt does not reach a resumed conversation either (`extra_args={'system-prompt-snapshot': 'off'}`).

**Precedence is code, then Logfire, then you:** a published section is applied over what your options say, and anything you change on the returned object afterwards is the last word.

## What becomes editable

| Source or canonical field | Block id or runtime mapping | Editable |
|---|---|---|
| `system_prompt='…'` | `system` | Yes. Removing the block sends `''`, which is what the SDK already sends for no custom prompt |
| `system_prompt={'type': 'preset', …, 'append': '…'}` | `append` | The `append` half only |
| Claude Code's own preset prompt, `system_prompt={'type': 'file', …}` | `preset:claude_code`, `system:file` | No. The CLI renders or reads them and never shows the SDK the text; published as dynamic blocks with no text, so the editor can show they exist |
| `agents={'reviewer': AgentDefinition(prompt=…)}` | `agent:reviewer` | Text only — see below |
| An entry with no id | appended to `system`, or to a preset's `append` | Conditional |
| `model` | `ClaudeAgentOptions.model` | Conditional. `anthropic:…`, an alias, or a bare id. Any other provider is refused and reported: this SDK picks its provider from the CLI's environment, not from the model string |
| `thinking` | `thinking` and `effort` together | Yes. `'minimal'` becomes `'low'`, the lowest level this CLI has |
| `max_tokens` | `CLAUDE_CODE_MAX_OUTPUT_TOKENS` in `env` | Yes |
| `timeout` | `API_TIMEOUT_MS` in `env` | Yes |
| `temperature`, `top_p`, `top_k`, `seed`, the penalties, `parallel_tool_calls`, `stop_sequences` | — | No. `ClaudeAgentOptions` has no such field and the CLI chooses them itself. Each is reported |
| In-process tools built with `sdk_mcp_server` | `mcp__<server>__<tool>`, grouped as `toolset: <server>` | Yes: name, description, top-level parameter descriptions |
| `create_sdk_mcp_server` tools, built-ins, external MCP servers | — | No. Nothing to rewrite, nothing the SDK ever sees; an override naming one reports `unknown-tool` |

Everything reported goes through `on_unmatched`: a `UserWarning` once per process by default, a `ValueError` under `'error'`, nothing under `'ignore'`.

**On a rename, your code sees the name your code gave the tool.** The model is offered and calls `mcp__shop__issue_refund`, while `allowed_tools`, `disallowed_tools`, a subagent's `tools`, `permission_prompt_tool_name` and exact hook matchers are all rewritten with the definition, and hooks, the permission callback and the handler are all still handed the code-side name. Two things a rename reaches that this adapter cannot follow, both inside the CLI process: the conversation transcript `--resume`/`--continue` replay, and `ToolUseBlock.name` on the message stream.

## What the live tests proved, and what they disproved

Every other test in this directory reads what the SDK *would* send. That leaves the other half of every claim open, because this adapter's whole surface is arguments to a process it does not implement — only the CLI can say whether it reads `CLAUDE_CODE_MAX_OUTPUT_TOKENS` out of the environment it was spawned with, or lets a model call an in-process tool under a managed name.

`tests/agent_control/claude_agent_sdk/test_live.py` runs the real `claude` CLI once and keeps what it said, through the repository's own `tests/otel_integrations/fake_claude.py`: in record mode it proxies the real binary and tees the stdio protocol to a JSON cassette, and in replay mode — the default, and what CI runs — it replays that cassette with no credentials, no network and no `claude` binary. Six cassettes, against `claude-haiku-4-5`, the cheapest current model, since what is under test is the CLI rather than the model.

Proved:

- a published `system` block is what the session answers in, and a published `thinking: 'low'` sets both `thinking` and `effort` on options the CLI accepts rather than rejects;
- **a renamed tool is called by the model as `mcp__shop__issue_refund`, and it runs your code**: the handler recorded the order it was actually asked to refund, the arguments arrived under the code's own parameter name, and a `PreToolUse` matcher written against `mcp__shop__refund_order` still fired and was handed that name;
- `max_tokens` reaches the CLI *and the CLI reads it from its environment* — a published cap of 16 stopped the response and the CLI named the `16 output token maximum` it had read, which a CLI that ignored the variable would not have done;
- `timeout` likewise: `API_TIMEOUT_MS=1` made the CLI give up on its own deadline rather than on one nobody set.

**Disproved — a removal the contract otherwise allows.** The assumption was that a subagent's prompt could be emptied like any other block's. It cannot: the CLI declares a subagent *by* its prompt and silently leaves out any subagent whose prompt is empty, so publishing a removal of `agent:<name>` would have taken the subagent, its description and its tools out of the session, from a section that only describes text. Removal is now refused and reported, and `test_the_cli_leaves_out_a_subagent_with_no_prompt` pins the CLI behaviour the refusal depends on — a test in which nothing about Agent Control is exercised at all.

## Known limits

- **Only in-process servers built with `sdk_mcp_server` are editable.** A rebuilt server keeps its position in `mcp_servers`, so unpatched tools keep their exact definitions and the order the model is shown them in.
- **A tool edit invalidates the prompt cache** for every session that starts afterwards; the tool list sits ahead of the system prompt in the cached prefix.
- **`ManagedAgent.refresh_model` sends only the model.** It does not re-apply instructions, settings or tools, because the CLI has already been started with those, and it must be passed the options your *code* built — that is what makes withdrawing a published model roll back to your model rather than to the CLI default.
- **Nothing about a resumed conversation is recorded.** The snapshot behaviour and the transcript carrying the managed name across `--resume` are stated from reading, not from a cassette.
- Only `claude-haiku-4-5` was recorded, against whichever `claude` build was on the recorder's PATH; nothing pins that version.
- The CLI's own telemetry does not carry the agent name; set `OTEL_RESOURCE_ATTRIBUTES` in `env` yourself if you want it to.

## One open review finding, deliberately left

**A rename can break a `PreToolUse` hook matcher written as a pattern.** As it stands that is *reported* through `on_unmatched` — a `UserWarning` by default, a `ValueError` under `'error'`, never silence — because rewriting a regular expression means editing it on a guess. Veria (low) and cubic (P1) both ask instead to **fail closed**: drop that tool's rename and keep the guard, the way the core already drops a rename that collides with a name in use. That is defensible and arguably right for a permission check, and it is also a behaviour change to a section this PR otherwise ports as reviewed, so it is [left on the thread](https://github.com/pydantic/logfire/pull/2394#discussion_r3974238963) for @DouweM to call. It is why Veria's summary still reads one open finding.

The rest of the round is closed. Four findings were real and fixed with regression tests: a rebuilt in-process server was named after the key it is filed under rather than its own name, so `{'shop': sdk_mcp_server('store', …)}` reached the CLI as `store` before a rename and `shop` after one; `anthropic:` passed the config schema and lowered to `model=''`, starting a session with no model at all; an `API_TIMEOUT_MS` too large to be a float raised `OverflowError` out of the call that merely *describes* the agent for the editor; and the extra's `>=0.2` floor became `>=0.2.82`, the lowest release the series has on PyPI and the first to export `EffortLevel`. The `refresh_model` finding was declined with its reason on the thread — holding the code model on the `ManagedAgent` would give it per-session state, which one instance configuring concurrent sessions would overwrite — and CodeRabbit resolved it.

Two more things recording turned up: `test_logfire_api` instrumented the Claude Agent SDK process-wide and never reverted it, and the hook matchers that instrumentation inserts shift the callback ids a cassette replays under, so a hook this adapter wrapped silently never ran. That call reverts now, the live fixture fails loudly if anything else leaves it applied, and a test asserting on a callback waits for it while the client can still run it.

## Also in this PR

- An `agent-control-claude-agent-sdk` extra: `logfire[agent-control]` plus `claude-agent-sdk>=0.2.82`. The SDK needs pydantic 2.11, so `tests/conftest.py` skips this adapter's directory below that floor, the way `agent_control` as a whole is already skipped below 2.10.
- `logfire-api` stubs for the new subpackage, matching how the core is mirrored there.
- Docs at `docs/reference/advanced/agent-control/claude-agent-sdk.md`, with the nav entry under **Agent Control**, which becomes a section so the core page and the adapter live together (the core's slug is unchanged, so no URL moves). The core page's adapter table now links this one and no longer says no adapter has shipped.
- A `--record-agent-control-cassettes` pytest option, and a `_scrub` pass that takes the recording machine — its account name, its config directory, its paths — out of a freshly recorded cassette before it is committed.

## Gates

CI is green on `37b28ff4`: every test leg (3.10–3.14, pydantic 2/2.4, otel 1/1.39), `lint`, `coverage`, `check-changelog`, Pyodide and minimal-install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
