### PR TITLE
Fix links in the offline setup bundle

### DIFF
--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -586,7 +586,11 @@ Close with a final report built from what you just confirmed — the run name, e
 
 # Reference Files
 
+<a id="reference-logfire-instrumentation-references-auth-md"></a>
+
 ## logfire-instrumentation/references/auth.md
+
+<a id="reference-logfire-instrumentation-references-auth-md--authenticate-and-select-the-exact-project"></a>
 
 # Authenticate and Select the Exact Project
 
@@ -659,6 +663,8 @@ run_logfire_js <target> whoami
 - `whoami`'s org/project/region is what every later step must match — instrumentation, verification, any link you give the user. Never substitute a different or "latest" project.
 - If both `.logfire/` credentials and `LOGFIRE_TOKEN` are present, `LOGFIRE_TOKEN` wins silently — `whoami` reports whichever is actually in effect. If they'd point at different projects, fix or unset the one you don't want before continuing.
 - Never print, log, hard-code, commit, or echo a token, and don't read `~/.logfire/default.toml`'s contents — a bad or missing credential surfaces as a CLI error, not a prompt. The one exception is reading `.logfire/logfire_credentials.json`'s `token` key programmatically, and only to hand it to a non-native-SDK application language that needs the actual value (see below) — never to print, display, or otherwise surface it.
+
+<a id="reference-logfire-instrumentation-references-auth-md--if-the-calling-skill-needs-a-write-token-not-just-a-cli-session"></a>
 
 ## If the calling skill needs a write token, not just a CLI session
 

--- a/scripts/build_offline_skill_prompt.py
+++ b/scripts/build_offline_skill_prompt.py
@@ -23,9 +23,10 @@ into a build step without this script knowing which.
 from __future__ import annotations
 
 import argparse
