### PR TITLE
Harden the OpenTelemetry flush regression test

### DIFF
--- a/logfire/_internal/logs.py
+++ b/logfire/_internal/logs.py
@@ -23,7 +23,7 @@ class ProxyLoggerProvider(LoggerProvider):
     provider: LoggerProvider
 
     loggers: WeakSet[ProxyLogger] = dataclasses.field(default_factory=WeakSet['ProxyLogger'])
-    # Provider callbacks may emit logs through this provider.
+    # Re-entrancy prevents provider callbacks that emit logs from deadlocking.
     lock: RLock = dataclasses.field(default_factory=RLock)
     suppressed_scopes: set[str] = dataclasses.field(default_factory=set[str])
     min_level: int = 0

--- a/tests/test_otel_logs.py
+++ b/tests/test_otel_logs.py
@@ -220,9 +220,11 @@ def test_log_events_with_kwargs(logs_exporter: TestLogExporter) -> None:
 
 @pytest.mark.timeout(5)
 def test_otel_logging_handler_during_force_flush_does_not_deadlock(config_kwargs: dict[str, Any]) -> None:
+    emitted: list[ReadWriteLogRecord] = []
+
     class ExportFailureProcessor(LogRecordProcessor):
         def on_emit(self, log_record: ReadWriteLogRecord) -> None:
-            pass
+            emitted.append(log_record)
 
         def shutdown(self) -> None:
             pass
@@ -241,9 +243,14 @@ def test_otel_logging_handler_during_force_flush_does_not_deadlock(config_kwargs
         handler = LoggingHandler(logger_provider=get_logger_provider())
 
     logger = logging.getLogger('opentelemetry.exporter.otlp.proto.http._log_exporter')
+    propagate = logger.propagate
     logger.addHandler(handler)
     logger.propagate = False
     try:
         logfire.force_flush(timeout_millis=1_000)
+        assert [record.log_record.body for record in emitted] == [
+            'Failed to export logs batch code: 404, reason: Not Found'
+        ]
     finally:
         logger.removeHandler(handler)
+        logger.propagate = propagate


### PR DESCRIPTION
Follow-up to [#2404](https://github.com/pydantic/logfire/pull/2404).

- Explain why `ProxyLoggerProvider` requires a re-entrant lock.
- Assert that the regression test exercises OpenTelemetry log re-entry.
- Restore the logger's original propagation setting after the test.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

