### PR TITLE
fix: preserve metric scope attributes when reconfiguring providers

### DIFF
--- a/logfire/_internal/metrics.py
+++ b/logfire/_internal/metrics.py
@@ -50,7 +50,7 @@ class ProxyMeterProvider(MeterProvider):
             else:
                 provider = self.provider
             inner_meter = provider.get_meter(name, version, schema_url, *[attributes] if attributes is not None else [])
-            meter = _ProxyMeter(inner_meter, name, version, schema_url)
+            meter = _ProxyMeter(inner_meter, name, version, schema_url, attributes)
             self.meters.add(meter)
             return meter
 
@@ -85,8 +85,10 @@ class _ProxyMeter(Meter):
         name: str,
         version: str | None,
         schema_url: str | None,
+        attributes: Attributes | None,
     ) -> None:
         super().__init__(name, version=version, schema_url=schema_url)
+        self._attributes = attributes
         self._lock = Lock()
         self._meter = meter
         self._instruments: WeakSet[_ProxyInstrument[Any]] = WeakSet()
@@ -97,7 +99,9 @@ class _ProxyMeter(Meter):
         Creates a real backing meter for this instance and notifies all created
         instruments so they can create real backing instruments.
         """
-        real_meter = meter_provider.get_meter(self._name, self._version, self._schema_url)
+        real_meter = meter_provider.get_meter(
+            self._name, self._version, self._schema_url, *[self._attributes] if self._attributes is not None else []
+        )
 
         with self._lock:
             self._meter = real_meter

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.metrics.export import (
     MetricExporter,
     MetricExportResult,
     MetricsData,
+    Sum,
 )
 from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
 
@@ -532,6 +533,44 @@ def test_reconfigure(caplog: pytest.LogCaptureFixture):
     # For comparison, this logs a warning because the advisory is different (unset)
     meter.create_histogram('foo', unit='x', description='bar')
     assert caplog.messages
+
+
+@pytest.mark.parametrize('disable_metrics', [False, True])
+def test_reconfigure_preserves_meter_scope_attributes(
+    metrics_reader: InMemoryMetricReader, config_kwargs: dict[str, Any], disable_metrics: bool
+) -> None:
+    meters = [
+        metrics.get_meter(
+            'model_usage', version='1.0', schema_url='https://example.com/schema', attributes={'provider': provider}
+        )
+        for provider in ['local-a', 'local-b']
+    ]
+    counters = [meter.create_counter('tokens') for meter in meters]
+
+    for iteration in range(3):
+        if iteration:
+            if disable_metrics:
+                logfire.configure(**config_kwargs, metrics=False)
+            metrics_reader = InMemoryMetricReader()
+            logfire.configure(**config_kwargs, metrics=logfire.MetricsOptions(additional_readers=[metrics_reader]))
+
+        counters[0].add(1)
+        counters[1].add(10)
+        metrics_data = metrics_reader.get_metrics_data()
+        assert metrics_data is not None
+        scopes = metrics_data.resource_metrics[0].scope_metrics
+        assert len(scopes) == 2
+        results: list[tuple[dict[str, Any], int | float]] = []
+        for scope in scopes:
+            assert scope.scope.name == 'model_usage'
+            assert scope.scope.version == '1.0'
+            assert scope.schema_url == 'https://example.com/schema'
+            data = scope.metrics[0].data
+            assert isinstance(data, Sum)
+            results.append((dict(scope.scope.attributes or {}), data.data_points[0].value))
+        assert sorted(results, key=lambda result: result[1]) == snapshot(
+            [({'provider': 'local-a'}, 1), ({'provider': 'local-b'}, 10)]
+        )
 
 
 def test_metrics_options_default_views() -> None:


### PR DESCRIPTION
Reconfiguring Logfire drops the scope attributes of existing OpenTelemetry meters. Two meters with the same name, version and schema but different attributes then share a backing meter: counters that previously exported separate values of `1` and `10` are combined into a single attribute-less scope with value `11`.

Retain the attributes in `_ProxyMeter` and forward them when recreating its backing meter. The regression uses the public metrics/configuration APIs and an in-memory reader to verify separate scope identities across repeated reconfiguration, including a `metrics=False` round trip.

Validation on Python 3.12.14:
- Metrics/core tests: 133 passed, 1 skipped; metrics/configuration/API tests: 136 passed, 1 skipped (overlapping groups).
- Ruff and formatting checks passed; full-repository Pyright passed (0 errors, 0 warnings).
- Offline reproduction passed with OpenTelemetry SDK 1.39.0 and 1.44.0.

The full integration matrix and combined coverage remain for upstream CI.

AI assistance: OpenAI Codex helped implement and test this change.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

