### PR TITLE
Use direct frontend application ingest in setup guidance

### DIFF
--- a/logfire/.agents/skills/logfire-instrumentation/SKILL.md
+++ b/logfire/.agents/skills/logfire-instrumentation/SKILL.md
@@ -85,8 +85,8 @@ Use these references:
 - [project detection](./references/javascript/project-detection.md): package manager, workspace, runtime, framework, and existing OpenTelemetry detection.
 - [installation and environment](./references/javascript/installation-and-env.md): package matrix, tokens, service metadata, and secret placement.
 - [Node runtime](./references/javascript/node-runtime.md): generic Node, Express, Fastify-style servers, startup preload rules, and shutdown.
-- [Next.js](./references/javascript/nextjs.md): server-side `@vercel/otel`, optional browser proxy, client-only provider, and server component/manual API patterns.
-- [React/browser](./references/javascript/react-browser.md): browser package setup, proxy requirement, React provider, and client error reporting.
+- [Next.js](./references/javascript/nextjs.md): server-side `@vercel/otel`, direct frontend application ingest, client-only provider, and server component/manual API patterns.
+- [React/browser](./references/javascript/react-browser.md): restricted frontend credentials, direct browser export, React provider, and client error reporting.
 - [Cloudflare and Deno](./references/javascript/cloudflare-and-deno.md): Workers `instrument()` setup, Wrangler secrets, Tail Workers, and Deno OTLP export.
 - [Vercel AI SDK](./references/javascript/ai-sdk.md): version-specific telemetry setup for model calls, tools, streaming, and metadata.
 - [patterns](./references/javascript/patterns.md): current manual API for logs, spans, function instrumentation, errors, tags, baggage, sampling, and scrubbing.
@@ -96,11 +96,11 @@ Use these references:
 
 - Use the runtime package that owns SDK setup: `@pydantic/logfire-node` for Node.js, `@pydantic/logfire-browser` for browser code, `@pydantic/logfire-cf-workers` for Cloudflare Workers, and `logfire` for runtime-agnostic manual spans when OpenTelemetry is already configured.
 - Load Node instrumentation before importing the app or instrumented libraries. Prefer `node --import ./instrumentation.js` for ESM and modern Node; use `--require` only for CommonJS.
-- Never expose a Logfire write token to browser code. Browser traces must go through an authenticated same-origin backend proxy.
+- Never expose an ordinary Logfire write token to browser code. Direct browser export requires the restricted public token and regional trace URL generated for a frontend application.
 - Use the current span shape: `logfire.span('message {id}', { attributes: { id }, callback: async () => ... })`.
 - Use structured attributes instead of string interpolation when the data should be queryable.
 - For caught errors, use `logfire.reportError(message, error, attributes?, options?)` and then rethrow when preserving behavior matters.
-- Verify with the project's normal typecheck/build/test command and a runtime smoke request. Also check that no `LOGFIRE_TOKEN` or raw write token is present in client-side code or public environment variables.
+- Verify with the project's normal typecheck/build/test command and a runtime smoke request. Also check that no `LOGFIRE_TOKEN` or ordinary write token is present in client-side code or public environment variables; the restricted frontend application token is the deliberate exception.
 
 ### Rust
 

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/frameworks.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/frameworks.md
@@ -16,6 +16,6 @@ This file is a compatibility index for older prompts that ask for the JS framewo
 ## Current Defaults
 
 - Use `node --import ./instrumentation.js` for modern Node ESM preload. Use `--require` only for CommonJS.