+import posixpath
 import re
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SKILLS_ROOT = REPO_ROOT / 'logfire' / '.agents' / 'skills'
@@ -54,6 +55,11 @@ SKILL_ORDER = [
 MANDATORY_REFERENCES = [
     'logfire-instrumentation/references/auth.md',
 ]
+RELATIVE_MARKDOWN_LINK = re.compile(
+    r'(?P<prefix>\]\()(?P<target>\.\.?/[^)#\s]+\.md)(?P<fragment>#[^)\s]+)?(?P<suffix>\))'
+)
+MARKDOWN_HEADING = re.compile(r'^(?P<marks>#{1,6})\s+(?P<title>.+)$')
+MARKDOWN_FENCE = re.compile(r'^(?P<marker>`{3,}|~{3,})')
 
 
 class BuildOfflinePromptError(RuntimeError):
@@ -83,8 +89,56 @@ def _reference_files(skill_dir: Path) -> list[Path]:
     return sorted(references_dir.rglob('*.md'))
 
 
-def _rewrite_public_links_for_offline_bundle(text: str) -> str:
-    """Point links to bundled skills back at their inlined offline sections."""
+def _reference_anchor(relative: str) -> str:
+    """Return the stable HTML anchor for one inlined reference file."""
+    slug = re.sub(r'[^a-z0-9]+', '-', relative.lower()).strip('-')
+    return f'reference-{slug}'
+
+
+def _reference_section_anchor(relative: str, fragment: str) -> str:
+    """Qualify a source heading fragment with its inlined reference file."""
+    return f'{_reference_anchor(relative)}--{fragment.removeprefix("#")}'
+
+
+def _markdown_heading_slug(title: str) -> str:
+    """Approximate GitHub's Markdown heading fragment for reference source headings."""
+    without_links = re.sub(r'\[([^]]+)]\([^)]+\)', r'\1', title)
+    return ''.join(
+        character for character in without_links.casefold() if character.isalnum() or character in ' _-'
+    ).replace(' ', '-')
+
+
+def _qualify_reference_headings(text: str, relative: str) -> str:
+    """Add collision-free aliases for headings inside one flattened reference file."""
+    occurrences: dict[str, int] = {}
+    fence: tuple[str, int] | None = None
+    rendered: list[str] = []
+    for line in text.splitlines(keepends=True):
+        fence_match = MARKDOWN_FENCE.match(line.lstrip())
+        if fence_match:
+            marker = fence_match.group('marker')
+            if fence is None:
+                fence = marker[0], len(marker)
+            elif marker[0] == fence[0] and len(marker) >= fence[1] and not line.lstrip()[len(marker) :].strip():
+                fence = None
+        elif fence is None and (heading := MARKDOWN_HEADING.fullmatch(line.rstrip('\r\n'))):
+            slug = _markdown_heading_slug(heading.group('title'))
+            occurrence = occurrences.get(slug, 0)
+            occurrences[slug] = occurrence + 1
+            fragment = slug if occurrence == 0 else f'{slug}-{occurrence}'
+            anchor = _reference_section_anchor(relative, fragment)
+            rendered.append(f'<a id="{anchor}"></a>\n\n')
+        rendered.append(line)
+    return ''.join(rendered)
+
+
+def _rewrite_public_links_for_offline_bundle(
+    text: str,
+    *,
+    source_path: PurePosixPath | None = None,
+    bundled_references: frozenset[str] = frozenset(),
+) -> str:
+    """Point links to bundled skills and references at their inlined sections."""
     auth_sources = (
         f'{PUBLIC_SKILLS_ROOT}/{AUTH_REFERENCE_PATH}',
         f'../{AUTH_REFERENCE_PATH}',
@@ -100,10 +154,25 @@ def _rewrite_public_links_for_offline_bundle(text: str) -> str:
     for name in SKILL_ORDER:
         text = text.replace(f'{PUBLIC_SKILLS_ROOT}/{name}/SKILL.md', f'#skill-{name}')
         text = text.replace(f'{PUBLIC_SKILLS_ROOT}/{name}/', f'../{name}/')
+
+    if source_path is not None:
+
+        def replace_relative_link(match: re.Match[str]) -> str:
+            target = match.group('target')
+            resolved = posixpath.normpath((source_path.parent / target).as_posix())
+            if resolved not in bundled_references:
+                return match.group(0)
+            fragment = match.group('fragment')
+            destination = (
+                f'#{_reference_section_anchor(resolved, fragment)}' if fragment else f'#{_reference_anchor(resolved)}'
+            )
+            return f'{match.group("prefix")}{destination}{match.group("suffix")}'
+
+        text = RELATIVE_MARKDOWN_LINK.sub(replace_relative_link, text)
     return text
 
 
-def _render_skill(name: str) -> str:
+def _render_skill(name: str, *, bundled_references: frozenset[str]) -> str:
     skill_dir = SKILLS_ROOT / name
     skill_md = skill_dir / 'SKILL.md'
     if not skill_md.is_file():
@@ -112,37 +181,39 @@ def _render_skill(name: str) -> str:
     section = [f'# Skill: {name}', '']
     if description:
         section += [f'*{description}*', '']
-    section.append(_rewrite_public_links_for_offline_bundle(body))
+    section.append(
+        _rewrite_public_links_for_offline_bundle(
+            body,
+            source_path=PurePosixPath(name) / 'SKILL.md',
+            bundled_references=bundled_references,
+        )
+    )
     return '\n'.join(section)
 
 
-def _render_appendix(name: str, *, only_mandatory: bool = False) -> str:
+def _render_appendix(name: str, *, bundled_references: frozenset[str]) -> str:
     skill_dir = SKILLS_ROOT / name
     parts: list[str] = []
     for ref in _reference_files(skill_dir):
         relative = ref.relative_to(SKILLS_ROOT)
-        if only_mandatory and relative.as_posix() not in MANDATORY_REFERENCES:
+        relative_path = relative.as_posix()
+        if relative_path not in bundled_references:
             continue
-        content = _rewrite_public_links_for_offline_bundle(ref.read_text(encoding='utf-8').strip())
-        parts.append(f'## {relative}\n\n{content}')
+        content = _rewrite_public_links_for_offline_bundle(
+            ref.read_text(encoding='utf-8').strip(),
+            source_path=PurePosixPath(relative_path),
+            bundled_references=bundled_references,
+        )
+        content = _qualify_reference_headings(content, relative_path)
+        parts.append(f'<a id="{_reference_anchor(relative_path)}"></a>\n\n## {relative}\n\n{content}')
     return '\n\n'.join(parts)
 
 
 def _preamble(*, include_references: bool) -> str:
-    # Every skill body links to its own and other skills' references by relative path
-    # (`./references/...`, `../logfire-x/references/...`) -- correct for the individual
-    # SKILL.md files these bodies are copied from verbatim, but not for this flattened
-    # bundle, which sits one directory above every skill it concatenates. Rather than
-    # rewrite every link (risking a subtly wrong path that's harder to catch than an
-    # unrewritten one), this note tells the reader the resolution rule directly: strip the
-    # relative prefix, keep the skill-qualified remainder, and match it against an
-    # appendix heading below -- never follow either link shape as a literal path.
     references_note = ' Authentication links jump directly to the inlined authentication appendix.'
     references_note += (
-        ' A pointer to any other file under `./references/...` (same skill) or '
-        '`../<skill-name>/references/...` (a different skill) means the matching entry in '
-        'the **Reference Files** appendix at the end, headed with that skill-qualified '
-        "path -- never follow either as a literal path from this file's own location."
+        ' Links to the other bundled reference files jump to their inlined entries in the '
+        '**Reference Files** appendix at the end.'
         if include_references
         else ' This build omits the other `./references/...` deep-dive files (language-specific '
         'edge cases) to stay shorter; if one turns out to matter, fetch it directly from the repo.'
@@ -165,10 +236,16 @@ def build(*, include_references: bool = True) -> str:
     Even when `include_references` is False, MANDATORY_REFERENCES are still inlined --
     see that constant for why omitting them isn't just "shorter", it's a dead link.
     """
-    skill_sections = [_render_skill(name) for name in SKILL_ORDER]
+    bundled_references = frozenset(
+        ref.relative_to(SKILLS_ROOT).as_posix()
+        for name in SKILL_ORDER
+        for ref in _reference_files(SKILLS_ROOT / name)
+        if include_references or ref.relative_to(SKILLS_ROOT).as_posix() in MANDATORY_REFERENCES
+    )
+    skill_sections = [_render_skill(name, bundled_references=bundled_references) for name in SKILL_ORDER]
     parts = [_preamble(include_references=include_references), *skill_sections]
     appendix_sections = [
-        rendered for name in SKILL_ORDER if (rendered := _render_appendix(name, only_mandatory=not include_references))
+        rendered for name in SKILL_ORDER if (rendered := _render_appendix(name, bundled_references=bundled_references))
     ]
     if appendix_sections:
         parts.append('# Reference Files\n\n' + '\n\n---\n\n'.join(appendix_sections))

--- a/tests/test_build_offline_skill_prompt.py
+++ b/tests/test_build_offline_skill_prompt.py
@@ -1,11 +1,14 @@
 import re
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from scripts.build_offline_skill_prompt import (
     MANDATORY_REFERENCES,
     PUBLIC_SKILLS_ROOT,
     SKILL_ORDER,
     SKILLS_ROOT,
+    _qualify_reference_headings,  # pyright: ignore[reportPrivateUsage]
+    _reference_anchor,  # pyright: ignore[reportPrivateUsage]
+    _reference_section_anchor,  # pyright: ignore[reportPrivateUsage]
     _rewrite_public_links_for_offline_bundle,  # pyright: ignore[reportPrivateUsage]
     build,
 )
@@ -23,7 +26,7 @@ CHECKED_IN_BUNDLE = SKILLS_ROOT / 'logfire-setup-offline.md'
 # sequence -- an earlier version chained them (`(?:\.\./[a-z0-9-]+/)?\./?references/...`),
 # which made a literal `.` mandatory right before `references/` and so never matched a
 # cross-skill link at all (nothing follows `../logfire-x/` but `references/` directly).
-REFERENCE_LINK = re.compile(r'\[[^\]]+\]\(((?:\.\./[a-z0-9-]+/)?(?:\./)?references/[\w./-]+\.md)(?:#[^)\s]*)?\)')
+REFERENCE_LINK = re.compile(r'\[[^\]]+\]\((\.\.?/[^)#\s]+\.md)(?:#[^)\s]*)?\)')
 
 
 def _appendix_headings(bundle: str) -> set[str]:
@@ -64,23 +67,62 @@ def test_full_build_has_no_dead_reference_links() -> None:
     assert headings, 'full build produced no Reference Files appendix at all'
     assert '[credential handoff instructions](#if-the-calling-skill-needs-a-write-token-not-just-a-cli-session)' in full
 
-    for link_path in REFERENCE_LINK.findall(full):
-        # Normalize `./references/x.md` and `../logfire-instrumentation/references/x.md`
-        # to the SKILLS_ROOT-relative form the appendix headings use.
-        normalized = link_path.removeprefix('./')
-        if not normalized.startswith('../'):
-            # `./references/...` is relative to the skill the link lives in; since every
-            # `## heading` is already skill-qualified, resolving this one exactly requires
-            # knowing which skill's body it came from. Conservatively accept it if ANY
-            # skill's `references/{rest}` is a real appendix heading -- still catches a
-            # reference renamed or deleted everywhere, which is the failure that matters.
-            rest = normalized.removeprefix('references/')
-            assert any(h.endswith(f'/references/{rest}') for h in headings), (
-                f'{link_path!r} does not resolve to any appendix entry (have: {sorted(headings)})'
-            )
-            continue
-        resolved = normalized.removeprefix('../')
-        assert resolved in headings, f'{link_path!r} -> {resolved!r} not in appendix (have: {sorted(headings)})'
+    assert not REFERENCE_LINK.findall(full), 'full build left filesystem-relative reference links unresolved'
+
+    for heading in headings:
+        assert f'<a id="{_reference_anchor(heading)}"></a>' in full
+    anchors = [_reference_anchor(heading) for heading in headings]
+    assert len(anchors) == len(set(anchors)), 'reference paths produced colliding appendix anchors'
+    for anchor in re.findall(r'\]\(#(reference-[^)]+)\)', full):
+        assert f'<a id="{anchor}"></a>' in full, f'generated link has no target: {anchor}'
+    all_anchors = re.findall(r'<a id="([^"]+)"></a>', full)
+    assert len(all_anchors) == len(set(all_anchors)), 'generated appendix anchors are not unique'
+
+
+def test_reference_links_inside_appendix_resolve_to_inlined_anchors() -> None:
+    """Sibling and parent-relative links must not escape the flattened offline bundle."""
+    references = frozenset(
+        {
+            'logfire-instrumentation/references/auth.md',
+            'logfire-instrumentation/references/javascript/ai-sdk.md',
+            'logfire-instrumentation/references/javascript/node-runtime.md',
+        }
+    )
+    source = '[Node](./node-runtime.md) and [auth](../auth.md)'
+
+    rewritten = _rewrite_public_links_for_offline_bundle(
+        source,
+        source_path=PurePosixPath('logfire-instrumentation/references/javascript/ai-sdk.md'),
+        bundled_references=references,
+    )
+
+    assert rewritten == (
+        '[Node](#reference-logfire-instrumentation-references-javascript-node-runtime-md) and '
+        '[auth](#reference-logfire-instrumentation-references-auth-md)'
+    )
+
+
+def test_reference_link_fragments_are_qualified_by_their_file() -> None:
+    """A section link must not collide with an earlier heading in the flat bundle."""
+    reference = 'logfire-instrumentation/references/python/logging-patterns.md'
+    rewritten = _rewrite_public_links_for_offline_bundle(
+        '[metrics](./references/python/logging-patterns.md#custom-metrics)',
+        source_path=PurePosixPath('logfire-instrumentation/SKILL.md'),
+        bundled_references=frozenset({reference}),
+    )
+
+    anchor = _reference_section_anchor(reference, '#custom-metrics')
+    assert rewritten == f'[metrics](#{anchor})'
+    assert f'<a id="{anchor}"></a>' in build(include_references=True)
+
+
+def test_reference_heading_aliases_do_not_rewrite_code_fences() -> None:
+    """Shell comments and similar code must not become anchors in generated examples."""
+    source = '# Real heading\n\n```sh\n```python\n# not a heading\n```\n'
+    qualified = _qualify_reference_headings(source, 'skill/references/example.md')
+
+    assert qualified.endswith('```sh\n```python\n# not a heading\n```\n')
+    assert qualified.count('<a id=') == 1
 
 
 def test_build_rewrites_public_links_only_for_inlined_skills() -> None:


### PR DESCRIPTION
## Summary

- rewrite relative reference links in the flattened offline setup bundle to stable in-document anchors
- give every inlined reference and section a file-qualified anchor without rewriting fenced examples
- verify generated links resolve uniquely and keep the checked-in compact bundle current

This supplies the source-side bundle fix used by [logfire-cli#132](https://github.com/pydantic/logfire-cli/pull/132). SDK and browser guidance corrections are intentionally split into focused follow-up PRs.

## Validation

- `uv run pytest tests/test_build_offline_skill_prompt.py -q` — 10 passed
- `make lint`
- `make typecheck`
- `uv run prek run --from-ref origin/main --to-ref HEAD --show-diff-on-failure`

AI-assisted: Codex implemented and reviewed the link transformation and tests.
