### PR TITLE
Update Delivery navigation instructions

### DIFF
--- a/docs/cookbook/track-llm-cost.md
+++ b/docs/cookbook/track-llm-cost.md
@@ -125,7 +125,7 @@ See **[Write dashboard queries](../how-to-guides/write-dashboard-queries.md)** f
 
 A dashboard shows spend when you look at it. An [alert](../guides/web-ui/alerts.md) tells you without looking: it's a SQL query Logfire runs on a schedule, and when the query returns rows, Logfire sends a notification. Write the query so that **rows mean "spend is too high"**, and you'll hear about a runaway bill instead of finding it later.
 
-In the sidebar, go to **Alerts** under **Notify**, click **New alert**, pick **Custom query**, and enter a query that returns a row only when the spend in your alert window exceeds your threshold (here, 50 US dollars):
+In the sidebar, go to **Alerts** under **Reliability**, click **New alert**, pick **Custom query**, and enter a query that returns a row only when the spend in your alert window exceeds your threshold (here, 50 US dollars):
 
 ```sql
 SELECT

--- a/docs/guides/web-ui/service-levels.md
+++ b/docs/guides/web-ui/service-levels.md
@@ -8,7 +8,7 @@ Set a measurable reliability goal for a service or large language model (LLM) pr
 
 A service level objective (SLO) is a target for how reliable a service should be, such as "99.9% of checkout requests succeed over the last 30 days." Logfire calls each SLO a **reliability target**. An SLO is an internal engineering target; a service level agreement (SLA) is an external contract.
 
-You'll find <OpenInLogfire path="service-levels" variant="inline" label="Service levels" /> under **Notify** in the project sidebar. The page lists every target in the project. Search by target name, service, provider, or description; filter by status; or group by service, status, time window, source, or not at all. Service detail pages show the same targets on their **Reliability** page.
+You'll find <OpenInLogfire path="service-levels" variant="inline" label="Service levels" /> under **Reliability** in the project sidebar. The page lists every target in the project. Search by target name, service, provider, or description; filter by status; or group by service, status, time window, source, or not at all. Service detail pages show the same targets on their **Reliability** page.
 
 !!! note "Plans and limits"
     Reliability targets are available on **Growth**, **Enterprise**, and self-hosted Logfire. Growth organizations can create up to five targets across the organization and use windows up to 30 days. Enterprise and self-hosted organizations have no target-count limit and can use windows up to 90 days. Project retention still limits the available history.

--- a/docs/how-to-guides/pagerduty.md
+++ b/docs/how-to-guides/pagerduty.md
@@ -49,7 +49,7 @@ For each service you approve, Logfire receives a key that lets it send alerts an
 
 A notification channel is an organization-level destination that you attach to one or more alerts.
 
-1. From your project's sidebar, open **Delivery**, then **Channels**.
+1. Open **Project settings** → **Notifications** → **Delivery** → **Channels**.
 2. Click **New channel**.
 3. Enter a name that explains who receives the page, such as `PagerDuty on-call`.
 4. Select **PagerDuty** as the type.

--- a/docs/how-to-guides/setup-slack-alerts.md
+++ b/docs/how-to-guides/setup-slack-alerts.md
@@ -40,7 +40,7 @@ There are a few ways to create an alert.  You can:
 We'll create an alert that will let us know if any HTTP request takes longer than a second to execute.
 
 * Login to **Logfire** and [navigate to your project](https://logfire-us.pydantic.dev/-/redirect/latest-project)
-* Click on **Alerts** in the **Notify** section of the left sidebar
+* Click on **Alerts** in the **Reliability** section of the left sidebar
 * Select the **New alert** button in the top right, then pick **Custom query**
 * Let's give this Alert a name of **Slow Requests**
 * For the query, we'll group results by the http path and duration.  We want to include the **max** duration in a given time frame.  We also want to filter out any traces that aren't http requests, and order by the max duration, so we can see which routes are the slowest.  This query looks like:
@@ -60,14 +60,10 @@ We'll create an alert that will let us know if any HTTP request takes longer tha
   ```
 * Click **Preview query results** and make sure you get some results back.  If your service is lightning fast, firstly congratulations! Secondly try adjust the duration cutoff to something smaller, like `duration > 0.1` (i.e, any requests taking longer than 100ms).
 
-    ![](../images/guide/browser-alerts-create-alert.png)
-
 * You can adjust when alerts are sent under the **When this alert fires** section.  With this style of alert, we just want to know if anything within the last 5 minutes has been slow.  So we can use the following options:
     * **Fire when**: the query has any results
     * **Look at rows from**: the last 5 minutes
     * **Check every**: 5 minutes
-
-    ![](../images/guide/browser-alerts-parameters.png)
 
 ### Send Alert to a Slack Channel
 
@@ -78,15 +74,13 @@ For this, you will need the [Webhook URL](#creating-a-slack-incoming-webhook) yo
 Let's set up a channel, then test that alerts can be sent with the URL.
 In the **Send notifications to** section of the alert form:
 
-* Select **Add channel** to open the New channel dialog (channels can also be managed from **Delivery** → **Channels** in the **Notify** section of the left sidebar; they are shared across all projects in your organization)
+* Select **Add channel** to open the New channel dialog (channels can also be managed from **Project settings** → **Notifications** → **Delivery** → **Channels**; they are shared across all projects in your organization)
 * Put in a name such as **Logfire Alerts**.  This does not need to be the name of your Slack channel
 * Select **Slack Webhook** as the type (or leave it as **Auto**; the Slack format is inferred from `hooks.slack.com` URLs)
 * Paste in your Webhook URL from the Slack [Apps Management Dashboard](https://api.slack.com/apps)
 * Click on **Send a test alert** and check that you can see the alert in Slack.  A successful test is required before you can create the channel
 * Click **Create channel** to create the channel and close the dialog
 * Click the checkbox next to your new channel to select it
-
-    ![](../images/guide/browser-alerts-create-channel.png)
 
 Once your Slack channel is connected, click **Create alert** to save all your changes. Your alert is now live!
 

--- a/docs/how-to-guides/slack-app.md
+++ b/docs/how-to-guides/slack-app.md
@@ -71,7 +71,7 @@ Logfire only lists channels the app is a member of, so this step is what makes a
 
 A *notification channel* in Logfire is a destination you attach to alerts and issues.
 
-1. In your project, go to **Delivery** → **Channels** in the **Notify** section of the sidebar, then click **New channel**. You can also create one inline from the **Send notifications to** section of an alert form.
+1. In your project, open **Project settings**, then select **Delivery** under **Notifications**. On the **Channels** tab, click **New channel**. You can also create one inline from the **Send notifications to** section of an alert form.
 2. Name it. This is a Logfire label, not the Slack channel name.
 3. Pick **Slack App** as the type. (**Slack Webhook** is the other route, covered in [Setup Slack Alerts](setup-slack-alerts.md).)
 4. Pick the **Slack workspace** you connected.


### PR DESCRIPTION
Follow-up documentation for pydantic/platform#39527.

- point notification-channel setup to Project settings → Notifications → Delivery
- update the Alerts sidebar section name to Reliability

Validation: changed-file pre-commit hooks and a docs-wide search for the old navigation wording.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/pydantic/logfire/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