-- Browser code must send traces to a same-origin backend proxy. Never use `LOGFIRE_TOKEN`, `OTEL_EXPORTER_OTLP_HEADERS`, or write-token literals in browser bundles.
+- Browser code sends directly with a restricted public frontend application token and its generated regional trace URL. Never expose `LOGFIRE_TOKEN`, `OTEL_EXPORTER_OTLP_HEADERS`, or another ordinary write token in a browser bundle.
 - Next.js server-side tracing should use `@vercel/otel`; do not use `@pydantic/logfire-node` as the primary Next server setup unless the app has a separate custom Node server.
 - Cloudflare Workers wrap the exported handler with `instrument()` from `@pydantic/logfire-cf-workers`; import manual spans/logs from `logfire`.

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/installation-and-env.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/installation-and-env.md
@@ -55,7 +55,7 @@ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://logfire-api.pydantic.dev/v1/metrics
 - Put `LOGFIRE_TOKEN` in server-only env files, deployment secrets, or Worker secrets.
 - Do not create `NEXT_PUBLIC_LOGFIRE_TOKEN`, `VITE_LOGFIRE_TOKEN`, `PUBLIC_LOGFIRE_TOKEN`, or any public write-token variable.
 - For browser code, create a frontend application and use its generated regional trace URL and restricted public token. Never reuse `LOGFIRE_TOKEN` or another ordinary write token in the browser.
