### PR TITLE
Make the Logfire evals skill executable for Python and Node.js

### DIFF
--- a/docs/comparisons/migrate-from-braintrust.md
+++ b/docs/comparisons/migrate-from-braintrust.md
@@ -13,21 +13,21 @@ Keep your existing Braintrust `Eval` code and send its next completed evaluation
 
 ## Send your next evaluation to Logfire
 
-You need a Logfire project and its **write token**, the credential that selects the destination project and lets the Braintrust SDK send evaluation data. Copy one from **Project → Settings → Write tokens** in Logfire.
+Create a project API key under **Project → Settings → API keys** with **Send telemetry** (`project:write_otlp`) and **Read datasets** (`project:read_datasets`). The key selects the destination project, sends the run, and lets the Braintrust SDK read experiment metadata for its final comparison summary. An ingest-only write token cannot complete that read.
 
-Set the Braintrust app URL to the compatibility endpoint for your Logfire data region. Put the write token in the variable where the Braintrust SDK expects its API key:
+Set the Braintrust app URL to the compatibility endpoint for your Logfire data region. Put the project API key in the variable where the Braintrust SDK expects its API key:
 
 ```bash
 # US project
 export BRAINTRUST_APP_URL="https://logfire-us.pydantic.dev/v1/braintrust"
-export BRAINTRUST_API_KEY="<your-logfire-write-token>"
+export BRAINTRUST_API_KEY="<your-logfire-project-api-key>"
 
 # Remove overrides that would send part of the run somewhere else.
 unset BRAINTRUST_API_URL
 unset BRAINTRUST_PROXY_URL
 ```
 
-For an EU project, use `https://logfire-eu.pydantic.dev/v1/braintrust` instead. Keep the token out of source control.
+For an EU project, use `https://logfire-eu.pydantic.dev/v1/braintrust` instead. Keep the API key out of source control.
 
 Run the same Python or TypeScript evaluation command you use today. The compatibility endpoint makes no request to Braintrust. It accepts the SDK protocol, translates the completed run into Logfire experiment data, and returns a result link that opens Logfire.
 
@@ -42,7 +42,7 @@ Let the SDK finish its normal score summary, then use either route:
 
 Confirm that the experiment contains the expected cases and evaluator results. Case data appears when the SDK requests its final comparison summary, so it does not appear incrementally while the run is still in progress.
 
-One naming difference matters immediately: the write token selects the actual Logfire project. The string passed as the first argument to `Eval(...)`, which Braintrust calls a project, becomes the dataset name used to group experiments inside that Logfire project.
+One naming difference matters immediately: the API key selects the actual Logfire project. The string passed as the first argument to `Eval(...)`, which Braintrust calls a project, becomes the dataset name used to group experiments inside that Logfire project.
 
 ## Translate evaluation concepts
 
@@ -51,7 +51,7 @@ The two systems use similar evaluation shapes, but some nouns have different bou
 | If you know this in Braintrust | Use this in Logfire | What changes |
 | --- | --- | --- |
 | Organization | Organization | The team and access-control boundary remains an organization. |
-| Project | Logfire project | A Logfire project holds the telemetry, datasets, experiments, prompts, and other resources for an application or environment. With the compatibility endpoint, the write token selects this project. |
+| Project | Logfire project | A Logfire project holds the telemetry, datasets, experiments, prompts, and other resources for an application or environment. With the compatibility endpoint, the project API key selects this project. |
 | `Eval("support", ...)` project argument | Dataset name `support` | The compatibility endpoint uses Braintrust's project argument to group related experiments as a Logfire dataset. In native Pydantic Evals, set [`Dataset.name`](../evaluate/evals-in-code.md) directly. |
 | Dataset | Code-defined or hosted dataset | Keep cases beside your code in a `pydantic_evals.Dataset`, or [manage a hosted dataset](../evaluate/manage-datasets.md) with your team in Logfire. Braintrust-hosted datasets do not pass through the compatibility endpoint. |
 | Dataset row `input` | `Case.inputs` | Both hold the value passed to the task. |
@@ -100,7 +100,9 @@ The endpoint does not provide Braintrust-hosted datasets, prompts, functions, re
 
 **The SDK still contacts Braintrust:** Unset `BRAINTRUST_API_URL` and `BRAINTRUST_PROXY_URL`. Those overrides take precedence over the URLs returned by compatibility login.
 
-**The endpoint returns `401`:** Confirm that `BRAINTRUST_API_KEY` contains a Logfire project write token, not a Logfire user token or a Braintrust API key. Confirm that the endpoint region matches the project.
+**The endpoint returns `401`:** Confirm that `BRAINTRUST_API_KEY` contains a Logfire project API key rather than a Logfire user token or Braintrust API key, and that the endpoint region matches the project.
+
+**The endpoint returns `403` while producing the summary:** Confirm that the project API key has both `project:write_otlp` and `project:read_datasets`. An ingest-only write token can start the run but cannot read the experiment metadata requested by the Braintrust SDK.
 
 **The experiment exists but has no cases:** Let the normal SDK summary finish. Do not set `summarize_scores=False`, rely on manual `flush()`, or use the Rust SDK for this compatibility path.
 

