### PR TITLE
Release v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## [v5.1.0] (2026-09-11)
+
+### Integrations
+
+* Add `logfire.instrument_litestar()` with support for Litestar 2.11 and later by @dmontagu in [#2249](https://github.com/pydantic/logfire/pull/2249)
+* Recommend Logfire extras when `logfire run` detects missing instrumentation packages by @krishna3554 in [#2082](https://github.com/pydantic/logfire/pull/2082)
+
+### Agent setup
+
+* Use canonical URLs between published Logfire skills by @strawgate in [#2373](https://github.com/pydantic/logfire/pull/2373)
+* Preserve the selected Logfire region or custom base URL throughout setup by @strawgate in [#2377](https://github.com/pydantic/logfire/pull/2377)
+* Continue project selection and verification after browser authentication by @strawgate in [#2384](https://github.com/pydantic/logfire/pull/2384)
+* Make eval setup executable for Python and Node.js by @strawgate in [#2400](https://github.com/pydantic/logfire/pull/2400) and [#2402](https://github.com/pydantic/logfire/pull/2402)
+* Correct setup guidance for Python, Node.js, Rust, and Gunicorn by @adtyavrdhn in [#2365](https://github.com/pydantic/logfire/pull/2365)
+
+### Fixes
+
+* Prevent OpenTelemetry logging from deadlocking during `force_flush()` by @L4XB in [#2404](https://github.com/pydantic/logfire/pull/2404)
+* Require directory boundaries when identifying non-user code paths by @yhz5613813 in [#2375](https://github.com/pydantic/logfire/pull/2375)
+
+## New Contributors
+
+* @yhz5613813 made their first contribution in [#2375](https://github.com/pydantic/logfire/pull/2375)
+* @krishna3554 made their first contribution in [#2082](https://github.com/pydantic/logfire/pull/2082)
+* @L4XB made their first contribution in [#2404](https://github.com/pydantic/logfire/pull/2404)
+
 ## [v5.0.0] (2026-09-04)
 
 ### Major changes
@@ -1275,3 +1301,4 @@ First release from new repo!
 [v4.40.0]: https://github.com/pydantic/logfire/compare/v4.39.0...v4.40.0
 [v4.41.0]: https://github.com/pydantic/logfire/compare/v4.40.0...v4.41.0
 [v5.0.0]: https://github.com/pydantic/logfire/compare/v4.41.0...v5.0.0
+[v5.1.0]: https://github.com/pydantic/logfire/compare/v5.0.0...v5.1.0

--- a/logfire-api/logfire_api/_internal/cli/run.pyi
+++ b/logfire-api/logfire_api/_internal/cli/run.pyi
@@ -14,6 +14,7 @@ TARGET_PACKAGE_ALIASES: Incomplete
 INSTRUMENTATION_CALL_ARGUMENTS: Incomplete
 MINIMUM_INSTRUMENTATION_VERSIONS: Incomplete
 OTEL_INSTRUMENTATION_MAP: Incomplete
+INSTRUMENTATION_TO_EXTRA: dict[str, str]
 
 @dataclass(frozen=True, order=True)
 class InstrumentationRecommendation:

--- a/logfire-api/logfire_api/_internal/logs.pyi
+++ b/logfire-api/logfire_api/_internal/logs.pyi
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from logfire._internal.constants import LEVEL_NUMBERS as LEVEL_NUMBERS
 from opentelemetry._logs import LogRecord, Logger, LoggerProvider
 from opentelemetry.util.types import _ExtendedAttributes
-from threading import Lock
+from threading import RLock
 from typing import Any, overload
 from weakref import WeakSet
 
@@ -12,7 +12,7 @@ class ProxyLoggerProvider(LoggerProvider):
     """A logger provider that wraps another internal logger provider allowing it to be re-assigned."""
     provider: LoggerProvider
     loggers: WeakSet[ProxyLogger] = dataclasses.field(default_factory=WeakSet['ProxyLogger'])
-    lock: Lock = dataclasses.field(default_factory=Lock)
+    lock: RLock = dataclasses.field(default_factory=RLock)
     suppressed_scopes: set[str] = dataclasses.field(default_factory=set[str])
     min_level: int = ...
     def get_logger(self, name: str, version: str | None = None, schema_url: str | None = None, attributes: _ExtendedAttributes | None = None) -> Logger: ...

--- a/logfire-api/pyproject.toml
+++ b/logfire-api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire-api"
-version = "5.0.0"
+version = "5.1.0"
 description = "Shim for the Logfire SDK which does nothing unless Logfire is installed"
 authors = [
     { name = "Pydantic Team", email = "engineering@pydantic.dev" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "logfire"
-version = "5.0.0"
+version = "5.1.0"
 description = "The best Python observability tool! 🪵🔥"
 requires-python = ">=3.10"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -2851,7 +2851,7 @@ wheels = [
 
 [[package]]
 name = "logfire"
-version = "5.0.0"
+version = "5.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "executing" },
@@ -3227,7 +3227,7 @@ dev = [
 
 [[package]]
 name = "logfire-api"
-version = "5.0.0"
+version = "5.1.0"
 source = { editable = "logfire-api" }
 
 [package.metadata]


### PR DESCRIPTION
Prepare the `v5.1.0` release.

- Update the `logfire` and `logfire-api` package versions.
- Add curated release notes to `CHANGELOG.md`.
- Regenerate the `logfire-api` stubs.

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.