-- A frontend application token is intentionally shipped to the browser, but keep it out of source control and chat. Use the repository's existing public runtime-config mechanism or the generated setup's placeholder.
+- A frontend application token is intentionally restricted and public. Embed the generated token and trace URL directly in the client bundle, or supply them through the app's public build/runtime configuration (for example, `VITE_LOGFIRE_FRONTEND_TOKEN` and `VITE_LOGFIRE_TRACE_URL`). Do not deploy the generated example with placeholder values.
 - Preserve an existing backend telemetry proxy. Add a new one only when the application needs its own authentication, origin checks, or rate limits; hiding the restricted token alone is not a reason.
 - Update `.env.example` or documented env templates with placeholder values, not real tokens.
 - If the app has separate frontend and backend packages, put the write token only in the backend package or hosting environment.

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/installation-and-env.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/installation-and-env.md
@@ -8,7 +8,7 @@ Use the package manager detected in [project-detection.md](./project-detection.m
 | --- | --- |
 | Node.js server, worker, CLI, script | `@pydantic/logfire-node @opentelemetry/auto-instrumentations-node` |
 | Next.js server-side tracing | `@vercel/otel logfire` |
-| Browser/React/Vite client tracing | `@pydantic/logfire-browser @opentelemetry/auto-instrumentations-web` |
+| Browser/React/Vite client tracing | `@pydantic/logfire-browser` |
 | Cloudflare Workers in-process tracing | `@pydantic/logfire-cf-workers logfire` |
 | Deno | usually no package install; import `npm:logfire` for manual spans |
 | Vercel AI SDK | no Logfire-specific package beyond the runtime setup; ensure `ai` telemetry is enabled in calls |
@@ -54,7 +54,9 @@ OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=https://logfire-api.pydantic.dev/v1/metrics
 
 - Put `LOGFIRE_TOKEN` in server-only env files, deployment secrets, or Worker secrets.
 - Do not create `NEXT_PUBLIC_LOGFIRE_TOKEN`, `VITE_LOGFIRE_TOKEN`, `PUBLIC_LOGFIRE_TOKEN`, or any public write-token variable.
-- Browser code must use a proxy URL such as `/logfire-proxy/v1/traces`, never a direct Logfire API URL with an Authorization header.
+- For browser code, create a frontend application and use its generated regional trace URL and restricted public token. Never reuse `LOGFIRE_TOKEN` or another ordinary write token in the browser.
+- A frontend application token is intentionally shipped to the browser, but keep it out of source control and chat. Use the repository's existing public runtime-config mechanism or the generated setup's placeholder.
+- Preserve an existing backend telemetry proxy. Add a new one only when the application needs its own authentication, origin checks, or rate limits; hiding the restricted token alone is not a reason.
 - Update `.env.example` or documented env templates with placeholder values, not real tokens.
 - If the app has separate frontend and backend packages, put the write token only in the backend package or hosting environment.
 
@@ -70,4 +72,4 @@ logfire.configure({
 })
 ```
 
-For browser telemetry, use a distinct service name such as `checkout-web`. For Next.js, use separate names for server and browser telemetry when both are enabled.
+For browser telemetry, the frontend application pins the service name, namespace, and optional environment. Do not override them in browser SDK configuration. For Next.js, keep the server service name distinct from the frontend application name.

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/nextjs.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/nextjs.md
@@ -66,66 +66,38 @@ export async function POST(request: Request) {
 
 ## Client-Side Browser Tracing
 
-Add browser tracing only when the app has or can safely add a same-origin proxy. Install:
+Browser tracing uses a frontend application, which supplies a restricted public token and pins the browser service identity at ingest. This is separate from the ordinary write token used by Next.js server-side tracing.
+
+Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated configuration. If that page is unavailable, enable **Frontend observability** under **Settings → Early access** or explain that browser setup cannot continue with an ordinary write token.
+
+Install:
 
 ```bash
-npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
+npm install @pydantic/logfire-browser
 ```
 
-Create a proxy file in the project root or `src` directory. For Next.js 16 and later use `proxy.ts`. For older apps that already use `middleware.ts`, follow the existing file convention unless the app has migrated to `proxy.ts`.
-
-```ts
-// proxy.ts
-import { NextRequest, NextResponse } from 'next/server'
-
-export default function proxy(request: NextRequest) {
-  const url = request.nextUrl.clone()
-
-  if (url.pathname === '/logfire-proxy/v1/traces') {
-    const token = process.env.LOGFIRE_TOKEN
-    if (!token) {
-      return new NextResponse('Logfire token is not configured', { status: 500 })
-    }
-
-    const requestHeaders = new Headers(request.headers)
-    requestHeaders.set('Authorization', token)
-
-    return NextResponse.rewrite(new URL('https://logfire-api.pydantic.dev/v1/traces'), {
-      request: {
-        headers: requestHeaders,
-      },
-    })
-  }
-
-  return NextResponse.next()
-}
-
-export const config = {
-  matcher: '/logfire-proxy/:path*',
-}
-```
-
-Set `LOGFIRE_TOKEN` server-side to a Logfire write token. It can be the same write token value used in `OTEL_EXPORTER_OTLP_HEADERS`, but it must not use a `NEXT_PUBLIC_` prefix.
-
-Create a client-only component:
+Create a client-only component using the exact regional trace URL and restricted token from the generated setup. Keep placeholders in committed code unless the repository intentionally commits public runtime configuration:
 
 ```tsx
 'use client'
 
-import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
 import * as logfire from '@pydantic/logfire-browser'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
 export function ClientInstrumentation() {
-  useEffect(() => {
-    const shutdown = logfire.configure({
-      traceUrl: '/logfire-proxy/v1/traces',
-      serviceName: 'nextjs-browser',
-      instrumentations: [getWebAutoInstrumentations()],
-    })
+  const configured = useRef(false)
 
-    return () => {
-      void shutdown()
+  useEffect(() => {
+    if (!configured.current) {
+      logfire.configure({
+        traceUrl: '<generated-regional-trace-url>',
+        traceExporterHeaders: () => ({
+          Authorization: 'Bearer <frontend-application-token>',
+        }),
+        autoInstrumentations: true,
+        rum: { webVitals: true },
+      })
+      configured.current = true
     }
   }, [])
 
@@ -133,10 +105,16 @@ export function ClientInstrumentation() {
 }
 ```
 
-If importing the component from server-rendered code, use `next/dynamic` with `ssr: false`.
+Mount this component once at the app root and do not return the asynchronous SDK cleanup from its effect. The ref prevents React Strict Mode's development-only second effect setup from configuring Logfire twice. Tests, previews, or app shells that intentionally replace the whole telemetry setup should await the cleanup returned by `configure()` before configuring a replacement.
+
+Import this Client Component normally from an App Router Server Component. If the app needs `next/dynamic` with `ssr: false`, put that dynamic import in another Client Component; Next.js rejects `ssr: false` directly in a Server Component.
+
+Do not set `serviceName`, `serviceNamespace`, or the environment in browser configuration; the frontend application pins those values. Never substitute the server's `LOGFIRE_TOKEN` or another ordinary write token for the frontend application token.
+
+If the repository already routes browser telemetry through a backend, preserve that architecture and follow the browser SDK guide's optional-proxy contract. Do not add a new Next.js rewrite merely to hide the restricted frontend token.
 
 ## Vercel Deployment Notes
 
-- Add OTLP and Logfire token values to the Vercel project environment.
+- Add server OTLP and ordinary Logfire token values to the Vercel project environment. Supply the separate frontend application configuration through the app's existing public runtime-config mechanism.
 - If spans do not appear after changing tracing env vars, clear the Vercel data cache for the project and redeploy.
-- Keep server and browser service names distinct when both are enabled.
+- Confirm server and browser data appear as distinct services; the frontend application's identity owns the browser service name.

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/nextjs.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/nextjs.md
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
 
 Browser tracing uses a frontend application, which supplies a restricted public token and pins the browser service identity at ingest. This is separate from the ordinary write token used by Next.js server-side tracing.
 
-Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated configuration. If that page is unavailable, enable **Frontend observability** under **Settings → Early access** or explain that browser setup cannot continue with an ordinary write token.
+Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated configuration. If that page is unavailable, explain that browser setup cannot continue with an ordinary write token and direct the user to [Logfire support](https://pydantic.dev/docs/logfire/get-started/help/).
 
 Install:
 
@@ -76,7 +76,7 @@ Install:
 npm install @pydantic/logfire-browser
 ```
 
-Create a client-only component using the exact regional trace URL and restricted token from the generated setup. Keep placeholders in committed code unless the repository intentionally commits public runtime configuration:
+Create a client-only component using the exact regional trace URL and restricted token from the generated setup. The restricted token is designed to be public and may be embedded in the client bundle or supplied through the app's public build/runtime configuration. Replace both placeholders before deploying:
 
 ```tsx
 'use client'

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/react-browser.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/react-browser.md
@@ -2,14 +2,16 @@
 
 Use this for browser-only telemetry in React, Vite, or other SPA projects. If the app is Next.js, read [nextjs.md](./nextjs.md) instead.
 
-## Security Requirement
+## Frontend Application Requirement
 
-Browser telemetry must go through an authenticated backend proxy. Do not put a Logfire write token or `Authorization` header in browser code. If a static frontend has no backend or proxy, do not add direct browser export; explain that a server-side proxy is required.
+Browser telemetry sends directly to Logfire with a restricted public frontend application token. The token can report only for that application; it cannot read project data or choose another service identity. Never put an ordinary Logfire write token in browser code.
+
+Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated trace URL and token configuration. If that page is unavailable, enable **Frontend observability** under **Settings → Early access** or explain that browser setup cannot continue with an ordinary write token.
 
 ## Install
 
 ```bash
-npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
+npm install @pydantic/logfire-browser
 ```
 
 ## Configure In Browser-Only Code
@@ -17,20 +19,23 @@ npm install @pydantic/logfire-browser @opentelemetry/auto-instrumentations-web
 For React, add a provider mounted once near the app root:
 
 ```tsx
-import { getWebAutoInstrumentations } from '@opentelemetry/auto-instrumentations-web'
 import * as logfire from '@pydantic/logfire-browser'
-import { useEffect, type ReactNode } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 
 export function LogfireProvider({ children }: { children: ReactNode }) {
-  useEffect(() => {
-    const shutdown = logfire.configure({
-      traceUrl: '/logfire-proxy/v1/traces',
-      serviceName: 'web-app',
-      instrumentations: [getWebAutoInstrumentations()],
-    })
+  const configured = useRef(false)
 
-    return () => {
-      void shutdown()
+  useEffect(() => {
+    if (!configured.current) {
+      logfire.configure({
+        traceUrl: '<generated-regional-trace-url>',
+        traceExporterHeaders: () => ({
+          Authorization: 'Bearer <frontend-application-token>',
+        }),
+        autoInstrumentations: true,
+        rum: { webVitals: true },
+      })
+      configured.current = true
     }
   }, [])
 
@@ -38,18 +43,13 @@ export function LogfireProvider({ children }: { children: ReactNode }) {
 }
 ```
 
-For non-React browser entrypoints, run `configure()` from the client entry file before adding manual spans.
+Mount this provider once at the app root and do not return the asynchronous SDK cleanup from its effect. The ref prevents React Strict Mode's development-only second effect setup from configuring Logfire twice. Tests, previews, or app shells that intentionally replace the whole telemetry setup should await the cleanup returned by `configure()` before configuring a replacement.
 
-## Backend Proxy Shape
+For non-React browser entrypoints, run the same generated configuration from the client entry file before adding manual spans. Do not set `serviceName`, `serviceNamespace`, or the environment; the frontend application pins those values at ingest.
 
-The proxy must:
+## Optional Backend Proxy
 
-- accept requests from the frontend origin only
-- forward `/v1/traces` OTLP requests to Logfire
-- add `Authorization: <write-token>` server-side
-- apply normal app authentication, CORS, origin checks, and rate limiting
-
-Use a path like `/logfire-proxy/v1/traces` so the browser sends same-origin requests.
+A backend proxy is not required to hide the restricted frontend token. Preserve one when the application already uses it, or add one only when the application specifically needs its own authentication, origin checks, or rate limits. Follow the browser SDK guide's optional-proxy contract and keep its existing security controls.
 
 ## Manual Client Events
 
@@ -75,6 +75,6 @@ window.addEventListener('unhandledrejection', (event) => {
 
 - Configure only in browser runtime code. Avoid importing `@pydantic/logfire-browser` from SSR modules.
 - Use `diagLogLevel: logfire.DiagLogLevel.ALL` only during local troubleshooting.
-- Browser `configure()` returns an async cleanup function. Use it in tests and providers.
+- Browser `configure()` returns an async cleanup function. Await it in tests, previews, or app shells that intentionally replace the telemetry setup, but not in the root provider effect above.
 - Browser does not install automatic pending-span processing; call `startPendingSpan()` explicitly for long operations.
 - Avoid high-volume spans for every mouse movement, render, or keystroke.

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/react-browser.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/react-browser.md
@@ -6,7 +6,7 @@ Use this for browser-only telemetry in React, Vite, or other SPA projects. If th
 
 Browser telemetry sends directly to Logfire with a restricted public frontend application token. The token can report only for that application; it cannot read project data or choose another service identity. Never put an ordinary Logfire write token in browser code.
 
-Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated trace URL and token configuration. If that page is unavailable, enable **Frontend observability** under **Settings → Early access** or explain that browser setup cannot continue with an ordinary write token.
+Open **Project settings → Frontend applications**, create or select the browser application, and copy its generated trace URL and token configuration. If that page is unavailable, explain that browser setup cannot continue with an ordinary write token and direct the user to [Logfire support](https://pydantic.dev/docs/logfire/get-started/help/).
 
 ## Install
 
@@ -16,7 +16,7 @@ npm install @pydantic/logfire-browser
 
 ## Configure In Browser-Only Code
 
-For React, add a provider mounted once near the app root:
+For React, add a provider mounted once near the app root. The restricted token is designed to be public and may be embedded in the client bundle or supplied through the app's public build/runtime configuration. Replace both placeholders before deploying:
 
 ```tsx
 import * as logfire from '@pydantic/logfire-browser'

--- a/logfire/.agents/skills/logfire-instrumentation/references/javascript/verification-troubleshooting.md
+++ b/logfire/.agents/skills/logfire-instrumentation/references/javascript/verification-troubleshooting.md
@@ -32,7 +32,7 @@ Next.js:
 1. Confirm `instrumentation.ts` is in root or `src`.
 2. Start the app with OTLP env vars set.
 3. Load a server-rendered route or call a route handler.
-4. If browser tracing was added, inspect browser network requests to `/logfire-proxy/v1/traces`.
+4. If browser tracing was added, inspect network requests to the generated regional `/v1/traces` URL, or to the existing proxy URL when the app deliberately uses one.
 
 Cloudflare:
 
@@ -51,7 +51,7 @@ Deno:
 - The start script was changed for `dev` but production uses a different uninstrumented script.
 - The app is ESM but the preload was added as `--require` instead of `--import`.
 - `LOGFIRE_TOKEN` is absent and local `.logfire` credentials are not configured.
-- Browser code is trying to send directly to Logfire instead of a same-origin proxy.
+- Browser code is using an ordinary write token instead of the restricted frontend application token, or its trace URL and token came from different applications or regions.
 - Next.js has `instrumentation.ts` in the wrong directory for the app structure.
 - Vercel AI SDK 7 has no registered `@ai-sdk/otel` integration, or an AI SDK 5/6 call is missing `experimental_telemetry: { isEnabled: true }`.
 - Existing OpenTelemetry configuration exports to a different backend or creates a competing tracer provider.
@@ -65,4 +65,4 @@ Summarize:
 - files changed for instrumentation and startup
 - environment variables or secrets the user must set
 - verification commands run and whether traces/log output were observed
-- any unverified runtime path, especially production-only scripts or browser proxy deployment
+- any unverified runtime path, especially production-only scripts or browser runtime configuration

--- a/logfire/.agents/skills/logfire-setup-offline.md
+++ b/logfire/.agents/skills/logfire-setup-offline.md
@@ -141,8 +141,8 @@ Use these references:
 - [project detection](./references/javascript/project-detection.md): package manager, workspace, runtime, framework, and existing OpenTelemetry detection.
 - [installation and environment](./references/javascript/installation-and-env.md): package matrix, tokens, service metadata, and secret placement.
 - [Node runtime](./references/javascript/node-runtime.md): generic Node, Express, Fastify-style servers, startup preload rules, and shutdown.
-- [Next.js](./references/javascript/nextjs.md): server-side `@vercel/otel`, optional browser proxy, client-only provider, and server component/manual API patterns.
-- [React/browser](./references/javascript/react-browser.md): browser package setup, proxy requirement, React provider, and client error reporting.
+- [Next.js](./references/javascript/nextjs.md): server-side `@vercel/otel`, direct frontend application ingest, client-only provider, and server component/manual API patterns.
+- [React/browser](./references/javascript/react-browser.md): restricted frontend credentials, direct browser export, React provider, and client error reporting.
 - [Cloudflare and Deno](./references/javascript/cloudflare-and-deno.md): Workers `instrument()` setup, Wrangler secrets, Tail Workers, and Deno OTLP export.
 - [Vercel AI SDK](./references/javascript/ai-sdk.md): version-specific telemetry setup for model calls, tools, streaming, and metadata.
 - [patterns](./references/javascript/patterns.md): current manual API for logs, spans, function instrumentation, errors, tags, baggage, sampling, and scrubbing.
@@ -152,11 +152,11 @@ Use these references:
 
 - Use the runtime package that owns SDK setup: `@pydantic/logfire-node` for Node.js, `@pydantic/logfire-browser` for browser code, `@pydantic/logfire-cf-workers` for Cloudflare Workers, and `logfire` for runtime-agnostic manual spans when OpenTelemetry is already configured.
 - Load Node instrumentation before importing the app or instrumented libraries. Prefer `node --import ./instrumentation.js` for ESM and modern Node; use `--require` only for CommonJS.
-- Never expose a Logfire write token to browser code. Browser traces must go through an authenticated same-origin backend proxy.
+- Never expose an ordinary Logfire write token to browser code. Direct browser export requires the restricted public token and regional trace URL generated for a frontend application.
 - Use the current span shape: `logfire.span('message {id}', { attributes: { id }, callback: async () => ... })`.
 - Use structured attributes instead of string interpolation when the data should be queryable.
 - For caught errors, use `logfire.reportError(message, error, attributes?, options?)` and then rethrow when preserving behavior matters.
-- Verify with the project's normal typecheck/build/test command and a runtime smoke request. Also check that no `LOGFIRE_TOKEN` or raw write token is present in client-side code or public environment variables.
+- Verify with the project's normal typecheck/build/test command and a runtime smoke request. Also check that no `LOGFIRE_TOKEN` or ordinary write token is present in client-side code or public environment variables; the restricted frontend application token is the deliberate exception.
 
 ### Rust
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -278,7 +278,9 @@ def test_browser_framework_examples_configure_once_without_strict_mode_shutdown(
         browser = (references / browser_doc).read_text()
         assert 'useRef(false)' in browser
         assert 'if (!configured.current)' in browser
-        assert 'void shutdown()' not in browser
+        effect_body = browser.split('useEffect(() => {', 1)[1].split('\n  }, [])', 1)[0]
+        assert '\n    return ' not in effect_body
+        assert '\n      return ' not in effect_body
     assert 'Import this Client Component normally' in (references / 'javascript/nextjs.md').read_text()
 
 

--- a/tests/test_agent_setup_prompt.py
+++ b/tests/test_agent_setup_prompt.py
@@ -243,6 +243,45 @@ def test_ai_sdk_guidance_matches_the_installed_major_and_patch_version() -> None
     assert 'AI SDK 5/6' in troubleshooting
 
 
+def test_browser_guidance_uses_restricted_frontend_application_direct_ingest() -> None:
+    references = REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-instrumentation' / 'references'
+    skill = (references.parent / 'SKILL.md').read_text()
+    nextjs = (references / 'javascript' / 'nextjs.md').read_text()
+    react = (references / 'javascript' / 'react-browser.md').read_text()
+    installation = (references / 'javascript' / 'installation-and-env.md').read_text()
+    frameworks = (references / 'javascript' / 'frameworks.md').read_text()
+    troubleshooting = (references / 'javascript' / 'verification-troubleshooting.md').read_text()
+
+    for source in (skill, nextjs, react, installation, frameworks, troubleshooting):
+        assert 'Browser telemetry must go through an authenticated backend proxy' not in source
+        assert 'Browser traces must go through an authenticated same-origin backend proxy' not in source
+        assert 'Browser code must use a proxy URL' not in source
+
+    for source in (nextjs, react):
+        assert '<generated-regional-trace-url>' in source
+        assert "Authorization: 'Bearer <frontend-application-token>'" in source
+        assert 'autoInstrumentations: true' in source
+        assert 'rum: { webVitals: true }' in source
+        assert '@opentelemetry/auto-instrumentations-web' not in source
+
+    assert 'optional-proxy contract' in nextjs
+    assert 'Optional Backend Proxy' in react
+    assert 'restricted public token and regional trace URL generated for a frontend application' in skill
+    assert 'restricted public token' in installation
+    assert 'Never reuse `LOGFIRE_TOKEN` or another ordinary write token in the browser' in installation
+    assert 'generated regional `/v1/traces` URL' in troubleshooting
+
+
+def test_browser_framework_examples_configure_once_without_strict_mode_shutdown() -> None:
+    references = REPO_ROOT / 'logfire' / '.agents' / 'skills' / 'logfire-instrumentation' / 'references'
+    for browser_doc in ('javascript/nextjs.md', 'javascript/react-browser.md'):
+        browser = (references / browser_doc).read_text()
+        assert 'useRef(false)' in browser
+        assert 'if (!configured.current)' in browser
+        assert 'void shutdown()' not in browser
+    assert 'Import this Client Component normally' in (references / 'javascript/nextjs.md').read_text()
+
+
 def test_python_logging_guidance_preserves_existing_configuration() -> None:
     logging = (
         REPO_ROOT


### PR DESCRIPTION
## Summary

- make restricted frontend-application credentials and direct regional ingest the default browser setup
- remove the mandatory Next.js proxy recipe and the instruction to abandon static frontend instrumentation
- distinguish the publishable frontend credential from ordinary project write tokens
- keep backend proxying as an optional application-specific architecture
- align React lifecycle, installation, service identity, verification, and troubleshooting guidance

This is stacked on #2407 because the generated offline bundle includes both sets of corrections.

## Validation

- `uv run pytest tests/test_agent_setup_prompt.py tests/test_build_offline_skill_prompt.py -q` — 30 passed
- `make lint`
- `make typecheck`
- typechecked the Next.js, React, browser, resource-attribute, and error-reporting examples against `next@16.3.5`, React 19, `@vercel/otel@2.1.3`, and `@pydantic/logfire-browser@0.20.1`
- verified the direct trace URL and Bearer frontend-application header shape against Platform's current generated setup source and tests
- checked every public documentation/support link live

No ordinary `LOGFIRE_TOKEN` was used in a browser fixture or sent to a live service.

AI-assisted: Codex implemented and adversarially verified the direct-ingest guidance and regression tests.
