### PR TITLE
Document database and queue monitoring Beta

### DIFF
--- a/docs/guides/web-ui/services.md
+++ b/docs/guides/web-ui/services.md
@@ -19,7 +19,7 @@ The inventory defaults to the last 15 minutes. Summary cards and the **Activity 
 - Quick links to service details, [Live View](live.md), and [Explore](explore.md).
 - A **Reliability** column when reliability targets are available.
 
-When the **Databases** or **Queues** toggle is available, you can include resources inferred from database and messaging spans. On narrow screens, rows become cards with the same key signals and separate sort controls.
+Database and queue monitoring is in Beta. Logfire automatically includes resources inferred from database and messaging spans in the inventory. On narrow screens, rows become cards with the same key signals and separate sort controls.
 
 Each resource type is limited to its 200 busiest entries in the selected range. Logfire displays a warning when results reach that limit.
 


### PR DESCRIPTION
## Summary

Update the Services guide for the database and queue monitoring Beta: resources now appear automatically in the unified inventory instead of requiring Early Access toggles.

Companion to pydantic/platform#39426.

## Validation

- `uv run pre-commit run --files docs/guides/web-ui/services.md`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