--- a/logfire/.agents/skills/logfire-evals/SKILL.md
+++ b/logfire/.agents/skills/logfire-evals/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: logfire-evals
-description: Evaluate Python AI/agent code against a dataset of test cases using pydantic_evals, and review results in Logfire's Datasets & Experiments UI. Also covers redirecting an existing Braintrust Eval() suite to Logfire with no code changes. Use this skill whenever the user asks to "set up evals", "add an evaluation", "test my agent against cases", "write a dataset of test cases", "score my LLM output", "add an LLM judge", "check tool-call correctness", "send Braintrust evals to Logfire", "migrate from Braintrust", or mentions pydantic_evals, Braintrust, Datasets & Experiments, or evaluating AI/agent behavior against known inputs. The `pydantic_evals` workflow is Python-only; the Braintrust redirect also supports TypeScript suites, env-vars-only. Both are for scoring DEFINED test cases offline — not for instrumenting live production traffic (use `logfire-instrumentation` for that) and not for infrastructure monitoring (use `logfire-infrastructure`).
+description: Run offline evaluations for Python (`pydantic_evals`) or JavaScript/TypeScript (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.
 ---
 
-# Evaluate with pydantic_evals and Logfire
+# Evaluate AI code with Logfire
 
 ## How This Works
 
-`pydantic_evals` runs your actual function or agent against a `Dataset` of `Case`s (input + expected output + metadata), scores each with one or more `Evaluator`s, and produces a report. It depends on `logfire` itself (the `datasets` extra pulls in the real SDK, not a mock), so whether `logfire.configure()` has run determines only whether results *also* upload to Logfire's Datasets & Experiments UI — omitting it keeps results entirely local and printed to the terminal, **silently, not an error**.
+Python's `pydantic_evals` and JavaScript/TypeScript's `logfire/evals` run the real task against cases, apply evaluators, and return a report. Both run locally without sending results anywhere. Uploading needs `logfire.configure()` in Python or a configured Logfire/OpenTelemetry exporter in JavaScript/TypeScript. Without it, the report remains local rather than failing.
 
-Agentic evaluators (tool-call correctness, trajectory matching) need more than that: they read the task's own execution span tree, so without a working `logfire.configure()` they don't just fail to upload — every case reports "No span tree available" and the check never ran at all.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and JavaScript/TypeScript `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 
-Cheap check, before anything else: does this repo already have an existing Braintrust suite — actual `Eval(...)` calls or `from braintrust import Eval` in source, not just a `braintrust` dependency listed without any real usage? This path needs **no CLI auth at all** — don't run Step 2 for it.
+Cheap check, before anything else: does this repo already have an existing Braintrust suite — actual `Eval(...)` calls or `from braintrust import Eval` in source, not just a `braintrust` dependency listed without any real usage? This path needs **no CLI auth at all** — don't run Step 2 for it. The compatibility endpoint is documented only for Logfire Cloud US and EU; for any other supplied origin, use the native evaluation path instead.
 
 Keep the existing `Eval()` code (Python `braintrust>=0.30.1` / TypeScript `braintrust>=3.24.0` — verified versions) and redirect its next run to Logfire by changing environment variables only, no `pydantic_evals` involved:
 
@@ -31,38 +31,33 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only `pydantic_evals` run using evaluators that do not need span data; omit `logfire.configure()` in Step 4 so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator such as `ToolCorrectness` requires Logfire, so authenticate before opening or running evaluation files and target the exact project first.
+Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Omit the Python `logfire.configure()` call or the JavaScript/TypeScript Logfire bootstrap so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](https://pydantic.dev/.well-known/agent-skills/logfire-instrumentation/references/auth.md) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
 ## Step 3: Detect What to Evaluate
 
-Identify the function or agent under test (a PydanticAI agent, an LLM-calling function, any callable that takes an input and returns an output) and whether a dataset already exists:
+Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
-- **In-code dataset**: a Python module defining `Case`/`Dataset` directly — the default for an agent-driven workflow.
-- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[ExactMatch]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
+- **In-code dataset**: a Python module using `pydantic_evals`, or a JavaScript/TypeScript module using `logfire/evals`. This is the default for an agent-driven workflow.
+- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
 
+Use the repository's existing package manager. Install only the missing integration for its language.
+
+### Python
+
 ```bash
-uv add 'logfire[datasets]'
+uv add 'pydantic-evals[logfire]'
 ```
 
 ```python
-from dataclasses import dataclass
-
 import logfire
 from pydantic_evals import Case, Dataset
-from pydantic_evals.evaluators import Evaluator, EvaluatorContext, IsInstance
+from pydantic_evals.evaluators import EqualsExpected, IsInstance
 
 logfire.configure()  # omit this and results stay local only, silently
-
-
-@dataclass
-class ExactMatch(Evaluator[str, str]):
-    def evaluate(self, ctx: EvaluatorContext[str, str]) -> bool:
-        return ctx.output == ctx.expected_output
-
 
 def classify_sentiment(text: str) -> str:
     ...  # the function under test
@@ -74,14 +69,47 @@ dataset = Dataset[str, str, None](
         Case(name='positive', inputs='I love this', expected_output='positive'),
         Case(name='negative', inputs='This is terrible', expected_output='negative'),
     ],
-    evaluators=[ExactMatch(), IsInstance(type_name='str')],
+    evaluators=[EqualsExpected(), IsInstance(type_name='str')],
 )
 
 report = dataset.evaluate_sync(classify_sentiment)  # or `await dataset.evaluate(...)`
 report.print(include_input=True, include_output=True)
 ```
 
-**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge`/any evaluator that makes a real, billed model call — a bug caught on 3 cases costs 3 model calls, the same bug caught on 300 costs 300:
+Use `logfire[datasets]` instead only when the task specifically needs the hosted-dataset API from Step 3.
+
+### JavaScript or TypeScript on Node.js
+
+Add `logfire` and the Node exporter if missing:
+
+```bash
+npm install logfire @pydantic/logfire-node
+```
+
+Configure Logfire before loading the task. Reuse an existing instrumentation entry point rather than configuring it twice.
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+import { Case, Dataset, EqualsExpected, renderReport } from 'logfire/evals'
+
+logfire.configure()
+
+const classifySentiment = (text: string) => (text.includes('love') ? 'positive' : 'negative')
+const dataset = new Dataset<string, string>({
+  name: 'sentiment-eval',
+  cases: [new Case({ name: 'positive', inputs: 'I love this', expectedOutput: 'positive' })],
+  evaluators: [new EqualsExpected()],
+})
+
+const report = await dataset.evaluate(classifySentiment)
+console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+```
+
+Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. JavaScript/TypeScript custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
+
+For Deno, Bun, browsers, or workers, keep the existing OpenTelemetry setup and follow the [runtime guidance](https://github.com/pydantic/logfire-js#evaluations); do not add the Node exporter to a non-Node runtime.
+
+**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes a real, billed model call. A bug caught on 3 cases costs 3 model calls; the same bug caught on 300 costs 300. In JavaScript/TypeScript, construct the smoke `Dataset` with `dataset.cases.slice(0, 3)` and preserve its evaluators and report evaluators.
 
 ```python
 smoke = Dataset(
@@ -96,7 +124,7 @@ smoke_report.print(include_input=True, include_output=True)
 
 Confirm the smoke run has zero unexpected errors and the assertions that should pass do. Then, if the full dataset is large or uses paid model calls, tell the user the case count and which evaluators will make model calls, and get explicit confirmation before running the full dataset — don't run an expensive full pass on the strength of a clean smoke test alone without saying so.
 
-Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
+The remaining details in this section are Python-specific. Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
 
 | Evaluator | Checks |
 |-----------|--------|

--- a/logfire/.agents/skills/logfire-evals/SKILL.md
+++ b/logfire/.agents/skills/logfire-evals/SKILL.md
@@ -9,7 +9,7 @@ description: Run offline evaluations for Python (`pydantic_evals`) or Node.js (`
 
 Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
 
-Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and Node.js `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available"; Node.js `HasMatchingSpan` can produce no evaluator result at all. Treat either signal as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 

--- a/logfire/.agents/skills/logfire-evals/SKILL.md
+++ b/logfire/.agents/skills/logfire-evals/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: logfire-evals
-description: Run offline evaluations for Python (`pydantic_evals`) or Node.js (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.
+description: Run offline Python (`pydantic_evals`) or Node.js (`logfire/evals`) evaluations and review them in Logfire. Also redirect existing Braintrust `Eval()` suites. Use for eval setup, test datasets, AI scoring, agent checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Not for live traffic or infrastructure monitoring.
 ---
 
 # Evaluate AI code with Logfire
 
 ## How This Works
 
-Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
+Python's `pydantic_evals` and Node.js's `logfire/evals` run a task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export inputs and outputs even if this skill did not configure it. Intentional upload needs `logfire.configure()` in Python or a configured Node.js exporter.
 
 Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available"; Node.js `HasMatchingSpan` can produce no evaluator result at all. Treat either signal as a setup failure, not evidence about the agent.
 
@@ -23,9 +23,9 @@ export BRAINTRUST_API_KEY="<logfire-project-api-key>"                     # Sett
 unset BRAINTRUST_API_URL BRAINTRUST_PROXY_URL  # these override the endpoint above if set — the #1 "it still hit Braintrust" cause
 ```
 
-The API key must belong to the destination project and include `project:write_otlp` and `project:read_datasets`. The SDK writes the run, then reads experiment metadata for its comparison summary; an ingest-only write token fails that read with `403`.
+The destination project's API key needs `project:write_otlp` and `project:read_datasets`: the SDK writes the run, then reads experiment metadata for its summary. An ingest-only write token fails with `403`.
 
-This is a **compatibility preview, not full parity**: covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It does not cover Braintrust-hosted datasets/prompts/functions, BTQL, the model proxy, server-side scoring, or post-finalization feedback — and `summarize_scores=False`, a manual `flush()` without a comparison, or the Rust SDK never request the summary this endpoint needs, so nothing lands even though the run appears to succeed. Full detail and the concept-translation table (Braintrust "project" → Logfire dataset name, "scorer" → evaluator, etc.): https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/.
+This **compatibility preview** covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It excludes Braintrust-hosted resources, BTQL, the model proxy, server-side scoring, and post-finalization feedback. Rust, `summarize_scores=False`, and manual `flush()` without comparison do not request the summary needed for projection. See the [full coverage and concept mapping](https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/).
 
 Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens directly in Logfire, and nothing else here (auth, dataset definition) applies to this path.
 
@@ -33,16 +33,16 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Run it in a fresh process that neither preloads nor imports the application's telemetry setup; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. Inspect the task's imports first: if it configures an exporter itself and the repository has no documented disable switch, stop rather than claiming the run is local-only. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
+For an explicitly local-only run without span evaluators, use a fresh process that neither preloads nor imports application telemetry; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. If the task configures an exporter and has no documented disable switch, stop rather than claiming local-only. Uploading, hosted datasets, and span evaluators require Logfire authentication to the exact project.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](https://pydantic.dev/.well-known/agent-skills/logfire-instrumentation/references/auth.md) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
 ## Step 3: Detect What to Evaluate
 
-Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
+Identify the real task and any dataset. Follow repository package, test, and dependency conventions. For a first eval, prefer 3-5 cases from tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an eval framework, or refactor unrelated code. Without a runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
 - **In-code dataset**: a Python module using `pydantic_evals`, or a Node.js module using `logfire/evals`. This is the default for an agent-driven workflow.
-- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
+- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). Hosted inputs and outputs must be JSON objects; scalar roots accepted by code-defined datasets are rejected. `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
 
@@ -81,6 +81,8 @@ report.print(include_input=True, include_output=True)
 Use `logfire[datasets]` instead only when the task specifically needs the hosted-dataset API from Step 3.
 
 ### JavaScript or TypeScript on Node.js
+
+Do not apply this section to Deno, Bun, browsers, or workers; their exporter setup is not validated by this skill.
 
 Add `logfire` and the Node exporter if missing:
 

--- a/logfire/.agents/skills/logfire-evals/SKILL.md
+++ b/logfire/.agents/skills/logfire-evals/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: logfire-evals
-description: Run offline evaluations for Python (`pydantic_evals`) or JavaScript/TypeScript (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.
+description: Run offline evaluations for Python (`pydantic_evals`) or Node.js (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.
 ---
 
 # Evaluate AI code with Logfire
 
 ## How This Works
 
-Python's `pydantic_evals` and JavaScript/TypeScript's `logfire/evals` run the real task against cases, apply evaluators, and return a report. Both run locally without sending results anywhere. Uploading needs `logfire.configure()` in Python or a configured Logfire/OpenTelemetry exporter in JavaScript/TypeScript. Without it, the report remains local rather than failing.
+Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
 
-Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and JavaScript/TypeScript `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and Node.js `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 
@@ -19,9 +19,11 @@ Keep the existing `Eval()` code (Python `braintrust>=0.30.1` / TypeScript `brain
 
 ```bash
 export BRAINTRUST_APP_URL="https://logfire-us.pydantic.dev/v1/braintrust"  # EU: logfire-eu.pydantic.dev
-export BRAINTRUST_API_KEY="<logfire-project-write-token>"                  # Project -> Settings -> Write tokens
+export BRAINTRUST_API_KEY="<logfire-project-api-key>"                     # Settings -> API Keys
 unset BRAINTRUST_API_URL BRAINTRUST_PROXY_URL  # these override the endpoint above if set — the #1 "it still hit Braintrust" cause
 ```
+
+The API key must belong to the destination project and include `project:write_otlp` and `project:read_datasets`. The SDK writes the run, then reads experiment metadata for its comparison summary; an ingest-only write token fails that read with `403`.
 
 This is a **compatibility preview, not full parity**: covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It does not cover Braintrust-hosted datasets/prompts/functions, BTQL, the model proxy, server-side scoring, or post-finalization feedback — and `summarize_scores=False`, a manual `flush()` without a comparison, or the Rust SDK never request the summary this endpoint needs, so nothing lands even though the run appears to succeed. Full detail and the concept-translation table (Braintrust "project" → Logfire dataset name, "scorer" → evaluator, etc.): https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/.
 
@@ -31,7 +33,7 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Omit the Python `logfire.configure()` call or the JavaScript/TypeScript Logfire bootstrap so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
+Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Run it in a fresh process that neither preloads nor imports the application's telemetry setup; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. Inspect the task's imports first: if it configures an exporter itself and the repository has no documented disable switch, stop rather than claiming the run is local-only. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](https://pydantic.dev/.well-known/agent-skills/logfire-instrumentation/references/auth.md) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
@@ -39,7 +41,7 @@ For a Logfire-backed run, use [Authenticate and Select the Exact Project](https:
 
 Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
-- **In-code dataset**: a Python module using `pydantic_evals`, or a JavaScript/TypeScript module using `logfire/evals`. This is the default for an agent-driven workflow.
+- **In-code dataset**: a Python module using `pydantic_evals`, or a Node.js module using `logfire/evals`. This is the default for an agent-driven workflow.
 - **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
@@ -57,10 +59,10 @@ import logfire
 from pydantic_evals import Case, Dataset
 from pydantic_evals.evaluators import EqualsExpected, IsInstance
 
-logfire.configure()  # omit this and results stay local only, silently
+logfire.configure()  # omit only in the isolated local-only process described above
 
 def classify_sentiment(text: str) -> str:
-    ...  # the function under test
+    return 'positive' if 'love' in text else 'negative'
 
 
 dataset = Dataset[str, str, None](
@@ -101,15 +103,18 @@ const dataset = new Dataset<string, string>({
   evaluators: [new EqualsExpected()],
 })
 
-const report = await dataset.evaluate(classifySentiment)
-console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+dataset.evaluate(classifySentiment).then((report) => {
+  console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+})
 ```
 
-Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. JavaScript/TypeScript custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
+Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. Node.js custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
 
-For Deno, Bun, browsers, or workers, keep the existing OpenTelemetry setup and follow the [runtime guidance](https://github.com/pydantic/logfire-js#evaluations); do not add the Node exporter to a non-Node runtime.
+### Smoke test before a paid or full run
 
-**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes a real, billed model call. A bug caught on 3 cases costs 3 model calls; the same bug caught on 300 costs 300. In JavaScript/TypeScript, construct the smoke `Dataset` with `dataset.cases.slice(0, 3)` and preserve its evaluators and report evaluators.
+**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes billed model calls. This catches setup errors before they multiply cost across the dataset.
+
+Python:
 
 ```python
 smoke = Dataset(
@@ -122,15 +127,29 @@ smoke_report = smoke.evaluate_sync(classify_sentiment)
 smoke_report.print(include_input=True, include_output=True)
 ```
 
+Node.js:
+
+```ts
+const smoke = new Dataset({
+  name: dataset.name,
+  cases: dataset.cases.slice(0, 3),
+  evaluators: dataset.evaluators,
+  reportEvaluators: dataset.reportEvaluators,
+})
+smoke.evaluate(classifySentiment).then((report) => {
+  console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+})
+```
+
 Confirm the smoke run has zero unexpected errors and the assertions that should pass do. Then, if the full dataset is large or uses paid model calls, tell the user the case count and which evaluators will make model calls, and get explicit confirmation before running the full dataset — don't run an expensive full pass on the strength of a clean smoke test alone without saying so.
 
-The remaining details in this section are Python-specific. Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
+The remaining details in this section are Python-specific. Custom evaluators inherit `Evaluator` and implement `evaluate`; use `@dataclass` for configurable fields and portable serialization. Case names must be unique within a dataset. The evaluators reached for most:
 
 | Evaluator | Checks |
 |-----------|--------|
 | `Equals(value)` / `EqualsExpected()` | Exact match against a literal / `expected_output` (no-op if `expected_output` is unset — don't rely on it silently catching that) |
 | `IsInstance(type_name)` | Output's type matches by name |
-| `LLMJudge(rubric, model=None, score=False)` | LLM-as-judge scoring; costs a real model call per case per judge — prefer boolean/categorical rubrics over 1-10 scales (judges are unstable on continuous scores), and benchmark the judge against ~20-100 hand-labeled cases before trusting it |
+| `LLMJudge(rubric, model=None, score=False)` | Subjective or rubric-based judgment; makes billed model requests, so validate the rubric against human-reviewed examples before treating it as a quality gate |
 | `ToolCorrectness(expected_tools, ...)` | Which tools an agent called — reads the span tree, so needs Step 2's `logfire.configure()` to work at all, not just to upload |
 
 Also available: `Contains`, `MaxDuration`, `TrajectoryMatch`, `ArgumentCorrectness`, `MaxToolCalls`, `MaxModelRequests` — same span-tree dependency as `ToolCorrectness` for the tool/trajectory ones; see `pydantic_evals.evaluators` for the full set. These five agentic (span-based) evaluators need `pydantic-evals>=2.4.0` — on an older pin, check `pyproject.toml`/`uv.lock` and upgrade before reaching for them, since the import itself is what fails, not a silent no-op.

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -387,13 +387,13 @@ Close with a final report built from what you just confirmed — org/project/reg
 
 # Skill: logfire-evals
 
-*Run offline evaluations for Python (`pydantic_evals`) or Node.js (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.*
+*Run offline Python (`pydantic_evals`) or Node.js (`logfire/evals`) evaluations and review them in Logfire. Also redirect existing Braintrust `Eval()` suites. Use for eval setup, test datasets, AI scoring, agent checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Not for live traffic or infrastructure monitoring.*
 
 # Evaluate AI code with Logfire
 
 ## How This Works
 
-Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
+Python's `pydantic_evals` and Node.js's `logfire/evals` run a task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export inputs and outputs even if this skill did not configure it. Intentional upload needs `logfire.configure()` in Python or a configured Node.js exporter.
 
 Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available"; Node.js `HasMatchingSpan` can produce no evaluator result at all. Treat either signal as a setup failure, not evidence about the agent.
 
@@ -409,9 +409,9 @@ export BRAINTRUST_API_KEY="<logfire-project-api-key>"                     # Sett
 unset BRAINTRUST_API_URL BRAINTRUST_PROXY_URL  # these override the endpoint above if set — the #1 "it still hit Braintrust" cause
 ```
 
-The API key must belong to the destination project and include `project:write_otlp` and `project:read_datasets`. The SDK writes the run, then reads experiment metadata for its comparison summary; an ingest-only write token fails that read with `403`.
+The destination project's API key needs `project:write_otlp` and `project:read_datasets`: the SDK writes the run, then reads experiment metadata for its summary. An ingest-only write token fails with `403`.
 
-This is a **compatibility preview, not full parity**: covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It does not cover Braintrust-hosted datasets/prompts/functions, BTQL, the model proxy, server-side scoring, or post-finalization feedback — and `summarize_scores=False`, a manual `flush()` without a comparison, or the Rust SDK never request the summary this endpoint needs, so nothing lands even though the run appears to succeed. Full detail and the concept-translation table (Braintrust "project" → Logfire dataset name, "scorer" → evaluator, etc.): https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/.
+This **compatibility preview** covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It excludes Braintrust-hosted resources, BTQL, the model proxy, server-side scoring, and post-finalization feedback. Rust, `summarize_scores=False`, and manual `flush()` without comparison do not request the summary needed for projection. See the [full coverage and concept mapping](https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/).
 
 Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens directly in Logfire, and nothing else here (auth, dataset definition) applies to this path.
 
@@ -419,16 +419,16 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Run it in a fresh process that neither preloads nor imports the application's telemetry setup; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. Inspect the task's imports first: if it configures an exporter itself and the repository has no documented disable switch, stop rather than claiming the run is local-only. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
+For an explicitly local-only run without span evaluators, use a fresh process that neither preloads nor imports application telemetry; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. If the task configures an exporter and has no documented disable switch, stop rather than claiming local-only. Uploading, hosted datasets, and span evaluators require Logfire authentication to the exact project.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](#authenticate-and-select-the-exact-project) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
 ## Step 3: Detect What to Evaluate
 
-Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
+Identify the real task and any dataset. Follow repository package, test, and dependency conventions. For a first eval, prefer 3-5 cases from tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an eval framework, or refactor unrelated code. Without a runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
 - **In-code dataset**: a Python module using `pydantic_evals`, or a Node.js module using `logfire/evals`. This is the default for an agent-driven workflow.
-- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
+- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). Hosted inputs and outputs must be JSON objects; scalar roots accepted by code-defined datasets are rejected. `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
 
@@ -467,6 +467,8 @@ report.print(include_input=True, include_output=True)
 Use `logfire[datasets]` instead only when the task specifically needs the hosted-dataset API from Step 3.
 
 ### JavaScript or TypeScript on Node.js
+
+Do not apply this section to Deno, Bun, browsers, or workers; their exporter setup is not validated by this skill.
 
 Add `logfire` and the Node exporter if missing:
 

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -395,7 +395,7 @@ Close with a final report built from what you just confirmed — org/project/reg
 
 Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
 
-Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and Node.js `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available"; Node.js `HasMatchingSpan` can produce no evaluator result at all. Treat either signal as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -387,15 +387,15 @@ Close with a final report built from what you just confirmed — org/project/reg
 
 # Skill: logfire-evals
 
-*Run offline evaluations for Python (`pydantic_evals`) or JavaScript/TypeScript (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.*
+*Run offline evaluations for Python (`pydantic_evals`) or Node.js (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.*
 
 # Evaluate AI code with Logfire
 
 ## How This Works
 
-Python's `pydantic_evals` and JavaScript/TypeScript's `logfire/evals` run the real task against cases, apply evaluators, and return a report. Both run locally without sending results anywhere. Uploading needs `logfire.configure()` in Python or a configured Logfire/OpenTelemetry exporter in JavaScript/TypeScript. Without it, the report remains local rather than failing.
+Python's `pydantic_evals` and Node.js's `logfire/evals` run the real task against cases, apply evaluators, and return a report. An active Logfire or OpenTelemetry provider may export evaluation inputs and outputs even if this skill did not configure it. Uploading intentionally needs `logfire.configure()` in Python or a configured exporter in Node.js.
 
-Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and JavaScript/TypeScript `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and Node.js `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 
@@ -405,9 +405,11 @@ Keep the existing `Eval()` code (Python `braintrust>=0.30.1` / TypeScript `brain
 
 ```bash
 export BRAINTRUST_APP_URL="https://logfire-us.pydantic.dev/v1/braintrust"  # EU: logfire-eu.pydantic.dev
-export BRAINTRUST_API_KEY="<logfire-project-write-token>"                  # Project -> Settings -> Write tokens
+export BRAINTRUST_API_KEY="<logfire-project-api-key>"                     # Settings -> API Keys
 unset BRAINTRUST_API_URL BRAINTRUST_PROXY_URL  # these override the endpoint above if set — the #1 "it still hit Braintrust" cause
 ```
+
+The API key must belong to the destination project and include `project:write_otlp` and `project:read_datasets`. The SDK writes the run, then reads experiment metadata for its comparison summary; an ingest-only write token fails that read with `403`.
 
 This is a **compatibility preview, not full parity**: covers inline/callable data, local tasks and scorers, multiple scores, one label per name, and normal summary finalization. It does not cover Braintrust-hosted datasets/prompts/functions, BTQL, the model proxy, server-side scoring, or post-finalization feedback — and `summarize_scores=False`, a manual `flush()` without a comparison, or the Rust SDK never request the summary this endpoint needs, so nothing lands even though the run appears to succeed. Full detail and the concept-translation table (Braintrust "project" → Logfire dataset name, "scorer" → evaluator, etc.): https://pydantic.dev/docs/logfire/get-started/comparisons/migrate-from-braintrust/.
 
@@ -417,7 +419,7 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Omit the Python `logfire.configure()` call or the JavaScript/TypeScript Logfire bootstrap so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
+Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Run it in a fresh process that neither preloads nor imports the application's telemetry setup; omit Python's `logfire.configure()` and any Node.js exporter bootstrap. Inspect the task's imports first: if it configures an exporter itself and the repository has no documented disable switch, stop rather than claiming the run is local-only. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](#authenticate-and-select-the-exact-project) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
@@ -425,7 +427,7 @@ For a Logfire-backed run, use [Authenticate and Select the Exact Project](#authe
 
 Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
-- **In-code dataset**: a Python module using `pydantic_evals`, or a JavaScript/TypeScript module using `logfire/evals`. This is the default for an agent-driven workflow.
+- **In-code dataset**: a Python module using `pydantic_evals`, or a Node.js module using `logfire/evals`. This is the default for an agent-driven workflow.
 - **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
@@ -443,10 +445,10 @@ import logfire
 from pydantic_evals import Case, Dataset
 from pydantic_evals.evaluators import EqualsExpected, IsInstance
 
-logfire.configure()  # omit this and results stay local only, silently
+logfire.configure()  # omit only in the isolated local-only process described above
 
 def classify_sentiment(text: str) -> str:
-    ...  # the function under test
+    return 'positive' if 'love' in text else 'negative'
 
 
 dataset = Dataset[str, str, None](
@@ -487,15 +489,18 @@ const dataset = new Dataset<string, string>({
   evaluators: [new EqualsExpected()],
 })
 
-const report = await dataset.evaluate(classifySentiment)
-console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+dataset.evaluate(classifySentiment).then((report) => {
+  console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+})
 ```
 
-Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. JavaScript/TypeScript custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
+Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. Node.js custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
 
-For Deno, Bun, browsers, or workers, keep the existing OpenTelemetry setup and follow the [runtime guidance](https://github.com/pydantic/logfire-js#evaluations); do not add the Node exporter to a non-Node runtime.
+### Smoke test before a paid or full run
 
-**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes a real, billed model call. A bug caught on 3 cases costs 3 model calls; the same bug caught on 300 costs 300. In JavaScript/TypeScript, construct the smoke `Dataset` with `dataset.cases.slice(0, 3)` and preserve its evaluators and report evaluators.
+**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes billed model calls. This catches setup errors before they multiply cost across the dataset.
+
+Python:
 
 ```python
 smoke = Dataset(
@@ -508,15 +513,29 @@ smoke_report = smoke.evaluate_sync(classify_sentiment)
 smoke_report.print(include_input=True, include_output=True)
 ```
 
+Node.js:
+
+```ts
+const smoke = new Dataset({
+  name: dataset.name,
+  cases: dataset.cases.slice(0, 3),
+  evaluators: dataset.evaluators,
+  reportEvaluators: dataset.reportEvaluators,
+})
+smoke.evaluate(classifySentiment).then((report) => {
+  console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+})
+```
+
 Confirm the smoke run has zero unexpected errors and the assertions that should pass do. Then, if the full dataset is large or uses paid model calls, tell the user the case count and which evaluators will make model calls, and get explicit confirmation before running the full dataset — don't run an expensive full pass on the strength of a clean smoke test alone without saying so.
 
-The remaining details in this section are Python-specific. Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
+The remaining details in this section are Python-specific. Custom evaluators inherit `Evaluator` and implement `evaluate`; use `@dataclass` for configurable fields and portable serialization. Case names must be unique within a dataset. The evaluators reached for most:
 
 | Evaluator | Checks |
 |-----------|--------|
 | `Equals(value)` / `EqualsExpected()` | Exact match against a literal / `expected_output` (no-op if `expected_output` is unset — don't rely on it silently catching that) |
 | `IsInstance(type_name)` | Output's type matches by name |
-| `LLMJudge(rubric, model=None, score=False)` | LLM-as-judge scoring; costs a real model call per case per judge — prefer boolean/categorical rubrics over 1-10 scales (judges are unstable on continuous scores), and benchmark the judge against ~20-100 hand-labeled cases before trusting it |
+| `LLMJudge(rubric, model=None, score=False)` | Subjective or rubric-based judgment; makes billed model requests, so validate the rubric against human-reviewed examples before treating it as a quality gate |
 | `ToolCorrectness(expected_tools, ...)` | Which tools an agent called — reads the span tree, so needs Step 2's `logfire.configure()` to work at all, not just to upload |
 
 Also available: `Contains`, `MaxDuration`, `TrajectoryMatch`, `ArgumentCorrectness`, `MaxToolCalls`, `MaxModelRequests` — same span-tree dependency as `ToolCorrectness` for the tool/trajectory ones; see `pydantic_evals.evaluators` for the full set. These five agentic (span-based) evaluators need `pydantic-evals>=2.4.0` — on an older pin, check `pyproject.toml`/`uv.lock` and upgrade before reaching for them, since the import itself is what fails, not a silent no-op.

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -387,19 +387,19 @@ Close with a final report built from what you just confirmed — org/project/reg
 
 # Skill: logfire-evals
 
-*Evaluate Python AI/agent code against a dataset of test cases using pydantic_evals, and review results in Logfire's Datasets & Experiments UI. Also covers redirecting an existing Braintrust Eval() suite to Logfire with no code changes. Use this skill whenever the user asks to "set up evals", "add an evaluation", "test my agent against cases", "write a dataset of test cases", "score my LLM output", "add an LLM judge", "check tool-call correctness", "send Braintrust evals to Logfire", "migrate from Braintrust", or mentions pydantic_evals, Braintrust, Datasets & Experiments, or evaluating AI/agent behavior against known inputs. The `pydantic_evals` workflow is Python-only; the Braintrust redirect also supports TypeScript suites, env-vars-only. Both are for scoring DEFINED test cases offline — not for instrumenting live production traffic (use `logfire-instrumentation` for that) and not for infrastructure monitoring (use `logfire-infrastructure`).*
+*Run offline evaluations for Python (`pydantic_evals`) or JavaScript/TypeScript (`logfire/evals`) and review experiments in Logfire. Also redirects existing Braintrust `Eval()` suites. Use for evaluation setup, test datasets, AI scoring, agent-behavior checks, LLM judges, Braintrust migration, or Logfire Datasets & Experiments. Do not use for live production traffic or infrastructure monitoring.*
 
-# Evaluate with pydantic_evals and Logfire
+# Evaluate AI code with Logfire
 
 ## How This Works
 
-`pydantic_evals` runs your actual function or agent against a `Dataset` of `Case`s (input + expected output + metadata), scores each with one or more `Evaluator`s, and produces a report. It depends on `logfire` itself (the `datasets` extra pulls in the real SDK, not a mock), so whether `logfire.configure()` has run determines only whether results *also* upload to Logfire's Datasets & Experiments UI — omitting it keeps results entirely local and printed to the terminal, **silently, not an error**.
+Python's `pydantic_evals` and JavaScript/TypeScript's `logfire/evals` run the real task against cases, apply evaluators, and return a report. Both run locally without sending results anywhere. Uploading needs `logfire.configure()` in Python or a configured Logfire/OpenTelemetry exporter in JavaScript/TypeScript. Without it, the report remains local rather than failing.
 
-Agentic evaluators (tool-call correctness, trajectory matching) need more than that: they read the task's own execution span tree, so without a working `logfire.configure()` they don't just fail to upload — every case reports "No span tree available" and the check never ran at all.
+Span-based evaluators inspect the task's OpenTelemetry span tree. Without working Logfire instrumentation, Python reports "No span tree available" and JavaScript/TypeScript `HasMatchingSpan` has no task spans to match. Treat either as a setup failure, not evidence about the agent.
 
 ## Step 1: Check for an Existing Braintrust Suite First
 
-Cheap check, before anything else: does this repo already have an existing Braintrust suite — actual `Eval(...)` calls or `from braintrust import Eval` in source, not just a `braintrust` dependency listed without any real usage? This path needs **no CLI auth at all** — don't run Step 2 for it.
+Cheap check, before anything else: does this repo already have an existing Braintrust suite — actual `Eval(...)` calls or `from braintrust import Eval` in source, not just a `braintrust` dependency listed without any real usage? This path needs **no CLI auth at all** — don't run Step 2 for it. The compatibility endpoint is documented only for Logfire Cloud US and EU; for any other supplied origin, use the native evaluation path instead.
 
 Keep the existing `Eval()` code (Python `braintrust>=0.30.1` / TypeScript `braintrust>=3.24.0` — verified versions) and redirect its next run to Logfire by changing environment variables only, no `pydantic_evals` involved:
 
@@ -417,38 +417,33 @@ Skip straight to Step 5 (Verify) — the SDK's own printed result URL also opens
 
 ## Step 2: Authenticate When the Run Needs Logfire
 
-Skip authentication and continue to Step 3 only when the user explicitly wants a local-only `pydantic_evals` run using evaluators that do not need span data; omit `logfire.configure()` in Step 4 so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator such as `ToolCorrectness` requires Logfire, so authenticate before opening or running evaluation files and target the exact project first.
+Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run using evaluators that do not need span data. Omit the Python `logfire.configure()` call or the JavaScript/TypeScript Logfire bootstrap so results stay in the terminal. Uploading results, using a hosted dataset, or running a span-based evaluator requires Logfire, so authenticate before running the evaluation and target the exact project first.
 
 For a Logfire-backed run, use [Authenticate and Select the Exact Project](#authenticate-and-select-the-exact-project) to derive the CLI target from the supplied Logfire URL and run its target-aware `whoami` check. Skip to Step 3 if that already reports the right project and resolved `--region` or `--base-url` target; otherwise, continue through the full authentication and project-selection sequence there. This CLI flow is for `logfire.configure()`; Step 3's hosted-dataset operations use a separate API key with different scopes.
 
 ## Step 3: Detect What to Evaluate
 
-Identify the function or agent under test (a PydanticAI agent, an LLM-calling function, any callable that takes an input and returns an output) and whether a dataset already exists:
+Identify the real task and any existing dataset. Follow repository package, test, and dependency conventions. For a first evaluation, prefer 3-5 cases from existing tests, schemas, examples, or synthetic fixtures, with deterministic checks for defined behavior. Do not copy the example unless it fits, replace an evaluation framework, or refactor unrelated code. If there is no runnable task or safe expected behavior, ask one focused question instead of inventing either.
 
-- **In-code dataset**: a Python module defining `Case`/`Dataset` directly — the default for an agent-driven workflow.
-- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[ExactMatch]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
+- **In-code dataset**: a Python module using `pydantic_evals`, or a JavaScript/TypeScript module using `logfire/evals`. This is the default for an agent-driven workflow.
+- **Hosted/managed dataset**: cases live in the Logfire UI, edited by non-engineers, pulled/pushed via a separate `LogfireAPIClient` (`from logfire.experimental.api_client import LogfireAPIClient`). `client.get_dataset(name)` with no type arguments returns a raw dict, not something `push_dataset` or `.evaluate_sync()` can take — pass the input/output (and metadata, if used) types to get back a real `pydantic_evals.Dataset`: `client.get_dataset(name, MyInputType, MyOutputType)`. If the stored dataset contains custom evaluators, also pass their classes with `custom_evaluator_types=[MyEvaluator]` (and custom report evaluators with `custom_report_evaluator_types=[...]`) so they can be deserialized. Push with `client.push_dataset(dataset)`. This needs its own API key from **Settings → API Keys** (scoped `project:read_datasets`/`project:write_datasets`), not Step 2's CLI auth flow. Only relevant if the user specifically wants case editing outside code.
 
 ## Step 4: Define the Dataset and Run It
 
+Use the repository's existing package manager. Install only the missing integration for its language.
+
+### Python
+
 ```bash
-uv add 'logfire[datasets]'
+uv add 'pydantic-evals[logfire]'
 ```
 
 ```python
-from dataclasses import dataclass
-
 import logfire
 from pydantic_evals import Case, Dataset
-from pydantic_evals.evaluators import Evaluator, EvaluatorContext, IsInstance
+from pydantic_evals.evaluators import EqualsExpected, IsInstance
 
 logfire.configure()  # omit this and results stay local only, silently
-
-
-@dataclass
-class ExactMatch(Evaluator[str, str]):
-    def evaluate(self, ctx: EvaluatorContext[str, str]) -> bool:
-        return ctx.output == ctx.expected_output
-
 
 def classify_sentiment(text: str) -> str:
     ...  # the function under test
@@ -460,14 +455,47 @@ dataset = Dataset[str, str, None](
         Case(name='positive', inputs='I love this', expected_output='positive'),
         Case(name='negative', inputs='This is terrible', expected_output='negative'),
     ],
-    evaluators=[ExactMatch(), IsInstance(type_name='str')],
+    evaluators=[EqualsExpected(), IsInstance(type_name='str')],
 )
 
 report = dataset.evaluate_sync(classify_sentiment)  # or `await dataset.evaluate(...)`
 report.print(include_input=True, include_output=True)
 ```
 
-**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge`/any evaluator that makes a real, billed model call — a bug caught on 3 cases costs 3 model calls, the same bug caught on 300 costs 300:
+Use `logfire[datasets]` instead only when the task specifically needs the hosted-dataset API from Step 3.
+
+### JavaScript or TypeScript on Node.js
+
+Add `logfire` and the Node exporter if missing:
+
+```bash
+npm install logfire @pydantic/logfire-node
+```
+
+Configure Logfire before loading the task. Reuse an existing instrumentation entry point rather than configuring it twice.
+
+```ts
+import * as logfire from '@pydantic/logfire-node'
+import { Case, Dataset, EqualsExpected, renderReport } from 'logfire/evals'
+
+logfire.configure()
+
+const classifySentiment = (text: string) => (text.includes('love') ? 'positive' : 'negative')
+const dataset = new Dataset<string, string>({
+  name: 'sentiment-eval',
+  cases: [new Case({ name: 'positive', inputs: 'I love this', expectedOutput: 'positive' })],
+  evaluators: [new EqualsExpected()],
+})
+
+const report = await dataset.evaluate(classifySentiment)
+console.log(renderReport(report, { includeInput: true, includeOutput: true }))
+```
+
+Other built-ins include `Equals`, `Contains`, `IsInstance`, `MaxDuration`, `HasMatchingSpan`, and `LLMJudge`. JavaScript/TypeScript custom evaluators extend `Evaluator`, and `LLMJudge` needs a judge callback. Use `@pydantic/logfire-node/datasets` only for hosted datasets.
+
+For Deno, Bun, browsers, or workers, keep the existing OpenTelemetry setup and follow the [runtime guidance](https://github.com/pydantic/logfire-js#evaluations); do not add the Node exporter to a non-Node runtime.
+
+**Before running the full dataset, run a smoke test on 2-3 cases** if the dataset is large or uses `LLMJudge` or any evaluator that makes a real, billed model call. A bug caught on 3 cases costs 3 model calls; the same bug caught on 300 costs 300. In JavaScript/TypeScript, construct the smoke `Dataset` with `dataset.cases.slice(0, 3)` and preserve its evaluators and report evaluators.
 
 ```python
 smoke = Dataset(
@@ -482,7 +510,7 @@ smoke_report.print(include_input=True, include_output=True)
 
 Confirm the smoke run has zero unexpected errors and the assertions that should pass do. Then, if the full dataset is large or uses paid model calls, tell the user the case count and which evaluators will make model calls, and get explicit confirmation before running the full dataset — don't run an expensive full pass on the strength of a clean smoke test alone without saying so.
 
-Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
+The remaining details in this section are Python-specific. Custom evaluators **must be `@dataclass`** subclasses — a plain class raises at run time. Case names must be unique within a dataset. The evaluators reached for most:
 
 | Evaluator | Checks |
 |-----------|--------|

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -191,6 +191,8 @@ def test_evals_skill_routes_native_python_and_javascript_setups() -> None:
     assert 'if it configures an exporter itself' in evals
     assert 'stop rather than claiming the run is local-only' in evals
     assert 'reportEvaluators: dataset.reportEvaluators' in evals
+    assert 'const report = await' not in evals
+    assert 'Node.js `HasMatchingSpan` can produce no evaluator result at all' in evals
     assert 'a plain class raises at run time' not in evals
     assert 'use `@dataclass` for configurable fields and portable serialization' in evals
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -163,15 +163,30 @@ def test_infrastructure_skill_uses_runnable_cost_conscious_collector_defaults() 
 def test_evals_skill_explains_how_to_restore_custom_evaluators() -> None:
     evals = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-evals' / 'SKILL.md').read_text()
 
-    assert 'custom_evaluator_types=[ExactMatch]' in evals
+    assert 'custom_evaluator_types=[MyEvaluator]' in evals
     assert 'custom_report_evaluator_types=[...]' in evals
 
 
 def test_evals_skill_keeps_local_runs_local_and_smoke_tests_report_evaluators() -> None:
     evals = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-evals' / 'SKILL.md').read_text()
 
-    assert 'Skip authentication and continue to Step 3 only when the user explicitly wants a local-only' in evals
+    assert 'Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run' in evals
     assert 'report_evaluators=dataset.report_evaluators' in evals
+
+
+def test_evals_skill_routes_native_python_and_javascript_setups() -> None:
+    evals = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-evals' / 'SKILL.md').read_text()
+
+    assert "uv add 'pydantic-evals[logfire]'" in evals
+    assert "uv add 'logfire[datasets]'" not in evals
+    assert 'Use `logfire[datasets]` instead only when' in evals
+    assert 'npm install logfire @pydantic/logfire-node' in evals
+    assert "from 'logfire/evals'" in evals
+    assert 'do not add the Node exporter to a non-Node runtime' in evals
+    assert 'compatibility endpoint is documented only for Logfire Cloud US and EU' in evals
+    assert 'The `pydantic_evals` workflow is Python-only' not in evals
+    assert '3-5 cases from existing tests' in evals
+    assert 'ask one focused question instead of inventing either' in evals
 
 
 def _wrap(component: str, prompt_lines: list[str]) -> str:

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -170,7 +170,7 @@ def test_evals_skill_explains_how_to_restore_custom_evaluators() -> None:
 def test_evals_skill_keeps_local_runs_local_and_smoke_tests_report_evaluators() -> None:
     evals = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-evals' / 'SKILL.md').read_text()
 
-    assert 'Skip authentication and continue to Step 3 only when the user explicitly wants a local-only run' in evals
+    assert 'For an explicitly local-only run without span evaluators' in evals
     assert 'report_evaluators=dataset.report_evaluators' in evals
 
 
@@ -180,16 +180,18 @@ def test_evals_skill_routes_native_python_and_javascript_setups() -> None:
     assert "uv add 'pydantic-evals[logfire]'" in evals
     assert "uv add 'logfire[datasets]'" not in evals
     assert 'Use `logfire[datasets]` instead only when' in evals
+    assert 'Hosted inputs and outputs must be JSON objects' in evals
     assert 'npm install logfire @pydantic/logfire-node' in evals
+    assert 'their exporter setup is not validated by this skill' in evals
     assert "from 'logfire/evals'" in evals
     assert 'compatibility endpoint is documented only for Logfire Cloud US and EU' in evals
     assert 'project:write_otlp` and `project:read_datasets' in evals
     assert '<logfire-project-write-token>' not in evals
     assert 'The `pydantic_evals` workflow is Python-only' not in evals
-    assert '3-5 cases from existing tests' in evals
+    assert '3-5 cases from tests' in evals
     assert 'ask one focused question instead of inventing either' in evals
-    assert 'if it configures an exporter itself' in evals
-    assert 'stop rather than claiming the run is local-only' in evals
+    assert 'If the task configures an exporter' in evals
+    assert 'stop rather than claiming local-only' in evals
     assert 'reportEvaluators: dataset.reportEvaluators' in evals
     assert 'const report = await' not in evals
     assert 'Node.js `HasMatchingSpan` can produce no evaluator result at all' in evals

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -182,11 +182,28 @@ def test_evals_skill_routes_native_python_and_javascript_setups() -> None:
     assert 'Use `logfire[datasets]` instead only when' in evals
     assert 'npm install logfire @pydantic/logfire-node' in evals
     assert "from 'logfire/evals'" in evals
-    assert 'do not add the Node exporter to a non-Node runtime' in evals
     assert 'compatibility endpoint is documented only for Logfire Cloud US and EU' in evals
+    assert 'project:write_otlp` and `project:read_datasets' in evals
+    assert '<logfire-project-write-token>' not in evals
     assert 'The `pydantic_evals` workflow is Python-only' not in evals
     assert '3-5 cases from existing tests' in evals
     assert 'ask one focused question instead of inventing either' in evals
+    assert 'if it configures an exporter itself' in evals
+    assert 'stop rather than claiming the run is local-only' in evals
+    assert 'reportEvaluators: dataset.reportEvaluators' in evals
+    assert 'a plain class raises at run time' not in evals
+    assert 'use `@dataclass` for configurable fields and portable serialization' in evals
+
+
+def test_braintrust_skill_and_guide_require_the_working_api_key_scopes() -> None:
+    evals = (REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-evals' / 'SKILL.md').read_text()
+    guide = (REPO_ROOT / 'docs' / 'comparisons' / 'migrate-from-braintrust.md').read_text()
+
+    for content in (evals, guide):
+        assert 'project:write_otlp' in content
+        assert 'project:read_datasets' in content
+        assert 'ingest-only write token' in content
+    assert '<your-logfire-write-token>' not in guide
 
 
 def _wrap(component: str, prompt_lines: list[str]) -> str:


### PR DESCRIPTION
## Summary

- route first-eval setup to native `pydantic_evals` for Python and `logfire/evals` for Node.js
- use `pydantic-evals[logfire]` for ordinary Python evals and reserve dataset extras for hosted dataset management
- make both full-run and smoke-test examples executable without assuming an ESM Node project
- distinguish a returned local report from telemetry privacy when an exporter is already active
- require the project API-key scopes the Braintrust SDK actually needs, and correct the linked migration guide
- document the object-root constraint observed in the hosted-dataset API
- regenerate the checked-in offline setup bundle

## Executed validation

- exact Python example and smoke block extracted from the skill and run successfully
- exact Node.js example and smoke block extracted from the skill, TypeScript-checked, and executed under a default CommonJS project
- released `logfire@0.22.8` with `@pydantic/logfire-node@0.18.24`; documented evaluator and hosted-dataset exports imported successfully
- proved an active OpenTelemetry exporter receives evaluation inputs even without Logfire-specific setup
- Python local-only run without the Logfire extra
- current evaluator failure modes, duplicate names, absent expected output, and `pydantic-evals` 2.4/2.3 agentic import boundary
- live hosted-dataset push, typed fetch, custom evaluator round trip, and delete; scalar-root rejection also reproduced
- Python hosted-dataset client suite: 115 passed
- Braintrust Python 0.30.1 end to end: 3 experiments, 8 case runs, 12 scores; Fusionfire projection verified
- Braintrust TypeScript 3.24.0 end to end: 3 case runs, 6 scores; Fusionfire projection verified
- confirmed an ingest-only write token fails summary generation with 403; reran successfully with a scoped project API key
- skill/offline-bundle tests: 22 passed; full focused set: 137 passed
- `make format`, `make lint`, `make typecheck`, and skill `quick_validate.py`

After merge, the public `pydantic/skills` distribution needs a fresh autosync before Platform #39162 depends on the updated content.