### PR TITLE
Route eval setup through the Logfire evals skill

### DIFF
--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -36,7 +36,7 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 |---------|--------|-------|
 | App instrumentation | Traces, logs, metrics, and AI/agent spans from application code — Python, JavaScript/TypeScript, Rust, or any OpenTelemetry language | [`logfire-instrumentation`](#skill-logfire-instrumentation) |
 | Infrastructure monitoring | Hosts, Docker, Kubernetes, database/queue/cache servers, cloud-provider metrics — no application code | [`logfire-infrastructure`](#skill-logfire-infrastructure) |
-| Evals | Score AI/agent output against test-case datasets with `pydantic_evals` | [`logfire-evals`](#skill-logfire-evals) |
+| Evals | Set up and run AI/agent evaluations against test-case datasets in Python or Node.js | [`logfire-evals`](#skill-logfire-evals) |
 | Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | [`logfire-query`](https://pydantic.dev/.well-known/agent-skills/logfire-query/SKILL.md) |
 | Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | [`logfire-ui`](https://pydantic.dev/.well-known/agent-skills/logfire-ui/SKILL.md) |
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |

--- a/logfire/.agents/skills/logfire-setup/SKILL.md
+++ b/logfire/.agents/skills/logfire-setup/SKILL.md
@@ -23,7 +23,7 @@ Read `AGENTS.md`/`CLAUDE.md`/`README.md` and skim the language, runtime, and pac
 |---------|--------|-------|
 | App instrumentation | Traces, logs, metrics, and AI/agent spans from application code — Python, JavaScript/TypeScript, Rust, or any OpenTelemetry language | [`logfire-instrumentation`](https://pydantic.dev/.well-known/agent-skills/logfire-instrumentation/SKILL.md) |
 | Infrastructure monitoring | Hosts, Docker, Kubernetes, database/queue/cache servers, cloud-provider metrics — no application code | [`logfire-infrastructure`](https://pydantic.dev/.well-known/agent-skills/logfire-infrastructure/SKILL.md) |
-| Evals | Score AI/agent output against test-case datasets with `pydantic_evals` | [`logfire-evals`](https://pydantic.dev/.well-known/agent-skills/logfire-evals/SKILL.md) |
+| Evals | Set up and run AI/agent evaluations against test-case datasets in Python or Node.js | [`logfire-evals`](https://pydantic.dev/.well-known/agent-skills/logfire-evals/SKILL.md) |
 | Querying telemetry | Search traces/logs/spans/metrics, summarize errors, find root cause | [`logfire-query`](https://pydantic.dev/.well-known/agent-skills/logfire-query/SKILL.md) |
 | Live UI | Open project pages, the live view, trace links, or the Explore page in a browser | [`logfire-ui`](https://pydantic.dev/.well-known/agent-skills/logfire-ui/SKILL.md) |
 | Feature flags | Runtime-managed variables (`logfire.var()`, `logfire.template_var()`) | no dedicated skill yet — see the product's own docs |

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -99,6 +99,8 @@ def test_setup_hub_routes_each_surface_to_its_skill() -> None:
 
     for skill in ('logfire-instrumentation', 'logfire-infrastructure', 'logfire-evals', 'logfire-query', 'logfire-ui'):
         assert f'[`{skill}`](https://pydantic.dev/.well-known/agent-skills/{skill}/SKILL.md)' in hub
+    assert '"set up evals for this agent"' in hub
+    assert 'evaluations against test-case datasets in Python or Node.js' in hub
     assert '../logfire-' not in hub
     assert 'not in this repo' not in hub
 


### PR DESCRIPTION
The Logfire setup hub already routes scoped eval requests to `logfire-evals`. Update its summary to describe the now-supported Python and Node.js workflows, and lock the routing language down with a focused test.

Validation: `uv run pytest tests/test_agent_setup_prompt.py -q` (15 passed)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

